### PR TITLE
refactor(queue): relocate create_default_executor to debate home (P4a Q2)

### DIFF
--- a/aragora/debate/queue_executor.py
+++ b/aragora/debate/queue_executor.py
@@ -1,0 +1,89 @@
+"""
+Default debate executor factory for the queue system.
+
+Builds the async job-executor callable that ``DebateWorker``
+(``aragora.queue.worker``) runs debate jobs through, wiring the domain-free
+queue transport to the Arena. Lives in ``aragora.debate`` rather than
+``aragora.queue`` because it imports ``aragora.agents.base`` and
+``aragora.debate.orchestrator``, both domain-layer packages
+(docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §5.2, §6.2, §10 Q2).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, cast
+
+from aragora.exceptions import InfrastructureError
+from aragora.queue.base import Job
+
+if TYPE_CHECKING:
+    from aragora.agents.base import AgentType
+
+
+async def create_default_executor() -> Callable[[Job], Coroutine[Any, Any, dict[str, Any]]]:
+    """
+    Create a default debate executor.
+
+    This imports the debate infrastructure and creates an executor
+    that runs debates using the Arena.
+
+    Returns:
+        An async function that executes debate jobs
+    """
+
+    async def execute_debate(job: Job) -> dict[str, Any]:
+        """Execute a debate from a job."""
+        # Import here to avoid circular imports
+        from aragora.queue.job import DebateResult, get_debate_payload
+
+        payload = get_debate_payload(job)
+
+        # Import debate infrastructure
+        try:
+            from aragora.agents.base import create_agent
+            from aragora.core import DebateProtocol, Environment
+            from aragora.debate.orchestrator import Arena
+        except ImportError as e:
+            raise InfrastructureError(f"Debate infrastructure not available: {e}")
+
+        # Create environment and protocol
+        env = Environment(task=payload.question)
+        # DebateProtocol dataclass fields have complex default handling
+        protocol = cast(Any, DebateProtocol)(
+            rounds=payload.rounds,
+            consensus=cast(Any, payload.consensus),
+        )
+
+        # Convert agent strings to Agent objects
+        agents_list = []
+        for agent_type in payload.agents:
+            agent = create_agent(cast("AgentType", agent_type))
+            if agent is not None:
+                agents_list.append(agent)
+        agents = agents_list
+
+        # Run debate
+        start_time = time.time()
+        arena = Arena(env, agents=agents, protocol=protocol)
+        result = await arena.run()
+
+        duration = time.time() - start_time
+
+        # Build result
+        debate_result = DebateResult(
+            debate_id=result.debate_id if hasattr(result, "debate_id") else job.id,
+            consensus_reached=(
+                result.consensus_reached if hasattr(result, "consensus_reached") else False
+            ),
+            final_answer=result.final_answer if hasattr(result, "final_answer") else None,
+            confidence=result.confidence if hasattr(result, "confidence") else 0.0,
+            rounds_used=result.rounds_used if hasattr(result, "rounds_used") else payload.rounds,
+            participants=payload.agents,
+            duration_seconds=duration,
+        )
+
+        return debate_result.to_dict()
+
+    return execute_debate

--- a/aragora/queue/README.md
+++ b/aragora/queue/README.md
@@ -94,8 +94,8 @@ print(f"Status: {status.status.value}")
 from aragora.queue import (
     create_redis_queue,
     DebateWorker,
-    create_default_executor,
 )
+from aragora.debate.queue_executor import create_default_executor
 
 # Create queue and executor
 queue = await create_redis_queue(consumer_name="worker-1")
@@ -133,7 +133,8 @@ python -m scripts.queue_worker --worker-id worker-2 &
 The core worker for processing debate jobs with full Arena integration.
 
 ```python
-from aragora.queue import DebateWorker, create_redis_queue, create_default_executor
+from aragora.queue import DebateWorker, create_redis_queue
+from aragora.debate.queue_executor import create_default_executor
 
 queue = await create_redis_queue(consumer_name="debate-worker-1")
 executor = await create_default_executor()
@@ -535,8 +536,16 @@ class DebateWorker:
     async def start() -> None
     async def stop(timeout=30.0) -> None
     def get_stats() -> dict[str, Any]
+```
 
-# Factory function
+#### create_default_executor
+
+Default `DebateExecutor` factory, defined in `aragora.debate.queue_executor` (not
+`aragora.queue`) since it imports the Arena and agent factory:
+
+```python
+from aragora.debate.queue_executor import create_default_executor
+
 async def create_default_executor() -> DebateExecutor
 ```
 

--- a/aragora/queue/__init__.py
+++ b/aragora/queue/__init__.py
@@ -20,7 +20,10 @@ Usage:
     job = await queue.get_status(job_id)
     print(f"Job status: {job.status}")
 
-    # Process jobs with a worker
+    # Process jobs with a worker (executor factory lives in aragora.debate -
+    # it imports agents/debate, so it is not part of this domain-free package)
+    from aragora.debate.queue_executor import create_default_executor
+
     executor = await create_default_executor()
     worker = DebateWorker(queue, "worker-1", executor)
     await worker.start()
@@ -61,7 +64,6 @@ from aragora.queue.streams import (
 from aragora.queue.worker import (
     DebateExecutor,
     DebateWorker,
-    create_default_executor,
     get_job_handler,
     get_registered_job_handlers,
     get_registered_workers,
@@ -98,7 +100,6 @@ __all__ = [
     # Worker
     "DebateWorker",
     "DebateExecutor",
-    "create_default_executor",
     # Job-handler registry (domain-free; P4a queue inversion Q1)
     "register_worker",
     "register_job_handler",

--- a/aragora/queue/worker.py
+++ b/aragora/queue/worker.py
@@ -14,13 +14,9 @@ import asyncio
 import logging
 import signal
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any
 from collections.abc import Callable, Coroutine
 
-if TYPE_CHECKING:
-    from aragora.agents.base import AgentType
-
-from aragora.exceptions import InfrastructureError
 from aragora.queue.base import Job, JobQueue
 from aragora.queue.config import get_queue_config
 from aragora.queue.retry import RetryPolicy, is_retryable_error
@@ -355,70 +351,3 @@ class DebateWorker:
                 break
             except (RuntimeError, OSError, ConnectionError) as e:
                 logger.error("Error claiming stale jobs: %s", e)
-
-
-async def create_default_executor() -> DebateExecutor:
-    """
-    Create a default debate executor.
-
-    This imports the debate infrastructure and creates an executor
-    that runs debates using the Arena.
-
-    Returns:
-        An async function that executes debate jobs
-    """
-
-    async def execute_debate(job: Job) -> dict[str, Any]:
-        """Execute a debate from a job."""
-        # Import here to avoid circular imports
-        from aragora.queue.job import DebateResult, get_debate_payload
-
-        payload = get_debate_payload(job)
-
-        # Import debate infrastructure
-        try:
-            from aragora.agents.base import create_agent
-            from aragora.core import DebateProtocol, Environment
-            from aragora.debate.orchestrator import Arena
-        except ImportError as e:
-            raise InfrastructureError(f"Debate infrastructure not available: {e}")
-
-        # Create environment and protocol
-        env = Environment(task=payload.question)
-        # DebateProtocol dataclass fields have complex default handling
-        protocol = cast(Any, DebateProtocol)(
-            rounds=payload.rounds,
-            consensus=cast(Any, payload.consensus),
-        )
-
-        # Convert agent strings to Agent objects
-        agents_list = []
-        for agent_type in payload.agents:
-            agent = create_agent(cast("AgentType", agent_type))
-            if agent is not None:
-                agents_list.append(agent)
-        agents = agents_list
-
-        # Run debate
-        start_time = time.time()
-        arena = Arena(env, agents=agents, protocol=protocol)
-        result = await arena.run()
-
-        duration = time.time() - start_time
-
-        # Build result
-        debate_result = DebateResult(
-            debate_id=result.debate_id if hasattr(result, "debate_id") else job.id,
-            consensus_reached=(
-                result.consensus_reached if hasattr(result, "consensus_reached") else False
-            ),
-            final_answer=result.final_answer if hasattr(result, "final_answer") else None,
-            confidence=result.confidence if hasattr(result, "confidence") else 0.0,
-            rounds_used=result.rounds_used if hasattr(result, "rounds_used") else payload.rounds,
-            participants=payload.agents,
-            duration_seconds=duration,
-        )
-
-        return debate_result.to_dict()
-
-    return execute_debate

--- a/docs-site/docs/guides/queue.md
+++ b/docs-site/docs/guides/queue.md
@@ -85,8 +85,8 @@ print(f"Status: {status}")
 from aragora.queue import (
     create_redis_queue,
     DebateWorker,
-    create_default_executor,
 )
+from aragora.debate.queue_executor import create_default_executor
 
 # Create queue and executor
 queue = await create_redis_queue(consumer_name="worker-1")

--- a/docs/resilience/QUEUE.md
+++ b/docs/resilience/QUEUE.md
@@ -80,8 +80,8 @@ print(f"Status: {status}")
 from aragora.queue import (
     create_redis_queue,
     DebateWorker,
-    create_default_executor,
 )
+from aragora.debate.queue_executor import create_default_executor
 
 # Create queue and executor
 queue = await create_redis_queue(consumer_name="worker-1")

--- a/scripts/queue_worker.py
+++ b/scripts/queue_worker.py
@@ -63,7 +63,7 @@ async def main(
         create_redis_queue,
         DebateWorker,
     )
-    from aragora.queue.worker import create_default_executor
+    from aragora.debate.queue_executor import create_default_executor
 
     logger = logging.getLogger(__name__)
     logger.info(f"Starting worker {worker_id} with concurrency={concurrency}")

--- a/tests/debate/test_queue_executor.py
+++ b/tests/debate/test_queue_executor.py
@@ -1,0 +1,90 @@
+"""Tests for the debate-home executor factory (P4a queue inversion Q2).
+
+``create_default_executor`` relocated here from ``aragora.queue.worker``
+(docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §6.2, §10 Q2): its nested
+``execute_debate`` lazily imports ``aragora.agents.base``, ``aragora.core``,
+and ``aragora.debate.orchestrator`` to run a debate through the Arena, which
+would otherwise pull those domain packages into the infrastructure-layer
+``aragora.queue`` package (an illegal upward edge under .importlinter).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.debate.queue_executor import create_default_executor
+from aragora.exceptions import InfrastructureError
+from aragora.queue.job import create_debate_job
+
+
+@pytest.mark.asyncio
+async def test_create_default_executor_returns_callable():
+    executor = await create_default_executor()
+    assert callable(executor)
+
+
+@pytest.mark.asyncio
+async def test_execute_debate_builds_result_from_arena_run():
+    executor = await create_default_executor()
+    job = create_debate_job(
+        question="Should we ship it?", agents=["claude", "openai-api"], rounds=2
+    )
+
+    fake_result = MagicMock()
+    fake_result.debate_id = "debate-123"
+    fake_result.consensus_reached = True
+    fake_result.final_answer = "Yes"
+    fake_result.confidence = 0.9
+    fake_result.rounds_used = 2
+
+    fake_arena = MagicMock()
+    fake_arena.run = AsyncMock(return_value=fake_result)
+
+    with (
+        patch("aragora.agents.base.create_agent", return_value=MagicMock()) as mock_create_agent,
+        patch("aragora.debate.orchestrator.Arena", return_value=fake_arena) as mock_arena_cls,
+    ):
+        result = await executor(job)
+
+    assert mock_create_agent.call_count == 2
+    mock_arena_cls.assert_called_once()
+    assert result["debate_id"] == "debate-123"
+    assert result["consensus_reached"] is True
+    assert result["final_answer"] == "Yes"
+    assert result["confidence"] == 0.9
+    assert result["rounds_used"] == 2
+    assert result["participants"] == ["claude", "openai-api"]
+
+
+@pytest.mark.asyncio
+async def test_execute_debate_skips_agent_types_that_create_agent_rejects():
+    executor = await create_default_executor()
+    job = create_debate_job(question="Q", agents=["claude", "unknown-agent"], rounds=1)
+
+    fake_arena = MagicMock()
+    fake_arena.run = AsyncMock(return_value=MagicMock())
+
+    def _create_agent_side_effect(agent_type):
+        return MagicMock() if agent_type == "claude" else None
+
+    with (
+        patch("aragora.agents.base.create_agent", side_effect=_create_agent_side_effect),
+        patch("aragora.debate.orchestrator.Arena", return_value=fake_arena) as mock_arena_cls,
+    ):
+        await executor(job)
+
+    _, kwargs = mock_arena_cls.call_args
+    assert len(kwargs["agents"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_execute_debate_raises_infrastructure_error_when_debate_stack_missing():
+    executor = await create_default_executor()
+    job = create_debate_job(question="Q", agents=[], rounds=1)
+
+    with patch.dict(sys.modules, {"aragora.debate.orchestrator": None}):
+        with pytest.raises(InfrastructureError):
+            await executor(job)

--- a/tests/queue/test_registry.py
+++ b/tests/queue/test_registry.py
@@ -1,16 +1,16 @@
-"""Tests for the domain-free job-handler registry (P4a queue inversion Q1).
+"""Tests for the domain-free job-handler registry (P4a queue inversion Q1/Q2).
 
 Covers the enabler surface introduced by the queue/job-handler registry
-inversion (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1, §5.2, §10 Q1):
+inversion (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §4.1, §5.2, §10 Q1/Q2):
 
 - ``register_worker`` / ``register_job_handler`` / ``get_registered_workers`` /
   ``get_registered_job_handlers`` / ``get_job_handler`` / ``reset_registry`` on
   ``aragora.queue.worker`` (re-exported from ``aragora.queue``).
 - ``DebateWorker`` + ``DebateExecutor`` re-exports from ``aragora.queue`` are
   KEPT.
-- The ``create_default_executor`` compatibility re-export is KEPT from
-  ``aragora.queue`` while the underlying symbol stays defined in
-  ``aragora.queue.worker`` (it only relocates in Q2).
+- The ``create_default_executor`` re-export is DROPPED from ``aragora.queue``
+  (no shim, §10 Q2). The factory itself relocated out of ``aragora.queue.worker``
+  to its debate-layer home ``aragora.debate.queue_executor``.
 - The registry functions carry ZERO domain imports.
 """
 
@@ -205,15 +205,20 @@ def test_debate_worker_and_executor_alias_reexported_from_queue_package():
     assert "DebateExecutor" in queue_pkg.__all__
 
 
-def test_create_default_executor_reexport_kept_from_queue_package():
-    """The Q1 registry enabler keeps the documented factory import path."""
+def test_create_default_executor_reexport_dropped_from_queue_package():
+    """The domain-coupled factory re-export is dropped (no shim, §5.2)."""
     import aragora.queue as queue_pkg
 
-    # The underlying symbol is untouched - it only relocates out of worker.py
-    # in Q2, so it must still be directly importable from its defining module.
-    assert queue_pkg.create_default_executor is worker.create_default_executor
-    assert "create_default_executor" in queue_pkg.__all__
-    assert hasattr(worker, "create_default_executor")
+    assert not hasattr(queue_pkg, "create_default_executor")
+    assert "create_default_executor" not in queue_pkg.__all__
+
+    # Q2 relocated the factory itself out of worker.py to its debate-layer
+    # home; the queue package (and its worker module) no longer defines it.
+    assert not hasattr(worker, "create_default_executor")
+
+    from aragora.debate.queue_executor import create_default_executor
+
+    assert callable(create_default_executor)
 
 
 def test_registry_functions_reexported_from_queue_package():
@@ -238,12 +243,10 @@ def test_registry_functions_reexported_from_queue_package():
 def test_registry_functions_have_zero_domain_imports():
     """The registry's own functions must not reference any domain package.
 
-    ``worker.py`` also hosts ``create_default_executor`` (pending relocation to
-    a debate-layer home in Q2), which legitimately lazy-imports domain packages
-    inside its own body. Scoping this static guard to just the registry
-    callables (instead of the whole file) avoids a false positive on that
-    pre-existing, unrelated code; the full-layer grimp/import-linter re-check
-    is the authoritative proof that ``aragora.queue`` gains no new edge.
+    Scoped to just the registry callables (instead of the whole file) so a
+    future addition to ``worker.py`` can't silently introduce a domain import
+    without failing this guard; the full-layer grimp/import-linter re-check is
+    the authoritative proof that ``aragora.queue`` gains no new edge.
     """
     domain_packages = (
         "agents",


### PR DESCRIPTION
## Source

P4a events/queue layering-inversion design, `docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md` §10 row Q2 / §6.2 / §5.2. Supersedes cancelled Batch 2a/2b. Follows Q1 (#8890, job-handler registry enabler).

## What changed

- Moved `create_default_executor` (the domain-coupled factory whose nested `execute_debate` lazily imports `aragora.agents.base` and `aragora.debate.orchestrator`) out of `aragora/queue/worker.py` into a new debate-layer home `aragora/debate/queue_executor.py`. `debate -> agents`/`debate -> debate.orchestrator` is a same/downward-layer import (legal); the old `queue -> debate` (infra importing domain) was the illegal upward edge this clears.
- Deleted `worker.py`'s now-unused `AgentType` `TYPE_CHECKING` import.
- `DebateExecutor` (type alias) and `DebateWorker` (transport base) stay in `aragora.queue`, unchanged.
- **No re-export shim** at the old path (Relocate-UP no-shim exemption, AGENTS.md + doc §8 — a shim would re-create the exact `queue -> debate` edge being cleared). Consumer census: zero SDK/`aragora/client` references to the old path; all in-repo consumers repointed (see below).
- **Incident #3 remediation (orchestrator gate-lift addendum):** PR #8893 (rogue automation, merged `433360a7da`) had restored the `create_default_executor` re-export that Q1 (#8890) dropped, and reverted Q1's registry test. This PR re-drops the re-export (import, `__all__` entry, docstring example) from `queue/__init__.py` and re-flips `test_create_default_executor_reexport_kept_from_queue_package` back to `test_create_default_executor_reexport_dropped_from_queue_package` (asserts import fails from `aragora.queue`, succeeds from the new debate home). #8893's unrelated `_same_job_handler` idempotency guard in `register_job_handler` is kept untouched (guards a different surface). `433360a7da` itself is not reverted.

## Repointed consumers (no shim, so every consumer moves)

- `scripts/queue_worker.py` (runtime consumer)
- `aragora/queue/README.md` (3 spots: "Running a Worker", `DebateWorker` example, API reference)
- `docs/resilience/QUEUE.md` + regenerated docs-site mirror `docs-site/docs/guides/queue.md` (`sync-docs.js`)
- `tests/queue/test_registry.py` (re-export test + docstrings)
- New `tests/debate/test_queue_executor.py` (4 tests: callable return, Arena-run result mapping, agent-filtering, `InfrastructureError` on missing debate stack)

## Validation

- `python3 -m pytest tests/debate/test_queue_executor.py tests/queue/ -q --timeout=60`: 685 passed.
- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/queue/worker.py aragora/queue/__init__.py aragora/debate/queue_executor.py`: `Success: no issues found in 3 source files` (matches the required CI changed-file gate exactly).
- `make test-smoke` (AWS-neutralized): exit 0, all 3 canary lines (`Core imports OK`, `Server imports OK`, `Memory imports OK`) — VAL-P4A-013.
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke`: 138 passed, 0 failed/error.
- `scripts/ci/check_import_contracts.py --layers foundation,infrastructure --json`: `resolved_violations` includes `aragora.queue -> aragora.debate`; the one `new_violations` entry (`aragora.utils -> aragora.caching`) is confirmed identical on a fresh clean `origin/main` worktree (pre-existing ambient, not introduced by this PR).
- `scripts/ci/check_import_contracts.py --json` (full, no `--layers`): same `queue -> debate` resolution; the 4 `new_violations` entries are all confirmed identical on clean `origin/main` (pre-existing ambient: `evaluation->connectors`, `evaluation->swarm`, `swarm->cli`, `utils->caching`) — zero new domain/application/interface edges from this move.
- Targeted grimp check: `worker.py` now has zero direct imports of `aragora.debate`/`aragora.agents`; `aragora.queue.workers.gauntlet_worker` (Q3 scope, untouched) still imports `aragora.agents.base`, confirming only `worker.py`'s share of `queue -> agents` was cleared, matching the doc's "Clears: `queue->debate` + `worker` share of `queue->agents`".
- `get_cross_subscriber_manager()` import path re-verified unchanged (unrelated canary).
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q`: 11 passed (docs-site mirror regen verified).

## Drift (recorded, not fixed here)

- Whole-tree `typecheck_differential.sh` reports `new=117 > floor 66` — pure ambient `scripts/`-automation drift (documented, expected pattern per mission `library/environment.md` for all remaining P4a queue/events batches); confirmed zero of the 117 lines touch any file this PR changes. Not bumping the floor (reserved for the dedicated P4a scrutiny re-measure).
- `docs/METRICS.md` / `aragora/module_tiers.yaml` NOT regenerated — path-frozen by other open PRs at dispatch time; no module added/removed/renamed (function relocation + one file addition), so no tier-count drift from this PR itself.
- `scripts/baselines/import_contracts_baseline.json` unchanged — the checker recomputes violations fresh each run (shrink is automatic/organic here, not a hand-edit); no path-freeze blocked this PR's files at dispatch.

## Risk

Low. Pure code relocation + doc/test repoints; behavior-preserving (function body unchanged). No public API surface change (no SDK/client consumer existed). Tier 1-2.
