### PR TITLE
fix(queue): preserve registry compatibility guards

### DIFF
--- a/aragora/queue/__init__.py
+++ b/aragora/queue/__init__.py
@@ -61,6 +61,7 @@ from aragora.queue.streams import (
 from aragora.queue.worker import (
     DebateExecutor,
     DebateWorker,
+    create_default_executor,
     get_job_handler,
     get_registered_job_handlers,
     get_registered_workers,
@@ -97,6 +98,7 @@ __all__ = [
     # Worker
     "DebateWorker",
     "DebateExecutor",
+    "create_default_executor",
     # Job-handler registry (domain-free; P4a queue inversion Q1)
     "register_worker",
     "register_job_handler",

--- a/aragora/queue/worker.py
+++ b/aragora/queue/worker.py
@@ -37,6 +37,22 @@ _REGISTERED_WORKERS: dict[str, Any] = {}
 _REGISTERED_JOB_HANDLERS: dict[str, DebateExecutor] = {}
 
 
+def _same_job_handler(existing: DebateExecutor, handler: DebateExecutor) -> bool:
+    """Return whether two handler callables represent the same registration."""
+    if existing is handler:
+        return True
+
+    existing_self = getattr(existing, "__self__", None)
+    handler_self = getattr(handler, "__self__", None)
+    existing_func = getattr(existing, "__func__", None)
+    handler_func = getattr(handler, "__func__", None)
+    if existing_self is None or handler_self is None:
+        return False
+    if existing_func is None or handler_func is None:
+        return False
+    return existing_self is handler_self and existing_func is handler_func
+
+
 def register_worker(name: str, worker: Any) -> None:
     """Register a queue worker instance under ``name`` (keyed, idempotent)."""
     _REGISTERED_WORKERS[name] = worker
@@ -50,7 +66,7 @@ def register_job_handler(job_type: str, handler: DebateExecutor) -> None:
     redirect queue execution.
     """
     existing = _REGISTERED_JOB_HANDLERS.get(job_type)
-    if existing is not None and existing is not handler:
+    if existing is not None and not _same_job_handler(existing, handler):
         raise ValueError(f"job handler already registered for job type {job_type!r}")
     _REGISTERED_JOB_HANDLERS[job_type] = handler
 

--- a/aragora/queue/worker.py
+++ b/aragora/queue/worker.py
@@ -43,7 +43,15 @@ def register_worker(name: str, worker: Any) -> None:
 
 
 def register_job_handler(job_type: str, handler: DebateExecutor) -> None:
-    """Register a job handler (executor) for ``job_type`` (keyed, idempotent)."""
+    """Register a job handler (executor) for ``job_type``.
+
+    Re-registering the same handler is a no-op. Registering a different handler
+    for an existing job type fails closed so import order cannot silently
+    redirect queue execution.
+    """
+    existing = _REGISTERED_JOB_HANDLERS.get(job_type)
+    if existing is not None and existing is not handler:
+        raise ValueError(f"job handler already registered for job type {job_type!r}")
     _REGISTERED_JOB_HANDLERS[job_type] = handler
 
 

--- a/tests/queue/test_registry.py
+++ b/tests/queue/test_registry.py
@@ -8,9 +8,9 @@ inversion (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1, §5.2, §10 Q1
   ``aragora.queue.worker`` (re-exported from ``aragora.queue``).
 - ``DebateWorker`` + ``DebateExecutor`` re-exports from ``aragora.queue`` are
   KEPT.
-- The ``create_default_executor`` re-export is DROPPED from ``aragora.queue``
-  (no shim) while the underlying symbol stays defined in ``aragora.queue.worker``
-  (it only relocates in Q2).
+- The ``create_default_executor`` compatibility re-export is KEPT from
+  ``aragora.queue`` while the underlying symbol stays defined in
+  ``aragora.queue.worker`` (it only relocates in Q2).
 - The registry functions carry ZERO domain imports.
 """
 
@@ -83,6 +83,14 @@ def test_register_job_handler_and_get():
 
 
 def test_register_job_handler_is_keyed_idempotent():
+    register_job_handler("dup", _noop_handler)
+    register_job_handler("dup", _noop_handler)
+
+    assert get_job_handler("dup") is _noop_handler
+    assert registered_job_handler_names().count("dup") == 1
+
+
+def test_register_job_handler_rejects_different_duplicate():
     async def first(job: object) -> dict[str, object]:
         return {}
 
@@ -90,10 +98,11 @@ def test_register_job_handler_is_keyed_idempotent():
         return {}
 
     register_job_handler("dup", first)
-    register_job_handler("dup", second)
 
-    assert get_job_handler("dup") is second
-    assert registered_job_handler_names().count("dup") == 1
+    with pytest.raises(ValueError, match="job handler already registered"):
+        register_job_handler("dup", second)
+
+    assert get_job_handler("dup") is first
 
 
 def test_get_job_handler_returns_none_when_unregistered():
@@ -139,15 +148,14 @@ def test_debate_worker_and_executor_alias_reexported_from_queue_package():
     assert "DebateExecutor" in queue_pkg.__all__
 
 
-def test_create_default_executor_reexport_dropped_from_queue_package():
-    """The domain-coupled factory re-export is dropped (no shim, §5.2)."""
+def test_create_default_executor_reexport_kept_from_queue_package():
+    """The Q1 registry enabler keeps the documented factory import path."""
     import aragora.queue as queue_pkg
-
-    assert not hasattr(queue_pkg, "create_default_executor")
-    assert "create_default_executor" not in queue_pkg.__all__
 
     # The underlying symbol is untouched - it only relocates out of worker.py
     # in Q2, so it must still be directly importable from its defining module.
+    assert queue_pkg.create_default_executor is worker.create_default_executor
+    assert "create_default_executor" in queue_pkg.__all__
     assert hasattr(worker, "create_default_executor")
 
 

--- a/tests/queue/test_registry.py
+++ b/tests/queue/test_registry.py
@@ -90,6 +90,63 @@ def test_register_job_handler_is_keyed_idempotent():
     assert registered_job_handler_names().count("dup") == 1
 
 
+def test_register_job_handler_is_idempotent_for_same_bound_method():
+    class Handler:
+        async def handle(self, job: object) -> dict[str, object]:
+            return {}
+
+    instance = Handler()
+
+    register_job_handler("bound", instance.handle)
+    register_job_handler("bound", instance.handle)
+
+    registered = get_job_handler("bound")
+    assert registered is not None
+    assert registered.__self__ is instance
+    assert registered.__func__ is Handler.handle
+    assert registered_job_handler_names().count("bound") == 1
+
+
+def test_register_job_handler_rejects_same_method_on_different_instance():
+    class Handler:
+        async def handle(self, job: object) -> dict[str, object]:
+            return {}
+
+    first = Handler()
+    second = Handler()
+
+    register_job_handler("bound", first.handle)
+
+    with pytest.raises(ValueError, match="job handler already registered"):
+        register_job_handler("bound", second.handle)
+
+    registered = get_job_handler("bound")
+    assert registered is not None
+    assert registered.__self__ is first
+    assert registered.__func__ is Handler.handle
+
+
+def test_register_job_handler_rejects_different_method_on_same_instance():
+    class Handler:
+        async def handle(self, job: object) -> dict[str, object]:
+            return {}
+
+        async def other(self, job: object) -> dict[str, object]:
+            return {}
+
+    instance = Handler()
+
+    register_job_handler("bound", instance.handle)
+
+    with pytest.raises(ValueError, match="job handler already registered"):
+        register_job_handler("bound", instance.other)
+
+    registered = get_job_handler("bound")
+    assert registered is not None
+    assert registered.__self__ is instance
+    assert registered.__func__ is Handler.handle
+
+
 def test_register_job_handler_rejects_different_duplicate():
     async def first(job: object) -> dict[str, object]:
         return {}


### PR DESCRIPTION
## Summary

Follow-up to #8890. The merged Q1 queue registry PR introduced two exact-head model-review P2 regressions:

- `aragora.queue` dropped the documented `create_default_executor` import path while queue docs still rely on it.
- `register_job_handler()` silently overwrote an existing handler for the same job type.

This PR keeps the documented compatibility export until the planned Q2 relocation and makes duplicate job-handler registration fail closed unless it is the same handler object being re-registered.

## Validation

- `python3 -m pytest tests/queue/test_registry.py -q` -> 14 passed
- `python3 -m ruff check aragora/queue/__init__.py aragora/queue/worker.py tests/queue/test_registry.py`
- `git diff --check`
- pre-push hooks passed, including changed-file mypy and ruff format

## Notes

This is a narrow compatibility/guard follow-up. No workflow, branch-protection, settlement, or model-quorum logic changes.
