### PR TITLE
fix(scripts): tighten founder decision queue ruling matching

### DIFF
--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -245,13 +245,24 @@ def _target_number(target: str) -> str | None:
 
 
 def _comment_resolves_item(body: str, item: DecisionItem) -> bool:
-    first_line = _strip_markdown_code(_first_nonempty_line(body)).lower()
-    expected = item.expected_reply.lower()
+    first_line = _strip_markdown_code(_first_nonempty_line(body))
+    expected = item.expected_reply
     if first_line and first_line == expected:
         return True
     number = _target_number(item.target)
+    if number is None:
+        return False
     lowered = body.lower()
-    return bool(number and number in lowered and "settlement" in lowered)
+    if "settlement" not in lowered:
+        return False
+    number_pattern = re.escape(number)
+    target_patterns = [
+        rf"#\s*{number_pattern}\b",
+        rf"/(?:issues|pull|pulls)/{number_pattern}\b",
+        rf"\b(?:issue|pr|pull request)\s+#?\s*{number_pattern}\b",
+        rf"\b{number_pattern}\b",
+    ]
+    return any(re.search(pattern, lowered) for pattern in target_patterns)
 
 
 def _item_resolved_after_packet(source: DecisionSource, item: DecisionItem) -> bool:

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -195,6 +195,140 @@ def test_collect_decision_items_omits_ruled_after_packet(tmp_path: Path) -> None
     assert items == []
 
 
+def test_collect_decision_items_requires_exact_one_word_reply_case(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8886: https://github.com/synaptent/aragora/pull/8886",
+                reply="B",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "b",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "B"
+
+
+def test_collect_decision_items_accepts_exact_one_word_reply(tmp_path: Path) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8886: https://github.com/synaptent/aragora/pull/8886",
+                reply="B",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "`B`",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert items == []
+
+
+def test_collect_decision_items_settlement_match_uses_target_number_boundary(
+    tmp_path: Path,
+) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #875: https://github.com/synaptent/aragora/pull/875",
+                reply="approve",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "Settlement recorded for PR #8756.",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert len(items) == 1
+    assert items[0].target.startswith("PR #875:")
+
+
+def test_collect_decision_items_settlement_match_resolves_exact_target(
+    tmp_path: Path,
+) -> None:
+    comments = [
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:00:00Z",
+            "thread_state": "open",
+            "body": _single_item_packet(
+                generated="2026-07-05T10:00:00Z",
+                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                reply="approve",
+            ),
+        },
+        {
+            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+            "issue_url": "https://api.github.com/repos/synaptent/aragora/issues/8845",
+            "created_at": "2026-07-05T10:05:00Z",
+            "thread_state": "open",
+            "body": "Settlement recorded for PR #8756.",
+        },
+    ]
+    comments_path = tmp_path / "comments.json"
+    comments_path.write_text(json.dumps(comments), encoding="utf-8")
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        issue_comments_json=comments_path,
+    )
+
+    assert items == []
+
+
 def test_collect_decision_items_omits_closed_thread_packet(tmp_path: Path) -> None:
     comments = [
         {


### PR DESCRIPTION
## Summary
- tighten founder decision queue ruling detection so one-word replies are exact-case matches
- require settlement comments to mention the target PR/issue number with a boundary instead of a substring
- add regressions for lowercase `b` vs expected `B`, exact `B`, and PR `#875` vs `#8756` settlement matching

## Validation
- `python -m pytest tests/scripts/test_founder_decision_queue.py -q`
- `python -m mypy scripts/founder_decision_queue.py tests/scripts/test_founder_decision_queue.py`
- `ruff check scripts/founder_decision_queue.py tests/scripts/test_founder_decision_queue.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `python scripts/founder_decision_queue.py --decisions-root /Users/armand/Development/aragora/.aragora/founder-decisions --now 2026-07-05T15:07:20Z`

## Notes
Follow-up to the non-blocking Claude `[P3]` comments from #8887 evidence on `scripts/founder_decision_queue.py`.
