### PR TITLE
ci(deploy): archive Vercel production uploads

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -198,7 +198,7 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          DEPLOY_URL=$(npx vercel deploy --archive=tgz --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
-          DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
+          DEPLOY_URL=$(npx vercel deploy --archive=tgz --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
           echo "Deployed URL: $DEPLOY_URL"
         env:

--- a/tests/scripts/test_vercel_deploy_archive_policy.py
+++ b/tests/scripts/test_vercel_deploy_archive_policy.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERCEL_WORKFLOWS = [
+    Path(".github/workflows/deploy-frontend.yml"),
+    Path(".github/workflows/deploy-secure.yml"),
+]
+
+
+def test_production_vercel_deploys_use_tgz_archive_upload() -> None:
+    deploy_lines = 0
+    violations: list[str] = []
+
+    for rel_path in VERCEL_WORKFLOWS:
+        text = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if "npx vercel deploy" not in line or "--prod" not in line:
+                continue
+            deploy_lines += 1
+            if "--archive=tgz" not in line:
+                violations.append(f"{rel_path}:{line_number}: {line.strip()}")
+
+    assert deploy_lines == 2
+    assert not violations, "Vercel production deploys must use --archive=tgz: " + "; ".join(
+        violations
+    )


### PR DESCRIPTION
## Summary
- add `--archive=tgz` to production Vercel deploy commands in `deploy-frontend.yml` and `deploy-secure.yml`
- add a workflow guard test requiring production Vercel deploy lines to use tar archive uploads

## Root Cause
The scheduled `Deploy Frontend` workflow failed before deployment because Vercel rejected the repo-root upload:

> `files` should NOT have more than 15000 items, received 15766.

The Vercel CLI error recommends `--archive=tgz`, which keeps the root-directory deploy behavior but avoids the file-count upload cap.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS='-p no:cacheprovider' python3 -m pytest -q tests/scripts/test_vercel_deploy_archive_policy.py tests/scripts/test_check_deploy_secure_sha_guard.py tests/scripts/test_check_workflow_checkout_integrity_policy.py -p no:rerunfailures`
- `python3 -m ruff check tests/scripts/test_vercel_deploy_archive_policy.py`
- `git diff --check`
- YAML parse check for `.github/workflows/deploy-frontend.yml` and `.github/workflows/deploy-secure.yml`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Notes: I did not manually trigger a production Vercel deploy from the feature branch. The next production verification is the normal workflow run after merge or an operator-triggered workflow_dispatch.
