### PR TITLE
[AGT-05] ReputationDelta — Brier-based reputation delta computation from resolved claims

### DIFF
--- a/aragora/prediction/__init__.py
+++ b/aragora/prediction/__init__.py
@@ -2,9 +2,11 @@
 
 All public symbols are importable regardless of the feature flag.
 The flag (``ARAGORA_PREDICTION_MARKETS_ENABLED``) only gates the runtime
-behaviour of :class:`InMemoryStakeableClaimStore` and the resolution adapter.
+behaviour of :class:`InMemoryStakeableClaimStore`, the resolution adapter,
+and :func:`compute_reputation_deltas`.
 """
 
+from aragora.prediction.reputation_delta import ReputationDelta, compute_reputation_deltas
 from aragora.prediction.stakeable_claim import (
     GithubResolutionAdapterStub,
     InMemoryStakeableClaimStore,
@@ -17,6 +19,8 @@ __all__ = [
     "GithubResolutionAdapterStub",
     "InMemoryStakeableClaimStore",
     "QuestionType",
+    "ReputationDelta",
     "ResolutionStatus",
     "StakeableClaim",
+    "compute_reputation_deltas",
 ]

--- a/aragora/prediction/reputation_delta.py
+++ b/aragora/prediction/reputation_delta.py
@@ -1,0 +1,116 @@
+"""ReputationDelta — AGT-05 sub-deliverable 5: Brier-based reputation delta computation.
+
+Converts resolved StakeableClaim objects into per-agent reputation deltas.
+Feed point for the ERC-8004 registry write path (future slice).
+
+Feature flag: ARAGORA_PREDICTION_MARKETS_ENABLED (same gate as stakeable_claim.py).
+No live dispatch, no blockchain writes, no external API calls.
+
+Advances: issue #6066 (AGT-05).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aragora.prediction.stakeable_claim import ResolutionStatus, StakeableClaim
+
+_ENV_FLAG = "ARAGORA_PREDICTION_MARKETS_ENABLED"
+
+
+def _flag_enabled() -> bool:
+    return os.environ.get(_ENV_FLAG, "").lower() in {"1", "true", "yes", "on"}
+
+
+def _require_enabled() -> None:
+    if not _flag_enabled():
+        raise RuntimeError(f"Prediction markets are disabled. Set {_ENV_FLAG}=1 to enable.")
+
+
+@dataclass(frozen=True)
+class ReputationDelta:
+    """Reputation change for one agent on one resolved claim.
+
+    delta = 0.25 - brier_score  (calibrated: 0 at no-skill baseline prob=0.5)
+    brier_score = (agent_probability - outcome)**2; outcome 1.0=YES 0.0=NO
+
+    Range: perfect prediction → +0.25; maximally wrong → -0.75.
+    """
+
+    agent_id: str
+    claim_id: str
+    delta: float            # calibrated reputation change in [-0.75, 0.25]
+    brier_score: float      # raw Brier score in [0.0, 1.0]
+    resolved_yes: bool      # True = RESOLVED_YES, False = RESOLVED_NO
+    agent_probability: float
+    computed_at: str        # ISO-8601 UTC
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent_id": self.agent_id,
+            "claim_id": self.claim_id,
+            "delta": self.delta,
+            "brier_score": self.brier_score,
+            "resolved_yes": self.resolved_yes,
+            "agent_probability": self.agent_probability,
+            "computed_at": self.computed_at,
+        }
+
+
+def compute_reputation_deltas(
+    claims: list[StakeableClaim],
+    *,
+    window_days: int = 90,
+    cutoff_dt: datetime | None = None,
+    require_enabled: bool = True,
+) -> list[ReputationDelta]:
+    """Return per-agent reputation deltas for resolved claims in a rolling window.
+
+    Only RESOLVED_YES / RESOLVED_NO claims whose ``expiry`` falls within
+    [cutoff_dt - window_days, cutoff_dt] are processed; all others are skipped.
+    Claims with no agent positions are also skipped.
+    """
+    if require_enabled:
+        _require_enabled()
+
+    if cutoff_dt is None:
+        cutoff_dt = datetime.now(UTC)
+    window_start = cutoff_dt - timedelta(days=window_days)
+    now_str = cutoff_dt.isoformat()
+    _resolved = {ResolutionStatus.RESOLVED_YES, ResolutionStatus.RESOLVED_NO}
+
+    deltas: list[ReputationDelta] = []
+    for claim in claims:
+        if claim.resolution_status not in _resolved:
+            continue
+        if claim.resolution_value is None or not claim.positions:
+            continue
+        try:
+            expiry_dt = datetime.fromisoformat(claim.expiry)
+        except ValueError:
+            continue
+        if expiry_dt.tzinfo is None:
+            expiry_dt = expiry_dt.replace(tzinfo=UTC)
+        if not (window_start <= expiry_dt <= cutoff_dt):
+            continue
+
+        outcome = 1.0 if claim.resolution_value else 0.0
+        resolved_yes = claim.resolution_status == ResolutionStatus.RESOLVED_YES
+        for agent_id, prob in claim.positions.items():
+            prob = float(prob)
+            brier = (prob - outcome) ** 2
+            deltas.append(
+                ReputationDelta(
+                    agent_id=agent_id,
+                    claim_id=claim.claim_id,
+                    delta=round(0.25 - brier, 6),
+                    brier_score=round(brier, 6),
+                    resolved_yes=resolved_yes,
+                    agent_probability=prob,
+                    computed_at=now_str,
+                )
+            )
+    return deltas

