### PR TITLE
docs(artifacts): When Reviewers Are Wrong — failure taxonomy with receipts + adjudicator eval fixtures (#8856 item 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ artifacts/
 !docs/artifacts/
 docs/artifacts/*
 !docs/artifacts/2026-07-decision-integrity-dogfooding.md
+!docs/artifacts/2026-07-reviewer-failure-taxonomy.md
 smoke_output/
 replays/*.mp3
 

--- a/docs/artifacts/2026-07-decision-integrity-dogfooding.md
+++ b/docs/artifacts/2026-07-decision-integrity-dogfooding.md
@@ -304,6 +304,8 @@ the credibility of this document.
    GitHub's search API with `in:comments` qualifiers, not a hand audit of 579
    threads. Treat them as accurate to search fidelity.
 
+7. **The reviewers themselves are sometimes confidently wrong.** A companion artifact, [When Reviewers Are Wrong](2026-07-reviewer-failure-taxonomy.md), catalogs six receipted reviewer failure classes from this same gate — every documented error a false negative (a true claim wrongly doubted), none a false claim merged.
+
 ## Why this is hard to fake
 
 A staged demo can show a model posting "LGTM." What a demo cannot fake is a

--- a/docs/artifacts/2026-07-reviewer-failure-taxonomy.md
+++ b/docs/artifacts/2026-07-reviewer-failure-taxonomy.md
@@ -1,0 +1,475 @@
+# When Reviewers Are Wrong: A Taxonomy of Multi-Model Review Failures, With Receipts
+
+**Date:** 2026-07-05
+**Repo:** [synaptent/aragora](https://github.com/synaptent/aragora)
+**Audience:** ML/eval engineers evaluating LLM-as-reviewer systems, and anyone
+deciding whether to trust an "AI review gate" with merge authority.
+**Companion to:** [Decision Integrity, Dogfooded](2026-07-decision-integrity-dogfooding.md)
+(the same gate's successes over 30 days).
+
+---
+
+## The claim
+
+Every vendor publishes the bugs their AI reviewers caught. Nobody publishes the
+times their AI reviewers were confidently wrong. This document does the second
+thing, from four days of this repository's public merge-gate record
+(2026-07-02 to 2026-07-05): six distinct reviewer failure classes, one
+receipted case study each, the exact machine refutation used against each, and
+the resolution mechanism that unstuck the pipeline — plus the control group of
+reviews where the same gate worked exactly as designed.
+
+The headline, stated up front and defended below: **in every documented failure,
+the reviewer error was a false negative — a true claim wrongly doubted. We
+found no case in this window where a reviewer PASS vouched for a claim that
+was false.** The gate errs toward doubt, not false trust. That asymmetry is
+the property you actually want from a merge gate, and it is measurable.
+
+Everything here is drawn from public PR/issue comments of this repository or
+from evidence-collector records committed alongside this document as
+machine-readable eval fixtures
+([`tests/governance/fixtures/adjudicator_eval_cases.json`](../../tests/governance/fixtures/adjudicator_eval_cases.json),
+10 cases, verbatim reviewer bodies at exact head SHAs). Every quote links to
+its source; where a quoted review body was produced by the evidence collector
+in a prepare-only round (recorded but not posted verbatim to the thread), the
+fixture file is the committed source and the linked thread comment restates the
+finding.
+
+## The setup, in one paragraph
+
+Merges in this repository are gated by adversarial review from independent
+frontier-model families — Claude (Anthropic) and GPT (OpenAI) as the counting
+"western frontier" pair — each producing a verdict (`PASS` /
+`CHANGES-REQUESTED`) with per-finding severities (`[P0]`–`[P3]`) at the exact
+PR head SHA. [Severity-gated dissent](https://github.com/synaptent/aragora/pull/8574)
+makes `[P0]`/`[P1]` blocking and `[P2]`/`[P3]` advisory (non-blocking but
+preserved, never discarded); the
+[tiered gate](https://github.com/synaptent/aragora/pull/8638) scales required
+evidence to blast radius; Tier 3–4 changes always end in recorded human risk
+acceptance. The full mechanism, with its 30-day numbers, is in the
+[companion artifact](2026-07-decision-integrity-dogfooding.md). This document
+is about the rounds where the reviewers — not the code — were the problem.
+
+## The window
+
+Seven PRs, 2026-07-02 to 2026-07-05, all ultimately merged. Roughly 30 review
+rounds and ~60 reviewer verdicts; the fixture file commits 20 verbatim bodies,
+and the remainder are receipted through in-thread evidence-round comments that
+quote them.
+
+| PR | Rounds | What happened | Outcome |
+|---|---|---|---|
+| [#8824](https://github.com/synaptent/aragora/pull/8824) | 7 | Both reviewers repeatedly reported a README link dead; the target file existed on `main` the whole time | Merged after machine refutation + absolute-URL premise removal |
+| [#8834](https://github.com/synaptent/aragora/pull/8834) | 4 | One reviewer read a stale PyPI index; the other called a UTC date "in the future" from its local clock | Merged after timestamped refutation; one dissent premise self-expired at local midnight |
+| [#8800](https://github.com/synaptent/aragora/pull/8800) | 4 | One reviewer re-raised its round-1 finding after the demanded audit was delivered | Operator-settled with the other family's counting PASS |
+| [#8802](https://github.com/synaptent/aragora/pull/8802) | 8 | Findings alternated between reviewers for seven adversarial rounds, several targeting a file the PR was fenced from touching; three rounds found real bugs (one a genuine security bug) | Merged; out-of-scope findings re-filed as [#8810](https://github.com/synaptent/aragora/issues/8810) |
+| [#8811](https://github.com/synaptent/aragora/pull/8811) | 3 | **Control:** both reviewers converged on the same real harmlessness bug in round 1 | Fixed; clean 2-0 PASS in round 3 |
+| [#8852](https://github.com/synaptent/aragora/pull/8852) | 3 | **Control:** three real `[P2]`s in round 1, including a reproduced WAL edge case | Fixed; clean 2-0 PASS twice |
+| [#8803](https://github.com/synaptent/aragora/pull/8803) | 1 | **Control:** clean 2-0 PASS, zero findings, single round | Merged |
+
+## The taxonomy
+
+| # | Failure class | Specimen | Who erred | Resolution mechanism |
+|---|---|---|---|---|
+| 1 | Diff-blind grounding | #8824 r1–r3 | both families | evidence-post + premise removal; grounding fix filed as [#8825](https://github.com/synaptent/aragora/issues/8825) |
+| 2 | Stale-external-world grounding | #8834 r1–r2 | openai | timestamped fresh-fetch refutation |
+| 3 | Temporal reasoning | #8834 r1–r2 | claude | timezone-explicit timestamps + premise self-expiry |
+| 4 | Verbatim-repeat dissent | #8800 r3 | openai | severity-gating + operator adjudication |
+| 5 | Out-of-scope carousel | #8802 r4/r6 | both families | re-filing (finding preserved as [#8810](https://github.com/synaptent/aragora/issues/8810)) |
+| 6 | Cross-family contradiction | #8802 r5 vs r7 | both, by definition | human adjudication (reference-implementation parity) |
+| — | Control: convergent real findings, clean passes | #8811, #8852, #8803 | nobody | the gate, working |
+
+### 1. Diff-blind grounding — the reviewer reasons over the diff, not the tree
+
+**Case: [#8824](https://github.com/synaptent/aragora/pull/8824), rounds 1–3.**
+A docs-only PR linked `docs/artifacts/2026-07-decision-integrity-dogfooding.md`
+from the README. That file had been on `main` since
+[#8801](https://github.com/synaptent/aragora/pull/8801) (merged
+2026-07-03T05:25Z, blob `3c0458f1`). Both reviewers, for three consecutive
+rounds, reported the link dead. Round 1, claude, as a blocking `[P1]`:
+
+> "The marquee evidence link `[Decision Integrity, Dogfooded](docs/artifacts/2026-07-decision-integrity-dogfooding.md)`
+> is dead: neither the file nor the `docs/artifacts/` directory exists at this
+> head, and this PR changes only `README.md`"
+> — claude review at head `1bbf572` (fixture `pr8824_r1_diff_blind_grounding`)
+
+Round 3, openai's wording exposes the mechanism:
+
+> "this PR's complete changed-file list does not include that artifact and the
+> reviewed checkout has no tracked target at that path"
+> — openai review at head `75893e9` (fixture `pr8824_r3_diff_blind_unanimous`;
+> quoted in the [round-3 disposition comment](https://github.com/synaptent/aragora/pull/8824#issuecomment-4879423633))
+
+The reviewer grounding reasons over the diff plus the changed-file list — it
+cannot see the base tree where the file already lives. The refutation was
+machine evidence, posted in-thread
+([round 2](https://github.com/synaptent/aragora/pull/8824#issuecomment-4879405120)):
+
+> "disproven at the branch tree with machine evidence: `git ls-tree HEAD --
+> docs/artifacts/` → blob 3c0458f1 present; `rg --files docs/artifacts/` now
+> lists the file (negation effective); `git check-ignore` → not ignored; the
+> file merged to main in #8801."
+
+Honest wrinkle — the reviewers were half right. There *was* a landmine, just
+not the one they named
+([round 1 comment](https://github.com/synaptent/aragora/pull/8824#issuecomment-4879384313)):
+
+> "both were wrong about the tree … but right about the landmine: the repo's
+> 'artifacts/' gitignore rule shadowed the tracked file from every
+> ignore-respecting tool, including reviewer grounding."
+
+#8824 itself fixed the `.gitignore` shadowing (a `!docs/artifacts/` negation).
+The dead-link claim survived even that; it stopped only when the README link
+became an absolute URL to `main` — verifiable without tree access — after which
+[openai PASSed at head `7e18207`](https://github.com/synaptent/aragora/pull/8824#issuecomment-4879436485).
+The structural fix is filed as
+[#8825 — "Reviewer grounding blind spot: evidence reviewers cannot verify
+files/links outside the PR diff"](https://github.com/synaptent/aragora/issues/8825).
+
+A closing recursion, for the record: the #8824 negation whitelisted exactly one
+filename, and a claude advisory `[P3]` in a later prepare-only round (collector
+record at head `56fc92a`) predicted the consequence — "Any sibling tracked
+artifact under `docs/artifacts/` stays invisible to the gitignore-respecting
+tools this change is meant to satisfy; prefer whitelisting `*.md` … rather than
+a single hard-coded filename that must be edited for every future artifact."
+Committing *this document* tripped exactly that foot-gun and required adding
+its own negation line to `.gitignore`. The advisory finding was right.
+
+### 2. Stale-external-world grounding — the reviewer's fetch of reality is out of date
+
+**Case: [#8834](https://github.com/synaptent/aragora/pull/8834), rounds 1–2.**
+A docs-only PR asserted `aragora-verify` 0.1.1 was live on PyPI. openai
+fetched PyPI and disagreed. Round 1:
+
+> "PyPI currently exposes only `0.1.0` for `aragora-verify`
+> ([PyPI JSON](https://pypi.org/pypi/aragora-verify/json)). This makes the
+> install command fail and overstates availability of the key_id binding fix."
+> — openai review at head `05487fa` (fixture `pr8834_r1_temporal_and_stale_external`)
+
+Round 2, same premise, escalated framing: "This creates a false security-release
+record for the signer-label binding fix." The refutation was a timestamped
+fresh fetch plus a clean-venv install, posted in-thread
+([refutation comment](https://github.com/synaptent/aragora/pull/8834#issuecomment-4880630705)):
+
+> "stale fetch. Live at 2026-07-04 04:26 UTC:
+> https://pypi.org/pypi/aragora-verify/json → latest **0.1.1**, uploaded
+> 2026-07-04T03:28Z, and a fresh venv `pip install 'aragora-verify>=0.1.1'`
+> resolves and installs 0.1.1"
+
+The release had been uploaded ~54 minutes before openai's first review of this
+PR; the reviewer's view (CDN cache or pre-propagation snapshot) was stale.
+Re-verified while preparing this document (2026-07-05): the PyPI JSON reports
+0.1.1 with wheel upload time `2026-07-04T03:28:00.547565Z`. openai returned
+PASS at the same head in the re-gate
+([posted 2026-07-04T05:03:39Z](https://github.com/synaptent/aragora/pull/8834#issuecomment-4880751502)).
+
+### 3. Temporal reasoning — the reviewer's clock is not the world's clock
+
+**Case: [#8834](https://github.com/synaptent/aragora/pull/8834), same rounds,
+other reviewer.** claude blocked the same PR with a `[P1]` because the release
+date looked impossible:
+
+> "the release is dated **2026-07-04, which is in the future** — today is
+> 2026-07-03."
+> — claude review at head `05487fa` (fixture `pr8834_r1_temporal_and_stale_external`)
+
+And in round 2, with full confidence in the wrong direction:
+
+> "The PR asserts 0.1.1 was **published 2026-07-04 03:28 UTC**, but today is
+> **2026-07-03**. UTC 2026-07-04 03:28 is in the future in *every* timezone"
+> — claude review at head `8955a4e` (fixture `pr8834_r2_temporal_and_stale_external`)
+
+It was not in the future in any timezone: the review ran at roughly
+2026-07-04T04:27Z, an hour *after* the upload. The reviewer's local calendar
+(UTC−5) still read July 3, and it projected that local date onto UTC. Two
+resolutions were applied, both visible in-thread. First, the legitimate kernel
+of the finding was fixed: every release timestamp in the docs became
+timezone-explicit ("2026-07-04 (03:28 UTC)"). Second — this is the striking
+part — the
+[operator settlement packet](https://github.com/synaptent/aragora/pull/8834#issuecomment-4880639145)
+explicitly priced in premise self-expiry:
+
+> "(b) wait ~1h until the reviewer clock passes local midnight (the P1's
+> premise self-expires) and run one premise-changed re-gate"
+
+The re-gate run minutes after the reviewer environment's local midnight
+returned openai PASS (posted 05:03:39Z ≈ 00:03 local), and claude PASSed the
+next head at
+[05:54Z](https://github.com/synaptent/aragora/pull/8834#issuecomment-4880875980).
+A dissent premise that expires on a wall-clock boundary is a failure mode
+worth naming: it is refutable by *waiting*.
+
+### 4. Verbatim-repeat dissent — the reviewer re-raises an answered finding
+
+**Case: [#8800](https://github.com/synaptent/aragora/pull/8800), round 3.**
+Round 1 on this CI-baseline PR demanded justification for a skip-count baseline
+move (68→75). The demanded audit was delivered: a per-skip table in the PR
+body tracing all 7 net-new skips to already-merged PRs, every one a
+conditional environment guard
+([revision comment](https://github.com/synaptent/aragora/pull/8800#issuecomment-4871650194)).
+Round 2's distinct finding (doc-history inconsistency) was also fixed. Round
+3, openai:
+
+> "[P2] `tests/.skip_baseline:1` raises the enforced skip budget from 68 to 75
+> without any corresponding test changes in this PR. … keep the baseline at 68
+> unless the PR itself introduces and justifies the 7 new skips."
+> — [openai review at head `1817ae0`](https://github.com/synaptent/aragora/pull/8800#issuecomment-4878231496)
+
+That is the round-1 finding restated, with no engagement with the delivered
+audit — the [park note](https://github.com/synaptent/aragora/pull/8800#issuecomment-4873062395)
+characterizes it as "openai re-raises round 1 verbatim … without engaging the
+provided audit," and quotes the round-1 wording it repeats. (Limitation: the
+round-1 review body itself was a prepare-only record not posted verbatim, so
+"verbatim" rests on the in-thread quote; the round-3 body is on record in full
+— fixture `pr8800_r3_verbatim_repeat_answered`.) Meanwhile claude's round-3
+PASS did the opposite of repeating itself: it ran the audit tooling at the
+head and verified the numbers
+("audit returns exactly 75, DIFF=0" —
+[claude review](https://github.com/synaptent/aragora/pull/8800#issuecomment-4878231397)).
+Resolution:
+[operator settlement](https://github.com/synaptent/aragora/pull/8800#issuecomment-4878231586)
+under severity-gated dissent — the `[P2]` is advisory and on record; the
+counting western-frontier PASS settles Tier 0.
+
+### 5. Out-of-scope carousel — findings rotate onto files the PR cannot touch
+
+**Case: [#8802](https://github.com/synaptent/aragora/pull/8802), seven
+adversarial rounds before the clean final.** This compliance-walkthrough PR
+was explicitly fenced from `aragora/gauntlet/odr_verify.py` (reserved to the
+#8765 lane). Findings alternated between reviewers round after round, and
+several targeted exactly the fenced file. Round 4, openai:
+
+> "[P2] … this PR only hardens `aragora-verify`; the in-repo
+> `aragora.gauntlet.odr_verify` path used by server/internal verification is
+> not updated and can still diverge on multi-signature cases."
+> — [openai review at head `21a4ac4`](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871391696)
+
+Round 6 was claude's turn to land on the same fenced file (the
+unsigned-with-key parity gap in `odr_verify.py`). True findings — about a file
+this PR was forbidden to change. The resolution was re-filing, not suppression:
+[#8810 — cross-verifier parity](https://github.com/synaptent/aragora/issues/8810)
+now carries them, scoped to the lane that owns the file
+([park packet](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871373189),
+[settlement](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871391778)).
+
+Honesty requires splitting this class down the middle: the carousel was
+**mixed value, not pure noise**. Of the seven rounds, three surfaced real,
+in-scope bugs that were fixed and regression-tested:
+
+- **Round 1:** fixture-generator nondeterminism via an ambient calibration DB
+  ([fixed](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871197557))
+- **Round 3:** a genuine security bug — "aragora-verify 0.1.0 reported VERIFIED
+  for a cryptographically valid signature even when its recorded `key_id` had
+  been relabeled" ([fixed in 0.1.1 with a regression test](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871349915))
+- **Round 5:** a real precedence divergence between the standalone and in-repo
+  verifiers ([fixed](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871658875))
+
+The pathology is not that reviewers find things; it is that an adversarial
+reviewer with no scope model will eventually wander outside the PR's reachable
+surface, and each such finding costs a full round.
+
+### 6. Cross-family contradiction — two reviewers demand opposite designs
+
+**Case: [#8802](https://github.com/synaptent/aragora/pull/8802) again, rounds
+5 vs 7.** Round 5, claude *required* a specific signature-verification
+precedence, citing the in-repo reference implementation:
+
+> "The in-repo reference verifier `aragora/gauntlet/odr_verify.py:596-641`
+> deliberately uses a *separate* `key_id_mismatch` flag checked **after**
+> `verified_any`, precisely so that a receipt containing one valid+matching
+> signature PASSes even if another entry carries a valid-but-relabeled
+> signature. … Fix: mirror the sibling's separate `key_id_mismatch` flag with
+> `verified_any`-wins ordering."
+> — claude round-5 review at head `05d8ef9` (collector record; requirement
+> restated in the
+> [round-5 fix comment](https://github.com/synaptent/aragora/pull/8802#issuecomment-4871658875))
+
+The fix was implemented exactly as demanded, with a two-signature regression
+test. Then round 7 (fresh head after a main merge), openai objected to
+precisely that ordering:
+
+> "[P2] `aragora-verify/src/aragora_verify/verifier.py:231` - `verified_any`
+> wins before `key_id_mismatch`, so an attacker can append a relabeled
+> duplicate signature … Fail or mark unverified when any evaluated signature
+> verifies with the supplied key but has a mismatched `key_id`."
+> — openai review at head `787d1f5` (fixture
+> `pr8802_r7_cross_family_contradiction`; summarized in the
+> [in-thread evidence note](https://github.com/synaptent/aragora/pull/8802#issuecomment-4879461357))
+
+Two frontier families, opposite positions, on one deliberate and documented
+design decision. No revision can satisfy both. This is the case that
+adversarial-review systems must route to a human — and the in-thread record
+already calls it by name: "a textbook ESCALATE specimen for the #8748/#8811
+adjudicator, resolved here by reference-implementation parity." The residual
+position is pinned on [#8810](https://github.com/synaptent/aragora/issues/8810);
+the PR reached a clean 2-0 PASS at the final head
+([claude](https://github.com/synaptent/aragora/pull/8802#issuecomment-4879458963),
+[openai](https://github.com/synaptent/aragora/pull/8802#issuecomment-4880146715)).
+
+## The control group — the same gate, working
+
+If the six classes above were the whole story, the fix would be "fire the
+reviewers." They are not the whole story.
+
+- **[#8811](https://github.com/synaptent/aragora/pull/8811) round 1 — clean
+  convergence on a real bug.** Both families independently found the same
+  `[P2]`: the observe-only adjudicator hook was wired into the settlement hot
+  path with no exception guard, so a crash in an *observational* feature could
+  break evidence collection exactly where harmlessness was required
+  ([round-1 record](https://github.com/synaptent/aragora/pull/8811#issuecomment-4879898764):
+  "both reviewers converge on the same real [P2] … No other findings; no
+  carousel — clean convergent dissent"). Fixed; round 3 was a 2-0 PASS
+  ([claude](https://github.com/synaptent/aragora/pull/8811#issuecomment-4881139661),
+  [openai](https://github.com/synaptent/aragora/pull/8811#issuecomment-4881139703)).
+
+- **[#8852](https://github.com/synaptent/aragora/pull/8852) round 1 — three
+  real `[P2]`s, one with a reproduction.** claude reproduced a WAL read-only
+  open failure ("Confirmed repro: sidecars present → RO read OK; sidecars
+  removed → `mode=ro FAILED: unable to open database file`; read-only
+  directory → same failure" — fixture `pr8852_r1_convergent_real_findings`);
+  openai found a branch-uniqueness gap and a stale-lease squat. All three
+  fixed with new tests
+  ([fix comment](https://github.com/synaptent/aragora/pull/8852#issuecomment-4884476574));
+  both families then PASSed twice
+  ([r2](https://github.com/synaptent/aragora/pull/8852#issuecomment-4884498921),
+  [r3](https://github.com/synaptent/aragora/pull/8852#issuecomment-4884676821)).
+
+- **[#8803](https://github.com/synaptent/aragora/pull/8803) — the boring ideal.**
+  Clean 2-0 PASS, zero findings, one round
+  ([claude](https://github.com/synaptent/aragora/pull/8803#issuecomment-4871390438),
+  [openai](https://github.com/synaptent/aragora/pull/8803#issuecomment-4871390511)).
+  Good PRs do exit the gate in one pass — and
+  [#8802's final round](https://github.com/synaptent/aragora/pull/8802#issuecomment-4880146715)
+  shows even a seven-round PR converging to an uncoerced 2-0.
+
+The thesis of this document is **not** "reviewers are bad." It is: reviewer
+errors exist, they are classifiable, and *in this record they all point the
+same direction* — doubt.
+
+## Error direction: the asymmetry that matters
+
+Tally the documented reviewer errors in this window:
+
+| Error | Direction | True state |
+|---|---|---|
+| Dead-link claims, #8824 (6 assertions across 4 heads, both families) | false negative | file existed on `main` (blob `3c0458f1`) |
+| Stale-PyPI claims, #8834 (3 assertions, openai) | false negative | 0.1.1 live, uploaded 03:28Z |
+| Future-date claims, #8834 (2 assertions, claude, one `[P1]`) | false negative | date was valid UTC, already past |
+| Verbatim re-raise, #8800 (openai) | false negative | audit already delivered in PR body |
+| Out-of-scope findings, #8802 (both families) | false negative for *this* PR | real findings, wrong lane — preserved as #8810 |
+| Precedence objection, #8802 r7 (openai) | design dissent | legitimate two-sided crux, not an error of fact |
+
+Every factual error withheld a PASS from a claim that was true. In the same
+window, the same reviewers found a real security bug (#8802 r3), a real
+crash-in-hot-path (#8811 r1), and a reproduced storage edge case (#8852 r1) —
+and no reviewer PASS in this window vouched for a claim later shown false.
+False alarms cost rounds and operator attention; false trust would cost
+correctness of merged code. This gate spent the cheap currency, not the
+expensive one. (See Limitations for why false trust is also structurally
+harder to observe — we state the asymmetry as this window's record, not a
+theorem.)
+
+## Resolution mechanisms, catalogued
+
+Each failure class came with a working countermeasure, all visible in-thread:
+
+| Mechanism | What it is | Where it worked |
+|---|---|---|
+| Evidence-post | Machine refutation posted into the review thread (`git ls-tree`, `check-ignore`, timestamped fetches, clean-venv installs) | #8824, #8834 |
+| Premise removal | Restate the claim so the reviewer's blind spot no longer applies (absolute URL instead of tree-relative link) | #8824 |
+| Premise self-expiry | Wait until a time-indexed dissent premise expires, then re-gate | #8834 |
+| Severity gating ([#8574](https://github.com/synaptent/aragora/pull/8574)) | `[P2]`/`[P3]` dissent is advisory: preserved, non-blocking, non-counting | #8800, #8802 |
+| Operator adjudication | Human settles a stalled-but-answered record, in-thread, head-pinned | #8800, #8802, #8834 |
+| Re-filing | Out-of-scope findings become issues owned by the right lane, never discarded | #8802 → #8810 |
+| Grounding fix (filed) | Give reviewers a tree/file-existence oracle, not just the diff | [#8825](https://github.com/synaptent/aragora/issues/8825) |
+
+## What this data enables
+
+**1. Adjudicator evaluation.** The
+[review adjudicator](../../aragora/swarm/review_adjudicator.py) (M0,
+[#8748](https://github.com/synaptent/aragora/issues/8748)) exists to escape
+exactly these stalls by classifying them SETTLE / BLOCK / ESCALATE. The ten
+fixture cases in
+[`tests/governance/fixtures/adjudicator_eval_cases.json`](../../tests/governance/fixtures/adjudicator_eval_cases.json)
+carry verbatim reviewer bodies plus the human-settled ground truth, and
+[`tests/governance/test_adjudicator_eval_fixtures.py`](../../tests/governance/test_adjudicator_eval_fixtures.py)
+pins the current M0 verdict on each. The current agreement matrix:
+
+| Case | M0 verdict today | Human ground truth | Delta |
+|---|---|---|---|
+| #8824 r1, #8834 r1/r2 (unrefuted `[P1]`) | BLOCK (hard bar) | block-at-snapshot | agrees — correct fail-safe |
+| #8824 r3, #8811 r1, #8852 r1 (unanimous CR) | abstain (not a stall) | block | compatible — base gate blocks |
+| #8803 (clean 2-0) | abstain (no dissent) | settle | compatible |
+| #8802 r7 (contradiction) | ESCALATE | escalate | **exact agreement** |
+| #8800 r3 (verbatim repeat, answered) | ESCALATE | settle | **gap: thread-history blindness** |
+| #8802 r4 (out-of-scope) | ESCALATE | settle + re-file | **gap: scope blindness** |
+
+The two gaps are the eval targets: an adjudicator that can see (a) whether a
+repeated finding was already answered in the thread and (b) whether a finding
+targets the PR's reachable scope would convert both ESCALATEs into the SETTLEs
+the human record shows are correct — without ever weakening the hard bar.
+Escalating to a human in the meantime is the safe failure mode, and the
+fixtures make the improvement measurable instead of anecdotal.
+
+**2. Grounding fixes.** Classes 1–3 are all grounding failures, not judgment
+failures: the diff-blind class has a concrete fix specified in
+[#8825](https://github.com/synaptent/aragora/issues/8825) (tree listing /
+file-existence oracle in the reviewer context, plus a regression fixture:
+"a docs-only PR linking a pre-existing tracked file yields no dead-link
+finding"). Stale-world and temporal classes suggest the same pattern:
+reviewers should be *equipped* to check (fresh fetch, timezone-normalized
+clock) rather than trusted to infer.
+
+**3. A benchmark seed.** Ten labeled cases from one week is not a benchmark,
+but the schema (verbatim multi-model verdicts + exact head + human disposition
++ resolution mechanism) is designed to accumulate: every future stall the gate
+survives is a fixture candidate.
+
+## Limitations — read before citing
+
+1. **Single repo, single week, two counting families.** Six classes observed
+   in four days at one codebase (plus Grok in one round) is an existence
+   proof and a taxonomy seed, not a frequency estimate. Class frequencies
+   here say more about this repo's docs-heavy week than about the models.
+2. **Selection effects, in both directions.** These seven PRs were selected
+   *because* their threads were eventful or cleanly exemplary. And the
+   headline asymmetry has an observation bias: a false reviewer PASS on a
+   false claim would surface only if something else caught it later —
+   false trust is structurally quieter than false doubt. Within this window
+   we also checked the direction the bias hides: post-merge, an independent
+   dry-run on #8852 surfaced additional real findings
+   ([post-merge note](https://github.com/synaptent/aragora/pull/8852#issuecomment-4884683135))
+   — findings a 2-0 PASS had not raised at an earlier head. The gate's PASS
+   is "no blocking finding found," not "no bug exists."
+3. **Prepared vs posted review bodies.** Some quoted review bodies come from
+   prepare-only evidence rounds: recorded by the collector at the exact head
+   and quoted in-thread, but not posted verbatim as comments at the time.
+   These are committed in full in the fixture file; each fixture marks
+   `posted_to_thread` per item. The #8800 round-1 body specifically was not
+   recoverable in full, so the "verbatim repeat" characterization rests on
+   the in-thread park note's quotation of it.
+4. **Second-precision timing is approximate.** The #8834 "local midnight"
+   flip is receipted at comment granularity (openai PASS posted
+   2026-07-04T05:03:39Z ≈ 00:03 reviewer-local); the reviewer's internal
+   completion time is not independently verifiable from the public record.
+5. **The taxonomy is descriptive, not exhaustive.** Reviewer transport
+   failures, rate limits, and harness hangs — the dominant *availability*
+   failure mode per the
+   [companion artifact's failure ledger](2026-07-decision-integrity-dogfooding.md#what-the-gate-does-not-catch-read-this-section)
+   — are deliberately out of scope here; this document is about reviewers
+   that answered and were wrong.
+6. **The operator is not a neutral referee.** Settlements quoted here were
+   made by the repo operator under recorded policy (severity-gated dissent,
+   tiered settlement, head-pinned authorizations). The record is public and
+   auditable, but "ground truth" labels in the fixtures encode the
+   operator's dispositions — dispute them by filing an issue against the
+   fixture, which is exactly the kind of correction this artifact exists to
+   invite.
+
+---
+
+*Prepared 2026-07-05 as the second dogfooding-class artifact
+([#8856](https://github.com/synaptent/aragora/issues/8856) item 3, tracked as
+[#8860](https://github.com/synaptent/aragora/issues/8860)), companion to
+[Decision Integrity, Dogfooded](2026-07-decision-integrity-dogfooding.md).
+All PR/issue links public. Corrections welcome — file an issue.*

--- a/tests/governance/fixtures/adjudicator_eval_cases.json
+++ b/tests/governance/fixtures/adjudicator_eval_cases.json
@@ -1,0 +1,390 @@
+{
+  "schema": "adjudicator_eval_cases.v1",
+  "description": "Machine-readable distillations of real multi-model review rounds from synaptent/aragora (2026-07-02..05), for evaluating aragora/swarm/review_adjudicator.py (M0, #8748). Each case carries the verbatim reviewer bodies at an exact head SHA, the adjudicator's expected CURRENT verdict (pinned by tests/governance/test_adjudicator_eval_fixtures.py), and the human-settled ground truth per the #8748 SETTLE/BLOCK/ESCALATE taxonomy. Where expected and ground truth disagree, the delta is the eval target, not a test failure. Narrative + receipts: docs/artifacts/2026-07-reviewer-failure-taxonomy.md. Reviewer bodies were produced by scripts/collect_quorum_evidence.py at the recorded head; 'posted_to_thread' distinguishes publicly posted verdicts from prepared (prepare-only) ones whose findings are quoted in the linked evidence-round comments.",
+  "disposition_taxonomy": [
+    "settle",
+    "block",
+    "escalate"
+  ],
+  "verdict_values": [
+    "adjudicated_settle",
+    "adjudicated_block",
+    "adjudicated_escalate",
+    "not_applicable"
+  ],
+  "cases": [
+    {
+      "id": "pr8824_r1_diff_blind_grounding",
+      "failure_classes": [
+        "diff_blind_grounding"
+      ],
+      "control": false,
+      "pr": 8824,
+      "head_sha": "1bbf572fa90015b36a829935a3e08004d7df51d9",
+      "round": "evidence round 1",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 1bbf572 (1bbf572fa90015b36a829935a3e08004d7df51d9), committed 2026-07-03T21:11:48Z.\nPR: #8824.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- [P1] `README.md:~83` — The marquee evidence link `[Decision Integrity, Dogfooded](docs/artifacts/2026-07-decision-integrity-dogfooding.md)` is dead: neither the file nor the `docs/artifacts/` directory exists at this head, and this PR changes only `README.md` (does not add the doc). The PR's headline credibility claim resolves to a 404 relative link on the public README.\n- [P2] `README.md:9,21,73-77` — The diff removes every \"PyPI publish pending\" hedge and asserts `pip install aragora-verify` (tagline, quickstart-table row, code block) plus links `https://pypi.org/project/aragora-verify/`. But the package's own `aragora-verify/CHANGELOG.md` still reads `## [0.1.0] — unreleased`, and `.github/workflows/publish-aragora-verify.yml` is a manual `workflow_dispatch` gated on a one-time PyPI trusted-publisher config (\"until that exists, the publish step will fail\"). If that manual publish hasn't actually landed, every `pip install aragora-verify` instruction and the PyPI link 404. Network egress is blocked in this review env, so I can't confirm the release exists — block merge until the published version is verified live (and update the CHANGELOG heading off \"unreleased\").\n- [P2] `README.md:22` — The showcased one-liner `aragora demo && aragora verify aragora-demo-receipt.json` only produces the receipt on the no-key/offline path (`aragora/cli/demo.py:699`, always writes `aragora-demo-receipt.json`). When any of `OPENROUTER_API_KEY`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY` is set, `main()` takes `_run_real_demo` (`demo.py:964-965`), which saves a receipt only when `--receipt` is passed (`demo.py:795`). So in any key-holding environment (including maintainers/most installs) the chained `aragora verify` fails file-not-found — or silently verifies a stale receipt from a prior run. The \"no API keys\" caveat covers the literal no-key case but not the copy-pasted `&&` chain for key-present users.\n\nVerified-good (not findings): `--pubkey`/`--chain`/positional args exist in `aragora-verify` CLI; `pip install ./aragora-verify` build-from-source is valid; `aragora verify <path>` positional and `aragora demo` subcommands exist; no-key demo path does emit the default receipt filename.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 1bbf572 (1bbf572fa90015b36a829935a3e08004d7df51d9), committed 2026-07-03T21:11:48Z.\nPR: #8824.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P3] `README.md:80` The new “Decision Integrity, Dogfooded” link points to `docs/artifacts/2026-07-decision-integrity-dogfooding.md`, but this PR changes only `README.md` and that target file is not present, so the README introduces a broken evidence/case-study link.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_block",
+      "expected_verdict_basis": "hard bar: an unrefuted [P1] is present; the scorer is never invoked",
+      "ground_truth": {
+        "findings_valid": false,
+        "disposition": "block",
+        "ideal_disposition_note": "Both dead-link findings were false: docs/artifacts/2026-07-decision-integrity-dogfooding.md existed on main since #8801 (blob 3c0458f1), machine-verified in-thread via git ls-tree, rg --files, and git check-ignore. BLOCK is still the correct fail-safe verdict at this snapshot — an unrefuted [P1] must never be machine-settled; the refutation evidence arrived in later rounds. An ideal adjudicator with tree access would refute-and-settle; that grounding fix is tracked as #8825.",
+        "resolution_mechanism": "evidence-post (machine refutation in-thread) + grounding-blind-spot filed as #8825",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8824#issuecomment-4879384313",
+          "https://github.com/synaptent/aragora/pull/8824#issuecomment-4879405120",
+          "https://github.com/synaptent/aragora/issues/8825"
+        ]
+      }
+    },
+    {
+      "id": "pr8824_r3_diff_blind_unanimous",
+      "failure_classes": [
+        "diff_blind_grounding"
+      ],
+      "control": false,
+      "pr": 8824,
+      "head_sha": "75893e9dc10bbfcad579427a55b422ab40c60f05",
+      "round": "evidence round 3",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 75893e9 (75893e9dc10bbfcad579427a55b422ab40c60f05), committed 2026-07-03T21:24:40Z.\nPR: #8824.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `README.md` (new dogfooding paragraph, ~line 81): the link `[Decision Integrity, Dogfooded](docs/artifacts/2026-07-decision-integrity-dogfooding.md)` is dead — that file (and the entire `docs/artifacts/` dir) does not exist anywhere in the tree at 75893e9. Confirmed via `find` over the whole worktree. This is the PR's headline evidence, yet the artifact itself is missing from the diff (only `.gitignore` + `README.md` changed). Renders as a broken relative link on GitHub and PyPI. Ship the evidence doc in this PR (or drop the link).\n- [P2] `README.md` (line 9, quick-start table, and verify code block): text is flipped from \"PyPI publishing … pending\" to `pip install aragora-verify` + a live `https://pypi.org/project/aragora-verify/` link. Local `aragora-verify/pyproject.toml` is still `version = \"0.1.0\"`. I could not reach PyPI from this sandbox (WebFetch/network blocked), so this is unverified — but if 0.1.0 isn't actually published, the flagship install command and the linked page 404. Confirm the release is live on PyPI before merge; a broken `pip install` at the top of an integrity-product README is a credibility hit.\n- [P3] `.gitignore` (`!docs/artifacts/` / `!docs/artifacts/**`): the negation mechanics are correct (root `artifacts/` stays ignored; a directly-matched dir re-included before its `**` contents works), but it's inert and its justifying comment (\"committed proof/compliance artifacts under docs/ … even though they are tracked\") is unmet — there is no `docs/artifacts/` in this PR. Land it together with the artifact it's meant to un-hide, or the rule and its rationale are orphaned.\n\nNote (not blocking): the `aragora demo --offline` → `aragora-demo-receipt.json`, `aragora verify <receipt>`, and `aragora-verify <receipt> --pubkey <key.pem>` commands all check out against the actual CLI/console-script definitions — those additions are accurate.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 75893e9 (75893e9dc10bbfcad579427a55b422ab40c60f05), committed 2026-07-03T21:24:40Z.\nPR: #8824.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `README.md:80` adds a link to `docs/artifacts/2026-07-decision-integrity-dogfooding.md`, but this PR’s complete changed-file list does not include that artifact and the reviewed checkout has no tracked target at that path. This makes the new README link broken for readers and doc-link validators.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "not_applicable",
+      "expected_verdict_basis": "no supportive signal: unanimous rejection is not a stall; the adjudicator abstains and the base gate blocks",
+      "ground_truth": {
+        "findings_valid": false,
+        "disposition": "block",
+        "ideal_disposition_note": "Unanimous false positive: both families repeated the dead-link claim against the machine proof already posted in-thread. openai's own wording — \"this PR's complete changed-file list does not include that artifact\" — reveals the mechanism: reviewers reason over the diff, not the base tree. Resolved by switching the README link to an absolute URL to main; openai then PASSed at head 7e18207.",
+        "resolution_mechanism": "evidence-post + premise removal (absolute URL verifiable without tree access)",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8824#issuecomment-4879423633",
+          "https://github.com/synaptent/aragora/pull/8824#issuecomment-4879436485",
+          "https://github.com/synaptent/aragora/issues/8825"
+        ]
+      }
+    },
+    {
+      "id": "pr8834_r1_temporal_and_stale_external",
+      "failure_classes": [
+        "temporal_reasoning",
+        "stale_external_world"
+      ],
+      "control": false,
+      "pr": 8834,
+      "head_sha": "05487fa9a92db458f8c219ba4e01128ffb4b685a",
+      "round": "evidence round 1",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 05487fa (05487fa9a92db458f8c219ba4e01128ffb4b685a), committed 2026-07-04T04:22:13Z.\nPR: #8834.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- **[P1]** `aragora-verify/CHANGELOG.md` (`## [0.1.1] — 2026-07-04`), `README.md` (the `pip install 'aragora-verify>=0.1.1'` note), and `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md` (\"...`>=0.1.1`, published 2026-07-04...\"): the release is dated **2026-07-04, which is in the future** — today is 2026-07-03. The PR removes the previously-accurate hedge (\"PyPI publish pending\", \"prefer the source build\") and replaces it with an unconditional \"it's published, just pip install it\" claim keyed to a date that hasn't arrived. If merged on the reviewed date, the docs assert availability that does not yet exist and the documented `pip install 'aragora-verify>=0.1.1'` will fail for any reader until PyPI actually serves 0.1.1. I could not confirm the PyPI state (network fetch is blocked in this environment), so the publication claim is unverifiable and is contradicted by its own future date — gate this on the actual upload landing, and use a date ≤ today.\n- **[P2]** `aragora-verify/pyproject.toml:7` still declares `version = \"0.1.0\"`, and this PR does not bump it. If 0.1.1 is being marked released and users are told to require `>=0.1.1`, a source/wheel build from this repo still resolves as 0.1.0 and fails the `>=0.1.1` constraint. Confirm the branch bumps the packaged version to 0.1.1 (I can see 0.1.0 in the tree; I could not read the PR-head pyproject to rule out an earlier commit bumping it).\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 05487fa (05487fa9a92db458f8c219ba4e01128ffb4b685a), committed 2026-07-04T04:22:13Z.\nPR: #8834.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `README.md:83`, `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md:61`, `aragora-verify/CHANGELOG.md:7`: The docs now state `aragora-verify` 0.1.1 is published and instruct `pip install 'aragora-verify>=0.1.1'`, but PyPI currently exposes only `0.1.0` for `aragora-verify` ([PyPI JSON](https://pypi.org/pypi/aragora-verify/json)). This makes the install command fail and overstates availability of the key_id binding fix. Keep the “PyPI pending/source build” wording until the package is actually published.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_block",
+      "expected_verdict_basis": "hard bar: claude's [P1] ('release dated in the future') is present",
+      "ground_truth": {
+        "findings_valid": false,
+        "disposition": "block",
+        "ideal_disposition_note": "claude's [P1] was a timezone error: the reviewer's local clock read Jul 3 while the PyPI upload was 2026-07-04T03:28Z (UTC) — the date was real, not 'in the future'. openai's [P2] was a stale external-world read: it fetched PyPI JSON and reported 0.1.1 absent while a timestamped fresh fetch plus a clean-venv install proved it live. Both were refuted with machine evidence in-thread; the legitimate kernel (timezone-ambiguous docs) was fixed by making every timestamp timezone-explicit. openai PASSed in the re-gate minutes after the reviewer environment's local midnight (comment posted 2026-07-04T05:03:39Z), once the 'future date' premise had self-expired.",
+        "resolution_mechanism": "evidence-post (timestamped refutation) + premise self-expiry (local midnight) + operator settlement",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880630705",
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880639145",
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880751502"
+        ]
+      }
+    },
+    {
+      "id": "pr8834_r2_temporal_and_stale_external",
+      "failure_classes": [
+        "temporal_reasoning",
+        "stale_external_world"
+      ],
+      "control": false,
+      "pr": 8834,
+      "head_sha": "8955a4eab53a3c2719ba86f06ea74d36d70ff9d3",
+      "round": "evidence round 2",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 8955a4e (8955a4eab53a3c2719ba86f06ea74d36d70ff9d3), committed 2026-07-04T04:27:02Z.\nPR: #8834.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- [P1] `aragora-verify/CHANGELOG.md:7` and `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md:61-62` — The PR asserts 0.1.1 was **published 2026-07-04 03:28 UTC**, but today is **2026-07-03**. UTC 2026-07-04 03:28 is in the future in *every* timezone, so as of this PR the publication has not yet happened. The change flips the docs from the previously-careful \"PyPI publish pending — prefer source build\" to an affirmative \"published / `pip install 'aragora-verify>=0.1.1'`\" for a *security-relevant* signer-label (`key_id`) binding fix. If the upload hasn't actually completed, `pip install 'aragora-verify>=0.1.1'` returns no matching distribution and users get no verifier. Confirm the release is actually live on PyPI (the very URL the doc cites, `https://pypi.org/pypi/aragora-verify/json`) and use the real, non-future upload timestamp before merging.\n- [P2] `README.md:83-85` — This revision removes the source-build fallback guidance (\"prefer the source build … for full signer-label protection\") entirely. That fallback is the only documented recovery path if the PyPI install fails. Given the P1 (publication not verifiably live), dropping the fallback is premature — keep it until the PyPI publish is confirmed.\n- [P3] I attempted to verify the publish claim against live PyPI via WebFetch and curl; both were denied in this environment. The claim could not be independently confirmed here, so it rests entirely on the author having actually completed the upload — please attach evidence (e.g., the PyPI JSON showing the 0.1.1 release) to the PR.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 8955a4e (8955a4eab53a3c2719ba86f06ea74d36d70ff9d3), committed 2026-07-04T04:27:02Z.\nPR: #8834.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `README.md:83` / `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md:62` claim `aragora-verify>=0.1.1` is published and installable, but live PyPI JSON still reports latest/versioned releases only as `0.1.0`. Users following this get a resolver failure or remain unable to obtain the documented key_id binding fix from PyPI.\n- [P2] `aragora-verify/CHANGELOG.md:7` marks `0.1.1` as released on `2026-07-04 03:28 UTC`, but the package index does not contain that release. This creates a false security-release record for the signer-label binding fix.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_block",
+      "expected_verdict_basis": "hard bar: claude's [P1] is present",
+      "ground_truth": {
+        "findings_valid": false,
+        "disposition": "block",
+        "ideal_disposition_note": "The purest temporal-reasoning specimen: claude asserted 'UTC 2026-07-04 03:28 is in the future in *every* timezone' while reviewing at roughly 2026-07-04T04:27Z — the UTC upload time was almost an hour in the past; only the reviewer's local (UTC-5) calendar still read Jul 3. openai simultaneously repeated the stale-PyPI premise ('the package index does not contain that release') against the live index. In the re-gate at this same head, run minutes after the reviewer environment's local midnight, openai returned PASS (posted 2026-07-04T05:03:39Z) — the premise had self-expired.",
+        "resolution_mechanism": "premise self-expiry (local midnight) + timestamped machine refutation + operator settlement",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880630705",
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880639145",
+          "https://github.com/synaptent/aragora/pull/8834#issuecomment-4880751502"
+        ]
+      }
+    },
+    {
+      "id": "pr8800_r3_verbatim_repeat_answered",
+      "failure_classes": [
+        "verbatim_repeat_dissent"
+      ],
+      "control": false,
+      "pr": 8800,
+      "head_sha": "1817ae054cbc6c68f025532abbf027e6a487b44f",
+      "round": "evidence round 3",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "pass",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 1817ae0 (1817ae054cbc6c68f025532abbf027e6a487b44f), committed 2026-07-03T06:00:00Z.\nPR: #8800.\nModel family: claude\n\nVerdict: PASS\n\nI verified every changed number against ground truth (ran `regenerate_module_tiers.py --json`, `audit_test_skips.py --count-only`/`--json` at this HEAD; PR touches no test files, so the counts are identical to PR head 1817ae0).\n\n- `module_tiers.yaml` tier moves are correct and drift-clean: `evaluation`→integrated (imp 12, tests 13) and `metrics`→deprecated (imp 0, tests 0) match the generator's ground truth exactly; tier totals 21/91/29/3=144 are internally consistent. `metrics` is confirmed a zero-importer deprecated re-export shim for `aragora.evaluation`, so the demotion is semantically right. The `module-tier-drift` CI gate (`--check`) only compares *tier* (not the py/importer/test counts), so the refreshed counts are cosmetic and cannot fail it.\n- `.skip_baseline` 68→75 is justified and set to the true current count (audit returns exactly 75, DIFF=0). The gate hard-fails at `CURRENT-BASELINE > 2`, so with the stale 68 baseline this check was already failing (+7); the bump fixes it while preserving the +2 discipline for future skips.\n- `SKIP_AUDIT.md` category/type tables match generator output exactly (both sum to 75; all percentages correct), and the added \"Baseline history\" note truthfully explains the 57→75 jump as file staleness (enforced baseline only moved 68→75).\n\n- [P3] `tests/SKIP_AUDIT.md:74-81` — the hand-authored \"Baseline history\" paragraph is not emitted by `generate_markdown()`, so the next `audit_test_skips.py --update-docs` run will silently overwrite/erase it. Purely cosmetic (no CI regenerates+diffs this doc — the skip-audit job runs only `--count-only`); consider moving the rationale into the script's template or a separate CHANGELOG if it should persist.\n\ndogfood: yes\n",
+          "posted_to_thread": true
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 1817ae0 (1817ae054cbc6c68f025532abbf027e6a487b44f), committed 2026-07-03T06:00:00Z.\nPR: #8800.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `tests/.skip_baseline:1` raises the enforced skip budget from 68 to 75 without any corresponding test changes in this PR. That weakens the CI guardrail and can mask future skipped-test regressions; keep the baseline at 68 unless the PR itself introduces and justifies the 7 new skips.\n\ndogfood: yes\n",
+          "posted_to_thread": true
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_escalate",
+      "expected_verdict_basis": "current M0 heuristic: the repeated finding still scores as grounded (file:line, concrete numbers) and grounded support exists, so the adjudicator escalates to a human instead of settling. Fail-safe, but not yet the SETTLE the operator record shows is correct.",
+      "ground_truth": {
+        "findings_valid": false,
+        "disposition": "settle",
+        "ideal_disposition_note": "openai re-raised its round-1 finding ('keep the baseline at 68 unless the PR justifies the skips') after the demanded per-skip audit was delivered in the PR body — all 7 net-new skips traced to already-merged PRs, every one a conditional environment guard. The operator settled with claude's counting PASS. The eval gap this fixture measures: an adjudicator that can see thread history (finding answered verbatim, no engagement with the answer) should SETTLE; the current text-only groundedness heuristic cannot see the answer and escalates.",
+        "resolution_mechanism": "operator settlement under severity-gated dissent (#8574) + tiered gate (#8638)",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8800#issuecomment-4873062395",
+          "https://github.com/synaptent/aragora/pull/8800#issuecomment-4878231496",
+          "https://github.com/synaptent/aragora/pull/8800#issuecomment-4878231586"
+        ]
+      }
+    },
+    {
+      "id": "pr8802_r4_out_of_scope_finding",
+      "failure_classes": [
+        "out_of_scope_carousel"
+      ],
+      "control": false,
+      "pr": 8802,
+      "head_sha": "21a4ac4c04ace6634f9357c3ae4ec316a900755a",
+      "round": "evidence round 4",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "pass",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 21a4ac4 (21a4ac4c04ace6634f9357c3ae4ec316a900755a), committed 2026-07-02T23:43:40Z.\nPR: #8802.\nModel family: claude\n\nVerdict: PASS\n\n- [P3] `aragora-verify/src/aragora_verify/verifier.py` (new `key_id == provided_key_id` guard, ~L217–231): the binding couples signature validity to Aragora's *specific* `key_id` scheme (`\"ed25519-\"+sha256(raw)[:16]`, from `compute_key_id`). The ODR spec (`docs/specs/OPEN_DECISION_RECEIPT.md` §6) does **not** normatively define `key_id` derivation and defers signatures entirely to #8225 (`signatures: []` mandated in v0.1). A cryptographically-valid receipt from any other conformant emitter that labels its key differently (JWK thumbprint, operator string, etc.) would be falsely rejected as \"signer-label tampering\" by a tool marketed on PyPI as a *general* ODR verifier. Impact today is nil (only Aragora's signer produces signed receipts, and it always matches), so this is a forward-looking interop note, and the \"tampering\" framing overstates the threat — the auditor already anchors trust in the pubkey they supply, so a relabeled-but-valid signature forges nothing.\n\n- [P3] `aragora-verify/src/aragora_verify/verifier.py` diverges from the canonical in-repo twin `aragora/gauntlet/odr_verify.py:598,620–641`: the in-repo verifier keeps a distinct `key_id_mismatch` flag (checked *after* `verified_any`, with a precise message), whereas the standalone folds the mismatch into `failed_matching` (checked *first*). Result: on a multi-signature doc containing one matching-and-valid signature plus a second valid-but-relabeled duplicate, the in-repo verifier returns PASS while the standalone returns FAIL — the two Aragora verifiers give different verdicts on the same document, and the standalone's generic \"signature check failed\" message is less precise than the in-repo \"signer identity not bound.\" Contrived case, but the regression tests exercise the in-repo path while the CLI smoke tests exercise the standalone, so the divergence is untested.\n\ndogfood: yes\n",
+          "posted_to_thread": true
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 21a4ac4 (21a4ac4c04ace6634f9357c3ae4ec316a900755a), committed 2026-07-02T23:43:40Z.\nPR: #8802.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `docs/compliance/ODR_VERIFICATION_WALKTHROUGH.md:101` The walkthrough claims signer-label tampering protection, but this PR only hardens `aragora-verify`; the in-repo `aragora.gauntlet.odr_verify` path used by server/internal verification is not updated and can still diverge on multi-signature cases. That creates inconsistent audit results between the advertised offline verifier and Aragora’s own verifier.\n\ndogfood: yes\n",
+          "posted_to_thread": true
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_escalate",
+      "expected_verdict_basis": "grounded advisory dissent plus grounded support: two-sided disagreement escalates to a human",
+      "ground_truth": {
+        "findings_valid": true,
+        "disposition": "settle",
+        "ideal_disposition_note": "The finding is real but out of the PR's reachable scope: aragora/gauntlet/odr_verify.py was fenced to the #8765 lane, so #8802 could not touch it. Correctly re-filed as #8810 and the PR operator-settled with claude's counting PASS. Scope-awareness is a second eval dimension the current adjudicator lacks: a grounded finding on an unreachable file should settle-with-refile, not block or escalate.",
+        "resolution_mechanism": "re-filing (finding preserved as #8810) + operator advisory settlement",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4871373189",
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4871391696",
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4871391778",
+          "https://github.com/synaptent/aragora/issues/8810"
+        ]
+      }
+    },
+    {
+      "id": "pr8802_r7_cross_family_contradiction",
+      "failure_classes": [
+        "cross_family_contradiction"
+      ],
+      "control": false,
+      "pr": 8802,
+      "head_sha": "787d1f55ad276e475219f1b4654df42d03776f43",
+      "round": "evidence round 7 (fresh head after main merge)",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "pass",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 787d1f5 (787d1f55ad276e475219f1b4654df42d03776f43), committed 2026-07-03T21:10:12Z.\nPR: #8802.\nModel family: claude\n\nVerdict: PASS\n\n- [P3] `aragora-verify/src/aragora_verify/cli.py:37-41` (and docstring `:5-9`) — regression introduced by this PR's new SKIP path. `verifier.py` now returns `signature=SKIP` for the *unsigned-receipt-with-`--pubkey`* case, which renders as `UNVERIFIED`. But `_render`'s hardcoded UNVERIFIED note still reads \"signatures are present but were NOT checked (no --pubkey)\". For `aragora-verify unsigned.odr.json --pubkey key.pem` this note is self-contradicting: no signatures are present and a pubkey *was* supplied — directly contradicted by the check line printed right below it (\"receipt carries no signatures; ... a public key was supplied\"). Verdict and exit code are correct; only the explanatory note (and the `cli.py` docstring's exit-3 description) are stale. Note the walkthrough doc §3 exit-code table *does* describe both cases correctly, so only the CLI text drifted.\n\n- [P3] `aragora-verify/src/aragora_verify/verifier.py` new `key_id_mismatch → FAIL \"signer-label tampering suspected\"` path vs. `schema.py:128-130` — the schema only requires `key_id` to be a non-empty string, but the signature check now hard-FAILs any cryptographically-valid signature whose `key_id` isn't exactly `compute_key_id(key)` (`ed25519-`+sha256[:16]). For Aragora-emitted receipts this is a non-issue (signer always uses that format), but a third-party/ODR receipt that is honestly signed with a different `key_id` convention now FAILs with a \"tampering suspected\" verdict even though nothing was altered — a false-positive/interop risk for a tool marketed as a general standalone verifier. Defensible per spec §6/#8225 (the format is normative) and matches the asserted `gauntlet.odr_verify` parity, but the two validation layers disagree on what `key_id` is allowed to be. (Parity with `aragora.gauntlet.odr_verify` is asserted by the comment/tests; that module isn't in this diff so I did not independently confirm it.)\n\ndogfood: yes\n",
+          "posted_to_thread": true
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 787d1f5 (787d1f55ad276e475219f1b4654df42d03776f43), committed 2026-07-03T21:10:12Z.\nPR: #8802.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `aragora-verify/src/aragora_verify/verifier.py:231` - `verified_any` wins before `key_id_mismatch`, so an attacker can append a relabeled duplicate signature because `signatures[]` is outside the signed digest. The verifier exits VERIFIED/`ok=true` as long as one correctly-bound signature is also present, leaving a forged signer label in a “verified” document. Fail or mark unverified when any evaluated signature verifies with the supplied key but has a mismatched `key_id`.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "adjudicated_escalate",
+      "expected_verdict_basis": "grounded dissent AND grounded support: a genuine two-sided crux",
+      "context_quotes": [
+        {
+          "source": "claude round-5 review at head 05d8ef98 (prepared body recorded by the evidence collector; requirement restated publicly in https://github.com/synaptent/aragora/pull/8802#issuecomment-4871658875 and https://github.com/synaptent/aragora/pull/8802#issuecomment-4879461357)",
+          "quote": "The in-repo reference verifier aragora/gauntlet/odr_verify.py:596-641 deliberately uses a *separate* key_id_mismatch flag checked **after** verified_any, precisely so that a receipt containing one valid+matching signature PASSes even if another entry carries a valid-but-relabeled signature. [...] Fix: mirror the sibling's separate key_id_mismatch flag with verified_any-wins ordering."
+        }
+      ],
+      "ground_truth": {
+        "findings_valid": null,
+        "disposition": "escalate",
+        "ideal_disposition_note": "The clean ESCALATE specimen: claude's round-5 [P2] REQUIRED the verified_any-wins precedence (to mirror the in-repo reference verifier); openai's round-7 [P2] objected to exactly that ordering as an attacker foothold. Two frontier families, opposite positions, one deliberate documented design decision — a human crux. Resolved by reference-implementation parity, pinned on #8810. The adjudicator's ESCALATE matches the human disposition exactly.",
+        "resolution_mechanism": "adjudication (human design decision, reference-implementation parity) + follow-up pinned on #8810",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4871658875",
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4879458963",
+          "https://github.com/synaptent/aragora/pull/8802#issuecomment-4879461357"
+        ]
+      }
+    },
+    {
+      "id": "pr8811_r1_convergent_real_finding",
+      "failure_classes": [],
+      "control": true,
+      "pr": 8811,
+      "head_sha": "4aeba63f14c37dd10520304492e6edc9a755ac6d",
+      "round": "evidence round 1",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 4aeba63 (4aeba63f14c37dd10520304492e6edc9a755ac6d), committed 2026-07-03T23:44:06Z.\nPR: #8811.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- **[P2]** `aragora/swarm/quorum_evidence.py:1983` (`_record_review_adjudication_if_applicable`, the `outcome.adjudication = adjudicate(outcome.items).to_receipt_dict()` call): the observe-only adjudicator is wired into every prepare/stall return path with no `try/except`. On the advisory-only-dissent stall path (dissent present, no `[P0]/[P1]`), `adjudicate()` reaches `from aragora_debate.evidence import EvidenceQualityAnalyzer` (`review_adjudicator.py:244`, outside the fail-closed loop). Since `aragora-debate` is not an `aragora` dependency, in any runtime without it installed + flag `ARAGORA_ENABLE_REVIEW_ADJUDICATOR=1`, `collect_evidence` raises `ModuleNotFoundError` instead of returning a `CollectOutcome` — a purely observational feature crashes the critical settlement flow. Wrap the `adjudicate(...)` call so any exception fails open (record no adjudication) rather than propagating.\n- **[P3]** `tests/governance/test_review_adjudicator_collect_observe.py`: no test covers the advisory-only-dissent path (flag on, no `[P0]/[P1]`) that actually invokes the scorer/`aragora_debate` import, so the fail-open behavior above is unpinned. Add a case that reaches `adjudicate`'s scorer path (e.g. `[P2]`-only dissent) and asserts collection still returns an outcome even when the analyzer import/scorer fails.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 4aeba63 (4aeba63f14c37dd10520304492e6edc9a755ac6d), committed 2026-07-03T23:44:06Z.\nPR: #8811.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `aragora/swarm/quorum_evidence.py:1979` `_record_review_adjudication_if_applicable()` lets observe-only adjudication exceptions propagate from `adjudicate(outcome.items)`. On advisory mixed stalls, `review_adjudicator.adjudicate()` imports `aragora_debate.evidence`, but `aragora-debate` is a separate/excluded package in the main distribution, so enabling `ARAGORA_ENABLE_REVIEW_ADJUDICATOR=1` can turn a prepare-only evidence collection into a hard CLI failure instead of emitting the normal outcome. Wrap this sidecar path fail-closed or make the dependency guaranteed.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "not_applicable",
+      "expected_verdict_basis": "no supportive signal: genuine unanimous rejection is not a stall; the adjudicator abstains and the base gate blocks",
+      "ground_truth": {
+        "findings_valid": true,
+        "disposition": "block",
+        "ideal_disposition_note": "Control group: both families independently converged on the same real [P2] — the observe-only adjudicator call in quorum_evidence.py had no try/except and could crash the settlement hot path. Fixed to claude's satisfaction in the next round. The gate working exactly as designed.",
+        "resolution_mechanism": "fix + re-review (converged to 2-0 PASS at head 15e87b1c)",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8811#issuecomment-4879898764",
+          "https://github.com/synaptent/aragora/pull/8811#issuecomment-4881139661",
+          "https://github.com/synaptent/aragora/pull/8811#issuecomment-4881139703"
+        ]
+      }
+    },
+    {
+      "id": "pr8852_r1_convergent_real_findings",
+      "failure_classes": [],
+      "control": true,
+      "pr": 8852,
+      "head_sha": "351b8831ddcc129af0b8ec2d7e694819974d91ef",
+      "round": "evidence round 1",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "changes_requested",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 351b883 (351b8831ddcc129af0b8ec2d7e694819974d91ef), committed 2026-07-05T01:38:36Z.\nPR: #8852.\nModel family: claude\n\nVerdict: CHANGES-REQUESTED\n\n- **[P2]** `scripts/check_work_lease.py` — `active_leases_for_branch`, the `sqlite3.connect(f\"file:{db_path}?mode=ro\", uri=True, ...)` open. The store is WAL-mode, and opening a WAL-format DB **read-only** requires SQLite to create the `-shm` file. When the `-wal`/`-shm` sidecars are absent (clean last-close removes them; also DB copied/restored without sidecars) **or** the store directory isn't writable by the invoking fleet user (different fleets share `<git-common-dir>/aragora-agent-state/` as different UIDs), the `mode=ro` open fails with `OperationalError: unable to open database file` even though the `.db` is perfectly readable. Confirmed repro:\n  - sidecars present → RO read OK;\n  - sidecars removed → `mode=ro FAILED: unable to open database file`;\n  - read-only directory → same failure.\n  This surfaces as `StoreUnreachableError` → `_warn_fail_open`. Impact: in v0 it emits spurious `WARNING`s that defeat the explicit rollout gate (\"flip to `--strict` once the warning rate is ~0\"), and under `--strict` (v1) it **false-positive blocks legitimate pushes**. The existing store never uses `mode=ro` (it opens read-write), so this is a new, untested access pattern — the tests only exercise the sidecar-present, same-process case. Suggest opening without `mode=ro` (guarded by the existing `db_path.exists()` check + `PRAGMA query_only=1`), or falling back to a normal open when the ro open raises `OperationalError`.\n\n- **[P3]** `scripts/check_work_lease.py` — `resolve_branch` raises `StoreUnreachableError` when the branch can't be determined (detached HEAD → `rev-parse --abbrev-ref HEAD` returns `\"HEAD\"`). Main catches this in the same handler as store errors and fail-opens (exit 0), so the default-branch preflight silently bypasses the lease rule even though the store is fully reachable — a coverage gap for detached-HEAD automated pushes, and a semantic mislabel (branch-resolution failure ≠ store unreachable).\n\nNotes (not blocking): the post-claim double-check is sound — the later-committing session always observes the earlier lease via `created_at`/`lease_id` ordering, so two branch-only claims (which never conflict at the store level, since `overlaps([],[])` is `False`) resolve to a single winner without double-ownership. `LeaseConflictError.conflicts` is confirmed `list[dict]`, so the `.get(...)` summary formatting is safe.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        },
+        {
+          "family": "openai",
+          "verdict": "changes_requested",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 351b883 (351b8831ddcc129af0b8ec2d7e694819974d91ef), committed 2026-07-05T01:38:36Z.\nPR: #8852.\nModel family: openai\n\nVerdict: CHANGES-REQUESTED\n\n- [P2] `scripts/check_work_lease.py:321` `--claim` creates an empty-scope lease by default, but `DevCoordinationStore.claim_lease` only conflicts on `allowed_globs` / `claimed_paths`, not branch. Fleets that claim directly through the store, which the new doc says is already sufficient, can still create multiple active leases for the same branch.\n- [P2] `scripts/check_work_lease.py:424` The pre-check blocks on any active foreign branch lease before calling `claim_lease`, so stale/dead-worker leases with future `expires_at` are never reaped by the store claim path. This contradicts the documented “dead-worker leases are reaped on claim” behavior and can squat a branch until TTL.\n\ndogfood: yes\n",
+          "posted_to_thread": false
+        }
+      ],
+      "expected_adjudicator_verdict": "not_applicable",
+      "expected_verdict_basis": "no supportive signal: genuine unanimous rejection is not a stall",
+      "ground_truth": {
+        "findings_valid": true,
+        "disposition": "block",
+        "ideal_disposition_note": "Control group: three real [P2]s in one round — claude reproduced the WAL read-only open failure (sidecars absent / read-only dir), openai found the branch-uniqueness gap and the stale-lease squat. All three fixed in e1747d1b with new tests; both families PASSed the next round.",
+        "resolution_mechanism": "fix + re-review (2-0 PASS at heads e1747d1b and f1a961a9)",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8852#issuecomment-4884476574",
+          "https://github.com/synaptent/aragora/pull/8852#issuecomment-4884498921",
+          "https://github.com/synaptent/aragora/pull/8852#issuecomment-4884498985"
+        ]
+      }
+    },
+    {
+      "id": "pr8803_r1_clean_convergent_pass",
+      "failure_classes": [],
+      "control": true,
+      "pr": 8803,
+      "head_sha": "32f2306cde92a61b447ee0343334f33abc5f8346",
+      "round": "evidence round 1",
+      "items": [
+        {
+          "family": "claude",
+          "verdict": "pass",
+          "body": "## Claude independent model review\n\nReviewer: claude (anthropic) — independent adversarial model review via the Aragora Claude reviewer, grounded on the exact PR head.\nHead: 32f2306 (32f2306cde92a61b447ee0343334f33abc5f8346), committed 2026-07-02T21:49:15Z.\nPR: #8803.\nModel family: claude\n\nVerdict: PASS\n\nNo findings.\n\ndogfood: yes",
+          "posted_to_thread": true
+        },
+        {
+          "family": "openai",
+          "verdict": "pass",
+          "body": "## OpenAI independent model review\n\nReviewer: openai (openai) — independent adversarial model review via Codex CLI OpenAI harness, grounded on the exact PR head.\nHead: 32f2306 (32f2306cde92a61b447ee0343334f33abc5f8346), committed 2026-07-02T21:49:15Z.\nPR: #8803.\nModel family: openai\n\nVerdict: PASS\n\nNo findings.\n\ndogfood: yes",
+          "posted_to_thread": true
+        }
+      ],
+      "expected_adjudicator_verdict": "not_applicable",
+      "expected_verdict_basis": "no dissent to adjudicate",
+      "ground_truth": {
+        "findings_valid": null,
+        "disposition": "settle",
+        "ideal_disposition_note": "Control group: clean 2-0 PASS with zero findings in a single round; settled and merged.",
+        "resolution_mechanism": "normal settlement (Tier 3 operator authorization, M0a posting precedent)",
+        "receipts": [
+          "https://github.com/synaptent/aragora/pull/8803#issuecomment-4871390438",
+          "https://github.com/synaptent/aragora/pull/8803#issuecomment-4871390511",
+          "https://github.com/synaptent/aragora/pull/8803#issuecomment-4871390568"
+        ]
+      }
+    }
+  ]
+}

--- a/tests/governance/test_adjudicator_eval_fixtures.py
+++ b/tests/governance/test_adjudicator_eval_fixtures.py
@@ -1,0 +1,183 @@
+"""Smoke tests for the adjudicator eval fixtures (#8856 item 3).
+
+``tests/governance/fixtures/adjudicator_eval_cases.json`` distills REAL
+multi-model review rounds (synaptent/aragora, 2026-07-02..05) into
+EvidenceItem-shaped cases: verbatim reviewer bodies at an exact head SHA, the
+adjudicator's expected CURRENT verdict, and the human-settled ground-truth
+disposition per the #8748 SETTLE/BLOCK/ESCALATE taxonomy. Narrative and
+receipts: ``docs/artifacts/2026-07-reviewer-failure-taxonomy.md``.
+
+These tests pin two different things — deliberately:
+
+1. **Current behavior** (``expected_adjudicator_verdict``): what M0
+   ``adjudicate()`` returns today on each case. If the adjudicator changes,
+   these assertions localize exactly which real-world case changed verdict.
+2. **Safety invariants**: advisory-only dissent must never produce BLOCK, and
+   an unrefuted [P1] must always produce BLOCK, regardless of scorer behavior.
+
+Where ``expected_adjudicator_verdict`` differs from
+``ground_truth.disposition`` (e.g. the verbatim-repeat case: ESCALATE today,
+SETTLE per the operator record), the delta is the documented eval target for
+adjudicator improvements — NOT a bug in these tests. Do not "fix" the fixture
+to make the numbers agree; improve the adjudicator and update the expected
+verdict with the receipts.
+
+The default groundedness scorer imports ``aragora_debate`` (same hard test
+dependency as ``tests/swarm/test_review_adjudicator.py``); only the
+scorer-dependent cases require it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from aragora.swarm.review_adjudicator import AdjudicationVerdict, adjudicate
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "adjudicator_eval_cases.json"
+
+# Cases whose expected verdict depends on the groundedness scorer (and thus the
+# aragora_debate package). Hard-bar BLOCK and NOT_APPLICABLE verdicts are
+# decided before the scorer is ever built, so they carry no such dependency.
+SCORER_DEPENDENT_VERDICTS = {"adjudicated_settle", "adjudicated_escalate"}
+
+VALID_DISPOSITIONS = {"settle", "block", "escalate"}
+VALID_VERDICTS = {v.value for v in AdjudicationVerdict}
+
+
+@dataclass
+class _Item:
+    """Minimal EvidenceItem-shaped stand-in (family, body, verdict, supportive)."""
+
+    family: str
+    body: str
+    verdict: str
+
+    @property
+    def supportive(self) -> bool:
+        return self.verdict == "pass"
+
+
+def _load_cases() -> list[dict[str, Any]]:
+    doc = json.loads(FIXTURE_PATH.read_text())
+    assert doc["schema"] == "adjudicator_eval_cases.v1"
+    return doc["cases"]
+
+
+def _items(case: dict[str, Any]) -> list[_Item]:
+    return [_Item(i["family"], i["body"], i["verdict"]) for i in case["items"]]
+
+
+def _case(case_id: str) -> dict[str, Any]:
+    matches = [c for c in _load_cases() if c["id"] == case_id]
+    assert len(matches) == 1, f"expected exactly one case {case_id!r}"
+    return matches[0]
+
+
+class TestFixtureShape:
+    def test_fixture_parses_and_case_fields_are_complete(self) -> None:
+        cases = _load_cases()
+        assert len(cases) >= 9
+        ids = [c["id"] for c in cases]
+        assert len(ids) == len(set(ids)), "case ids must be unique"
+        for case in cases:
+            assert case["pr"] > 0
+            assert len(case["head_sha"]) == 40
+            assert case["expected_adjudicator_verdict"] in VALID_VERDICTS
+            assert case["ground_truth"]["disposition"] in VALID_DISPOSITIONS
+            assert case["ground_truth"]["receipts"], case["id"]
+            assert all(
+                r.startswith("https://github.com/synaptent/aragora/")
+                for r in case["ground_truth"]["receipts"]
+            ), case["id"]
+            assert len(case["items"]) >= 2
+            for item in case["items"]:
+                assert item["family"] in {"claude", "openai"}
+                assert item["verdict"] in {"pass", "changes_requested"}
+                assert item["body"].strip(), case["id"]
+
+    def test_taxonomy_covers_failure_classes_and_controls(self) -> None:
+        cases = _load_cases()
+        classes = {fc for c in cases for fc in c["failure_classes"]}
+        assert classes == {
+            "diff_blind_grounding",
+            "stale_external_world",
+            "temporal_reasoning",
+            "verbatim_repeat_dissent",
+            "out_of_scope_carousel",
+            "cross_family_contradiction",
+        }
+        assert sum(1 for c in cases if c["control"]) >= 3
+
+
+class TestAdjudicatorVerdictsOnRealCases:
+    """Pin the CURRENT M0 verdict for every fixture case."""
+
+    @pytest.mark.parametrize("case", _load_cases(), ids=lambda c: c["id"])
+    def test_expected_verdict_matches(self, case: dict[str, Any]) -> None:
+        if case["expected_adjudicator_verdict"] in SCORER_DEPENDENT_VERDICTS:
+            pytest.importorskip("aragora_debate")
+        result = adjudicate(_items(case))
+        assert result.verdict.value == case["expected_adjudicator_verdict"], case["id"]
+
+
+class TestClearCaseInvariants:
+    """The named clear cases from the taxonomy artifact, asserted individually."""
+
+    def test_unrefuted_p1_blocks_without_scorer(self) -> None:
+        # pr8824_r1: both dead-link findings were FALSE (the file existed on
+        # main, blob 3c0458f1), but at this snapshot the [P1] was unrefuted —
+        # BLOCK is the correct fail-safe verdict, reached via the hard bar with
+        # the scorer never invoked (a raising scorer must not change it).
+        def _raising_scorer(_body: str) -> float:
+            raise AssertionError("hard-bar path must not invoke the scorer")
+
+        result = adjudicate(_items(_case("pr8824_r1_diff_blind_grounding")), scorer=_raising_scorer)
+        assert result.verdict is AdjudicationVerdict.BLOCK
+        assert result.blocking_findings
+
+    def test_real_convergent_p1_class_blocks(self) -> None:
+        # pr8834_r1 carries the [P1] hard bar; same deterministic BLOCK path.
+        result = adjudicate(_items(_case("pr8834_r1_temporal_and_stale_external")))
+        assert result.verdict is AdjudicationVerdict.BLOCK
+
+    def test_cross_family_contradiction_escalates(self) -> None:
+        pytest.importorskip("aragora_debate")
+        # pr8802_r7: claude's round-5 [P2] REQUIRED the verified_any-wins
+        # precedence; openai's round-7 [P2] objected to exactly that ordering.
+        # A genuine two-sided crux — ESCALATE, matching the human disposition.
+        result = adjudicate(_items(_case("pr8802_r7_cross_family_contradiction")))
+        assert result.verdict is AdjudicationVerdict.ESCALATE
+        assert result.escalated_findings
+
+    def test_verbatim_repeat_answered_never_blocks(self) -> None:
+        pytest.importorskip("aragora_debate")
+        # pr8800_r3: openai re-raised its answered round-1 finding; the operator
+        # record settles it (ground truth = settle). The current heuristic
+        # escalates (it cannot see that the finding was answered in-thread) —
+        # fail-safe to a human, and the documented eval gap. The invariant that
+        # must hold under any future scorer: advisory [P2] dissent with a
+        # counting PASS present resolves toward settlement (SETTLE or a human
+        # via ESCALATE), never an autonomous BLOCK.
+        case = _case("pr8800_r3_verbatim_repeat_answered")
+        result = adjudicate(_items(case))
+        assert result.verdict in (AdjudicationVerdict.SETTLE, AdjudicationVerdict.ESCALATE)
+        assert result.verdict is not AdjudicationVerdict.BLOCK
+        assert result.verdict.value == case["expected_adjudicator_verdict"]
+        assert case["ground_truth"]["disposition"] == "settle"
+
+    def test_unanimous_rejection_and_clean_pass_are_not_stalls(self) -> None:
+        # Control group: real convergent findings (both CR) and clean 2-0 PASS
+        # are not stalls — the adjudicator abstains and the base gate decides.
+        for case_id in (
+            "pr8811_r1_convergent_real_finding",
+            "pr8852_r1_convergent_real_findings",
+            "pr8803_r1_clean_convergent_pass",
+            "pr8824_r3_diff_blind_unanimous",
+        ):
+            result = adjudicate(_items(_case(case_id)))
+            assert result.verdict is AdjudicationVerdict.NOT_APPLICABLE, case_id


### PR DESCRIPTION
## Summary

Second dogfooding-class external artifact (#8856 item 3, tracked as #8860): **`docs/artifacts/2026-07-reviewer-failure-taxonomy.md`** — a taxonomy of six multi-model review failure classes observed in this repo's own merge gate, 2026-07-02..05, written for a skeptical ML/eval audience in the style of the dogfooding artifact: every claim linked, exact quotes, the machine refutation used per case, and an honest limitations section.

**The six classes (one receipted case study each):**
1. **Diff-blind grounding** — #8824 r1–r3: both reviewers claimed `docs/artifacts/2026-07-decision-integrity-dogfooding.md` didn't exist (on main since #8801, blob `3c0458f1`); openai's own wording ("this PR's complete changed-file list") exposes the mechanism; refuted in-thread with `git ls-tree`/`rg`/`check-ignore`; filed as #8825
2. **Stale-external-world grounding** — #8834: openai reported PyPI 0.1.1 absent against a timestamped fresh fetch + clean-venv install proving it live
3. **Temporal reasoning** — #8834: claude called a UTC release date "in the future in *every* timezone" from its local clock; the dissent premise self-expired at reviewer-local midnight
4. **Verbatim-repeat dissent** — #8800 r3: openai re-raised its round-1 finding after the demanded per-skip audit was delivered; operator-settled with claude's counting PASS
5. **Out-of-scope carousel** — #8802, seven adversarial rounds; several findings targeted fenced `odr_verify.py`, re-filed as #8810 — honestly split: rounds 1/3/5 were REAL (incl. the key_id security bug), the carousel is mixed value
6. **Cross-family contradiction** — #8802: claude r5 REQUIRED verified_any-wins precedence; openai r7 objected to exactly that ordering

Plus the **control group** the thesis requires (#8811 r1 convergent real bug, #8852 r1 three real P2s incl. reproduced WAL edge case, #8803 clean 2-0) — the headline: **every documented reviewer error in the window was a false negative; no reviewer PASS vouched for a false claim** (selection-effect caveats stated).

**Adjudicator eval fixtures:** `tests/governance/fixtures/adjudicator_eval_cases.json` — 10 cases with verbatim reviewer bodies at exact head SHAs, human-settled ground truth per the #8748 SETTLE/BLOCK/ESCALATE taxonomy, and per-item `posted_to_thread` provenance. `tests/governance/test_adjudicator_eval_fixtures.py` pins the current M0 `adjudicate()` verdict on every case (17 tests): hard-bar P1 → BLOCK (scorer never invoked), cross-family contradiction → ESCALATE (exact human agreement), verbatim-repeat → never BLOCK (currently ESCALATE vs ground-truth SETTLE — the documented thread-history-blindness eval gap), unanimous CR / clean 2-0 → NOT_APPLICABLE. **The adjudicator itself is untouched.**

**Also in this diff:**
- `.gitignore`: negation line for the new artifact — committing this document tripped the exact single-filename foot-gun a claude advisory [P3] predicted on #8824 (recursion noted in the artifact)
- One cross-link line added to the dogfooding artifact's failure ledger (item 7)

## Verification

- `pytest tests/governance/test_adjudicator_eval_fixtures.py tests/governance/test_review_adjudicator_collect_observe.py tests/swarm/test_review_adjudicator.py` → 43 passed
- pre-commit (ruff, ruff-format, gitleaks, json, portability guard) green on all changed files
- `git check-ignore` confirms the new artifact is not shadowed
- Load-bearing facts re-verified while writing: blob `3c0458f1` via `git ls-tree`, #8801 merge, live PyPI JSON (0.1.1 uploaded 2026-07-04T03:28:00Z)

## Fences respected

No gate machinery changes, no `odr_verify.py`, no workflow files, adjudicator unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)