### PR TITLE
test(ci): justified-skip convention — report-only counts split + unjustified-only baseline comparison (#8862)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,7 +448,8 @@ jobs:
 
       - name: Skip baseline enforcement
         run: |
-          CURRENT=$(python scripts/audit_test_skips.py --count-only)
+          TOTAL=$(python scripts/audit_test_skips.py --count-only)
+          CURRENT=$(python scripts/audit_test_skips.py --unjustified-count-only)
           if [ ! -f tests/.skip_baseline ]; then
             echo "::error::tests/.skip_baseline file is missing — cannot enforce skip count"
             exit 1
@@ -459,21 +460,22 @@ jobs:
             echo "::error::Invalid skip count values: current='$CURRENT', baseline='$BASELINE'"
             exit 1
           fi
-          echo "Current skip count: $CURRENT"
-          echo "Baseline: $BASELINE"
+          echo "Total skip count: $TOTAL"
+          echo "Unjustified skip count: $CURRENT"
+          echo "Unjustified baseline: $BASELINE"
           DIFF=$((CURRENT - BASELINE))
           if [ "$DIFF" -gt 0 ]; then
-            echo "::error::Skip count increased by $DIFF (from $BASELINE to $CURRENT). No increase allowed without updating tests/.skip_baseline."
+            echo "::error::Unjustified skip count increased by $DIFF (from $BASELINE to $CURRENT). No increase allowed without updating tests/.skip_baseline."
             echo ""
-            echo "If this increase is intentional, update the baseline:"
+            echo "If this unjustified increase is intentional, update the baseline:"
             echo "  echo $CURRENT > tests/.skip_baseline"
             echo "  git add tests/.skip_baseline && git commit -m 'chore: update skip baseline to $CURRENT'"
             exit 1
           fi
           if [ "$DIFF" -lt 0 ]; then
-            echo "::notice::Skip count decreased by $((-DIFF)). Consider updating tests/.skip_baseline to $CURRENT."
+            echo "::notice::Unjustified skip count decreased by $((-DIFF)). Consider updating tests/.skip_baseline to $CURRENT."
           fi
-          echo "Skip baseline check passed (current=$CURRENT, baseline=$BASELINE)"
+          echo "Skip baseline check passed (unjustified=$CURRENT, baseline=$BASELINE)"
         env:
           PYTHONPATH: .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -371,27 +371,29 @@ jobs:
 
       - name: Run skip audit
         run: |
-          CURRENT=$(python scripts/audit_test_skips.py --count-only)
+          TOTAL=$(python scripts/audit_test_skips.py --count-only)
+          CURRENT=$(python scripts/audit_test_skips.py --unjustified-count-only)
           BASELINE=$(cat tests/.skip_baseline 2>/dev/null || echo 600)
           THRESHOLD=2  # Fail if skips increase by more than this (tightened Feb 2026)
-          echo "Current skip count: $CURRENT"
-          echo "Baseline: $BASELINE"
+          echo "Total skip count: $TOTAL"
+          echo "Unjustified skip count: $CURRENT"
+          echo "Unjustified baseline: $BASELINE"
           echo "Threshold: $THRESHOLD"
 
           DIFF=$((CURRENT - BASELINE))
           if [ "$DIFF" -gt "$THRESHOLD" ]; then
-            echo "::error::Skip count increased by $DIFF (from $BASELINE to $CURRENT)"
+            echo "::error::Unjustified skip count increased by $DIFF (from $BASELINE to $CURRENT)"
             echo "::error::This exceeds the threshold of $THRESHOLD additional skips"
             echo "Run 'python scripts/audit_test_skips.py' locally to see details"
             exit 1
           elif [ "$DIFF" -gt 0 ]; then
-            echo "::warning::Skip count increased slightly: $CURRENT > $BASELINE baseline (+$DIFF)"
+            echo "::warning::Unjustified skip count increased slightly: $CURRENT > $BASELINE baseline (+$DIFF)"
             echo "Consider updating tests/.skip_baseline if these skips are intentional"
           elif [ "$DIFF" -lt 0 ]; then
-            echo "::notice::Skip count decreased by $((-DIFF))! Consider updating baseline."
+            echo "::notice::Unjustified skip count decreased by $((-DIFF))! Consider updating baseline."
           fi
           # Store for potential artifact
-          echo "$CURRENT" > skip_count.txt
+          echo "$TOTAL" > skip_count.txt
 
       - name: Upload skip audit
         uses: actions/upload-artifact@v4

--- a/docs/testing/TEST_SKIP_POLICY.md
+++ b/docs/testing/TEST_SKIP_POLICY.md
@@ -6,7 +6,9 @@ This document defines the policy for using `@pytest.mark.skip` markers in the Ar
 
 Skip markers are essential for maintaining a green CI pipeline while allowing tests that depend on optional components. However, excessive or stale skips reduce test coverage confidence.
 
-**Current baseline:** ~370 skip markers (tracked in `tests/.skip_baseline`)
+**Current baseline:** tracked in `tests/.skip_baseline`. As of the justified-skip
+v1 redesign, this file stores the **unjustified** skip baseline; total skips are
+still reported separately.
 
 ## Categories
 
@@ -57,14 +59,33 @@ Always include a clear reason:
 @pytest.mark.skip()  # No reason at all
 ```
 
+### Justified Skip Convention
+
+Use the report-only convention `justified-skip[category]: rationale` when a skip is
+intentional and should not count against the unjustified skip baseline.
+
+```python
+@pytest.mark.skipif(
+    not HAS_Z3,
+    reason="justified-skip[optional_dependency]: Z3 solver not installed",
+)
+```
+
+The category is a short machine-readable token. The rationale must explain why
+the skip remains intentional at the skip site. Existing skips are **not**
+auto-blessed: convert them only after reviewing the skip and adding a local
+rationale. This v1 remains report-only beyond the existing baseline arithmetic;
+it does not fail builds merely because a skip lacks the convention.
+
 ## CI Enforcement
 
 The `skip-audit` job in `.github/workflows/test.yml`:
 
-1. Counts current skip markers
-2. Compares against baseline (`tests/.skip_baseline`)
-3. **Warns** if count increases by 1-5
-4. **Fails** if count increases by >5
+1. Counts total skip markers for reporting
+2. Counts unjustified skip markers for baseline arithmetic
+3. Compares unjustified skips against baseline (`tests/.skip_baseline`)
+4. **Warns** if unjustified skips increase by 1-2
+5. **Fails** if unjustified skips increase by >2
 
 ### Updating the Baseline
 
@@ -73,11 +94,12 @@ When adding legitimate new skips:
 ```bash
 # Check current count
 python scripts/audit_test_skips.py --count-only
+python scripts/audit_test_skips.py --unjustified-count-only
 
 # Review the changes
 python scripts/audit_test_skips.py
 
-# Update baseline (requires justification in commit message)
+# Update unjustified baseline (requires justification in commit message)
 echo "NEW_COUNT" > tests/.skip_baseline
 ```
 
@@ -90,9 +112,20 @@ python scripts/audit_test_skips.py
 # Count only (used by CI)
 python scripts/audit_test_skips.py --count-only
 
+# Unjustified count only (used by baseline arithmetic)
+python scripts/audit_test_skips.py --unjustified-count-only
+
 # List uncategorized skips (need review)
 python scripts/audit_test_skips.py | grep uncategorized
 ```
+
+## Migration Readout
+
+Before tightening enforcement, run `python scripts/audit_test_skips.py --json` and
+review the `unjustified_total`, `by_unjustified_category`, and
+`by_justification_category` fields. Convert only reviewed intentional skips to
+`justified-skip[category]: rationale`; leave uncertain skips unjustified so they
+remain visible in the baseline.
 
 ## Reducing Skip Count
 

--- a/scripts/audit_test_skips.py
+++ b/scripts/audit_test_skips.py
@@ -38,6 +38,9 @@ class SkipMarker:
     reason: str
     category: str
     condition: str | None = None
+    justified: bool = False
+    justification_category: str | None = None
+    justification_rationale: str | None = None
 
 
 # Category patterns - order matters (first match wins)
@@ -150,6 +153,44 @@ CATEGORY_PATTERNS = {
     ],
 }
 