--- a/tests/prediction/test_reputation_delta.py
+++ b/tests/prediction/test_reputation_delta.py
@@ -1,0 +1,173 @@
+"""Tests for aragora.prediction.reputation_delta (AGT-05 sub-deliverable 5)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from aragora.prediction.reputation_delta import ReputationDelta, compute_reputation_deltas
+from aragora.prediction.stakeable_claim import QuestionType, ResolutionStatus, StakeableClaim
+
+
+def _claim(
+    *,
+    claim_id: str = "c-1",
+    status: ResolutionStatus = ResolutionStatus.RESOLVED_YES,
+    resolution_value: bool | None = True,
+    positions: dict[str, float] | None = None,
+    days_before_cutoff: int = 10,
+    cutoff: datetime | None = None,
+) -> StakeableClaim:
+    ref = cutoff or datetime.now(UTC)
+    expiry = (ref - timedelta(days=days_before_cutoff)).isoformat()
+    return StakeableClaim(
+        claim_id=claim_id,
+        question="Will PR #1 merge?",
+        question_type=QuestionType.PR_MERGE,
+        target_ref="owner/repo#1",
+        expiry=expiry,
+        resolution_status=status,
+        resolution_value=resolution_value,
+        positions=positions or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlag:
+    def test_flag_off_raises(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PREDICTION_MARKETS_ENABLED", raising=False)
+        with pytest.raises(RuntimeError, match="disabled"):
+            compute_reputation_deltas([_claim(positions={"a": 0.9})])
+
+    def test_require_enabled_false_bypasses(self, monkeypatch):
+        monkeypatch.delenv("ARAGORA_PREDICTION_MARKETS_ENABLED", raising=False)
+        result = compute_reputation_deltas([_claim(positions={"a": 0.9})], require_enabled=False)
+        assert len(result) == 1
+
+    def test_flag_on_succeeds(self, monkeypatch):
+        monkeypatch.setenv("ARAGORA_PREDICTION_MARKETS_ENABLED", "1")
+        result = compute_reputation_deltas([_claim(positions={"a": 0.9})])
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# Claim filtering
+# ---------------------------------------------------------------------------
+
+
+class TestClaimFiltering:
+    def test_open_excluded(self):
+        c = _claim(status=ResolutionStatus.OPEN, resolution_value=None, positions={"a": 0.8})
+        assert compute_reputation_deltas([c], require_enabled=False) == []
+
+    def test_expired_excluded(self):
+        c = _claim(status=ResolutionStatus.EXPIRED, resolution_value=None, positions={"a": 0.8})
+        assert compute_reputation_deltas([c], require_enabled=False) == []
+
+    def test_inconclusive_excluded(self):
+        c = _claim(status=ResolutionStatus.INCONCLUSIVE, resolution_value=None, positions={"a": 0.8})
+        assert compute_reputation_deltas([c], require_enabled=False) == []
+
+    def test_no_positions_skipped(self):
+        assert compute_reputation_deltas([_claim(positions={})], require_enabled=False) == []
+
+    def test_old_claim_outside_window_excluded(self):
+        cutoff = datetime.now(UTC)
+        c = _claim(days_before_cutoff=200, positions={"a": 0.9}, cutoff=cutoff)
+        assert compute_reputation_deltas([c], window_days=90, cutoff_dt=cutoff, require_enabled=False) == []
+
+    def test_recent_claim_included(self):
+        cutoff = datetime.now(UTC)
+        c = _claim(days_before_cutoff=10, positions={"a": 0.9}, cutoff=cutoff)
+        result = compute_reputation_deltas([c], window_days=90, cutoff_dt=cutoff, require_enabled=False)
+        assert len(result) == 1
+
+    def test_future_expiry_excluded(self):
+        cutoff = datetime.now(UTC)
+        future = (cutoff + timedelta(days=10)).isoformat()
+        c = StakeableClaim(
+            claim_id="c-f", question="Q", question_type=QuestionType.PR_MERGE,
+            target_ref="r#1", expiry=future,
+            resolution_status=ResolutionStatus.RESOLVED_YES, resolution_value=True,
+            positions={"a": 0.9},
+        )
+        assert compute_reputation_deltas([c], cutoff_dt=cutoff, require_enabled=False) == []
+
+
+# ---------------------------------------------------------------------------
+# Delta arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaArithmetic:
+    def test_perfect_yes_prediction(self):
+        d = compute_reputation_deltas([_claim(positions={"a": 1.0})], require_enabled=False)[0]
+        assert d.brier_score == pytest.approx(0.0, abs=1e-6)
+        assert d.delta == pytest.approx(0.25, abs=1e-6)
+
+    def test_perfect_no_prediction(self):
+        c = _claim(status=ResolutionStatus.RESOLVED_NO, resolution_value=False, positions={"a": 0.0})
+        d = compute_reputation_deltas([c], require_enabled=False)[0]
+        assert d.brier_score == pytest.approx(0.0, abs=1e-6)
+        assert d.delta == pytest.approx(0.25, abs=1e-6)
+
+    def test_no_skill_baseline_zero_delta(self):
+        d = compute_reputation_deltas([_claim(positions={"a": 0.5})], require_enabled=False)[0]
+        assert d.brier_score == pytest.approx(0.25, abs=1e-6)
+        assert d.delta == pytest.approx(0.0, abs=1e-6)
+
+    def test_maximally_wrong_most_negative_delta(self):
+        c = _claim(status=ResolutionStatus.RESOLVED_NO, resolution_value=False, positions={"a": 1.0})
+        d = compute_reputation_deltas([c], require_enabled=False)[0]
+        assert d.brier_score == pytest.approx(1.0, abs=1e-6)
+        assert d.delta == pytest.approx(-0.75, abs=1e-6)
+
+    def test_multiple_agents_scored_independently(self):
+        c = _claim(
+            status=ResolutionStatus.RESOLVED_YES, resolution_value=True,
+            positions={"skilled": 1.0, "unskilled": 0.0},
+        )
+        by_agent = {d.agent_id: d for d in compute_reputation_deltas([c], require_enabled=False)}
+        assert by_agent["skilled"].delta == pytest.approx(0.25, abs=1e-6)
+        assert by_agent["unskilled"].delta == pytest.approx(-0.75, abs=1e-6)
+
+    def test_multiple_claims_produce_multiple_deltas(self):
+        cutoff = datetime.now(UTC)
+        claims = [
+            _claim(claim_id=f"c-{i}", positions={"a": 0.8}, cutoff=cutoff) for i in range(3)
+        ]
+        deltas = compute_reputation_deltas(claims, cutoff_dt=cutoff, require_enabled=False)
+        assert len(deltas) == 3
+        assert {d.claim_id for d in deltas} == {"c-0", "c-1", "c-2"}
+
+
+# ---------------------------------------------------------------------------
+# ReputationDelta dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestReputationDelta:
+    def test_to_dict_has_all_keys(self):
+        d = ReputationDelta(
+            agent_id="a", claim_id="c", delta=0.25, brier_score=0.0,
+            resolved_yes=True, agent_probability=1.0, computed_at="2026-07-05T00:00:00+00:00",
+        )
+        result = d.to_dict()
+        for key in ("agent_id", "claim_id", "delta", "brier_score",
+                    "resolved_yes", "agent_probability", "computed_at"):
+            assert key in result
+
+    def test_resolved_yes_field_matches_status(self):
+        yes_d = compute_reputation_deltas([_claim(positions={"a": 0.7})], require_enabled=False)[0]
+        no_d = compute_reputation_deltas(
+            [_claim(claim_id="c-no", status=ResolutionStatus.RESOLVED_NO,
+                    resolution_value=False, positions={"a": 0.3})],
+            require_enabled=False,
+        )[0]
+        assert yes_d.resolved_yes is True
+        assert no_d.resolved_yes is False


### PR DESCRIPTION
## Slice

Adds `aragora/prediction/reputation_delta.py` with a `ReputationDelta` frozen dataclass and `compute_reputation_deltas()` function. Converts resolved `StakeableClaim` objects (RESOLVED_YES / RESOLVED_NO) into per-agent Brier-calibrated reputation deltas — the computation half of AGT-05 sub-deliverable 5 (reputation update path). The ERC-8004 registry write is a separate future slice.

Calibration: `delta = 0.25 - brier_score`, so the no-skill baseline (prob=0.5) yields 0.0, perfect predictions yield +0.25, and maximally wrong predictions yield −0.75.

## Gating

- Default: OFF (flag: `ARAGORA_PREDICTION_MARKETS_ENABLED` — same gate as `stakeable_claim.py`)
- Live queue effect: none
- Advances issue: #6066 (AGT-05 — Skin-in-the-game reputation flow)

## Tests

- `TestFeatureFlag` (3 tests) — flag off raises; `require_enabled=False` bypasses; flag on passes
- `TestClaimFiltering` (7 tests) — OPEN/EXPIRED/INCONCLUSIVE excluded; no-positions skipped; old claim outside window excluded; recent claim included; future expiry excluded; RESOLVED_NO included
- `TestDeltaArithmetic` (6 tests) — perfect YES/NO → +0.25; no-skill baseline → 0.0; maximally wrong → −0.75; multiple agents scored independently; multiple claims produce separate deltas
- `TestReputationDelta` (2 tests) — `to_dict()` keys; `resolved_yes` field matches RESOLVED_YES/NO status

## Validation

- `pytest tests/prediction/test_reputation_delta.py --noconftest` — **18 passed**
- `ruff check aragora/prediction/reputation_delta.py aragora/prediction/__init__.py tests/prediction/test_reputation_delta.py` — clean
- `mypy aragora/prediction/reputation_delta.py --ignore-missing-imports` — clean
- Net diff: 293 LOC (3 files: implementation, tests, `__init__.py` re-export)

## Out of scope

- ERC-8004 registry write path (future AGT-05 slice; `ReputationDelta.to_dict()` is the feed point)
- Dispatch eligibility wiring to `team_selector` (AGT-05 SD-6)
- Reversal / re-opening path (AGT-05 SD-7)
- Per-domain slicing (`prediction_market`, `debate_position`, etc.) — this slice covers the `prediction_market` domain only

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJKZJw8Gtrw7pmrbcucw86) — Vision-Layer Incubator run 2026-07-05_

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJKZJw8Gtrw7pmrbcucw86)_