### PR TITLE
refactor(queue): add domain-free job-handler registry (P4a Q1)

### DIFF
--- a/aragora/queue/__init__.py
+++ b/aragora/queue/__init__.py
@@ -61,7 +61,14 @@ from aragora.queue.streams import (
 from aragora.queue.worker import (
     DebateExecutor,
     DebateWorker,
-    create_default_executor,
+    get_job_handler,
+    get_registered_job_handlers,
+    get_registered_workers,
+    register_job_handler,
+    register_worker,
+    registered_job_handler_names,
+    registered_worker_names,
+    reset_registry,
 )
 
 __all__ = [
@@ -90,5 +97,13 @@ __all__ = [
     # Worker
     "DebateWorker",
     "DebateExecutor",
-    "create_default_executor",
+    # Job-handler registry (domain-free; P4a queue inversion Q1)
+    "register_worker",
+    "register_job_handler",
+    "get_registered_workers",
+    "get_registered_job_handlers",
+    "get_job_handler",
+    "registered_worker_names",
+    "registered_job_handler_names",
+    "reset_registry",
 ]

--- a/aragora/queue/worker.py
+++ b/aragora/queue/worker.py
@@ -30,6 +30,53 @@ logger = logging.getLogger(__name__)
 # Type alias for the debate executor function
 DebateExecutor = Callable[[Job], Coroutine[Any, Any, dict[str, Any]]]
 
+# Domain-free job-handler registry (zero domain imports, eager or lazy). Lets
+# domain/application/interface home modules self-register their worker and job
+# handler instances instead of being imported directly by aragora.queue.
+_REGISTERED_WORKERS: dict[str, Any] = {}
+_REGISTERED_JOB_HANDLERS: dict[str, DebateExecutor] = {}
+
+
+def register_worker(name: str, worker: Any) -> None:
+    """Register a queue worker instance under ``name`` (keyed, idempotent)."""
+    _REGISTERED_WORKERS[name] = worker
+
+
+def register_job_handler(job_type: str, handler: DebateExecutor) -> None:
+    """Register a job handler (executor) for ``job_type`` (keyed, idempotent)."""
+    _REGISTERED_JOB_HANDLERS[job_type] = handler
+
+
+def get_registered_workers() -> dict[str, Any]:
+    """Return a shallow copy of all registered workers, keyed by name."""
+    return dict(_REGISTERED_WORKERS)
+
+
+def get_registered_job_handlers() -> dict[str, DebateExecutor]:
+    """Return a shallow copy of all registered job handlers, keyed by job type."""
+    return dict(_REGISTERED_JOB_HANDLERS)
+
+
+def get_job_handler(job_type: str) -> DebateExecutor | None:
+    """Return the registered handler for ``job_type``, or ``None`` if unregistered."""
+    return _REGISTERED_JOB_HANDLERS.get(job_type)
+
+
+def registered_worker_names() -> list[str]:
+    """Return the sorted names of all registered workers."""
+    return sorted(_REGISTERED_WORKERS)
+
+
+def registered_job_handler_names() -> list[str]:
+    """Return the sorted job types of all registered job handlers."""
+    return sorted(_REGISTERED_JOB_HANDLERS)
+
+
+def reset_registry() -> None:
+    """Clear both the worker and job-handler registries (for tests)."""
+    _REGISTERED_WORKERS.clear()
+    _REGISTERED_JOB_HANDLERS.clear()
+
 
 class DebateWorker:
     """

--- a/scripts/queue_worker.py
+++ b/scripts/queue_worker.py
@@ -62,8 +62,8 @@ async def main(
     from aragora.queue import (
         create_redis_queue,
         DebateWorker,
-        create_default_executor,
     )
+    from aragora.queue.worker import create_default_executor
 
     logger = logging.getLogger(__name__)
     logger.info(f"Starting worker {worker_id} with concurrency={concurrency}")

--- a/tests/queue/test_registry.py
+++ b/tests/queue/test_registry.py
@@ -1,0 +1,206 @@
+"""Tests for the domain-free job-handler registry (P4a queue inversion Q1).
+
+Covers the enabler surface introduced by the queue/job-handler registry
+inversion (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1, §5.2, §10 Q1):
+
+- ``register_worker`` / ``register_job_handler`` / ``get_registered_workers`` /
+  ``get_registered_job_handlers`` / ``get_job_handler`` / ``reset_registry`` on
+  ``aragora.queue.worker`` (re-exported from ``aragora.queue``).
+- ``DebateWorker`` + ``DebateExecutor`` re-exports from ``aragora.queue`` are
+  KEPT.
+- The ``create_default_executor`` re-export is DROPPED from ``aragora.queue``
+  (no shim) while the underlying symbol stays defined in ``aragora.queue.worker``
+  (it only relocates in Q2).
+- The registry functions carry ZERO domain imports.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from aragora.queue import worker
+from aragora.queue.worker import (
+    DebateExecutor,
+    DebateWorker,
+    get_job_handler,
+    get_registered_job_handlers,
+    get_registered_workers,
+    register_job_handler,
+    register_worker,
+    registered_job_handler_names,
+    registered_worker_names,
+    reset_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate each test: empty registry before and after."""
+    reset_registry()
+    yield
+    reset_registry()
+
+
+async def _noop_handler(job: object) -> dict[str, object]:
+    return {}
+
+
+def test_register_worker_and_get():
+    instance = object()
+    register_worker("w1", instance)
+
+    registered = get_registered_workers()
+    assert registered["w1"] is instance
+    assert "w1" in registered_worker_names()
+
+
+def test_register_worker_is_keyed_idempotent():
+    first, second = object(), object()
+    register_worker("dup", first)
+    register_worker("dup", second)
+
+    registered = get_registered_workers()
+    assert registered["dup"] is second
+    assert registered_worker_names().count("dup") == 1
+
+
+def test_get_registered_workers_returns_copy_not_live_reference():
+    register_worker("w1", object())
+    snapshot = get_registered_workers()
+    snapshot["injected"] = object()
+
+    assert "injected" not in get_registered_workers()
+
+
+def test_register_job_handler_and_get():
+    register_job_handler("demo", _noop_handler)
+
+    assert get_job_handler("demo") is _noop_handler
+    assert get_registered_job_handlers()["demo"] is _noop_handler
+    assert "demo" in registered_job_handler_names()
+
+
+def test_register_job_handler_is_keyed_idempotent():
+    async def first(job: object) -> dict[str, object]:
+        return {}
+
+    async def second(job: object) -> dict[str, object]:
+        return {}
+
+    register_job_handler("dup", first)
+    register_job_handler("dup", second)
+
+    assert get_job_handler("dup") is second
+    assert registered_job_handler_names().count("dup") == 1
+
+
+def test_get_job_handler_returns_none_when_unregistered():
+    assert get_job_handler("missing") is None
+
+
+def test_get_registered_job_handlers_returns_copy_not_live_reference():
+    register_job_handler("demo", _noop_handler)
+    snapshot = get_registered_job_handlers()
+    snapshot["injected"] = _noop_handler
+
+    assert "injected" not in get_registered_job_handlers()
+
+
+def test_reset_registry_clears_both_registries():
+    register_worker("w1", object())
+    register_job_handler("demo", _noop_handler)
+
+    reset_registry()
+
+    assert get_registered_workers() == {}
+    assert get_registered_job_handlers() == {}
+    assert registered_worker_names() == []
+    assert registered_job_handler_names() == []
+
+
+def test_worker_and_job_handler_registries_are_independent():
+    """Registering under the same key in each registry must not collide."""
+    register_worker("shared_name", "worker-instance")
+    register_job_handler("shared_name", _noop_handler)
+
+    assert get_registered_workers()["shared_name"] == "worker-instance"
+    assert get_job_handler("shared_name") is _noop_handler
+
+
+def test_debate_worker_and_executor_alias_reexported_from_queue_package():
+    """DebateWorker + DebateExecutor stay re-exported (§5.2: both are public)."""
+    import aragora.queue as queue_pkg
+
+    assert queue_pkg.DebateWorker is DebateWorker
+    assert queue_pkg.DebateExecutor is DebateExecutor
+    assert "DebateWorker" in queue_pkg.__all__
+    assert "DebateExecutor" in queue_pkg.__all__
+
+
+def test_create_default_executor_reexport_dropped_from_queue_package():
+    """The domain-coupled factory re-export is dropped (no shim, §5.2)."""
+    import aragora.queue as queue_pkg
+
+    assert not hasattr(queue_pkg, "create_default_executor")
+    assert "create_default_executor" not in queue_pkg.__all__
+
+    # The underlying symbol is untouched - it only relocates out of worker.py
+    # in Q2, so it must still be directly importable from its defining module.
+    assert hasattr(worker, "create_default_executor")
+
+
+def test_registry_functions_reexported_from_queue_package():
+    import aragora.queue as queue_pkg
+
+    names = (
+        "register_worker",
+        "register_job_handler",
+        "get_registered_workers",
+        "get_registered_job_handlers",
+        "get_job_handler",
+        "registered_worker_names",
+        "registered_job_handler_names",
+        "reset_registry",
+    )
+    for name in names:
+        assert hasattr(queue_pkg, name), f"{name} missing from aragora.queue"
+        assert name in queue_pkg.__all__, f"{name} missing from aragora.queue.__all__"
+        assert getattr(queue_pkg, name) is getattr(worker, name)
+
+
+def test_registry_functions_have_zero_domain_imports():
+    """The registry's own functions must not reference any domain package.
+
+    ``worker.py`` also hosts ``create_default_executor`` (pending relocation to
+    a debate-layer home in Q2), which legitimately lazy-imports domain packages
+    inside its own body. Scoping this static guard to just the registry
+    callables (instead of the whole file) avoids a false positive on that
+    pre-existing, unrelated code; the full-layer grimp/import-linter re-check
+    is the authoritative proof that ``aragora.queue`` gains no new edge.
+    """
+    domain_packages = (
+        "agents",
+        "debate",
+        "gauntlet",
+        "integrations",
+        "memory",
+        "nomic",
+        "ranking",
+        "server",
+    )
+    registry_callables = (
+        register_worker,
+        register_job_handler,
+        get_registered_workers,
+        get_registered_job_handlers,
+        get_job_handler,
+        registered_worker_names,
+        registered_job_handler_names,
+        reset_registry,
+    )
+    for fn in registry_callables:
+        source = inspect.getsource(fn)
+        offenders = [pkg for pkg in domain_packages if f"aragora.{pkg}" in source]
+        assert not offenders, f"{fn.__name__} references domain packages: {offenders}"


### PR DESCRIPTION
## Source

P4a events/queue inversion, Batch **Q1** (`docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md` §10 row Q1, §4.1/§5.2/§7). Pure ENABLER for the queue-side worker relocation batches (Q2-Q4), mirroring the already-landed events-side `aragora.events.cross_subscribers` registry (E1).

## What changed

- **`aragora/queue/worker.py`**: added a domain-free job-handler registry — `register_worker` / `register_job_handler` / `get_registered_workers` / `get_registered_job_handlers` / `get_job_handler` / `registered_worker_names` / `registered_job_handler_names` / `reset_registry`. Lets a domain/application/interface home module self-register its worker or job handler instead of `aragora.queue` importing it directly (the mechanism Q3/Q4 will use when `queue.workers.*` relocate).
- **`aragora/queue/__init__.py`**: re-exports the 8 registry functions above. **Dropped** the `create_default_executor` re-export (no shim — a re-export would re-create the `queue -> {agents,debate}` edge this inversion exists to clear in Q2). **Kept** the `DebateWorker` transport base and the `DebateExecutor` type-alias re-exports (both public, domain-free, per §5.2).
- **`scripts/queue_worker.py`**: repointed its `create_default_executor` import from `aragora.queue` to `aragora.queue.worker` (the function's unmoved defining module) since the top-level re-export it relied on is now gone. This is the only runtime consumer of the dropped re-export; no test or doc referenced it (`create_default_executor`'s repoint to its *final* debate-layer home is Q2's job, per the design doc's explicit batch assignment — see "Scope notes" below).
- **`tests/queue/test_registry.py`** (new): registration/get/idempotent-overwrite/reset behavior for both registries, re-export surface checks (`DebateWorker`/`DebateExecutor` kept, `create_default_executor` dropped from `aragora.queue` but still directly importable from `aragora.queue.worker`), and a static zero-domain-import guard scoped to the registry functions themselves (not the whole file, since `worker.py` also legitimately hosts `create_default_executor`'s pre-existing lazy domain imports pending its Q2 relocation).

`create_default_executor` itself is **untouched** — it stays defined in `queue/worker.py` exactly as before; only its `queue/__init__.py` re-export is removed. It only relocates to `aragora/debate/queue_executor.py` in Q2.

## Scope notes (why docs aren't touched here)

The design doc's §6.2/§5.1 consumer census assigns the `queue/README.md`, `docs/resilience/QUEUE.md` (+ its `docs-site/docs/guides/queue.md` mirror), and `queue/__init__.py` docstring repoints to **Q2** ("repoint to the new home… part of the owning batch's diff, not a separate task" — the new home, `aragora/debate/queue_executor.py`, doesn't exist until Q2 creates it). Repointing them now to the interim `aragora.queue.worker` path would just be redone by Q2 pointing at the final path. No doctest/markdown-execution check exists in this repo (verified), so this doesn't leave anything actually broken — only a documentation example that Q2 will correct.

## Validation

```
$ python3 -m pytest tests/queue/test_registry.py -v            # 13 passed
$ python3 -m pytest tests/queue/ -q                             # 677 passed
$ python3 -m mypy --ignore-missing-imports --follow-imports=skip aragora/queue/__init__.py aragora/queue/worker.py
Success: no issues found in 2 source files
$ ruff check aragora/ tests/ && ruff format --check aragora/ tests/ scripts/
All checks passed! / 10644 files already formatted
$ AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke
Smoke tests passed!
$ PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke
138 passed
$ python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure
FAIL: 1 pre-existing violation (aragora.utils -> aragora.caching, #8672 known issue) — IDENTICAL before/after this change
$ python3 scripts/ci/check_import_contracts.py --json   # full-layer, no --layers filter
new_violations IDENTICAL before/after: {evaluation->connectors, evaluation->swarm, swarm->cli, utils->caching}
(all 4 pre-existing/ambient per AGENTS.md "Known Pre-Existing Issues"; zero new, zero resolved)
```

Confirmed the `aragora.queue -> {agents,debate,gauntlet,integrations,memory,nomic,ranking,server}` baseline entries in `scripts/baselines/import_contracts_baseline.json` are byte-identical before/after (this PR is a pure enabler — clears no edge, per the doc's own "Clears: none").

## Risks

- Low risk, purely additive registry + one dropped unused-until-now re-export with its single runtime consumer repointed in the same diff.
- No `docs/METRICS.md` / `aragora/module_tiers.yaml` regen: both are currently path-frozen by open PRs (#8823, #8827/#8519) — module structure is otherwise unchanged (no new module added, no module removed) so there is no metrics/tier drift to record from this PR itself.
