### PR TITLE
fix(gauntlet): correct odr_verify.py docstring's unwired-endpoint overclaim (misc-docs-tooling)

### DIFF
--- a/aragora/gauntlet/odr_verify.py
+++ b/aragora/gauntlet/odr_verify.py
@@ -1,16 +1,21 @@
 """In-package verification engine for Open Decision Receipts (ODR v0.1).
 
-This is the *server-side single implementation* that the ``POST
-/api/receipts/verify`` endpoint and any internal caller wrap. It reuses the
+This is an in-tree **library** engine, not a wired API: it reuses the
 emitter's canonicalization and digest (``odr_export.jcs_canonicalize`` /
 ``odr_content_digest`` / ``load_odr_schema``) so a receipt verifies against the
-exact bytes it was emitted and signed over.
+exact bytes it was emitted and signed over. No shipped CLI subcommand or HTTP
+route calls it today — the existing ``/api/v2/receipts/{id}/verify*`` and
+``/receipts/{id}/verify`` routes verify the native or legacy receipt instead
+(see ``docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`` "Two verifiers" for the
+full picture). It is available for internal callers to import directly and is
+exercised by its own test suite.
 
 The standalone, zero-Aragora-dependency mirror of this engine is the
-``aragora-verify`` PyPI package (issue #8226); both follow the same content
-profile (``docs/specs/OPEN_DECISION_RECEIPT.md``) and signature construction
-(§6 / issue #8225), so a receipt verifies identically whether checked here or
-by an external auditor with only the public key.
+``aragora-verify`` PyPI package (issue #8226); the two are kept in lockstep —
+both follow the same content profile (``docs/specs/OPEN_DECISION_RECEIPT.md``)
+and signature construction (§6 / issue #8225), so a receipt verifies
+identically whether checked here or by an external auditor with only the
+public key.
 
 Checks:
 

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -53,16 +53,18 @@ from scratch.
 The public (ODR) lineage has **two independent verification implementations** that
 must be kept in lockstep:
 
-1. **`aragora/gauntlet/odr_verify.py`** — the in-tree engine landed via #8389. Its own
-   module docstring describes it as "the server-side single implementation that the
-   `POST /api/receipts/verify` endpoint and any internal caller wrap." As of this
-   reconciliation, no shipped CLI subcommand or HTTP route actually imports
-   `verify_odr_document` / `odr_verify` — the existing `/api/v2/receipts/{id}/verify*`
-   routes and `/receipts/{id}/verify` verify the **native or legacy** receipt
-   (`store.verify_signature`/`verify_integrity`, or
+1. **`aragora/gauntlet/odr_verify.py`** — the in-tree engine landed via #8389. Its module
+   docstring previously overclaimed itself as "the server-side single implementation
+   that the `POST /api/receipts/verify` endpoint and any internal caller wrap"; that
+   wording has been corrected because no shipped CLI subcommand or HTTP route actually
+   imports `verify_odr_document` / `odr_verify` — the existing
+   `/api/v2/receipts/{id}/verify*` routes and `/receipts/{id}/verify` verify the
+   **native or legacy** receipt instead (`store.verify_signature`/`verify_integrity`, or
    `aragora.export.decision_receipt.DecisionReceipt.verify_integrity`), not an ODR
-   document. `odr_verify.py` is exercised today by its own test suite
-   (`tests/gauntlet/test_odr_verify.py`, `tests/gauntlet/test_odr_verify_schema.py`)
+   document. The docstring now states this accurately: an in-tree **library** engine,
+   kept in lockstep with the standalone `aragora-verify` package, not yet wired to any
+   shipped CLI/HTTP entry point. `odr_verify.py` is exercised today by its own test
+   suite (`tests/gauntlet/test_odr_verify.py`, `tests/gauntlet/test_odr_verify_schema.py`)
    and is available for internal callers to import directly.
 2. **`aragora-verify`** (this repo's standalone `aragora-verify/` package, **published
    on PyPI**) — the "no-trust" path: pure stdlib + `cryptography`, zero Aragora


### PR DESCRIPTION
## Summary

Honesty fix (mission: Public Utility & DecisionReceipt Productization, milestone `misc-docs-tooling`, feature `misc-odr-verify-docstring-honesty`).

`aragora/gauntlet/odr_verify.py`'s module docstring claimed to be "the server-side single implementation that the `POST /api/receipts/verify` endpoint and any internal caller wrap." That is not true today: no CLI subcommand or HTTP route in the tree imports `verify_odr_document`/`odr_verify` outside of `odr_verify.py`'s own two test files. The existing `/api/v2/receipts/{id}/verify*` and `/receipts/{id}/verify` routes verify the **native or legacy** receipt instead (`store.verify_signature`/`verify_integrity`, or `aragora.export.decision_receipt.DecisionReceipt.verify_integrity`).

This PR softens the docstring to state reality: an in-tree **library** engine for ODR verification, kept in lockstep with the standalone `aragora-verify` PyPI package, not yet wired to any shipped CLI/HTTP entry point. It does **not** wire a new endpoint, and does not change `verify_odr_document`'s logic or any other behavior.

`docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`'s "Two verifiers" section quoted the old docstring text verbatim as evidence of the gap; it is updated in the same commit so it no longer describes the (now-corrected) docstring as currently saying the false thing, while preserving the substantive finding (still no shipped CLI/HTTP caller).

## Scope / Tier

- **Docstring + doc-prose only.** No code paths, schemas, or public APIs changed. `verify_odr_document` behavior is byte-for-byte identical before/after (see verification below).
- Touches `aragora/**` (a `.py` file), so per the mission's merge policy this is **not** auto-merge eligible even though the diff is comment-only. Parked for operator review.
- No `.github/workflows/`, `docs/RECEIPT_CONTRACT.md`, `odr_schema.json`, or public class/CLI signature touched.

## Preconditions verified

- `rg 'odr_verify|verify_odr_document' aragora/ --type py` (excluding tests): only self-references inside `odr_verify.py` (`__all__` entry + its own `def verify_odr_document`) and `scripts/generate_odr_fixture.py` (a fixture-generation script, not a CLI subcommand/HTTP route). No server route or CLI subcommand imports it.
- Curated receipt/verify test scope green baseline before this change: **242 passed** (current baseline post-#8822; the feature's "229" reference is stale mission context — the invariant is zero failures).

## Validation

```
# Curated receipt/verify scope, before AND after the docstring edit — identical count, zero failures
.../venv/bin/python -m pytest tests/cli/test_verify.py tests/export/test_decision_receipt.py \
  tests/gauntlet/test_receipt.py tests/gauntlet/test_odr_verify.py tests/gauntlet/test_odr_verify_schema.py -q
# => 242 passed (both runs)

# Scoped lint + typecheck on the only touched .py file
.../venv/bin/python -m ruff check aragora/gauntlet/odr_verify.py
# => All checks passed!
PYTHONPATH=<worktree> .../venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip aragora/gauntlet/odr_verify.py
# => Success: no issues found in 1 source file

# Manual behavior-parity check (docstring-only change)
python -c "from aragora.gauntlet import odr_verify; import json; \
  d = json.load(open('docs/specs/examples/example-decision-receipt.odr.json')); \
  r = odr_verify.verify_odr_document(d); print(r.ok, [ (c.name, c.status) for c in r.checks ])"
# => True [('schema_conformance','pass'), ('canonical_digest','pass'), ('signature','warn'), ('quorum_consistency','pass'), ('chain_link','skip')]
# identical to pre-change behavior

# Docs checks (this PR also touches docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md)
python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js   # zero diff beyond the two intended files (docs/specs/** is outside the sync-docs mirror set)
python scripts/check_docs_consistency.py     # Check 1-4 PASS
python scripts/validate_doc_links.py         # all links valid

bash scripts/automation_pr_preflight.sh origin/main HEAD   # exit 0 (non-fatal source-without-tests warning noted below)
```

**Why no new/changed tests:** this is a pure docstring + doc-prose correction with zero behavioral change to `verify_odr_document` or any other function (confirmed via the manual parity check above, and the curated suite passing at an identical count before and after). `automation_pr_preflight.sh` flags "source changed without test changes" as a non-fatal warning for exactly this reason; the validation commands above are the requested substitute.

## Not in scope (intentionally)

- Wiring `odr_verify.py` into a live CLI subcommand or HTTP route — explicitly out of scope per the feature description.
- `aragora-verify/src/aragora_verify/verifier.py` has a similar overclaim in its own module docstring ("The single library behind both the `aragora-verify` CLI and the server's `POST /api/receipts/verify` endpoint"). That file is outside this feature's named scope (`aragora/gauntlet/odr_verify.py` only) and is called out as a discovered issue for a future feature rather than fixed here.

## Merge policy

**Parked for operator review — do NOT auto-merge.** Labelled `operator-review-required`.