+JUSTIFIED_SKIP_PATTERN = re.compile(
+    r"^\s*justified[-_]skip\[(?P<category>[a-z][a-z0-9_-]*)\]\s*:\s*(?P<rationale>\S.*)$",
+    re.IGNORECASE,
+)
+
+
+def parse_justified_skip(reason: str) -> tuple[str | None, str | None]:
+    """Extract the report-only justified-skip convention from a skip reason."""
+    match = JUSTIFIED_SKIP_PATTERN.match(reason)
+    if not match:
+        return None, None
+
+    return match.group("category").lower(), match.group("rationale").strip()
+
+
+def make_skip_marker(
+    *,
+    file: str,
+    line: int,
+    marker_type: str,
+    reason: str,
+    condition: str | None = None,
+) -> SkipMarker:
+    """Build a SkipMarker with categorization and justified-skip metadata."""
+    justification_category, justification_rationale = parse_justified_skip(reason)
+
+    return SkipMarker(
+        file=file,
+        line=line,
+        marker_type=marker_type,
+        reason=reason,
+        category=categorize_reason(reason),
+        condition=condition,
+        justified=justification_category is not None,
+        justification_category=justification_category,
+        justification_rationale=justification_rationale,
+    )
+
 
 def categorize_reason(reason: str) -> str:
     """Categorize a skip reason based on pattern matching."""
