### PR TITLE
feat(scripts): render founder decision queue

### DIFF
--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Render pending founder/operator decision packets.
+
+This is a read-only transport-compression helper. It scans local founder
+decision packet markdown files, plus optional exported issue comments, and
+prints one table of pending rulings with their expected one-word replies.
+It never posts, mutates PRs, reruns checks, settles, or merges.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+UTC = timezone.utc
+DEFAULT_DECISIONS_ROOT = Path(".aragora/founder-decisions")
+
+
+@dataclass(frozen=True)
+class DecisionItem:
+    item: str
+    target: str
+    requested_action: str
+    expected_reply: str
+    source: str
+    packet_generated_at: datetime | None = None
+
+    def dedupe_key(self) -> tuple[str, str, str]:
+        return (
+            _compact_text(self.target).lower(),
+            _compact_text(self.requested_action).lower(),
+            _compact_text(self.expected_reply).lower(),
+        )
+
+
+def _compact_text(value: str) -> str:
+    return " ".join(value.strip().split())
+
+
+def _strip_markdown_code(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped.startswith("`") and stripped.endswith("`"):
+        return stripped[1:-1].strip()
+    return stripped
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _packet_generated_at(markdown: str) -> datetime | None:
+    match = re.search(r"^Generated:\s*(.+?)\s*$", markdown, flags=re.MULTILINE)
+    if not match:
+        return None
+    return _parse_datetime(match.group(1))
+
+
+def _split_table_row(line: str) -> list[str] | None:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return None
+    cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+    if not cells:
+        return None
+    return cells
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    return all(cell and set(cell) <= {"-", ":", " "} for cell in cells)
+
+
+def _pending_ruling_rows(markdown: str) -> list[list[str]]:
+    lines = markdown.splitlines()
+    in_section = False
+    rows: list[list[str]] = []
+    for line in lines:
+        if line.startswith("## "):
+            heading = line.lstrip("#").strip().lower()
+            if heading == "pending rulings":
+                in_section = True
+                continue
+            if in_section:
+                break
+        if not in_section:
+            continue
+        cells = _split_table_row(line)
+        if cells is None:
+            continue
+        rows.append(cells)
+    return rows
+
+
+def parse_decision_packet(markdown: str, *, source: str) -> list[DecisionItem]:
+    """Parse a founder decision packet markdown body."""
+
+    rows = _pending_ruling_rows(markdown)
+    if not rows:
+        return []
+    header: list[str] | None = None
+    data_rows: list[list[str]] = []
+    for row in rows:
+        if _is_separator_row(row):
+            continue
+        if header is None:
+            header = [cell.lower().strip() for cell in row]
+            continue
+        data_rows.append(row)
+    if header is None:
+        return []
+
+    def index(name: str) -> int | None:
+        try:
+            return header.index(name)
+        except ValueError:
+            return None
+
+    priority_i = index("priority")
+    link_i = index("link")
+    action_i = index("requested action")
+    reply_i = index("one-word reply")
+    if link_i is None or action_i is None or reply_i is None:
+        return []
+
+    generated_at = _packet_generated_at(markdown)
+    items: list[DecisionItem] = []
+    for row in data_rows:
+        if max(link_i, action_i, reply_i) >= len(row):
+            continue
+        priority = row[priority_i] if priority_i is not None and priority_i < len(row) else ""
+        target = _compact_text(row[link_i])
+        requested_action = _compact_text(row[action_i])
+        expected_reply = _strip_markdown_code(_compact_text(row[reply_i]))
+        if not target or not expected_reply:
+            continue
+        item = f"Priority {priority}" if priority else target
+        items.append(
+            DecisionItem(
+                item=item,
+                target=target,
+                requested_action=requested_action,
+                expected_reply=expected_reply,
+                source=source,
+                packet_generated_at=generated_at,
+            )
+        )
+    return items
+
+
+def _load_issue_comment_bodies(path: Path) -> list[tuple[str, str]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    bodies: list[tuple[str, str]] = []
+    for index, comment in enumerate(payload):
+        if not isinstance(comment, dict):
+            continue
+        body = comment.get("body")
+        if not isinstance(body, str) or "## Pending Rulings" not in body:
+            continue
+        source = str(comment.get("html_url") or comment.get("url") or f"{path}#{index}")
+        bodies.append((source, body))
+    return bodies
+
+
+def collect_decision_items(
+    *,
+    decisions_root: Path = DEFAULT_DECISIONS_ROOT,
+    packet_files: Iterable[Path] = (),
+    issue_comments_json: Path | None = None,
+) -> list[DecisionItem]:
+    sources: list[tuple[str, str]] = []
+    if decisions_root.exists():
+        for path in sorted(decisions_root.glob("*.md")):
+            try:
+                sources.append((str(path), path.read_text(encoding="utf-8")))
+            except OSError:
+                continue
+    for path in packet_files:
+        try:
+            sources.append((str(path), path.read_text(encoding="utf-8")))
+        except OSError:
+            continue
+    if issue_comments_json is not None:
+        sources.extend(_load_issue_comment_bodies(issue_comments_json))
+
+    deduped: dict[tuple[str, str, str], DecisionItem] = {}
+    for source, body in sources:
+        for item in parse_decision_packet(body, source=source):
+            deduped.setdefault(item.dedupe_key(), item)
+    return list(deduped.values())
+
+
+def _format_age(item: DecisionItem, *, now: datetime) -> str:
+    if item.packet_generated_at is None:
+        return "unknown"
+    seconds = max(0.0, (now - item.packet_generated_at).total_seconds())
+    hours = seconds / 3600.0
+    if hours < 1:
+        return f"{int(seconds // 60)}m"
+    if hours < 48:
+        return f"{hours:.1f}h"
+    return f"{hours / 24.0:.1f}d"
+
+
+def render_markdown(items: Iterable[DecisionItem], *, now: datetime | None = None) -> str:
+    now_dt = (now or datetime.now(tz=UTC)).astimezone(UTC)
+    rows = list(items)
+    lines = [
+        "# Founder Decision Queue",
+        "",
+        f"Generated: {now_dt.isoformat().replace('+00:00', 'Z')}",
+        "",
+    ]
+    if not rows:
+        lines.append("No pending operator rulings found.")
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "| Item | PR/Issue | Expected reply | Age | Source |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for item in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _escape_table_cell(item.item),
+                    _escape_table_cell(item.target),
+                    f"`{_escape_table_cell(item.expected_reply)}`",
+                    _format_age(item, now=now_dt),
+                    _escape_table_cell(item.source),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _escape_table_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Render pending founder/operator one-word decision packets."
+    )
+    parser.add_argument(
+        "--decisions-root",
+        default=str(DEFAULT_DECISIONS_ROOT),
+        help="Directory of local founder decision packet markdown files.",
+    )
+    parser.add_argument(
+        "--packet-file",
+        action="append",
+        default=[],
+        help="Additional founder decision packet markdown file to parse.",
+    )
+    parser.add_argument(
+        "--issue-comments-json",
+        default=None,
+        help="Optional JSON export of issue comments containing founder decision packets.",
+    )
+    parser.add_argument(
+        "--now",
+        default=None,
+        help="Override current UTC timestamp for deterministic rendering.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of Markdown.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.now:
+        now = _parse_datetime(args.now)
+        if now is None:
+            raise SystemExit(f"invalid --now timestamp: {args.now}")
+    else:
+        now = datetime.now(tz=UTC)
+    items = collect_decision_items(
+        decisions_root=Path(args.decisions_root),
+        packet_files=[Path(path) for path in args.packet_file],
+        issue_comments_json=Path(args.issue_comments_json) if args.issue_comments_json else None,
+    )
+    if args.json:
+        payload = {
+            "generated_at": now.isoformat().replace("+00:00", "Z"),
+            "count": len(items),
+            "items": [
+                {
+                    "item": item.item,
+                    "target": item.target,
+                    "requested_action": item.requested_action,
+                    "expected_reply": item.expected_reply,
+                    "source": item.source,
+                    "packet_generated_at": (
+                        item.packet_generated_at.isoformat().replace("+00:00", "Z")
+                        if item.packet_generated_at
+                        else None
+                    ),
+                    "age": _format_age(item, now=now),
+                }
+                for item in items
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+    print(render_markdown(items, now=now), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -38,6 +38,20 @@ class DecisionItem:
         )
 
 
+@dataclass(frozen=True)
+class DecisionSource:
+    source: str
+    body: str
+    thread_key: str
+    source_created_at: datetime | None = None
+    thread_open: bool = True
+    later_thread_comments: tuple[tuple[datetime | None, str], ...] = ()
+
+    @property
+    def packet_time(self) -> datetime | None:
+        return self.source_created_at or _packet_generated_at(self.body)
+
+
 def _compact_text(value: str) -> str:
     return " ".join(value.strip().split())
 
@@ -88,9 +102,9 @@ def _pending_ruling_rows(markdown: str) -> list[list[str]]:
     in_section = False
     rows: list[list[str]] = []
     for line in lines:
-        if line.startswith("## "):
+        if line.startswith("#"):
             heading = line.lstrip("#").strip().lower()
-            if heading == "pending rulings":
+            if not in_section and heading == "pending rulings":
                 in_section = True
                 continue
             if in_section:
@@ -99,6 +113,8 @@ def _pending_ruling_rows(markdown: str) -> list[list[str]]:
             continue
         cells = _split_table_row(line)
         if cells is None:
+            if rows and line.strip():
+                break
             continue
         rows.append(cells)
     return rows
@@ -160,23 +176,188 @@ def parse_decision_packet(markdown: str, *, source: str) -> list[DecisionItem]:
     return items
 
 
-def _load_issue_comment_bodies(path: Path) -> list[tuple[str, str]]:
+def _packet_sort_key(source: DecisionSource) -> tuple[datetime, str]:
+    return (
+        source.packet_time or datetime.min.replace(tzinfo=UTC),
+        source.source,
+    )
+
+
+def _newest_sources_by_thread(sources: Iterable[DecisionSource]) -> list[DecisionSource]:
+    newest: dict[str, DecisionSource] = {}
+    for source in sources:
+        current = newest.get(source.thread_key)
+        if current is None or _packet_sort_key(source) > _packet_sort_key(current):
+            newest[source.thread_key] = source
+    return list(newest.values())
+
+
+def _local_thread_key(path: Path, *, decisions_root: Path | None = None) -> str:
+    if decisions_root is not None:
+        return f"local:{decisions_root.resolve()}"
+    parent = path.parent if path.parent != Path("") else Path(".")
+    return f"local:{parent.resolve()}"
+
+
+def _thread_key_from_comment(comment: dict[str, Any], *, fallback: str) -> str:
+    for key in ("issue_url", "pull_request_url", "thread_url"):
+        value = comment.get(key)
+        if isinstance(value, str) and value:
+            return value
+    for key in ("html_url", "url"):
+        value = comment.get(key)
+        if not isinstance(value, str) or not value:
+            continue
+        match = re.search(r"/(?:issues|pulls|pull)/(\d+)(?:[/#?]|$)", value)
+        if match:
+            return f"github-thread:{match.group(1)}"
+    return fallback
+
+
+def _thread_open_from_comment(comment: dict[str, Any], *, default: bool) -> bool:
+    for key in ("thread_state", "issue_state", "pr_state", "state"):
+        value = comment.get(key)
+        if isinstance(value, str):
+            return value.lower() == "open"
+    return default
+
+
+def _comment_created_at(comment: dict[str, Any]) -> datetime | None:
+    value = comment.get("created_at") or comment.get("updated_at")
+    if not isinstance(value, str):
+        return None
+    return _parse_datetime(value)
+
+
+def _first_nonempty_line(body: str) -> str:
+    for line in body.splitlines():
+        compact = _compact_text(line)
+        if compact:
+            return compact
+    return ""
+
+
+def _target_number(target: str) -> str | None:
+    match = re.search(r"(?:pull|issues)/(\d+)|#(\d+)", target)
+    if not match:
+        return None
+    return match.group(1) or match.group(2)
+
+
+def _comment_resolves_item(body: str, item: DecisionItem) -> bool:
+    first_line = _strip_markdown_code(_first_nonempty_line(body)).lower()
+    expected = item.expected_reply.lower()
+    if first_line and first_line == expected:
+        return True
+    number = _target_number(item.target)
+    lowered = body.lower()
+    return bool(number and number in lowered and "settlement" in lowered)
+
+
+def _item_resolved_after_packet(source: DecisionSource, item: DecisionItem) -> bool:
+    packet_time = source.packet_time
+    for created_at, body in source.later_thread_comments:
+        if packet_time is not None and created_at is not None and created_at <= packet_time:
+            continue
+        if _comment_resolves_item(body, item):
+            return True
+    return False
+
+
+def _load_issue_comment_sources(path: Path) -> list[DecisionSource]:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return []
-    if not isinstance(payload, list):
+
+    default_thread_open = True
+    if isinstance(payload, dict):
+        state = payload.get("state") or payload.get("thread_state")
+        if isinstance(state, str):
+            default_thread_open = state.lower() == "open"
+        comments_payload = payload.get("comments")
+    else:
+        comments_payload = payload
+
+    if not isinstance(comments_payload, list):
         return []
-    bodies: list[tuple[str, str]] = []
-    for index, comment in enumerate(payload):
-        if not isinstance(comment, dict):
-            continue
+    comments = [comment for comment in comments_payload if isinstance(comment, dict)]
+    sources: list[DecisionSource] = []
+    for index, comment in enumerate(comments):
         body = comment.get("body")
         if not isinstance(body, str) or "## Pending Rulings" not in body:
             continue
         source = str(comment.get("html_url") or comment.get("url") or f"{path}#{index}")
-        bodies.append((source, body))
+        thread_key = _thread_key_from_comment(comment, fallback=f"{path}")
+        created_at = _comment_created_at(comment)
+        later_comments: list[tuple[datetime | None, str]] = []
+        for other in comments:
+            other_body = other.get("body")
+            if not isinstance(other_body, str) or "## Pending Rulings" in other_body:
+                continue
+            if _thread_key_from_comment(other, fallback=f"{path}") != thread_key:
+                continue
+            later_comments.append((_comment_created_at(other), other_body))
+        sources.append(
+            DecisionSource(
+                source=source,
+                body=body,
+                thread_key=thread_key,
+                source_created_at=created_at,
+                thread_open=_thread_open_from_comment(comment, default=default_thread_open),
+                later_thread_comments=tuple(later_comments),
+            )
+        )
+    return sources
+
+
+def _legacy_load_issue_comment_bodies(path: Path) -> list[tuple[str, str]]:
+    """Compatibility shim for tests or callers that imported the private helper."""
+
+    bodies: list[tuple[str, str]] = []
+    for source in _load_issue_comment_sources(path):
+        bodies.append((source.source, source.body))
     return bodies
+
+
+_load_issue_comment_bodies = _legacy_load_issue_comment_bodies
+
+
+def _collect_sources(
+    *,
+    decisions_root: Path,
+    packet_files: Iterable[Path],
+    issue_comments_json: Path | None,
+) -> list[DecisionSource]:
+    sources: list[DecisionSource] = []
+    if decisions_root.exists():
+        for path in sorted(decisions_root.glob("*.md")):
+            try:
+                body = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            sources.append(
+                DecisionSource(
+                    source=str(path),
+                    body=body,
+                    thread_key=_local_thread_key(path, decisions_root=decisions_root),
+                )
+            )
+    for path in packet_files:
+        try:
+            body = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        sources.append(
+            DecisionSource(
+                source=str(path),
+                body=body,
+                thread_key=_local_thread_key(path),
+            )
+        )
+    if issue_comments_json is not None:
+        sources.extend(_load_issue_comment_sources(issue_comments_json))
+    return sources
 
 
 def collect_decision_items(
@@ -185,24 +366,18 @@ def collect_decision_items(
     packet_files: Iterable[Path] = (),
     issue_comments_json: Path | None = None,
 ) -> list[DecisionItem]:
-    sources: list[tuple[str, str]] = []
-    if decisions_root.exists():
-        for path in sorted(decisions_root.glob("*.md")):
-            try:
-                sources.append((str(path), path.read_text(encoding="utf-8")))
-            except OSError:
-                continue
-    for path in packet_files:
-        try:
-            sources.append((str(path), path.read_text(encoding="utf-8")))
-        except OSError:
-            continue
-    if issue_comments_json is not None:
-        sources.extend(_load_issue_comment_bodies(issue_comments_json))
-
     deduped: dict[tuple[str, str, str], DecisionItem] = {}
-    for source, body in sources:
-        for item in parse_decision_packet(body, source=source):
+    sources = _collect_sources(
+        decisions_root=decisions_root,
+        packet_files=packet_files,
+        issue_comments_json=issue_comments_json,
+    )
+    for source in _newest_sources_by_thread(sources):
+        if not source.thread_open:
+            continue
+        for item in parse_decision_packet(source.body, source=source.source):
+            if _item_resolved_after_packet(source, item):
+                continue
             deduped.setdefault(item.dedupe_key(), item)
     return list(deduped.values())
 

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "founder_decision_queue.py"
+    spec = importlib.util.spec_from_file_location("founder_decision_queue_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fdq = _load_module()
+
+
+PACKET = """# Founder Decision Queue Packet
+
+Generated: 2026-07-05T13:07:20Z
+
+## Pending Rulings
+
+| Priority | Link | Current blocker | Requested action | One-word reply |
+| --- | --- | --- | --- | --- |
+| 1 | PR #8756: https://github.com/synaptent/aragora/pull/8756 | Tier 4 blocked. | Approve exact-head Tier 4 preapproval. | `approve` |
+| 2 | PR #8406: https://github.com/synaptent/aragora/pull/8406 | Stale owner. | Release or preserve the stale owner claim. | `release` |
+| 3 | PR #8886 decision request: https://github.com/synaptent/aragora/pull/8886#issuecomment-4886125338 | Policy crux. | Choose Option B. | `B` |
+
+## Current Live Snapshots
+
+Not part of the decision table.
+"""
+
+
+def test_parse_decision_packet_extracts_pending_rulings() -> None:
+    items = fdq.parse_decision_packet(PACKET, source="local.md")
+
+    assert [item.item for item in items] == ["Priority 1", "Priority 2", "Priority 3"]
+    assert items[0].target.startswith("PR #8756")
+    assert items[0].expected_reply == "approve"
+    assert items[1].expected_reply == "release"
+    assert items[2].expected_reply == "B"
+    assert items[0].packet_generated_at.isoformat() == "2026-07-05T13:07:20+00:00"
+
+
+def test_render_markdown_empty_queue() -> None:
+    rendered = fdq.render_markdown([], now=fdq._parse_datetime("2026-07-05T14:00:00Z"))
+
+    assert rendered.startswith("# Founder Decision Queue")
+    assert "No pending operator rulings found." in rendered
+    assert "| Item |" not in rendered
+
+
+def test_collect_decision_items_deduplicates_issue_comment_export(tmp_path: Path) -> None:
+    decisions_root = tmp_path / "founder-decisions"
+    decisions_root.mkdir()
+    (decisions_root / "packet.md").write_text(PACKET, encoding="utf-8")
+    comments = [
+        {
+            "html_url": "https://example.test/comment",
+            "body": PACKET,
+        }
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=decisions_root,
+        issue_comments_json=comments_path,
+    )
+
+    assert len(items) == 3
+    rendered = fdq.render_markdown(
+        items,
+        now=fdq._parse_datetime("2026-07-05T15:07:20Z"),
+    )
+    assert "| Priority 1 | PR #8756:" in rendered
+    assert "`approve`" in rendered
+    assert "2.0h" in rendered

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -40,6 +40,23 @@ Not part of the decision table.
 """
 
 
+def _single_item_packet(*, generated: str, target: str, reply: str) -> str:
+    return f"""# Founder Decision Queue Packet
+
+Generated: {generated}
+
+## Pending Rulings
+
+| Priority | Link | Current blocker | Requested action | One-word reply |
+| --- | --- | --- | --- | --- |
+| 1 | {target} | Needs a decision. | Rule on this item. | `{reply}` |
+
+## Current Live Snapshots
+
+Not part of the decision table.
+"""
+
+
 def test_parse_decision_packet_extracts_pending_rulings() -> None:
     items = fdq.parse_decision_packet(PACKET, source="local.md")
 
@@ -49,6 +66,28 @@ def test_parse_decision_packet_extracts_pending_rulings() -> None:
     assert items[1].expected_reply == "release"
     assert items[2].expected_reply == "B"
     assert items[0].packet_generated_at.isoformat() == "2026-07-05T13:07:20+00:00"
+
+
+def test_pending_rulings_parser_stops_before_nested_tables() -> None:
+    packet = (
+        _single_item_packet(
+            generated="2026-07-05T13:07:20Z",
+            target="PR #1: https://github.com/synaptent/aragora/pull/1",
+            reply="approve",
+        )
+        + """
+### Follow-up Table
+
+| Priority | Link | Current blocker | Requested action | One-word reply |
+| --- | --- | --- | --- | --- |
+| 2 | PR #2: https://github.com/synaptent/aragora/pull/2 | Not pending. | Ignore. | `release` |
+"""
+    )
+
+    items = fdq.parse_decision_packet(packet, source="local.md")
+
+    assert len(items) == 1
+    assert items[0].target.startswith("PR #1")
 
 
 def test_render_markdown_empty_queue() -> None:
@@ -85,3 +124,130 @@ def test_collect_decision_items_deduplicates_issue_comment_export(tmp_path: Path
     assert "| Priority 1 | PR #8756:" in rendered
     assert "`approve`" in rendered
     assert "2.0h" in rendered
+
+
+def test_collect_decision_items_keeps_newest_packet_on_thread(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="approve",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T11:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T11:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="hold",
+            ),
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "hold"
+
+
+def test_collect_decision_items_omits_ruled_after_packet(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="approve",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "approve",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert items == []
+
+
+def test_collect_decision_items_omits_closed_thread_packet(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "closed",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="approve",
+            ),
+        }
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert items == []
+
+
+def test_collect_decision_items_keeps_open_unruled_packet(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="approve",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "not a ruling",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "approve"


### PR DESCRIPTION
## Summary

Adds a read-only `scripts/founder_decision_queue.py` helper that renders pending founder/operator one-word decision packets into a single markdown table. The helper scans local `.aragora/founder-decisions/*.md` packet files and optional exported issue-comment JSON, deduplicates equivalent rows, and emits either Markdown or JSON.

This supports the transport-loop goal by turning posted decision packets into a repeatable status surface instead of requiring chat archaeology.

## Validation

- `python -m pytest tests/scripts/test_founder_decision_queue.py -q` -> `3 passed, 8 warnings`
- `python -m mypy scripts/founder_decision_queue.py tests/scripts/test_founder_decision_queue.py` -> `Success: no issues found in 2 source files`
- `ruff check scripts/founder_decision_queue.py tests/scripts/test_founder_decision_queue.py` -> passed
- `git diff --check` -> passed
- `python scripts/founder_decision_queue.py --decisions-root /Users/armand/Development/aragora/.aragora/founder-decisions --now 2026-07-05T15:07:20Z` -> rendered #8756/#8406/#8886 decision rows
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Safety

Read-only renderer only. No evidence apply, settlement, merge, status-setting, workflow edits, branch-protection edits, or protected-file edits.
