### PR TITLE
docs(onboarding): separate PyPI demo from source receipt verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ standalone verifier ([`pip install -U 'aragora-verify>=0.1.1'`](https://pypi.org
 
 PyPI `aragora` releases through 2.7.4 support `aragora demo`, but they do not
 include the explicit `--offline` flag or the source checkout's verifiable
-native demo-receipt round trip.
+native demo-receipt round trip. If that public-package demo writes
+`aragora-demo-receipt.json`, treat it as demo output, not the verification
+example; use the source checkout path below for `receipt verify`.
 
 ## The problem
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ standalone verifier ([`pip install -U 'aragora-verify>=0.1.1'`](https://pypi.org
 | Call the Aragora API from Python | `pip install aragora-sdk` |
 | Self-host the full platform | `docker compose -f deploy/demo/docker-compose.yml up` |
 
-As of 2026-07-05, the latest PyPI `aragora` package is 2.7.4: it supports
-`aragora demo`, but it does not yet include the explicit `--offline` flag or
-the source checkout's verifiable native demo-receipt round trip.
+The PyPI `aragora` package at 2.7.4 supports `aragora demo`, but it does not
+include the explicit `--offline` flag or the source checkout's verifiable
+native demo-receipt round trip.
 
 ## The problem
 
@@ -96,15 +96,24 @@ evidence, with reproducible queries and caught-bug case studies:
 
 ## Try it now
 
+Current PyPI package:
+
 ```bash
 pip install aragora
-aragora demo                        # zero-key demo in the current PyPI package
+aragora demo                        # no provider key needed; uses offline mocks when no key is set
+```
 
-# Current source checkout: verifiable native demo receipt
+Current source checkout:
+
+```bash
 python3 -m pip install -e .
 aragora demo --offline --receipt aragora-demo-receipt.json
 aragora receipt verify aragora-demo-receipt.json
+```
 
+Live review with a provider key:
+
+```bash
 export ANTHROPIC_API_KEY=...        # provider credential for live model review
 aragora review-pr 123               # multi-agent review of a GitHub PR
 aragora receipt export <id> --format odr -o receipt.odr.json   # portable receipt

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ standalone verifier ([`pip install -U 'aragora-verify>=0.1.1'`](https://pypi.org
 | Run the standalone debate engine | `pip install aragora-debate` |
 | Verify an Open Decision Receipt with the standalone verifier | `pip install -U 'aragora-verify>=0.1.1' && aragora-verify receipt.odr.json` |
 | Run the current PyPI zero-key demo | `pip install aragora && aragora demo` |
-| See a native debate → receipt → verify loop in ~15 seconds, no API keys, from a current source checkout | `python3 -m pip install -e . && aragora demo --offline --receipt aragora-demo-receipt.json && aragora receipt verify aragora-demo-receipt.json` |
+| See a native debate → receipt → verify loop from a current source checkout | `python3 -m pip install -e . && aragora demo --offline --receipt aragora-demo-receipt.json && aragora receipt verify aragora-demo-receipt.json` |
 | Call the Aragora API from Python | `pip install aragora-sdk` |
 | Self-host the full platform | `docker compose -f deploy/demo/docker-compose.yml up` |
 
-The PyPI `aragora` package at 2.7.4 supports `aragora demo`, but it does not
+PyPI `aragora` releases through 2.7.4 support `aragora demo`, but they do not
 include the explicit `--offline` flag or the source checkout's verifiable
 native demo-receipt round trip.
 
@@ -100,7 +100,7 @@ Current PyPI package:
 
 ```bash
 pip install aragora
-aragora demo                        # no provider key needed; uses offline mocks when no key is set
+aragora demo                        # no provider key required in PyPI 2.7.4
 ```
 
 Current source checkout:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ standalone verifier ([`pip install -U 'aragora-verify>=0.1.1'`](https://pypi.org
 |------------|---------|
 | Run the standalone debate engine | `pip install aragora-debate` |
 | Verify an Open Decision Receipt with the standalone verifier | `pip install -U 'aragora-verify>=0.1.1' && aragora-verify receipt.odr.json` |
-| See a native debate → receipt → verify loop in ~15 seconds, no API keys | `pip install aragora && aragora demo --offline && aragora verify aragora-demo-receipt.json` |
+| Run the current PyPI zero-key demo | `pip install aragora && aragora demo` |
+| See a native debate → receipt → verify loop in ~15 seconds, no API keys, from a current source checkout | `python3 -m pip install -e . && aragora demo --offline --receipt aragora-demo-receipt.json && aragora receipt verify aragora-demo-receipt.json` |
 | Call the Aragora API from Python | `pip install aragora-sdk` |
 | Self-host the full platform | `docker compose -f deploy/demo/docker-compose.yml up` |
+
+As of 2026-07-05, the latest PyPI `aragora` package is 2.7.4: it supports
+`aragora demo`, but it does not yet include the explicit `--offline` flag or
+the source checkout's verifiable native demo-receipt round trip.
 
 ## The problem
 
@@ -93,7 +98,12 @@ evidence, with reproducible queries and caught-bug case studies:
 
 ```bash
 pip install aragora
-aragora demo --offline              # zero-key debate, writes a local receipt
+aragora demo                        # zero-key demo in the current PyPI package
+
+# Current source checkout: verifiable native demo receipt
+python3 -m pip install -e .
+aragora demo --offline --receipt aragora-demo-receipt.json
+aragora receipt verify aragora-demo-receipt.json
 
 export ANTHROPIC_API_KEY=...        # provider credential for live model review
 aragora review-pr 123               # multi-agent review of a GitHub PR

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,7 +119,9 @@ aragora receipt verify aragora-demo-receipt.json
 
 PyPI `aragora` releases through 2.7.4 run `aragora demo`, but the explicit
 `--offline` flag and verifiable native demo-receipt round trip are available
-from source until a later package release carries them.
+from source until a later package release carries them. If the public-package
+demo writes `aragora-demo-receipt.json`, treat it as demo output, not the
+verification example; use the source checkout path above for `receipt verify`.
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,13 +100,27 @@ Then visit:
 
 ## 7. CLI
 
+Current PyPI package:
+
 ```bash
 pip install aragora
-aragora demo                                            # zero-key offline demo + receipt
+aragora demo                                            # zero-key offline demo
 aragora ask "Should we build or buy our auth system?"   # real debate (needs an API key)
-aragora verify aragora-demo-receipt.json                # verify a receipt offline
 aragora serve --api-port 8080 --ws-port 8765
 ```
+
+Current source checkout:
+
+```bash
+python3 -m pip install -e .
+aragora demo --offline --receipt aragora-demo-receipt.json
+aragora receipt verify aragora-demo-receipt.json
+```
+
+As of 2026-07-05, the latest PyPI `aragora` package is 2.7.4: it runs
+`aragora demo`, but the explicit `--offline` flag and verifiable native
+demo-receipt round trip are available from source until the next package
+release carries them.
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ Current PyPI package:
 
 ```bash
 pip install aragora
-aragora demo                                            # no provider key needed; uses offline mocks when no key is set
+aragora demo                                            # no provider key required in PyPI 2.7.4
 aragora ask "Should we build or buy our auth system?"   # real debate (needs an API key)
 aragora serve --api-port 8080 --ws-port 8765
 ```
@@ -117,9 +117,9 @@ aragora demo --offline --receipt aragora-demo-receipt.json
 aragora receipt verify aragora-demo-receipt.json
 ```
 
-The PyPI `aragora` package at 2.7.4 runs `aragora demo`, but the explicit
+PyPI `aragora` releases through 2.7.4 run `aragora demo`, but the explicit
 `--offline` flag and verifiable native demo-receipt round trip are available
-from source until the next package release carries them.
+from source until a later package release carries them.
 
 ## Next Steps
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ Current PyPI package:
 
 ```bash
 pip install aragora
-aragora demo                                            # zero-key offline demo
+aragora demo                                            # no provider key needed; uses offline mocks when no key is set
 aragora ask "Should we build or buy our auth system?"   # real debate (needs an API key)
 aragora serve --api-port 8080 --ws-port 8765
 ```
@@ -117,10 +117,9 @@ aragora demo --offline --receipt aragora-demo-receipt.json
 aragora receipt verify aragora-demo-receipt.json
 ```
 
-As of 2026-07-05, the latest PyPI `aragora` package is 2.7.4: it runs
-`aragora demo`, but the explicit `--offline` flag and verifiable native
-demo-receipt round trip are available from source until the next package
-release carries them.
+The PyPI `aragora` package at 2.7.4 runs `aragora demo`, but the explicit
+`--offline` flag and verifiable native demo-receipt round trip are available
+from source until the next package release carries them.
 
 ## Next Steps
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -249,6 +249,16 @@ class TestArgumentParser:
         args = parser.parse_args(["demo", "rate-limiter"])
         assert args.name == "rate-limiter"
 
+    def test_real_parser_accepts_demo_offline_receipt_path(self):
+        """The public demo round-trip flags must stay wired on the real parser."""
+        parser = cli_parser.build_parser()
+
+        args = parser.parse_args(["demo", "--offline", "--receipt", "aragora-demo-receipt.json"])
+
+        assert args.command == "demo"
+        assert args.offline is True
+        assert args.receipt == "aragora-demo-receipt.json"
+
     def test_parse_serve_command(self, parser):
         """Should parse serve command with defaults."""
         args = parser.parse_args(["serve"])

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -31,6 +31,11 @@ def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
         "Current PyPI package:",
         "Current source checkout:",
     )
+    source_try_it_now = _section_between(
+        readme,
+        "Current source checkout:",
+        "Live review with a provider key:",
+    )
     pypi_table_row = _line_containing(readme, "Run the current PyPI zero-key demo")
 
     assert "pip install aragora && aragora demo --offline" not in readme
@@ -46,6 +51,9 @@ def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
     assert "aragora verify" not in pypi_try_it_now
     assert "Current source checkout:" in readme
     assert "PyPI `aragora` releases through" in readme
+    assert re.search(r"demo output,\s+not the\s+verification\s+example", readme)
+    assert "aragora demo --offline --receipt aragora-demo-receipt.json" in source_try_it_now
+    assert "aragora receipt verify aragora-demo-receipt.json" in source_try_it_now
 
 
 def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> None:
@@ -69,3 +77,4 @@ def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> No
     assert "aragora demo --offline --receipt aragora-demo-receipt.json" in source_section
     assert "aragora receipt verify aragora-demo-receipt.json" in source_section
     assert "PyPI `aragora` releases through" in quickstart
+    assert re.search(r"demo output,\s+not the\s+verification\s+example", quickstart)

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -4,23 +4,48 @@ These tests keep the README/quickstart from advertising an unreleased PyPI
 path as if it were available in the current public package.
 """
 
+import re
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _section_between(text: str, start: str, end: str) -> str:
+    after_start = text.split(start, 1)[1]
+    return after_start.split(end, 1)[0]
+
+
 def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
     readme = (REPO_ROOT / "README.md").read_text()
+    pypi_try_it_now = _section_between(
+        readme,
+        "Current PyPI package:",
+        "Current source checkout:",
+    )
 
     assert "pip install aragora && aragora demo --offline" not in readme
+    assert re.search(r"pip install aragora\s*&&\s*aragora demo --offline", readme) is None
+    assert "--offline" not in pypi_try_it_now
+    assert "receipt verify" not in pypi_try_it_now
+    assert "aragora verify" not in pypi_try_it_now
     assert "current source checkout" in readme
     assert "PyPI `aragora` package" in readme
 
 
 def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> None:
     quickstart = (REPO_ROOT / "docs" / "quickstart.md").read_text()
+    pypi_section = _section_between(
+        quickstart,
+        "Current PyPI package:",
+        "Current source checkout:",
+    )
+    source_section = quickstart.split("Current source checkout:", 1)[1]
 
     assert "Current PyPI package" in quickstart
     assert "Current source checkout" in quickstart
-    assert "aragora receipt verify aragora-demo-receipt.json" in quickstart
+    assert "--offline" not in pypi_section
+    assert "receipt verify" not in pypi_section
+    assert "aragora verify" not in pypi_section
+    assert "aragora demo --offline --receipt aragora-demo-receipt.json" in source_section
+    assert "aragora receipt verify aragora-demo-receipt.json" in source_section

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -1,0 +1,26 @@
+"""Guards for public first-run demo documentation.
+
+These tests keep the README/quickstart from advertising an unreleased PyPI
+path as if it were available in the current public package.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
+    readme = (REPO_ROOT / "README.md").read_text()
+
+    assert "pip install aragora && aragora demo --offline" not in readme
+    assert "current source checkout" in readme
+    assert "PyPI `aragora` package" in readme
+
+
+def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> None:
+    quickstart = (REPO_ROOT / "docs" / "quickstart.md").read_text()
+
+    assert "Current PyPI package" in quickstart
+    assert "Current source checkout" in quickstart
+    assert "aragora receipt verify aragora-demo-receipt.json" in quickstart

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -18,6 +18,12 @@ def _section_between(text: str, start: str, end: str) -> str:
     return after_start.split(end, 1)[0]
 
 
+def _line_containing(text: str, needle: str) -> str:
+    matches = [line for line in text.splitlines() if needle in line]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
     readme = (REPO_ROOT / "README.md").read_text()
     pypi_try_it_now = _section_between(
@@ -25,15 +31,21 @@ def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
         "Current PyPI package:",
         "Current source checkout:",
     )
+    pypi_table_row = _line_containing(readme, "Run the current PyPI zero-key demo")
 
     assert "pip install aragora && aragora demo --offline" not in readme
     assert re.search(r"pip install aragora\s*&&\s*aragora demo --offline", readme) is None
     assert re.search(r"pip install aragora\s+aragora demo --offline", readme) is None
+    assert "--offline" not in pypi_table_row
+    assert "--receipt" not in pypi_table_row
+    assert "receipt verify" not in pypi_table_row
+    assert "aragora verify" not in pypi_table_row
     assert "--offline" not in pypi_try_it_now
+    assert "--receipt" not in pypi_try_it_now
     assert "receipt verify" not in pypi_try_it_now
     assert "aragora verify" not in pypi_try_it_now
     assert "Current source checkout:" in readme
-    assert "PyPI `aragora` releases through 2.7.4" in readme
+    assert "PyPI `aragora` releases through" in readme
 
 
 def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> None:
@@ -51,7 +63,9 @@ def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> No
     assert re.search(r"pip install aragora\s*&&\s*aragora demo --offline", quickstart) is None
     assert re.search(r"pip install aragora\s+aragora demo --offline", quickstart) is None
     assert "--offline" not in pypi_section
+    assert "--receipt" not in pypi_section
     assert "receipt verify" not in pypi_section
     assert "aragora verify" not in pypi_section
     assert "aragora demo --offline --receipt aragora-demo-receipt.json" in source_section
     assert "aragora receipt verify aragora-demo-receipt.json" in source_section
+    assert "PyPI `aragora` releases through" in quickstart

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -12,6 +12,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def _section_between(text: str, start: str, end: str) -> str:
+    assert start in text
+    assert end in text
     after_start = text.split(start, 1)[1]
     return after_start.split(end, 1)[0]
 
@@ -26,11 +28,12 @@ def test_readme_does_not_claim_pypi_demo_offline_receipt_round_trip() -> None:
 
     assert "pip install aragora && aragora demo --offline" not in readme
     assert re.search(r"pip install aragora\s*&&\s*aragora demo --offline", readme) is None
+    assert re.search(r"pip install aragora\s+aragora demo --offline", readme) is None
     assert "--offline" not in pypi_try_it_now
     assert "receipt verify" not in pypi_try_it_now
     assert "aragora verify" not in pypi_try_it_now
-    assert "current source checkout" in readme
-    assert "PyPI `aragora` package" in readme
+    assert "Current source checkout:" in readme
+    assert "PyPI `aragora` releases through 2.7.4" in readme
 
 
 def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> None:
@@ -44,6 +47,9 @@ def test_quickstart_separates_pypi_demo_from_source_receipt_verification() -> No
 
     assert "Current PyPI package" in quickstart
     assert "Current source checkout" in quickstart
+    assert "pip install aragora && aragora demo --offline" not in quickstart
+    assert re.search(r"pip install aragora\s*&&\s*aragora demo --offline", quickstart) is None
+    assert re.search(r"pip install aragora\s+aragora demo --offline", quickstart) is None
     assert "--offline" not in pypi_section
     assert "receipt verify" not in pypi_section
     assert "aragora verify" not in pypi_section


### PR DESCRIPTION
## Summary
- correct the README and quickstart so the current PyPI `aragora` package path is `pip install aragora && aragora demo`, not the unreleased `demo --offline` receipt-verification round trip
- document the verifiable native demo receipt flow as a current-source checkout path until the next package release carries it
- add regression coverage so public docs do not re-advertise the unreleased PyPI path, and so the real CLI parser keeps accepting `demo --offline --receipt`

## Live finding
Current source already passes the native demo receipt path:
`python3 -m aragora.cli.main demo --offline --receipt <tmp>/source-demo-receipt.json` exits 0, and `python3 -m aragora.cli.main receipt verify <tmp>/source-demo-receipt.json` reports `Result: VALID (3/3 checks passed)`.

Latest public PyPI `aragora` is 2.7.4, so the docs must not present that source-only round trip as a current `pip install aragora` fact.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' python3 -m pytest -q tests/cli/test_public_demo_onboarding_docs.py tests/cli/test_cli_main.py::TestArgumentParser::test_real_parser_accepts_demo_offline_receipt_path tests/cli/test_receipt_roundtrip.py tests/cli/test_demo_command.py tests/cli/test_demo_real.py -p no:rerunfailures`
- `tmpdir=$(mktemp -d); PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD python3 -m aragora.cli.main demo --offline --receipt "$tmpdir/source-demo-receipt.json"; PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD python3 -m aragora.cli.main receipt verify "$tmpdir/source-demo-receipt.json"`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Fixes #8877
Refs #7401
Refs #8858