@@ -215,12 +256,11 @@ def parse_decorator(decorator: ast.expr, file_path: str, line: int) -> SkipMarke
                         else:
                             reason = "No reason provided"
 
-                    return SkipMarker(
+                    return make_skip_marker(
                         file=file_path,
                         line=line,
                         marker_type=func.attr,
                         reason=reason,
-                        category=categorize_reason(reason),
                         condition=condition if condition else None,
                     )
 
@@ -232,12 +272,11 @@ def parse_decorator(decorator: ast.expr, file_path: str, line: int) -> SkipMarke
                 and decorator.value.attr == "mark"
                 and decorator.attr == "skip"
             ):
-                return SkipMarker(
+                return make_skip_marker(
                     file=file_path,
                     line=line,
                     marker_type="skip",
                     reason="No reason provided",
-                    category="uncategorized",
                 )
 
     return None
@@ -267,12 +306,11 @@ def find_pytest_skip_calls(tree: ast.AST, file_path: str) -> list[SkipMarker]:
                         reason = "No reason provided"
 
                     markers.append(
-                        SkipMarker(
+                        make_skip_marker(
                             file=file_path,
                             line=node.lineno,
                             marker_type="pytest.skip",
                             reason=reason,
-                            category=categorize_reason(reason),
                         )
                     )
 
@@ -315,12 +353,11 @@ def find_module_level_importorskip(tree: ast.AST, file_path: str) -> SkipMarker 
             if not reason:
                 reason = f"{module_name} not installed" if module_name else "No reason provided"
 
-            return SkipMarker(
+            return make_skip_marker(
                 file=file_path,
                 line=call_node.lineno,
                 marker_type="pytest.importorskip",
                 reason=reason,
-                category=categorize_reason(reason),
             )
 
     return None
@@ -377,17 +414,34 @@ def audit_skips(tests_dir: Path) -> list[SkipMarker]:
 def generate_report(markers: list[SkipMarker]) -> dict:
     """Generate a structured report from skip markers."""
     by_category = defaultdict(list)
+    by_unjustified_category = defaultdict(list)
+    by_justification_category = defaultdict(list)
     by_file = defaultdict(list)
     by_type = defaultdict(int)
+    justified_markers = []
+    unjustified_markers = []
 
     for marker in markers:
         by_category[marker.category].append(marker)
         by_file[marker.file].append(marker)
         by_type[marker.marker_type] += 1
+        if marker.justified:
+            justified_markers.append(marker)
+            if marker.justification_category:
+                by_justification_category[marker.justification_category].append(marker)
+        else:
+            unjustified_markers.append(marker)
+            by_unjustified_category[marker.category].append(marker)
 
     return {
         "total": len(markers),
+        "justified_total": len(justified_markers),
+        "unjustified_total": len(unjustified_markers),
         "by_category": {k: len(v) for k, v in sorted(by_category.items())},
+        "by_unjustified_category": {k: len(v) for k, v in sorted(by_unjustified_category.items())},
+        "by_justification_category": {
+            k: len(v) for k, v in sorted(by_justification_category.items())
+        },
         "by_type": dict(by_type),
         "by_file": {k: len(v) for k, v in sorted(by_file.items(), key=lambda x: -len(x[1]))},
         "high_skip_files": [
@@ -406,8 +460,37 @@ def generate_markdown(report: dict) -> str:
         "",
         f"**Generated**: {report['generated_at'][:10]}",
         f"**Total Skip Markers**: {report['total']}",
+        f"**Justified Skip Markers**: {report['justified_total']}",
+        f"**Unjustified Skip Markers**: {report['unjustified_total']}",
         "",
         "---",
+        "",
+        "## Justified Skip Convention",
+        "",
+        "Use the skip reason prefix `justified-skip[category]: rationale` when a skip",
+        "is intentional and should not count against the unjustified skip baseline.",
+        "",
+        "The category must be a short machine-readable token, and the rationale must",
+        "explain why the skip is intentionally retained at the skip site.",
+        "",
+        "Example:",
+        "",
+        "```python",
+        '@pytest.mark.skipif(not HAS_Z3, reason="justified-skip[optional_dependency]: Z3 solver not installed")',
+        "```",
+        "",
+        "This v1 is report-only: unmarked skips remain visible as unjustified, and",
+        "the total skip count is still reported.",
+        "",
+        "---",
+        "",
+        "## Justified vs Unjustified",
+        "",
+        "| Metric | Count |",
+        "|--------|-------|",
+        f"| Total skip markers | {report['total']} |",
+        f"| Justified skip markers | {report['justified_total']} |",
+        f"| Unjustified skip markers | {report['unjustified_total']} |",
         "",
         "## Summary by Category",
         "",
@@ -419,6 +502,46 @@ def generate_markdown(report: dict) -> str:
     for category, count in sorted(report["by_category"].items(), key=lambda x: -x[1]):
         pct = (count / total * 100) if total > 0 else 0
         lines.append(f"| {category} | {count} | {pct:.1f}% |")
+
+    lines.extend(
+        [
+            "",
+            "## Summary by Unjustified Category",
+            "",
+            "| Category | Count | Percentage of Unjustified |",
+            "|----------|-------|---------------------------|",
+        ]
+    )
+
+    unjustified_total = report["unjustified_total"]
+    if report["by_unjustified_category"]:
+        for category, count in sorted(
+            report["by_unjustified_category"].items(), key=lambda x: -x[1]
+        ):
+            pct = (count / unjustified_total * 100) if unjustified_total > 0 else 0
+            lines.append(f"| {category} | {count} | {pct:.1f}% |")
+    else:
+        lines.append("| _none_ | 0 | 0.0% |")
+
+    lines.extend(
+        [
+            "",
+            "## Summary by Justification Category",
+            "",
+            "| Justification Category | Count | Percentage of Justified |",
+            "|------------------------|-------|-------------------------|",
+        ]
+    )
+
+    justified_total = report["justified_total"]
+    if report["by_justification_category"]:
+        for category, count in sorted(
+            report["by_justification_category"].items(), key=lambda x: -x[1]
+        ):
+            pct = (count / justified_total * 100) if justified_total > 0 else 0
+            lines.append(f"| {category} | {count} | {pct:.1f}% |")
+    else:
+        lines.append("| _none_ | 0 | 0.0% |")
 
     lines.extend(
         [
@@ -467,6 +590,18 @@ def generate_markdown(report: dict) -> str:
             "",
             "---",
             "",
+            "## Migration Readout Plan",
+            "",
+            "1. Run `python scripts/audit_test_skips.py --json` to inspect existing",
+            "   unjustified skip markers.",
+            "2. Convert only reviewed, intentional skips by changing their reason to",
+            "   `justified-skip[category]: rationale`.",
+            "3. Do not auto-bless old skip markers without adding a local rationale.",
+            "4. Keep monitoring total skips and unjustified skips separately before any",
+            "   stronger enforcement is added.",
+            "",
+            "---",
+            "",
             "## Remediation Guidelines",
             "",
             "1. **optional_dependency**: Add to `[project.optional-dependencies.test]` in pyproject.toml",
@@ -480,10 +615,13 @@ def generate_markdown(report: dict) -> str:
             "",
             "## Skip Count Baseline",
             "",
-            f"Current baseline: **{report['total']}** skips",
+            f"Current unjustified baseline: **{report['unjustified_total']}** skips",
+            f"Current total skip count: **{report['total']}** skips",
             "",
-            "CI will warn if skip count exceeds this baseline.",
-            "Update `tests/.skip_baseline` when intentionally adding skips.",
+            "`tests/.skip_baseline` stores the unjustified skip baseline. CI still",
+            "reports total skips, but baseline arithmetic only uses unjustified skips.",
+            "Update `tests/.skip_baseline` only when intentionally adding an",
+            "unjustified skip.",
             "",
         ]
     )
@@ -603,6 +741,11 @@ def _emit_output(output: str) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Audit test skip markers")
     parser.add_argument("--count-only", action="store_true", help="Only output total count")
+    parser.add_argument(
+        "--unjustified-count-only",
+        action="store_true",
+        help="Only output the count of skips without a justified-skip reason",
+    )
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--update-docs", action="store_true", help="Update tests/SKIP_AUDIT.md")
     parser.add_argument(
@@ -653,6 +796,10 @@ def main():
         _emit_output(str(report["total"]))
         return
 
+    if args.unjustified_count_only:
+        _emit_output(str(report["unjustified_total"]))
+        return
+
     if args.json:
         _emit_output(json.dumps(report, indent=2))
         return
@@ -665,12 +812,12 @@ def main():
 
         # Update baseline
         baseline_path = tests_dir / ".skip_baseline"
-        baseline_path.write_text(str(report["total"]))
+        baseline_path.write_text(f"{report['unjustified_total']}\n")
         _emit_output(
             "\n".join(
                 [
                     f"Updated {docs_path}",
-                    f"Updated {baseline_path} with baseline: {report['total']}",
+                    f"Updated {baseline_path} with unjustified baseline: {report['unjustified_total']}",
                 ]
             )
         )
@@ -706,9 +853,33 @@ def main():
         return
 
     # Default: print summary
-    lines = [f"Total skip markers: {report['total']}", "", "By category:"]
+    lines = [
+        f"Total skip markers: {report['total']}",
+        f"Justified skip markers: {report['justified_total']}",
+        f"Unjustified skip markers: {report['unjustified_total']}",
+        "",
+        "By category:",
+    ]
     for category, count in sorted(report["by_category"].items(), key=lambda x: -x[1]):
         lines.append(f"  {category}: {count}")
+
+    lines.extend(["", "By unjustified category:"])
+    if report["by_unjustified_category"]:
+        for category, count in sorted(
+            report["by_unjustified_category"].items(), key=lambda x: -x[1]
+        ):
+            lines.append(f"  {category}: {count}")
+    else:
+        lines.append("  none: 0")
+
+    lines.extend(["", "By justification category:"])
+    if report["by_justification_category"]:
+        for category, count in sorted(
+            report["by_justification_category"].items(), key=lambda x: -x[1]
+        ):
+            lines.append(f"  {category}: {count}")
+    else:
+        lines.append("  none: 0")
 
     lines.extend(["", "By type:"])
     for marker_type, count in sorted(report["by_type"].items(), key=lambda x: -x[1]):

--- a/tests/SKIP_AUDIT.md
+++ b/tests/SKIP_AUDIT.md
@@ -1,9 +1,38 @@
 # Test Skip Marker Audit
 
-**Generated**: 2026-07-04
+**Generated**: 2026-07-05
 **Total Skip Markers**: 77
+**Justified Skip Markers**: 0
+**Unjustified Skip Markers**: 77
 
 ---
+
+## Justified Skip Convention
+
+Use the skip reason prefix `justified-skip[category]: rationale` when a skip
+is intentional and should not count against the unjustified skip baseline.
+
+The category must be a short machine-readable token, and the rationale must
+explain why the skip is intentionally retained at the skip site.
+
+Example:
+
+```python
+@pytest.mark.skipif(not HAS_Z3, reason="justified-skip[optional_dependency]: Z3 solver not installed")
+```
+
+This v1 is report-only: unmarked skips remain visible as unjustified, and
+the total skip count is still reported.
+
+---
+
+## Justified vs Unjustified
+
+| Metric | Count |
+|--------|-------|
+| Total skip markers | 77 |
+| Justified skip markers | 0 |
+| Unjustified skip markers | 77 |
 
 ## Summary by Category
 
@@ -16,6 +45,24 @@
 | platform_specific | 6 | 7.8% |
 | performance | 4 | 5.2% |
 | known_bug | 1 | 1.3% |
+
+## Summary by Unjustified Category
+
+| Category | Count | Percentage of Unjustified |
+|----------|-------|---------------------------|
+| integration_dependency | 29 | 37.7% |
+| missing_feature | 17 | 22.1% |
+| uncategorized | 12 | 15.6% |
+| optional_dependency | 8 | 10.4% |
+| platform_specific | 6 | 7.8% |
+| performance | 4 | 5.2% |
+| known_bug | 1 | 1.3% |
+
+## Summary by Justification Category
+
+| Justification Category | Count | Percentage of Justified |
+|------------------------|-------|-------------------------|
+| _none_ | 0 | 0.0% |
 
 ## Summary by Marker Type
 
@@ -58,6 +105,18 @@
 
 ---
 
+## Migration Readout Plan
+
+1. Run `python scripts/audit_test_skips.py --json` to inspect existing
+   unjustified skip markers.
+2. Convert only reviewed, intentional skips by changing their reason to
+   `justified-skip[category]: rationale`.
+3. Do not auto-bless old skip markers without adding a local rationale.
+4. Keep monitoring total skips and unjustified skips separately before any
+   stronger enforcement is added.
+
+---
+
 ## Remediation Guidelines
 
 1. **optional_dependency**: Add to `[project.optional-dependencies.test]` in pyproject.toml
@@ -71,16 +130,10 @@
 
 ## Skip Count Baseline
 
-Current baseline: **77** skips
+Current unjustified baseline: **77** skips
+Current total skip count: **77** skips
 
-Baseline history: the enforced value lives in `tests/.skip_baseline`
-(68 → 75 in PR #8800, 75 → 77 in the PR that regenerated this file on
-2026-07-04; each bump ships a per-skip audit table of every net-new
-marker in that PR's description). Note on doc-vs-file history: this
-generated document goes stale between bumps — it was regenerated on
-2026-04-06 when the count was 57, so this file's diff once jumped 57→75;
-that reflected staleness, not 18 unaudited skips. The enforced baseline
-has only ever moved 68 → 75 → 77.
-
-CI will warn if skip count exceeds this baseline.
-Update `tests/.skip_baseline` when intentionally adding skips.
+`tests/.skip_baseline` stores the unjustified skip baseline. CI still
+reports total skips, but baseline arithmetic only uses unjustified skips.
+Update `tests/.skip_baseline` only when intentionally adding an
+unjustified skip.

--- a/tests/scripts/test_audit_test_skips.py
+++ b/tests/scripts/test_audit_test_skips.py
@@ -56,7 +56,11 @@ def test_main_json_uses_pipe_safe_emitter(
         "generate_report",
         lambda _markers: {
             "total": 0,
+            "justified_total": 0,
+            "unjustified_total": 0,
             "by_category": {},
+            "by_unjustified_category": {},
+            "by_justification_category": {},
             "by_type": {},
             "by_file": {},
             "high_skip_files": [],
@@ -90,7 +94,11 @@ def test_main_default_summary_uses_pipe_safe_emitter(
         "generate_report",
         lambda _markers: {
             "total": 2,
+            "justified_total": 1,
+            "unjustified_total": 1,
             "by_category": {"known_bug": 1, "optional_dependency": 1},
+            "by_unjustified_category": {"known_bug": 1},
+            "by_justification_category": {"optional_dependency": 1},
             "by_type": {"skip": 2},
             "by_file": {"tests/test_example.py": 2},
             "high_skip_files": [{"file": "tests/test_example.py", "count": 2}],
@@ -103,5 +111,87 @@ def test_main_default_summary_uses_pipe_safe_emitter(
     audit_test_skips.main()
 
     assert "Total skip markers: 2" in emitted[0]
+    assert "Justified skip markers: 1" in emitted[0]
+    assert "Unjustified skip markers: 1" in emitted[0]
     assert "known_bug: 1" in emitted[0]
+    assert "optional_dependency: 1" in emitted[0]
     assert "tests/test_example.py: 2" in emitted[0]
+
+
+def test_generate_report_splits_justified_and_unjustified(tmp_path: Path) -> None:
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    test_file = tests_dir / "test_example.py"
+    test_file.write_text(
+        "\n".join(
+            [
+                "import pytest",
+                "",
+                "@pytest.mark.skip(",
+                '    reason="justified-skip[optional_dependency]: package not installed"',
+                ")",
+                "def test_optional_dep():",
+                "    pass",
+                "",
+                '@pytest.mark.skip(reason="Known bug: GH-123")',
+                "def test_known_bug():",
+                "    pass",
+                "",
+                "def test_runtime_skip():",
+                '    pytest.skip("justified_skip[platform_specific]: symlink unavailable")',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = audit_test_skips.generate_report(audit_test_skips.audit_skips(tests_dir))
+
+    assert report["total"] == 3
+    assert report["justified_total"] == 2
+    assert report["unjustified_total"] == 1
+    assert report["by_justification_category"] == {
+        "optional_dependency": 1,
+        "platform_specific": 1,
+    }
+    assert report["by_unjustified_category"] == {"known_bug": 1}
+
+    justified = [marker for marker in report["markers"] if marker["justified"]]
+    assert justified[0]["justification_rationale"] == "package not installed"
+
+
+def test_main_unjustified_count_only_uses_report_metric(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    emitted = []
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["audit_test_skips.py", "--unjustified-count-only", "--tests-dir", str(tests_dir)],
+    )
+    monkeypatch.setattr(audit_test_skips, "audit_skips", lambda _tests_dir: [])
+    monkeypatch.setattr(
+        audit_test_skips,
+        "generate_report",
+        lambda _markers: {
+            "total": 9,
+            "justified_total": 7,
+            "unjustified_total": 2,
+            "by_category": {},
+            "by_unjustified_category": {},
+            "by_justification_category": {},
+            "by_type": {},
+            "by_file": {},
+            "high_skip_files": [],
+            "markers": [],
+            "generated_at": "2026-06-13T00:00:00",
+        },
+    )
+    monkeypatch.setattr(audit_test_skips, "_emit_output", emitted.append)
+
+    audit_test_skips.main()
+
+    assert emitted == ["2"]


### PR DESCRIPTION
Rescued from a stranded local Codex worktree (completed, validated, unpushed due to a stale steering-mailbox restriction — mailbox now rotated). Implements #8862 (skip-audit redesign from #8856 item 5).

- scripts/audit_test_skips.py: parses `justified-skip[category]: rationale` convention; splits total/justified/unjustified counts across JSON/default/markdown output; adds `--unjustified-count-only` for baseline arithmetic (`--count-only` stays total)
- **⚠️ Tier-4 surface**: updates CI/release skip-baseline checks to compare only unjustified counts — workflow-file edits require operator settlement per repo convention; this stays a PARKED DRAFT until that review
- tests/SKIP_AUDIT.md regenerated; docs/testing/TEST_SKIP_POLICY.md updated; focused tests (5 passing)
- Validation at commit d82c7aab: --count-only=77, --unjustified-count-only=77 (no skips yet migrated to the convention — migration is the follow-up that makes the counts diverge)

Credit: implementation by the Codex fleet lane; rescue + lease-claimed push by the conductor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)