### PR TITLE
[DIC-27] ArbitrationRow in DIC-18 truth map — age display

### DIFF
--- a/aragora/epistemic/__init__.py
+++ b/aragora/epistemic/__init__.py
@@ -178,6 +178,7 @@ from .genealogy_report import (
     build_genealogy_report,
 )
 from .truth_map import (
+    ArbitrationRow,
     OrgTruthMapReport,
     build_truth_map,
     build_truth_map_from_manifests,
@@ -249,6 +250,7 @@ __all__ = [
     "garden_outstanding_crux",
     "garden_resolved_crux",
     "run_gardening_pass",
+    "ArbitrationRow",
     "build_truth_map",
     "build_truth_map_from_manifests",
     "CodeUnitGenealogy",

--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -143,6 +143,7 @@ class OrgTruthMapReport:
     crux_summaries: list[CruxSummaryRow] = field(default_factory=list)
     genealogies: list[GenealogyRow] = field(default_factory=list)
     arbitrations: list[ArbitrationRow] = field(default_factory=list)
+    arbitration_enabled: bool = False
     total_claims: int = 0
     passing_claims: int = 0
     failing_claims: int = 0
@@ -162,7 +163,7 @@ class OrgTruthMapReport:
             "error": self.error_claims,
             "open_crux_count": self.open_crux_count,
         }
-        if _arbitration_enabled():
+        if self.arbitration_enabled:
             summary["active_arbitrations"] = self.active_arbitration_count
 
         d: dict[str, Any] = {
@@ -260,8 +261,9 @@ def build_truth_map(
                 )
             )
 
+    arbitration_enabled = _arbitration_enabled()
     arbitration_rows: list[ArbitrationRow] = []
-    if arbitration_inputs and _arbitration_enabled():
+    if arbitration_inputs and arbitration_enabled:
         for arb in arbitration_inputs:
             arbitration_rows.append(
                 ArbitrationRow(
@@ -287,6 +289,7 @@ def build_truth_map(
         crux_summaries=crux_rows,
         genealogies=genealogy_rows,
         arbitrations=arbitration_rows,
+        arbitration_enabled=arbitration_enabled,
         total_claims=len(rows),
         passing_claims=counts[ClaimStatus.PASS],
         failing_claims=counts[ClaimStatus.FAIL],

--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -153,21 +153,24 @@ class OrgTruthMapReport:
     active_arbitration_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
+        summary = {
+            "total_claims": self.total_claims,
+            "passing": self.passing_claims,
+            "failing": self.failing_claims,
+            "stale": self.stale_claims,
+            "unsupported": self.unsupported_claims,
+            "error": self.error_claims,
+            "open_crux_count": self.open_crux_count,
+        }
+        if _arbitration_enabled():
+            summary["active_arbitrations"] = self.active_arbitration_count
+
         d: dict[str, Any] = {
             "generated_at": self.generated_at,
             "claims": [c.to_dict() for c in self.claims],
             "crux_summaries": [cs.to_dict() for cs in self.crux_summaries],
             "genealogies": [g.to_dict() for g in self.genealogies],
-            "summary": {
-                "total_claims": self.total_claims,
-                "passing": self.passing_claims,
-                "failing": self.failing_claims,
-                "stale": self.stale_claims,
-                "unsupported": self.unsupported_claims,
-                "error": self.error_claims,
-                "open_crux_count": self.open_crux_count,
-                "active_arbitrations": self.active_arbitration_count,
-            },
+            "summary": summary,
         }
         if self.arbitrations:
             d["arbitrations"] = [a.to_dict() for a in self.arbitrations]

--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -276,9 +276,7 @@ def build_truth_map(
                 )
             )
 
-    active_arb_count = sum(
-        1 for a in arbitration_rows if not a.is_expired and not a.is_reversed
-    )
+    active_arb_count = sum(1 for a in arbitration_rows if not a.is_expired and not a.is_reversed)
 
     return OrgTruthMapReport(
         generated_at=datetime.datetime.utcnow().isoformat() + "Z",

--- a/aragora/epistemic/truth_map.py
+++ b/aragora/epistemic/truth_map.py
@@ -1,7 +1,8 @@
 """Organizational Truth Map report (DIC-18 / #6028).
 
 Read-only operator report aggregating ExecutableClaim verification results
-(DIC-14) and optional CruxFinderResult summaries (DIC-15).
+(DIC-14), optional CruxFinderResult summaries (DIC-15), and optional
+DIC-27 operator arbitration records with age display.
 Default OFF — callers must explicitly invoke ``build_truth_map`` or
 ``build_truth_map_from_manifests``.  No queue mutation, no side effects.
 """
@@ -18,12 +19,41 @@ from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
 
 if TYPE_CHECKING:
     from aragora.debate.crux_mode import CruxFinderResult
+    from aragora.epistemic.arbitration import CruxArbitration
     from aragora.epistemic.genealogy import GenealogyStore
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
 def _genealogy_enabled() -> bool:
     raw = str(os.environ.get("ARAGORA_GENEALOGY_ENABLED") or "").strip().lower()
-    return raw in {"1", "true", "yes", "on"}
+    return raw in _TRUTHY
+
+
+def _arbitration_enabled() -> bool:
+    """Return True when ARAGORA_CRUX_ARBITRATION_ENABLED is set.
+
+    Same flag as :func:`aragora.epistemic.arbitration.crux_arbitration_enabled`.
+    Inlined here to avoid a module-level import of arbitration.py.
+    """
+    raw = str(os.environ.get("ARAGORA_CRUX_ARBITRATION_ENABLED") or "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _age_days(iso_timestamp: str) -> float:
+    """Return the age in fractional days from *iso_timestamp* to now (UTC).
+
+    Fails open: an unparseable timestamp returns 0.0 rather than raising,
+    so a bad created_at does not abort truth-map generation.
+    """
+    try:
+        dt = datetime.datetime.fromisoformat(iso_timestamp)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        delta = datetime.datetime.now(datetime.timezone.utc) - dt
+        return max(0.0, delta.total_seconds() / 86400)
+    except (ValueError, OverflowError):
+        return 0.0
 
 
 @dataclass
@@ -75,6 +105,36 @@ class GenealogyRow:
 
 
 @dataclass
+class ArbitrationRow:
+    """DIC-27 operator arbitration record for the truth map (age display).
+
+    Populated in ``build_truth_map`` when ``ARAGORA_CRUX_ARBITRATION_ENABLED``
+    is set and the caller supplies ``arbitration_inputs``.  Provides at-a-glance
+    age and status so operators can see stale or reversed arbitrations without
+    opening individual receipt files.
+
+    Only included in the truth map when the DIC-27 flag is active; the field
+    is always present on :class:`OrgTruthMapReport` but defaults to an empty
+    list, so existing callers are unaffected.
+    """
+
+    arbitration_id: str
+    crux_id: str
+    question_family_id: str
+    statement: str
+    operator: str
+    side: str
+    created_at: str
+    expires_at: str
+    age_days: float
+    is_expired: bool
+    is_reversed: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class OrgTruthMapReport:
     """Read-only aggregated truth map for an Aragora deployment."""
 
@@ -82,6 +142,7 @@ class OrgTruthMapReport:
     claims: list[ClaimRow] = field(default_factory=list)
     crux_summaries: list[CruxSummaryRow] = field(default_factory=list)
     genealogies: list[GenealogyRow] = field(default_factory=list)
+    arbitrations: list[ArbitrationRow] = field(default_factory=list)
     total_claims: int = 0
     passing_claims: int = 0
     failing_claims: int = 0
@@ -89,9 +150,10 @@ class OrgTruthMapReport:
     unsupported_claims: int = 0
     error_claims: int = 0
     open_crux_count: int = 0
+    active_arbitration_count: int = 0
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "generated_at": self.generated_at,
             "claims": [c.to_dict() for c in self.claims],
             "crux_summaries": [cs.to_dict() for cs in self.crux_summaries],
@@ -104,8 +166,12 @@ class OrgTruthMapReport:
                 "unsupported": self.unsupported_claims,
                 "error": self.error_claims,
                 "open_crux_count": self.open_crux_count,
+                "active_arbitrations": self.active_arbitration_count,
             },
         }
+        if self.arbitrations:
+            d["arbitrations"] = [a.to_dict() for a in self.arbitrations]
+        return d
 
 
 def build_truth_map(
@@ -116,6 +182,7 @@ def build_truth_map(
     top_k_cruxes: int = 3,
     open_crux_score_threshold: float = 0.3,
     genealogy_inputs: "list[tuple[str, GenealogyStore]] | None" = None,
+    arbitration_inputs: "list[CruxArbitration] | None" = None,
 ) -> OrgTruthMapReport:
     """Build an OrgTruthMapReport from pre-computed claim and crux inputs.
 
@@ -124,6 +191,12 @@ def build_truth_map(
     via :func:`aragora.epistemic.genealogy.get_genealogy` and added as a
     :class:`GenealogyRow` drill-down.  When the flag is off the parameter
     is silently ignored so callers can wire it unconditionally.
+
+    ``arbitration_inputs`` is an optional list of :class:`CruxArbitration`
+    objects (DIC-27).  When ``ARAGORA_CRUX_ARBITRATION_ENABLED`` is set, each
+    arbitration is converted to an :class:`ArbitrationRow` with age computed
+    from ``created_at``.  When the flag is off the parameter is silently
+    ignored so callers can wire it unconditionally.
     """
     meta = claim_metadata or {}
     rows: list[ClaimRow] = []
@@ -184,11 +257,35 @@ def build_truth_map(
                 )
             )
 
+    arbitration_rows: list[ArbitrationRow] = []
+    if arbitration_inputs and _arbitration_enabled():
+        for arb in arbitration_inputs:
+            arbitration_rows.append(
+                ArbitrationRow(
+                    arbitration_id=arb.arbitration_id,
+                    crux_id=arb.crux.crux_id,
+                    question_family_id=arb.crux.question_family_id,
+                    statement=arb.crux.statement,
+                    operator=arb.operator,
+                    side=arb.side,
+                    created_at=arb.created_at,
+                    expires_at=arb.expires_at,
+                    age_days=round(_age_days(arb.created_at), 2),
+                    is_expired=arb.is_expired,
+                    is_reversed=arb.is_reversed,
+                )
+            )
+
+    active_arb_count = sum(
+        1 for a in arbitration_rows if not a.is_expired and not a.is_reversed
+    )
+
     return OrgTruthMapReport(
         generated_at=datetime.datetime.utcnow().isoformat() + "Z",
         claims=rows,
         crux_summaries=crux_rows,
         genealogies=genealogy_rows,
+        arbitrations=arbitration_rows,
         total_claims=len(rows),
         passing_claims=counts[ClaimStatus.PASS],
         failing_claims=counts[ClaimStatus.FAIL],
@@ -196,6 +293,7 @@ def build_truth_map(
         unsupported_claims=counts[ClaimStatus.UNSUPPORTED],
         error_claims=counts[ClaimStatus.ERROR],
         open_crux_count=open_crux_total,
+        active_arbitration_count=active_arb_count,
     )
 
 

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -70,7 +70,7 @@ class TestFlagOff:
         monkeypatch.delenv("ARAGORA_CRUX_ARBITRATION_ENABLED", raising=False)
         d = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).to_dict()
         assert "arbitrations" not in d
-        assert d["summary"]["active_arbitrations"] == 0
+        assert "active_arbitrations" not in d["summary"]
 
     def test_none_inputs_produces_no_rows_flag_on(self, flag_on):
         report = build_truth_map(claim_results=[], arbitration_inputs=None)

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -126,6 +126,14 @@ class TestFlagOn:
         assert len(d["arbitrations"]) == 1
         assert d["summary"]["active_arbitrations"] == 1
 
+    def test_serialization_stable_when_flag_disabled_after_build(self, flag_on, monkeypatch):
+        report = build_truth_map(claim_results=[], arbitration_inputs=[_arb()])
+        before = report.to_dict()
+
+        monkeypatch.delenv("ARAGORA_CRUX_ARBITRATION_ENABLED", raising=False)
+
+        assert report.to_dict() == before
+
     def test_empty_inputs_zero_count(self, flag_on):
         d = build_truth_map(claim_results=[], arbitration_inputs=[]).to_dict()
         assert "arbitrations" not in d
@@ -154,3 +162,13 @@ class TestFlagOn:
             "is_reversed",
         }
         assert expected == set(d.keys())
+
+
+def test_serialization_stable_when_flag_enabled_after_build(monkeypatch):
+    monkeypatch.delenv("ARAGORA_CRUX_ARBITRATION_ENABLED", raising=False)
+    report = build_truth_map(claim_results=[], arbitration_inputs=[_arb()])
+    before = report.to_dict()
+
+    monkeypatch.setenv("ARAGORA_CRUX_ARBITRATION_ENABLED", "1")
+
+    assert report.to_dict() == before

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -141,8 +141,16 @@ class TestFlagOn:
         row = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).arbitrations[0]
         d = row.to_dict()
         expected = {
-            "arbitration_id", "crux_id", "question_family_id", "statement",
-            "operator", "side", "created_at", "expires_at",
-            "age_days", "is_expired", "is_reversed",
+            "arbitration_id",
+            "crux_id",
+            "question_family_id",
+            "statement",
+            "operator",
+            "side",
+            "created_at",
+            "expires_at",
+            "age_days",
+            "is_expired",
+            "is_reversed",
         }
         assert expected == set(d.keys())

--- a/tests/epistemic/test_truth_map_arbitration.py
+++ b/tests/epistemic/test_truth_map_arbitration.py
@@ -1,0 +1,148 @@
+"""DIC-27 arbitration rows in the DIC-18 truth map.
+
+Verifies that build_truth_map surfaces DIC-27 CruxArbitration objects as
+ArbitrationRow entries (with age in days) under ARAGORA_CRUX_ARBITRATION_ENABLED.
+
+Gating:
+- Flag OFF (default): arbitration_inputs silently ignored; no rows, count=0.
+- Flag ON: rows built from supplied CruxArbitration objects; age is non-negative.
+
+No queue mutations, no boss-ready labels. Advances issue #6221 (DIC-27).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.epistemic.arbitration import (
+    PERSISTENT_CRUX_MIN_CONSECUTIVE,
+    PERSISTENT_CRUX_MIN_SCORE,
+    PersistentCrux,
+    build_arbitration,
+)
+from aragora.epistemic.claim_verifier import ClaimResult, ClaimStatus
+from aragora.epistemic.truth_map import ArbitrationRow, build_truth_map
+
+_CRUX_A = PersistentCrux(
+    crux_id="crux_test_001",
+    statement="Three consecutive green soaks required before widening B2.",
+    question_family_id="qfam_b2_expansion",
+    consecutive_debate_count=PERSISTENT_CRUX_MIN_CONSECUTIVE,
+    load_bearing_score=PERSISTENT_CRUX_MIN_SCORE,
+    cruxset_receipt_ids=("rcpt_a", "rcpt_b", "rcpt_c"),
+)
+
+_CRUX_B = PersistentCrux(
+    crux_id="crux_test_002",
+    statement="Embedding quality determines retrieval accuracy.",
+    question_family_id="qfam_retrieval",
+    consecutive_debate_count=5,
+    load_bearing_score=0.85,
+    cruxset_receipt_ids=("rcpt_x",),
+)
+
+
+def _arb(crux=_CRUX_A, **kw):
+    kw.setdefault("operator", "alice")
+    kw.setdefault("side", "accept")
+    kw.setdefault("rationale", "Soaks confirm the claim.")
+    return build_arbitration(crux, **kw)
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv("ARAGORA_CRUX_ARBITRATION_ENABLED", "1")
+
+
+# ---------------------------------------------------------------------------
+# Flag-OFF: arbitration_inputs silently ignored
+# ---------------------------------------------------------------------------
+
+
+class TestFlagOff:
+    def test_no_rows_when_flag_unset(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_CRUX_ARBITRATION_ENABLED", raising=False)
+        report = build_truth_map(claim_results=[], arbitration_inputs=[_arb()])
+        assert report.arbitrations == []
+        assert report.active_arbitration_count == 0
+
+    def test_to_dict_excludes_arbitrations_key(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_CRUX_ARBITRATION_ENABLED", raising=False)
+        d = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).to_dict()
+        assert "arbitrations" not in d
+        assert d["summary"]["active_arbitrations"] == 0
+
+    def test_none_inputs_produces_no_rows_flag_on(self, flag_on):
+        report = build_truth_map(claim_results=[], arbitration_inputs=None)
+        assert report.arbitrations == []
+        assert report.active_arbitration_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Flag-ON: ArbitrationRow populated correctly
+# ---------------------------------------------------------------------------
+
+
+class TestFlagOn:
+    def test_single_arb_one_row(self, flag_on):
+        report = build_truth_map(claim_results=[], arbitration_inputs=[_arb()])
+        assert len(report.arbitrations) == 1
+
+    def test_row_fields_match_arbitration(self, flag_on):
+        arb = _arb(operator="carol", side="reject", rationale="Not supported.")
+        row = build_truth_map(claim_results=[], arbitration_inputs=[arb]).arbitrations[0]
+        assert row.arbitration_id == arb.arbitration_id
+        assert row.crux_id == _CRUX_A.crux_id
+        assert row.question_family_id == _CRUX_A.question_family_id
+        assert row.operator == "carol"
+        assert row.side == "reject"
+        assert row.created_at == arb.created_at
+        assert row.expires_at == arb.expires_at
+
+    def test_age_days_non_negative(self, flag_on):
+        row = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).arbitrations[0]
+        assert row.age_days >= 0.0
+
+    def test_fresh_arb_not_expired_not_reversed(self, flag_on):
+        row = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).arbitrations[0]
+        assert row.is_expired is False
+        assert row.is_reversed is False
+
+    def test_multiple_arbs_multiple_rows(self, flag_on):
+        arb1 = _arb(_CRUX_A, side="accept", rationale="R1")
+        arb2 = _arb(_CRUX_B, operator="bob", side="defer", rationale="R2")
+        report = build_truth_map(claim_results=[], arbitration_inputs=[arb1, arb2])
+        assert len(report.arbitrations) == 2
+        crux_ids = {r.crux_id for r in report.arbitrations}
+        assert crux_ids == {"crux_test_001", "crux_test_002"}
+
+    def test_active_count_counts_non_expired_non_reversed(self, flag_on):
+        report = build_truth_map(claim_results=[], arbitration_inputs=[_arb()])
+        assert report.active_arbitration_count == 1
+
+    def test_to_dict_includes_arbitrations_and_summary_key(self, flag_on):
+        d = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).to_dict()
+        assert "arbitrations" in d
+        assert len(d["arbitrations"]) == 1
+        assert d["summary"]["active_arbitrations"] == 1
+
+    def test_empty_inputs_zero_count(self, flag_on):
+        d = build_truth_map(claim_results=[], arbitration_inputs=[]).to_dict()
+        assert "arbitrations" not in d
+        assert d["summary"]["active_arbitrations"] == 0
+
+    def test_claims_and_arbs_coexist(self, flag_on):
+        results = [ClaimResult(claim_id="c1", status=ClaimStatus.PASS, message="", detail={})]
+        report = build_truth_map(claim_results=results, arbitration_inputs=[_arb()])
+        assert report.total_claims == 1
+        assert len(report.arbitrations) == 1
+
+    def test_row_to_dict_has_all_keys(self, flag_on):
+        row = build_truth_map(claim_results=[], arbitration_inputs=[_arb()]).arbitrations[0]
+        d = row.to_dict()
+        expected = {
+            "arbitration_id", "crux_id", "question_family_id", "statement",
+            "operator", "side", "created_at", "expires_at",
+            "age_days", "is_expired", "is_reversed",
+        }
+        assert expected == set(d.keys())


### PR DESCRIPTION
## Slice

Adds `ArbitrationRow` to the DIC-18 organizational truth map so operator arbitrations (DIC-27) are visible with their age in days. `OrgTruthMapReport` gains an `arbitrations: list[ArbitrationRow]` field and an `active_arbitration_count` summary counter. `build_truth_map()` accepts an optional `arbitration_inputs` list that is silently ignored when the flag is off.

## Gating

- Default: OFF (flag: `ARAGORA_CRUX_ARBITRATION_ENABLED` — same gate as `arbitration.py`)
- Live queue effect: none — read-only truth-map output, no queue mutation
- Advances issue: #6221 (DIC-27 — Operator Crux Arbitration)

## Tests

- `TestFlagOff::test_no_rows_when_flag_unset` — arbitration_inputs ignored; rows=[], count=0
- `TestFlagOff::test_to_dict_excludes_arbitrations_key` — `to_dict()` omits the key when empty
- `TestFlagOff::test_none_inputs_produces_no_rows_flag_on` — None inputs always yield empty
- `TestFlagOn::test_single_arb_one_row` — one ArbitrationRow per CruxArbitration
- `TestFlagOn::test_row_fields_match_arbitration` — id, crux_id, question_family_id, operator, side, timestamps all propagated
- `TestFlagOn::test_age_days_non_negative` — computed age ≥ 0 for fresh arbitrations
- `TestFlagOn::test_fresh_arb_not_expired_not_reversed` — is_expired=False, is_reversed=False for new arbs
- `TestFlagOn::test_multiple_arbs_multiple_rows` — N arbs → N rows with correct crux_ids
- `TestFlagOn::test_active_arbitration_count_counts_non_expired_non_reversed` — count=1 for one fresh arb
- `TestFlagOn::test_to_dict_includes_arbitrations_and_summary_key` — `to_dict()` includes `arbitrations` list and `summary.active_arbitrations`
- `TestFlagOn::test_empty_inputs_zero_count` — empty list → no key in dict, count=0
- `TestFlagOn::test_claims_and_arbs_coexist` — claims and arbitration rows are independent
- `TestFlagOn::test_row_to_dict_has_all_keys` — all 11 expected keys present

## Validation

- `pytest tests/epistemic/test_truth_map_arbitration.py --noconftest` — **13 passed**
- `python3 -c "import ast; ast.parse(open('aragora/epistemic/truth_map.py').read())"` — clean
- `python3 -c "import ast; ast.parse(open('aragora/epistemic/__init__.py').read())"` — clean
- Net diff: 250 LOC (103 in truth_map.py, 2 in __init__.py, 148 test file)

## Out of scope

- Belief-network priors-update path on arbitration write (explicit future work per `arbitration.py` docstring; depends on DIC-15/16 production-green)
- Interactive CLI prompt for `aragora crux arbitrate` (separate DIC-27 sub-deliverable)
- `build_truth_map_from_manifests` does not yet pass `arbitration_inputs`; callers that want arbitrations in manifest-based maps call `build_truth_map` directly

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2CgKqMneqQEdjCfJHt4Rv)_