### PR TITLE
fix(scripts): keep live founder decision packets visible

### DIFF
--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -83,6 +83,13 @@ def _packet_generated_at(markdown: str) -> datetime | None:
     return _parse_datetime(match.group(1))
 
 
+def _is_consolidated_local_packet(markdown: str) -> bool:
+    match = re.search(r"^Purpose:\s*(.+?)\s*$", markdown, flags=re.MULTILINE)
+    if not match:
+        return False
+    return "consolidat" in match.group(1).lower()
+
+
 def _split_table_row(line: str) -> list[str] | None:
     stripped = line.strip()
     if not stripped.startswith("|") or not stripped.endswith("|"):
@@ -193,10 +200,7 @@ def _newest_sources_by_thread(sources: Iterable[DecisionSource]) -> list[Decisio
 
 
 def _local_thread_key(path: Path, *, decisions_root: Path | None = None) -> str:
-    if decisions_root is not None:
-        return f"local:{decisions_root.resolve()}"
-    parent = path.parent if path.parent != Path("") else Path(".")
-    return f"local:{parent.resolve()}"
+    return f"local-file:{path.resolve()}"
 
 
 def _thread_key_from_comment(comment: dict[str, Any], *, fallback: str) -> str:
@@ -242,6 +246,13 @@ def _target_number(target: str) -> str | None:
     if not match:
         return None
     return match.group(1) or match.group(2)
+
+
+def _target_identity_key(item: DecisionItem) -> str:
+    number = _target_number(item.target)
+    if number is not None:
+        return f"github-number:{number}"
+    return f"text:{_compact_text(item.target).lower()}"
 
 
 def _comment_resolves_item(body: str, item: DecisionItem) -> bool:
@@ -342,18 +353,29 @@ def _collect_sources(
 ) -> list[DecisionSource]:
     sources: list[DecisionSource] = []
     if decisions_root.exists():
+        local_sources: list[DecisionSource] = []
         for path in sorted(decisions_root.glob("*.md")):
             try:
                 body = path.read_text(encoding="utf-8")
             except OSError:
                 continue
-            sources.append(
+            local_sources.append(
                 DecisionSource(
                     source=str(path),
                     body=body,
                     thread_key=_local_thread_key(path, decisions_root=decisions_root),
                 )
             )
+        consolidation_sources = [
+            source for source in local_sources if _is_consolidated_local_packet(source.body)
+        ]
+        if consolidation_sources:
+            checkpoint = max(consolidation_sources, key=_packet_sort_key)
+            checkpoint_key = _packet_sort_key(checkpoint)
+            local_sources = [
+                source for source in local_sources if _packet_sort_key(source) >= checkpoint_key
+            ]
+        sources.extend(local_sources)
     for path in packet_files:
         try:
             body = path.read_text(encoding="utf-8")
@@ -378,19 +400,32 @@ def collect_decision_items(
     issue_comments_json: Path | None = None,
 ) -> list[DecisionItem]:
     deduped: dict[tuple[str, str, str], DecisionItem] = {}
+    seen_targets: set[str] = set()
+    items: list[DecisionItem] = []
     sources = _collect_sources(
         decisions_root=decisions_root,
         packet_files=packet_files,
         issue_comments_json=issue_comments_json,
     )
-    for source in _newest_sources_by_thread(sources):
+    for source in sorted(
+        _newest_sources_by_thread(sources),
+        key=_packet_sort_key,
+        reverse=True,
+    ):
         if not source.thread_open:
             continue
         for item in parse_decision_packet(source.body, source=source.source):
             if _item_resolved_after_packet(source, item):
                 continue
-            deduped.setdefault(item.dedupe_key(), item)
-    return list(deduped.values())
+            if item.dedupe_key() in deduped:
+                continue
+            target_key = _target_identity_key(item)
+            if target_key in seen_targets:
+                continue
+            deduped[item.dedupe_key()] = item
+            seen_targets.add(target_key)
+            items.append(item)
+    return items
 
 
 def _format_age(item: DecisionItem, *, now: datetime) -> str:

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -57,6 +57,25 @@ Not part of the decision table.
 """
 
 
+def _consolidated_packet(*, generated: str, target: str, reply: str) -> str:
+    return f"""# Founder Decision Queue Packet
+
+Generated: {generated}
+
+Purpose: consolidate the current operator rulings after live state drift.
+
+## Pending Rulings
+
+| Priority | Link | Current blocker | Requested action | One-word reply |
+| --- | --- | --- | --- | --- |
+| 1 | {target} | Needs a decision. | Rule on this item. | `{reply}` |
+
+## Current Live Snapshots
+
+Not part of the decision table.
+"""
+
+
 def test_parse_decision_packet_extracts_pending_rulings() -> None:
     items = fdq.parse_decision_packet(PACKET, source="local.md")
 
@@ -124,6 +143,97 @@ def test_collect_decision_items_deduplicates_issue_comment_export(tmp_path: Path
     assert "| Priority 1 | PR #8756:" in rendered
     assert "`approve`" in rendered
     assert "2.0h" in rendered
+
+
+def test_collect_decision_items_keeps_distinct_local_packets(tmp_path: Path) -> None:
+    decisions_root = tmp_path / "founder-decisions"
+    decisions_root.mkdir()
+    (decisions_root / "older.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T10:00:00Z",
+            target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+            reply="approve",
+        ),
+        encoding="utf-8",
+    )
+    (decisions_root / "newer.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T11:00:00Z",
+            target="PR #8897: https://github.com/synaptent/aragora/pull/8897",
+            reply="ready",
+        ),
+        encoding="utf-8",
+    )
+
+    items = fdq.collect_decision_items(decisions_root=decisions_root)
+
+    assert {item.expected_reply for item in items} == {"approve", "ready"}
+    assert {fdq._target_number(item.target) for item in items} == {"8756", "8897"}
+
+
+def test_collect_decision_items_newer_local_packet_supersedes_same_target(
+    tmp_path: Path,
+) -> None:
+    decisions_root = tmp_path / "founder-decisions"
+    decisions_root.mkdir()
+    target = "PR #8756: https://github.com/synaptent/aragora/pull/8756"
+    (decisions_root / "older.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T10:00:00Z",
+            target=target,
+            reply="approve",
+        ),
+        encoding="utf-8",
+    )
+    (decisions_root / "newer.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T11:00:00Z",
+            target=target,
+            reply="hold",
+        ),
+        encoding="utf-8",
+    )
+
+    items = fdq.collect_decision_items(decisions_root=decisions_root)
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "hold"
+    assert items[0].source.endswith("newer.md")
+
+
+def test_collect_decision_items_uses_latest_local_consolidation_checkpoint(
+    tmp_path: Path,
+) -> None:
+    decisions_root = tmp_path / "founder-decisions"
+    decisions_root.mkdir()
+    (decisions_root / "stale.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T09:00:00Z",
+            target="PR #8895: https://github.com/synaptent/aragora/pull/8895",
+            reply="ready",
+        ),
+        encoding="utf-8",
+    )
+    (decisions_root / "consolidated.md").write_text(
+        _consolidated_packet(
+            generated="2026-07-05T10:00:00Z",
+            target="PR #8894: https://github.com/synaptent/aragora/pull/8894",
+            reply="ready",
+        ),
+        encoding="utf-8",
+    )
+    (decisions_root / "newer.md").write_text(
+        _single_item_packet(
+            generated="2026-07-05T11:00:00Z",
+            target="PR #8897: https://github.com/synaptent/aragora/pull/8897",
+            reply="ready",
+        ),
+        encoding="utf-8",
+    )
+
+    items = fdq.collect_decision_items(decisions_root=decisions_root)
+
+    assert {fdq._target_number(item.target) for item in items} == {"8894", "8897"}
 
 
 def test_collect_decision_items_keeps_newest_packet_on_thread(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Give local founder decision packet files independent thread keys so newer single-PR packets do not hide older distinct pending packets.
- Let newer local packets supersede older packets for the same target.
- Treat the latest consolidated local packet as a checkpoint so stale older local rulings do not reappear.

## Validation

- `python3 -m pytest tests/scripts/test_founder_decision_queue.py -q`
- `python3 -m ruff check scripts/founder_decision_queue.py tests/scripts/test_founder_decision_queue.py`
- `python3 scripts/founder_decision_queue.py --decisions-root /Users/armand/Development/aragora/.aragora/founder-decisions --json`

Live render after fix: 4 items (#8897, #8894, #8896, #8823).