### PR TITLE
feat: report-only dogfood dashboard rescue (#8861)

### DIFF
--- a/docs/status/generated/decision_integrity_dogfood_dashboard/latest.json
+++ b/docs/status/generated/decision_integrity_dogfood_dashboard/latest.json
@@ -1,0 +1,314 @@
+{
+  "generated_at": "2026-07-05T08:36:54Z",
+  "issue": 8861,
+  "known_gaps": [
+    {
+      "gap": "GitHub Search API counts are live, regenerable marker counts; exact audited truth still requires thread-by-thread PR evidence enumeration.",
+      "metric_id": "github_search_counts",
+      "status": "limited"
+    },
+    {
+      "gap": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. This is a phrase marker only; it does not prove the comment SHA matched the PR head.",
+      "metric_id": "exact_head_marker_comments",
+      "status": "limited"
+    },
+    {
+      "gap": "This is only a live phrase-marker proxy. The remaining stronger grounding gap is a per-PR audit that resolves each evidence comment SHA against the actual merged head.",
+      "metric_id": "exact_head_marker_coverage",
+      "status": "limited"
+    },
+    {
+      "gap": "Operator merge-executor receipts are local machine artifacts, not repo-visible public proof.",
+      "metric_id": "operator_local_merge_executor_receipts",
+      "status": "local_only"
+    }
+  ],
+  "metrics": [
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 --jq .total_count",
+      "details": {
+        "count": 495
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "merged_prs",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "495"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"independent model review\" in:comments --jq .total_count",
+      "details": {
+        "count": 462
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with \"independent model review\" comments",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "independent_model_review_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"independent model review\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "462"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"Verdict: PASS\" in:comments --jq .total_count",
+      "details": {
+        "count": 464
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with \"Verdict: PASS\" comments",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "verdict_pass_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"Verdict: PASS\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "464"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"merge-quorum\" in:comments --jq .total_count",
+      "details": {
+        "count": 146
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs mentioning \"merge-quorum\"",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "merge_quorum_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"merge-quorum\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "146"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"CHANGES-REQUESTED\" in:comments --jq .total_count",
+      "details": {
+        "count": 35
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with \"CHANGES-REQUESTED\" comments",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "changes_requested_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"CHANGES-REQUESTED\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "35"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P0]\" in:comments --jq .total_count",
+      "details": {
+        "count": 18
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with [P0] comment markers",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "p0_dissent_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P0]\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "18"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P1]\" in:comments --jq .total_count",
+      "details": {
+        "count": 64
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with [P1] comment markers",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "p1_dissent_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P1]\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "64"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P2]\" in:comments --jq .total_count",
+      "details": {
+        "count": 99
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with [P2] comment markers",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "p2_dissent_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P2]\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "99"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P3]\" in:comments --jq .total_count",
+      "details": {
+        "count": 290
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with [P3] comment markers",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "p3_dissent_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"[P3]\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "290"
+    },
+    {
+      "caveat": "GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. This is a phrase marker only; it does not prove the comment SHA matched the PR head.",
+      "command": "gh api -X GET search/issues -f q=repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"exact-head\" in:comments --jq .total_count",
+      "details": {
+        "count": 427
+      },
+      "error": "",
+      "failure_behavior": "Mark stale after SLA; if the query fails, show failed and rerun manually.",
+      "label": "Merged PRs with \"exact-head\" comment markers",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "exact_head_marker_comments",
+      "source_query": "repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 \"exact-head\" in:comments",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "427"
+    },
+    {
+      "caveat": "Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit.",
+      "command": "n/a",
+      "details": {
+        "denominator": 495,
+        "numerator": 462
+      },
+      "error": "",
+      "failure_behavior": "Derived metric follows the staleness/failure behavior of its inputs.",
+      "label": "Independent-review marker coverage",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "independent_model_review_coverage",
+      "source_query": "derived from independent_model_review_comments/merged_prs",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "462/495 (93.3%)"
+    },
+    {
+      "caveat": "Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit.",
+      "command": "n/a",
+      "details": {
+        "denominator": 495,
+        "numerator": 464
+      },
+      "error": "",
+      "failure_behavior": "Derived metric follows the staleness/failure behavior of its inputs.",
+      "label": "Verdict PASS marker coverage",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "verdict_pass_coverage",
+      "source_query": "derived from verdict_pass_comments/merged_prs",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "464/495 (93.7%)"
+    },
+    {
+      "caveat": "Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit.",
+      "command": "n/a",
+      "details": {
+        "denominator": 495,
+        "numerator": 146
+      },
+      "error": "",
+      "failure_behavior": "Derived metric follows the staleness/failure behavior of its inputs.",
+      "label": "Merge-quorum marker coverage",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "merge_quorum_marker_coverage",
+      "source_query": "derived from merge_quorum_comments/merged_prs",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "146/495 (29.5%)"
+    },
+    {
+      "caveat": "This is only a live phrase-marker proxy. The remaining stronger grounding gap is a per-PR audit that resolves each evidence comment SHA against the actual merged head.",
+      "command": "n/a",
+      "details": {
+        "denominator": 495,
+        "numerator": 427
+      },
+      "error": "",
+      "failure_behavior": "Derived metric follows the staleness/failure behavior of its inputs.",
+      "label": "Exact-head marker coverage",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "exact_head_marker_coverage",
+      "source_query": "derived from exact_head_marker_comments/merged_prs",
+      "stale_after_hours": 24,
+      "status": "limited",
+      "value": "427/495 (86.3%)"
+    },
+    {
+      "caveat": "These are committed settlement receipts, not operator-local merge-executor receipts.",
+      "command": "git fetch origin elves/close-the-loop-20260701; for f in b3-8767-settlement b4-8768-settlement b6-cleanup-batch1; do git show FETCH_HEAD:docs/elves/receipts/$f.json; done; python3 - <<'EOF' ... DecisionReceipt.from_dict(...).verify_integrity() ... EOF",
+      "details": {
+        "failed": [],
+        "verified": [
+          "docs/elves/receipts/b3-8767-settlement.json",
+          "docs/elves/receipts/b4-8768-settlement.json",
+          "docs/elves/receipts/b6-cleanup-batch1.json"
+        ]
+      },
+      "error": "",
+      "failure_behavior": "If any receipt is missing or fails integrity verification, mark the metric failed.",
+      "label": "Committed settlement receipts verified",
+      "last_updated_at": "2026-07-05T08:36:54Z",
+      "metric_id": "settlement_receipts_verified",
+      "source_query": "elves/close-the-loop-20260701:docs/elves/receipts/b3-8767-settlement.json,docs/elves/receipts/b4-8768-settlement.json,docs/elves/receipts/b6-cleanup-batch1.json",
+      "stale_after_hours": 168,
+      "status": "ok",
+      "value": "3/3"
+    },
+    {
+      "caveat": "Operator merge-executor receipts are local machine artifacts, not repo-visible public proof.",
+      "command": "find .aragora/merge_executor/receipts, ~/.aragora/merge-executor-receipts -maxdepth 1 -type f -name '*.json'",
+      "details": {
+        "exact_head_receipt_count": 5,
+        "prs": [
+          8775,
+          8776,
+          8800,
+          8801,
+          8840
+        ],
+        "receipt_count": 5,
+        "roots": [
+          ".aragora/merge_executor/receipts",
+          "~/.aragora/merge-executor-receipts"
+        ]
+      },
+      "error": "",
+      "failure_behavior": "If local paths are absent, mark missing; do not infer public receipt counts from operator-local storage.",
+      "label": "Operator-local merge-executor receipts observed",
+      "last_updated_at": "2026-07-04T21:45:57Z",
+      "metric_id": "operator_local_merge_executor_receipts",
+      "source_query": ".aragora/merge_executor/receipts, ~/.aragora/merge-executor-receipts",
+      "stale_after_hours": 168,
+      "status": "local_only",
+      "value": "5"
+    }
+  ],
+  "repo": "synaptent/aragora",
+  "report_only": true,
+  "schema": "decision-integrity-dogfood-dashboard/v1",
+  "source_artifact": "docs/artifacts/2026-07-decision-integrity-dogfooding.md",
+  "window": {
+    "end": "2026-07-05",
+    "note": "Rolling 30-day GitHub search window using the July artifact query shapes.",
+    "start": "2026-06-05"
+  }
+}

--- a/docs/status/generated/decision_integrity_dogfood_dashboard/latest.md
+++ b/docs/status/generated/decision_integrity_dogfood_dashboard/latest.md
@@ -1,0 +1,73 @@
+# Decision-Integrity Dogfood Dashboard
+
+Last updated: 2026-07-05T08:36:54Z
+
+Report-only generated companion for the frozen July dogfood proof artifact. It does not schedule publishing, mutate queues, post comments, or authorize merges.
+
+## Scope
+
+- Repo: `synaptent/aragora`
+- Tracking issue: `#8861`
+- Source artifact: `docs/artifacts/2026-07-decision-integrity-dogfooding.md`
+- GitHub search window: `2026-06-05`..`2026-07-05`
+- Query shape: reused from the July artifact, with the window made regenerable.
+
+## Metrics
+
+| Metric | Value | Status | Last updated | Source |
+| --- | ---: | --- | --- | --- |
+| Merged PRs | `495` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05` |
+| Merged PRs with "independent model review" comments | `462` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "independent model review" in:comments` |
+| Merged PRs with "Verdict: PASS" comments | `464` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "Verdict: PASS" in:comments` |
+| Merged PRs mentioning "merge-quorum" | `146` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "merge-quorum" in:comments` |
+| Merged PRs with "CHANGES-REQUESTED" comments | `35` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "CHANGES-REQUESTED" in:comments` |
+| Merged PRs with [P0] comment markers | `18` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "[P0]" in:comments` |
+| Merged PRs with [P1] comment markers | `64` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "[P1]" in:comments` |
+| Merged PRs with [P2] comment markers | `99` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "[P2]" in:comments` |
+| Merged PRs with [P3] comment markers | `290` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "[P3]" in:comments` |
+| Merged PRs with "exact-head" comment markers | `427` | `limited` | `2026-07-05T08:36:54Z` | `repo:synaptent/aragora is:pr is:merged merged:2026-06-05..2026-07-05 "exact-head" in:comments` |
+| Independent-review marker coverage | `462/495 (93.3%)` | `limited` | `2026-07-05T08:36:54Z` | `derived from independent_model_review_comments/merged_prs` |
+| Verdict PASS marker coverage | `464/495 (93.7%)` | `limited` | `2026-07-05T08:36:54Z` | `derived from verdict_pass_comments/merged_prs` |
+| Merge-quorum marker coverage | `146/495 (29.5%)` | `limited` | `2026-07-05T08:36:54Z` | `derived from merge_quorum_comments/merged_prs` |
+| Exact-head marker coverage | `427/495 (86.3%)` | `limited` | `2026-07-05T08:36:54Z` | `derived from exact_head_marker_comments/merged_prs` |
+| Committed settlement receipts verified | `3/3` | `ok` | `2026-07-05T08:36:54Z` | `elves/close-the-loop-20260701:docs/elves/receipts/b3-8767-settlement.json,docs/elves/receipts/b4-8768-settlement.json,docs/elves/receipts/b6-cleanup-batch1.json` |
+| Operator-local merge-executor receipts observed | `5` | `local_only` | `2026-07-04T21:45:57Z` | `.aragora/merge_executor/receipts, ~/.aragora/merge-executor-receipts` |
+
+## Stale And Failure Behavior
+
+| Metric | Stale after | Failure behavior | Caveat |
+| --- | ---: | --- | --- |
+| Merged PRs | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with "independent model review" comments | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with "Verdict: PASS" comments | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs mentioning "merge-quorum" | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with "CHANGES-REQUESTED" comments | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with [P0] comment markers | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with [P1] comment markers | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with [P2] comment markers | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with [P3] comment markers | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. |
+| Merged PRs with "exact-head" comment markers | 24h | Mark stale after SLA; if the query fails, show failed and rerun manually. | GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. This is a phrase marker only; it does not prove the comment SHA matched the PR head. |
+| Independent-review marker coverage | 24h | Derived metric follows the staleness/failure behavior of its inputs. | Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit. |
+| Verdict PASS marker coverage | 24h | Derived metric follows the staleness/failure behavior of its inputs. | Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit. |
+| Merge-quorum marker coverage | 24h | Derived metric follows the staleness/failure behavior of its inputs. | Coverage is based on GitHub Search comment markers and is not a thread-by-thread audit. |
+| Exact-head marker coverage | 24h | Derived metric follows the staleness/failure behavior of its inputs. | This is only a live phrase-marker proxy. The remaining stronger grounding gap is a per-PR audit that resolves each evidence comment SHA against the actual merged head. |
+| Committed settlement receipts verified | 168h | If any receipt is missing or fails integrity verification, mark the metric failed. | These are committed settlement receipts, not operator-local merge-executor receipts. |
+| Operator-local merge-executor receipts observed | 168h | If local paths are absent, mark missing; do not infer public receipt counts from operator-local storage. | Operator merge-executor receipts are local machine artifacts, not repo-visible public proof. |
+
+## Local Receipt Notes
+
+- Operator-local exact-head receipts observed: `5`/`5`
+- These local receipts are useful operator proof, but not outsider-verifiable until promoted into repo-visible signed or hash-verifiable artifacts.
+
+## Known Gaps
+
+- `github_search_counts` status `limited`: GitHub Search API counts are live, regenerable marker counts; exact audited truth still requires thread-by-thread PR evidence enumeration.
+- `exact_head_marker_comments` status `limited`: GitHub Search API total_count is a live search-index marker count, not a hand-audited exact truth set. This is a phrase marker only; it does not prove the comment SHA matched the PR head.
+- `exact_head_marker_coverage` status `limited`: This is only a live phrase-marker proxy. The remaining stronger grounding gap is a per-PR audit that resolves each evidence comment SHA against the actual merged head.
+- `operator_local_merge_executor_receipts` status `local_only`: Operator merge-executor receipts are local machine artifacts, not repo-visible public proof.
+
+## Regenerate
+
+```bash
+python3 scripts/render_decision_integrity_dogfood_dashboard.py --output docs/status/generated/decision_integrity_dogfood_dashboard/latest.md --json-output docs/status/generated/decision_integrity_dogfood_dashboard/latest.json
+```

--- a/scripts/render_decision_integrity_dogfood_dashboard.py
+++ b/scripts/render_decision_integrity_dogfood_dashboard.py
@@ -1,0 +1,810 @@
+#!/usr/bin/env python3
+"""Render a report-only live dashboard for the July decision-integrity proof."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+DEFAULT_REPO = "synaptent/aragora"
+SOURCE_ARTIFACT = "docs/artifacts/2026-07-decision-integrity-dogfooding.md"
+DEFAULT_OUTPUT = (
+    REPO_ROOT
+    / "docs"
+    / "status"
+    / "generated"
+    / "decision_integrity_dogfood_dashboard"
+    / "latest.md"
+)
+DEFAULT_JSON_OUTPUT = DEFAULT_OUTPUT.with_suffix(".json")
+SETTLEMENT_RECEIPT_BRANCH = "elves/close-the-loop-20260701"
+SETTLEMENT_RECEIPT_PATHS = (
+    "docs/elves/receipts/b3-8767-settlement.json",
+    "docs/elves/receipts/b4-8768-settlement.json",
+    "docs/elves/receipts/b6-cleanup-batch1.json",
+)
+DEFAULT_LOCAL_MERGE_RECEIPT_ROOTS = (
+    REPO_ROOT / ".aragora" / "merge_executor" / "receipts",
+    Path.home() / ".aragora" / "merge-executor-receipts",
+)
+
+CommandRunner = Callable[[Sequence[str], int], subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class SearchSpec:
+    metric_id: str
+    label: str
+    query: str
+    caveat: str
+
+
+@dataclass
+class DashboardMetric:
+    metric_id: str
+    label: str
+    value: str
+    status: str
+    last_updated_at: str
+    source_query: str
+    command: str
+    stale_after_hours: int
+    failure_behavior: str
+    caveat: str = ""
+    error: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _parse_utc_timestamp(value: str) -> dt.datetime:
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    parsed = dt.datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _iso_z(value: dt.datetime) -> str:
+    return (
+        value.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+
+
+def _default_window(now: dt.datetime) -> tuple[str, str]:
+    end = now.astimezone(dt.timezone.utc).date()
+    start = end - dt.timedelta(days=30)
+    return start.isoformat(), end.isoformat()
+
+
+def _repo_stable_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        pass
+    home = Path.home().resolve()
+    try:
+        return "~/" + resolved.relative_to(home).as_posix()
+    except ValueError:
+        return str(resolved)
+
+
+def _run_command(args: Sequence[str], timeout: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _search_specs(*, repo: str, window_start: str, window_end: str) -> list[SearchSpec]:
+    base = f"repo:{repo} is:pr is:merged merged:{window_start}..{window_end}"
+    search_caveat = (
+        "GitHub Search API total_count is a live search-index marker count, not a "
+        "hand-audited exact truth set."
+    )
+    return [
+        SearchSpec(
+            metric_id="merged_prs",
+            label="Merged PRs",
+            query=base,
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="independent_model_review_comments",
+            label='Merged PRs with "independent model review" comments',
+            query=f'{base} "independent model review" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="verdict_pass_comments",
+            label='Merged PRs with "Verdict: PASS" comments',
+            query=f'{base} "Verdict: PASS" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="merge_quorum_comments",
+            label='Merged PRs mentioning "merge-quorum"',
+            query=f'{base} "merge-quorum" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="changes_requested_comments",
+            label='Merged PRs with "CHANGES-REQUESTED" comments',
+            query=f'{base} "CHANGES-REQUESTED" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="p0_dissent_comments",
+            label="Merged PRs with [P0] comment markers",
+            query=f'{base} "[P0]" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="p1_dissent_comments",
+            label="Merged PRs with [P1] comment markers",
+            query=f'{base} "[P1]" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="p2_dissent_comments",
+            label="Merged PRs with [P2] comment markers",
+            query=f'{base} "[P2]" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="p3_dissent_comments",
+            label="Merged PRs with [P3] comment markers",
+            query=f'{base} "[P3]" in:comments',
+            caveat=search_caveat,
+        ),
+        SearchSpec(
+            metric_id="exact_head_marker_comments",
+            label='Merged PRs with "exact-head" comment markers',
+            query=f'{base} "exact-head" in:comments',
+            caveat=(
+                f"{search_caveat} This is a phrase marker only; it does not prove the "
+                "comment SHA matched the PR head."
+            ),
+        ),
+    ]
+
+
+def _github_search_command(query: str) -> list[str]:
+    return ["gh", "api", "-X", "GET", "search/issues", "-f", f"q={query}", "--jq", ".total_count"]
+
+
+def _apply_staleness(metric: DashboardMetric, *, now: dt.datetime) -> DashboardMetric:
+    if not metric.last_updated_at or metric.status in {"failed", "missing"}:
+        return metric
+    try:
+        updated = _parse_utc_timestamp(metric.last_updated_at)
+    except ValueError:
+        return metric
+    age_hours = (now - updated).total_seconds() / 3600
+    if age_hours <= metric.stale_after_hours:
+        return metric
+    metric.status = "stale"
+    stale_note = (
+        f"Last update is {age_hours:.1f}h old, exceeding the "
+        f"{metric.stale_after_hours}h freshness SLA."
+    )
+    metric.caveat = f"{metric.caveat} {stale_note}".strip()
+    return metric
+
+
+def collect_github_search_metrics(
+    *,
+    repo: str,
+    window_start: str,
+    window_end: str,
+    now: dt.datetime,
+    runner: CommandRunner = _run_command,
+    stale_after_hours: int = 24,
+) -> list[DashboardMetric]:
+    metrics: list[DashboardMetric] = []
+    for spec in _search_specs(repo=repo, window_start=window_start, window_end=window_end):
+        command = _github_search_command(spec.query)
+        proc = runner(command, 120)
+        command_text = " ".join(command)
+        if proc.returncode != 0:
+            metric = DashboardMetric(
+                metric_id=spec.metric_id,
+                label=spec.label,
+                value="n/a",
+                status="failed",
+                last_updated_at="",
+                source_query=spec.query,
+                command=command_text,
+                stale_after_hours=stale_after_hours,
+                failure_behavior="Mark this metric failed; do not carry forward an older count.",
+                caveat=spec.caveat,
+                error=(proc.stderr or proc.stdout or "GitHub search command failed").strip(),
+            )
+            metrics.append(metric)
+            continue
+        try:
+            count = int((proc.stdout or "").strip())
+        except ValueError:
+            metric = DashboardMetric(
+                metric_id=spec.metric_id,
+                label=spec.label,
+                value="n/a",
+                status="failed",
+                last_updated_at="",
+                source_query=spec.query,
+                command=command_text,
+                stale_after_hours=stale_after_hours,
+                failure_behavior="Mark this metric failed; do not carry forward an older count.",
+                caveat=spec.caveat,
+                error=f"Could not parse GitHub search total_count from: {proc.stdout!r}",
+            )
+            metrics.append(metric)
+            continue
+        metric = DashboardMetric(
+            metric_id=spec.metric_id,
+            label=spec.label,
+            value=str(count),
+            status="limited",
+            last_updated_at=_iso_z(now),
+            source_query=spec.query,
+            command=command_text,
+            stale_after_hours=stale_after_hours,
+            failure_behavior="Mark stale after SLA; if the query fails, show failed and rerun manually.",
+            caveat=spec.caveat,
+            details={"count": count},
+        )
+        metrics.append(_apply_staleness(metric, now=now))
+    return metrics
+
+
+def _metric_count(metrics_by_id: dict[str, DashboardMetric], metric_id: str) -> int | None:
+    metric = metrics_by_id.get(metric_id)
+    if not metric or metric.status == "failed":
+        return None
+    count = metric.details.get("count")
+    return count if isinstance(count, int) else None
+
+
+def _coverage_metric(
+    *,
+    metric_id: str,
+    label: str,
+    numerator_id: str,
+    denominator_id: str,
+    metrics_by_id: dict[str, DashboardMetric],
+    now: dt.datetime,
+    caveat: str,
+) -> DashboardMetric:
+    numerator = _metric_count(metrics_by_id, numerator_id)
+    denominator = _metric_count(metrics_by_id, denominator_id)
+    if numerator is None or denominator is None:
+        return DashboardMetric(
+            metric_id=metric_id,
+            label=label,
+            value="n/a",
+            status="failed",
+            last_updated_at="",
+            source_query=f"derived from {numerator_id}/{denominator_id}",
+            command="n/a",
+            stale_after_hours=24,
+            failure_behavior="Derived metric is failed when either input count failed.",
+            caveat=caveat,
+            error="Missing successful input metric.",
+        )
+    value = (
+        "n/a" if denominator == 0 else f"{numerator}/{denominator} ({numerator / denominator:.1%})"
+    )
+    return DashboardMetric(
+        metric_id=metric_id,
+        label=label,
+        value=value,
+        status="limited",
+        last_updated_at=_iso_z(now),
+        source_query=f"derived from {numerator_id}/{denominator_id}",
+        command="n/a",
+        stale_after_hours=24,
+        failure_behavior="Derived metric follows the staleness/failure behavior of its inputs.",
+        caveat=caveat,
+        details={"numerator": numerator, "denominator": denominator},
+    )
+
+
+def build_coverage_metrics(
+    *, search_metrics: list[DashboardMetric], now: dt.datetime
+) -> list[DashboardMetric]:
+    by_id = {metric.metric_id: metric for metric in search_metrics}
+    return [
+        _coverage_metric(
+            metric_id="independent_model_review_coverage",
+            label="Independent-review marker coverage",
+            numerator_id="independent_model_review_comments",
+            denominator_id="merged_prs",
+            metrics_by_id=by_id,
+            now=now,
+            caveat=(
+                "Coverage is based on GitHub Search comment markers and is not a "
+                "thread-by-thread audit."
+            ),
+        ),
+        _coverage_metric(
+            metric_id="verdict_pass_coverage",
+            label="Verdict PASS marker coverage",
+            numerator_id="verdict_pass_comments",
+            denominator_id="merged_prs",
+            metrics_by_id=by_id,
+            now=now,
+            caveat=(
+                "Coverage is based on GitHub Search comment markers and is not a "
+                "thread-by-thread audit."
+            ),
+        ),
+        _coverage_metric(
+            metric_id="merge_quorum_marker_coverage",
+            label="Merge-quorum marker coverage",
+            numerator_id="merge_quorum_comments",
+            denominator_id="merged_prs",
+            metrics_by_id=by_id,
+            now=now,
+            caveat=(
+                "Coverage is based on GitHub Search comment markers and is not a "
+                "thread-by-thread audit."
+            ),
+        ),
+        _coverage_metric(
+            metric_id="exact_head_marker_coverage",
+            label="Exact-head marker coverage",
+            numerator_id="exact_head_marker_comments",
+            denominator_id="merged_prs",
+            metrics_by_id=by_id,
+            now=now,
+            caveat=(
+                "This is only a live phrase-marker proxy. The remaining stronger "
+                "grounding gap is a per-PR audit that resolves each evidence comment "
+                "SHA against the actual merged head."
+            ),
+        ),
+    ]
+
+
+def _artifact_receipt_command() -> str:
+    names = " ".join(path.split("/")[-1].removesuffix(".json") for path in SETTLEMENT_RECEIPT_PATHS)
+    return (
+        f"git fetch origin {SETTLEMENT_RECEIPT_BRANCH}; "
+        f"for f in {names}; do git show FETCH_HEAD:docs/elves/receipts/$f.json; done; "
+        "python3 - <<'EOF' ... DecisionReceipt.from_dict(...).verify_integrity() ... EOF"
+    )
+
+
+def collect_settlement_receipt_metric(
+    *,
+    now: dt.datetime,
+    runner: CommandRunner = _run_command,
+    stale_after_hours: int = 168,
+) -> DashboardMetric:
+    command = _artifact_receipt_command()
+    fetch = runner(["git", "fetch", "origin", SETTLEMENT_RECEIPT_BRANCH], 300)
+    if fetch.returncode != 0:
+        return DashboardMetric(
+            metric_id="settlement_receipts_verified",
+            label="Committed settlement receipts verified",
+            value="n/a",
+            status="failed",
+            last_updated_at="",
+            source_query=f"{SETTLEMENT_RECEIPT_BRANCH}:{','.join(SETTLEMENT_RECEIPT_PATHS)}",
+            command=command,
+            stale_after_hours=stale_after_hours,
+            failure_behavior="Mark failed; receipt proof is not refreshed until the branch fetch succeeds.",
+            error=(fetch.stderr or fetch.stdout or "git fetch failed").strip(),
+        )
+
+    try:
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+    except Exception as exc:
+        return DashboardMetric(
+            metric_id="settlement_receipts_verified",
+            label="Committed settlement receipts verified",
+            value="n/a",
+            status="failed",
+            last_updated_at="",
+            source_query=f"{SETTLEMENT_RECEIPT_BRANCH}:{','.join(SETTLEMENT_RECEIPT_PATHS)}",
+            command=command,
+            stale_after_hours=stale_after_hours,
+            failure_behavior="Mark failed; verifier import must work before publishing the count.",
+            error=f"DecisionReceipt import failed: {exc}",
+        )
+
+    verified: list[str] = []
+    failed: list[dict[str, str]] = []
+    for receipt_path in SETTLEMENT_RECEIPT_PATHS:
+        show = runner(["git", "show", f"FETCH_HEAD:{receipt_path}"], 120)
+        if show.returncode != 0:
+            failed.append(
+                {
+                    "path": receipt_path,
+                    "error": (show.stderr or show.stdout or "git show failed").strip(),
+                }
+            )
+            continue
+        try:
+            payload = json.loads(show.stdout)
+            receipt = DecisionReceipt.from_dict(payload)
+            if receipt.verify_integrity():
+                verified.append(receipt_path)
+            else:
+                failed.append({"path": receipt_path, "error": "verify_integrity returned False"})
+        except Exception as exc:
+            failed.append({"path": receipt_path, "error": str(exc)})
+
+    status = "ok" if not failed else "failed"
+    metric = DashboardMetric(
+        metric_id="settlement_receipts_verified",
+        label="Committed settlement receipts verified",
+        value=f"{len(verified)}/{len(SETTLEMENT_RECEIPT_PATHS)}",
+        status=status,
+        last_updated_at=_iso_z(now) if status == "ok" else "",
+        source_query=f"{SETTLEMENT_RECEIPT_BRANCH}:{','.join(SETTLEMENT_RECEIPT_PATHS)}",
+        command=command,
+        stale_after_hours=stale_after_hours,
+        failure_behavior="If any receipt is missing or fails integrity verification, mark the metric failed.",
+        caveat="These are committed settlement receipts, not operator-local merge-executor receipts.",
+        error="; ".join(f"{item['path']}: {item['error']}" for item in failed),
+        details={"verified": verified, "failed": failed},
+    )
+    return _apply_staleness(metric, now=now)
+
+
+def _load_merge_executor_receipt(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema") != "merge-executor-receipt/v1":
+        return None
+    return payload
+
+
+def collect_local_merge_executor_receipt_metric(
+    *,
+    now: dt.datetime,
+    receipt_roots: Sequence[Path] = DEFAULT_LOCAL_MERGE_RECEIPT_ROOTS,
+    stale_after_hours: int = 168,
+) -> DashboardMetric:
+    receipt_paths: list[Path] = []
+    valid_payloads: list[dict[str, Any]] = []
+    for root in receipt_roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.glob("*.json")):
+            payload = _load_merge_executor_receipt(path)
+            if payload is None:
+                continue
+            receipt_paths.append(path)
+            valid_payloads.append(payload)
+
+    exact_head_count = 0
+    newest_mtime: float | None = None
+    prs: list[int] = []
+    for path, payload in zip(receipt_paths, valid_payloads, strict=True):
+        try:
+            newest_mtime = max(newest_mtime or 0.0, path.stat().st_mtime)
+        except OSError:
+            pass
+        if isinstance(payload.get("pr"), int):
+            prs.append(int(payload["pr"]))
+        head_sha = str(payload.get("head_sha") or "").strip()
+        packet = (
+            payload.get("packet_entry") if isinstance(payload.get("packet_entry"), dict) else {}
+        )
+        packet_head = str(packet.get("head_sha") or "").strip()
+        if head_sha and packet_head and head_sha == packet_head:
+            exact_head_count += 1
+
+    if newest_mtime is not None:
+        last_updated = _iso_z(dt.datetime.fromtimestamp(newest_mtime, tz=dt.timezone.utc))
+    else:
+        last_updated = _iso_z(now)
+    root_text = ", ".join(_display_path(root) for root in receipt_roots)
+    command = f"find {root_text} -maxdepth 1 -type f -name '*.json'"
+    status = "local_only" if receipt_paths else "missing"
+    value = str(len(receipt_paths)) if receipt_paths else "0"
+    metric = DashboardMetric(
+        metric_id="operator_local_merge_executor_receipts",
+        label="Operator-local merge-executor receipts observed",
+        value=value,
+        status=status,
+        last_updated_at=last_updated,
+        source_query=root_text,
+        command=command,
+        stale_after_hours=stale_after_hours,
+        failure_behavior=(
+            "If local paths are absent, mark missing; do not infer public receipt counts from "
+            "operator-local storage."
+        ),
+        caveat=(
+            "Operator merge-executor receipts are local machine artifacts, not repo-visible "
+            "public proof."
+        ),
+        details={
+            "roots": [_display_path(root) for root in receipt_roots],
+            "receipt_count": len(receipt_paths),
+            "exact_head_receipt_count": exact_head_count,
+            "prs": sorted(prs),
+        },
+    )
+    return _apply_staleness(metric, now=now)
+
+
+def build_payload(
+    *,
+    repo: str,
+    window_start: str,
+    window_end: str,
+    now: dt.datetime,
+    runner: CommandRunner = _run_command,
+    receipt_roots: Sequence[Path] = DEFAULT_LOCAL_MERGE_RECEIPT_ROOTS,
+) -> dict[str, Any]:
+    search_metrics = collect_github_search_metrics(
+        repo=repo,
+        window_start=window_start,
+        window_end=window_end,
+        now=now,
+        runner=runner,
+    )
+    metrics = [
+        *search_metrics,
+        *build_coverage_metrics(search_metrics=search_metrics, now=now),
+        collect_settlement_receipt_metric(now=now, runner=runner),
+        collect_local_merge_executor_receipt_metric(now=now, receipt_roots=receipt_roots),
+    ]
+    known_gaps = [
+        {
+            "metric_id": "github_search_counts",
+            "status": "limited",
+            "gap": (
+                "GitHub Search API counts are live, regenerable marker counts; exact audited "
+                "truth still requires thread-by-thread PR evidence enumeration."
+            ),
+        }
+    ]
+    for metric in metrics:
+        is_true_gap = metric.status in {
+            "failed",
+            "missing",
+            "local_only",
+            "stale",
+        } or metric.metric_id in {
+            "exact_head_marker_comments",
+            "exact_head_marker_coverage",
+        }
+        if is_true_gap and (metric.error or metric.caveat):
+            known_gaps.append(
+                {
+                    "metric_id": metric.metric_id,
+                    "status": metric.status,
+                    "gap": metric.error or metric.caveat,
+                }
+            )
+    return {
+        "schema": "decision-integrity-dogfood-dashboard/v1",
+        "generated_at": _iso_z(now),
+        "report_only": True,
+        "repo": repo,
+        "issue": 8861,
+        "source_artifact": SOURCE_ARTIFACT,
+        "window": {
+            "start": window_start,
+            "end": window_end,
+            "note": "Rolling 30-day GitHub search window using the July artifact query shapes.",
+        },
+        "metrics": [asdict(metric) for metric in metrics],
+        "known_gaps": known_gaps,
+    }
+
+
+def _format_value(value: Any) -> str:
+    if value is None or value == "":
+        return "n/a"
+    return str(value)
+
+
+def _render_metric_table(metrics: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "| Metric | Value | Status | Last updated | Source |",
+        "| --- | ---: | --- | --- | --- |",
+    ]
+    for metric in metrics:
+        source = str(metric.get("source_query") or "").replace("|", "\\|")
+        lines.append(
+            "| "
+            f"{_format_value(metric.get('label'))} | "
+            f"`{_format_value(metric.get('value'))}` | "
+            f"`{_format_value(metric.get('status'))}` | "
+            f"`{_format_value(metric.get('last_updated_at'))}` | "
+            f"`{source}` |"
+        )
+    return lines
+
+
+def _render_metric_behavior(metrics: list[dict[str, Any]]) -> list[str]:
+    lines = [
+        "| Metric | Stale after | Failure behavior | Caveat |",
+        "| --- | ---: | --- | --- |",
+    ]
+    for metric in metrics:
+        caveat = str(metric.get("caveat") or "").replace("|", "\\|")
+        failure = str(metric.get("failure_behavior") or "").replace("|", "\\|")
+        lines.append(
+            "| "
+            f"{_format_value(metric.get('label'))} | "
+            f"{_format_value(metric.get('stale_after_hours'))}h | "
+            f"{failure} | "
+            f"{caveat or '-'} |"
+        )
+    return lines
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    metrics = [metric for metric in payload.get("metrics", []) if isinstance(metric, dict)]
+    gaps = [gap for gap in payload.get("known_gaps", []) if isinstance(gap, dict)]
+    local_receipts = next(
+        (
+            metric
+            for metric in metrics
+            if metric.get("metric_id") == "operator_local_merge_executor_receipts"
+        ),
+        {},
+    )
+    local_details = local_receipts.get("details") if isinstance(local_receipts, dict) else {}
+    if not isinstance(local_details, dict):
+        local_details = {}
+
+    lines = [
+        "# Decision-Integrity Dogfood Dashboard",
+        "",
+        f"Last updated: {payload.get('generated_at', 'unknown')}",
+        "",
+        "Report-only generated companion for the frozen July dogfood proof artifact. It does not schedule publishing, mutate queues, post comments, or authorize merges.",
+        "",
+        "## Scope",
+        "",
+        f"- Repo: `{payload.get('repo', DEFAULT_REPO)}`",
+        f"- Tracking issue: `#{payload.get('issue', 8861)}`",
+        f"- Source artifact: `{payload.get('source_artifact', SOURCE_ARTIFACT)}`",
+        (
+            f"- GitHub search window: `{payload.get('window', {}).get('start')}`.."
+            f"`{payload.get('window', {}).get('end')}`"
+        ),
+        "- Query shape: reused from the July artifact, with the window made regenerable.",
+        "",
+        "## Metrics",
+        "",
+        *_render_metric_table(metrics),
+        "",
+        "## Stale And Failure Behavior",
+        "",
+        *_render_metric_behavior(metrics),
+        "",
+        "## Local Receipt Notes",
+        "",
+        (
+            "- Operator-local exact-head receipts observed: "
+            f"`{local_details.get('exact_head_receipt_count', 0)}`/"
+            f"`{local_details.get('receipt_count', 0)}`"
+        ),
+        "- These local receipts are useful operator proof, but not outsider-verifiable until promoted into repo-visible signed or hash-verifiable artifacts.",
+        "",
+        "## Known Gaps",
+        "",
+    ]
+    if gaps:
+        for gap in gaps:
+            lines.append(
+                f"- `{gap.get('metric_id')}` status `{gap.get('status')}`: {gap.get('gap')}"
+            )
+    else:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "## Regenerate",
+            "",
+            "```bash",
+            (
+                "python3 scripts/render_decision_integrity_dogfood_dashboard.py "
+                f"--output {_repo_stable_path(DEFAULT_OUTPUT)} "
+                f"--json-output {_repo_stable_path(DEFAULT_JSON_OUTPUT)}"
+            ),
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_dashboard(
+    *, payload: dict[str, Any], output: Path, json_output: Path
+) -> tuple[Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    json_output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(render_markdown(payload), encoding="utf-8")
+    json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output, json_output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--window-start", default="")
+    parser.add_argument("--window-end", default="")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Markdown dashboard output path (default: {DEFAULT_OUTPUT})",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=DEFAULT_JSON_OUTPUT,
+        help=f"JSON dashboard output path (default: {DEFAULT_JSON_OUTPUT})",
+    )
+    parser.add_argument(
+        "--now",
+        default="",
+        help="UTC timestamp override for deterministic tests, for example 2026-07-05T12:00:00Z",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    now = _parse_utc_timestamp(args.now) if args.now else _utcnow()
+    default_start, default_end = _default_window(now)
+    window_start = args.window_start or default_start
+    window_end = args.window_end or default_end
+    payload = build_payload(
+        repo=str(args.repo),
+        window_start=window_start,
+        window_end=window_end,
+        now=now,
+    )
+    output, json_output = write_dashboard(
+        payload=payload,
+        output=args.output.resolve(),
+        json_output=args.json_output.resolve(),
+    )
+    print(str(output))
+    print(str(json_output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_render_decision_integrity_dogfood_dashboard.py
+++ b/tests/scripts/test_render_decision_integrity_dogfood_dashboard.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_scripts_dir = str(_REPO_ROOT / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import render_decision_integrity_dogfood_dashboard as mod  # noqa: E402
+
+from aragora.gauntlet.receipt_models import DecisionReceipt  # noqa: E402
+
+
+def _completed(
+    args: Sequence[str],
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(list(args), returncode, stdout=stdout, stderr=stderr)
+
+
+def _valid_receipt_payload(receipt_id: str) -> dict[str, object]:
+    receipt = DecisionReceipt(
+        receipt_id=receipt_id,
+        gauntlet_id=f"gauntlet-{receipt_id}",
+        timestamp="2026-07-02T00:00:00Z",
+        input_summary="settlement",
+        input_hash="input-hash",
+        risk_summary={"critical": 0, "high": 0, "medium": 0, "low": 0},
+        attacks_attempted=0,
+        attacks_successful=0,
+        probes_run=0,
+        vulnerabilities_found=0,
+        verdict="PASS",
+        confidence=0.9,
+        robustness_score=1.0,
+    )
+    return receipt.to_dict()
+
+
+class _FakeRunner:
+    def __init__(self) -> None:
+        self.commands: list[list[str]] = []
+        self.receipts = {
+            path: json.dumps(_valid_receipt_payload(path.split("/")[-1]))
+            for path in mod.SETTLEMENT_RECEIPT_PATHS
+        }
+
+    def __call__(self, args: Sequence[str], timeout: int) -> subprocess.CompletedProcess[str]:
+        del timeout
+        command = list(args)
+        self.commands.append(command)
+        if command[:5] == ["gh", "api", "-X", "GET", "search/issues"]:
+            query = next(item.removeprefix("q=") for item in command if item.startswith("q="))
+            if query.endswith("is:merged merged:2026-06-05..2026-07-05"):
+                return _completed(command, stdout="10\n")
+            if '"independent model review"' in query:
+                return _completed(command, stdout="8\n")
+            if '"Verdict: PASS"' in query:
+                return _completed(command, stdout="7\n")
+            if '"merge-quorum"' in query:
+                return _completed(command, stdout="6\n")
+            if '"CHANGES-REQUESTED"' in query:
+                return _completed(command, stdout="3\n")
+            if '"[P0]"' in query:
+                return _completed(command, stdout="0\n")
+            if '"[P1]"' in query:
+                return _completed(command, stdout="2\n")
+            if '"[P2]"' in query:
+                return _completed(command, stdout="4\n")
+            if '"[P3]"' in query:
+                return _completed(command, stdout="1\n")
+            if '"exact-head"' in query:
+                return _completed(command, stdout="5\n")
+            return _completed(command, stdout="0\n")
+        if command == ["git", "fetch", "origin", mod.SETTLEMENT_RECEIPT_BRANCH]:
+            return _completed(command, stdout="")
+        if command[:2] == ["git", "show"]:
+            path = command[2].removeprefix("FETCH_HEAD:")
+            return _completed(command, stdout=self.receipts[path])
+        return _completed(command, returncode=1, stderr="unexpected command")
+
+
+def _metric(payload: dict[str, object], metric_id: str) -> dict[str, object]:
+    metrics = payload["metrics"]
+    assert isinstance(metrics, list)
+    for item in metrics:
+        assert isinstance(item, dict)
+        if item["metric_id"] == metric_id:
+            return item
+    raise AssertionError(f"missing metric {metric_id}")
+
+
+def test_build_payload_collects_report_only_metrics_and_receipts(tmp_path: Path) -> None:
+    receipt_root = tmp_path / "receipts"
+    receipt_root.mkdir()
+    (receipt_root / "MERGE_EXECUTOR_RECEIPT_20260705T000000Z_PR9001.json").write_text(
+        json.dumps(
+            {
+                "schema": "merge-executor-receipt/v1",
+                "pr": 9001,
+                "head_sha": "abc123",
+                "packet_entry": {"head_sha": "abc123"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (receipt_root / "ignore.json").write_text('{"schema":"other"}', encoding="utf-8")
+    runner = _FakeRunner()
+
+    payload = mod.build_payload(
+        repo="synaptent/aragora",
+        window_start="2026-06-05",
+        window_end="2026-07-05",
+        now=mod._parse_utc_timestamp("2026-07-05T12:00:00Z"),
+        runner=runner,
+        receipt_roots=[receipt_root],
+    )
+
+    assert payload["report_only"] is True
+    assert _metric(payload, "merged_prs")["value"] == "10"
+    assert _metric(payload, "independent_model_review_coverage")["value"] == "8/10 (80.0%)"
+    assert _metric(payload, "exact_head_marker_coverage")["value"] == "5/10 (50.0%)"
+    assert _metric(payload, "settlement_receipts_verified")["value"] == "3/3"
+    local = _metric(payload, "operator_local_merge_executor_receipts")
+    assert local["value"] == "1"
+    details = local["details"]
+    assert isinstance(details, dict)
+    assert details["exact_head_receipt_count"] == 1
+    assert all(command[:3] != ["gh", "issue", "comment"] for command in runner.commands)
+    assert all(command[:3] != ["gh", "pr", "comment"] for command in runner.commands)
+
+
+def test_search_command_failure_marks_metric_failed() -> None:
+    def failing_runner(args: Sequence[str], timeout: int) -> subprocess.CompletedProcess[str]:
+        del timeout
+        return _completed(args, returncode=1, stderr="rate limited")
+
+    metrics = mod.collect_github_search_metrics(
+        repo="synaptent/aragora",
+        window_start="2026-06-05",
+        window_end="2026-07-05",
+        now=mod._parse_utc_timestamp("2026-07-05T12:00:00Z"),
+        runner=failing_runner,
+    )
+
+    assert metrics
+    assert {metric.status for metric in metrics} == {"failed"}
+    assert all("do not carry forward" in metric.failure_behavior for metric in metrics)
+    assert all(metric.error == "rate limited" for metric in metrics)
+
+
+def test_stale_metric_is_labeled_without_changing_value() -> None:
+    metric = mod.DashboardMetric(
+        metric_id="x",
+        label="X",
+        value="42",
+        status="ok",
+        last_updated_at="2026-07-01T00:00:00Z",
+        source_query="query",
+        command="command",
+        stale_after_hours=24,
+        failure_behavior="fail closed",
+    )
+
+    out = mod._apply_staleness(
+        metric,
+        now=mod._parse_utc_timestamp("2026-07-05T00:00:00Z"),
+    )
+
+    assert out.value == "42"
+    assert out.status == "stale"
+    assert "freshness SLA" in out.caveat
+
+
+def test_render_markdown_surfaces_gap_and_regenerate_command() -> None:
+    payload = {
+        "generated_at": "2026-07-05T12:00:00Z",
+        "repo": "synaptent/aragora",
+        "issue": 8861,
+        "source_artifact": mod.SOURCE_ARTIFACT,
+        "window": {"start": "2026-06-05", "end": "2026-07-05"},
+        "metrics": [
+            {
+                "metric_id": "operator_local_merge_executor_receipts",
+                "label": "Operator-local merge-executor receipts observed",
+                "value": "0",
+                "status": "missing",
+                "last_updated_at": "2026-07-05T12:00:00Z",
+                "source_query": "/tmp/receipts",
+                "command": "find /tmp/receipts",
+                "stale_after_hours": 168,
+                "failure_behavior": "mark missing",
+                "caveat": "local-only",
+                "details": {"receipt_count": 0, "exact_head_receipt_count": 0},
+            }
+        ],
+        "known_gaps": [
+            {
+                "metric_id": "exact_head_marker_coverage",
+                "status": "limited",
+                "gap": "phrase-marker proxy only",
+            }
+        ],
+    }
+
+    markdown = mod.render_markdown(payload)
+
+    assert "# Decision-Integrity Dogfood Dashboard" in markdown
+    assert "Report-only generated companion" in markdown
+    assert "`exact_head_marker_coverage` status `limited`: phrase-marker proxy only" in markdown
+    assert "python3 scripts/render_decision_integrity_dogfood_dashboard.py" in markdown


### PR DESCRIPTION
## Summary
- Rescues the report-only decision-integrity dogfood dashboard work for #8861 from the shared checkout into an isolated branch.
- Adds the renderer, focused tests, and generated JSON/Markdown dashboard outputs.
- Leaves the original untracked shared-checkout copies untouched for operator safety.

## Validation
- python -m pytest tests/scripts/test_render_decision_integrity_dogfood_dashboard.py -q (4 passed, 8 existing deprecation warnings)
- bash scripts/automation_pr_preflight.sh origin/main HEAD (preflight: ok)
- pre-commit hooks during commit and push passed

## Coordination
- origin/main base: 04ca641e77cc866c1baff916f457562b488da1c7
- Lease claimed before push: ec962244-1e4 via scripts/check_work_lease.py codex/8861-dogfood-dashboard-rescue --claim
