### PR TITLE
fix(cli): avoid optional package imports in doctor checks

### DIFF
--- a/aragora/cli/doctor.py
+++ b/aragora/cli/doctor.py
@@ -13,6 +13,7 @@ Checks:
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import os
 import sys
 from dataclasses import dataclass
@@ -171,23 +172,30 @@ def check_packages() -> list[HealthCheck]:
         except Exception as exc:  # noqa: BLE001 - doctor should surface broken imports, not crash
             checks.append((pkg, f"MISSING ({type(exc).__name__})", False))
 
+    def _optional_package_check(pkg: str, label: str) -> None:
+        # Optional probes must be presence checks only. Importing native-heavy
+        # packages like torch can segfault or exhaust CI workers before doctor
+        # can report a useful health summary.
+        try:
+            available = importlib.util.find_spec(pkg) is not None
+        except Exception as exc:  # noqa: BLE001 - diagnostic probe must not crash doctor
+            checks.append((label, f"not installed ({type(exc).__name__})", None))
+            return
+
+        if available:
+            checks.append((label, "installed", True))
+        else:
+            checks.append((label, "not installed", None))
+
     # Optional ML packages
     optional_ml = ["torch", "transformers", "sentence_transformers"]
     for pkg in optional_ml:
-        try:
-            __import__(pkg)
-            checks.append((f"{pkg} (ML)", "installed", True))
-        except Exception as exc:  # noqa: BLE001 - optional imports may fail due broken transitive deps
-            checks.append((f"{pkg} (ML)", f"not installed ({type(exc).__name__})", None))
+        _optional_package_check(pkg, f"{pkg} (ML)")
 
     # Optional integrations
     optional_int = ["redis", "asyncpg", "boto3", "opentelemetry"]
     for pkg in optional_int:
-        try:
-            __import__(pkg)
-            checks.append((f"{pkg} (integration)", "installed", True))
-        except Exception as exc:  # noqa: BLE001 - doctor should not crash on broken optional deps
-            checks.append((f"{pkg} (integration)", f"not installed ({type(exc).__name__})", None))
+        _optional_package_check(pkg, f"{pkg} (integration)")
 
     return checks
 

--- a/tests/cli/test_cli_training.py
+++ b/tests/cli/test_cli_training.py
@@ -26,7 +26,7 @@ def runner():
 class TestExportSft:
     """Tests for export-sft command."""
 
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_sft_basic(self, mock_exporter_class, runner, tmp_path):
         """export-sft creates output file."""
         mock_exporter = MagicMock()
@@ -42,7 +42,7 @@ class TestExportSft:
         assert "100" in result.output
         assert "SFT" in result.output
 
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_sft_with_options(self, mock_exporter_class, runner, tmp_path):
         """export-sft respects options."""
         mock_exporter = MagicMock()
@@ -75,7 +75,7 @@ class TestExportSft:
 class TestExportDpo:
     """Tests for export-dpo command."""
 
-    @patch("aragora.cli.training.DPOExporter")
+    @patch("aragora.training.exporters.DPOExporter")
     def test_export_dpo_basic(self, mock_exporter_class, runner, tmp_path):
         """export-dpo creates output file."""
         mock_exporter = MagicMock()
@@ -91,7 +91,7 @@ class TestExportDpo:
         assert "75" in result.output
         assert "DPO" in result.output
 
-    @patch("aragora.cli.training.DPOExporter")
+    @patch("aragora.training.exporters.DPOExporter")
     def test_export_dpo_with_elo_diff(self, mock_exporter_class, runner, tmp_path):
         """export-dpo respects min-elo-diff option."""
         mock_exporter = MagicMock()
@@ -117,7 +117,7 @@ class TestExportDpo:
 class TestExportGauntlet:
     """Tests for export-gauntlet command."""
 
-    @patch("aragora.cli.training.GauntletExporter")
+    @patch("aragora.training.exporters.GauntletExporter")
     def test_export_gauntlet_basic(self, mock_exporter_class, runner, tmp_path):
         """export-gauntlet creates output file."""
         mock_exporter = MagicMock()
@@ -137,9 +137,9 @@ class TestExportGauntlet:
 class TestExportAll:
     """Tests for export-all command."""
 
-    @patch("aragora.cli.training.GauntletExporter")
-    @patch("aragora.cli.training.DPOExporter")
-    @patch("aragora.cli.training.SFTExporter")
+    @patch("aragora.training.exporters.GauntletExporter")
+    @patch("aragora.training.exporters.DPOExporter")
+    @patch("aragora.training.exporters.SFTExporter")
     def test_export_all_creates_multiple_files(
         self, mock_sft, mock_dpo, mock_gauntlet, runner, tmp_path
     ):
@@ -173,7 +173,7 @@ class TestTestConnection:
         assert "TINKER_API_KEY" in result.output
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     @patch.dict("os.environ", {"TINKER_API_KEY": "test-key"})
     def test_connection_success(self, mock_client_class, mock_run, runner):
         """test-connection succeeds with valid key."""
@@ -192,7 +192,7 @@ class TestTrainSft:
     """Tests for train-sft command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TrainingScheduler")
+    @patch("aragora.training.TrainingScheduler")
     def test_train_sft_schedules_job(self, mock_scheduler_class, mock_run, runner):
         """train-sft schedules a training job."""
         mock_scheduler = AsyncMock()
@@ -222,7 +222,7 @@ class TestTrainDpo:
     """Tests for train-dpo command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TrainingScheduler")
+    @patch("aragora.training.TrainingScheduler")
     def test_train_dpo_schedules_job(self, mock_scheduler_class, mock_run, runner):
         """train-dpo schedules a DPO training job."""
         mock_scheduler = AsyncMock()
@@ -240,7 +240,7 @@ class TestListModels:
     """Tests for list-models command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     def test_list_models_empty(self, mock_client_class, mock_run, runner):
         """list-models shows message when no models."""
         mock_run.return_value = None
@@ -255,7 +255,7 @@ class TestSample:
     """Tests for sample command."""
 
     @patch("aragora.cli.training.asyncio.run")
-    @patch("aragora.cli.training.TinkerClient")
+    @patch("aragora.training.tinker_client.TinkerClient")
     def test_sample_generates_text(self, mock_client_class, mock_run, runner):
         """sample command generates text."""
         mock_client = AsyncMock()
@@ -275,8 +275,8 @@ class TestSample:
 class TestStats:
     """Tests for stats command."""
 
-    @patch("aragora.cli.training.EloSystem")
-    @patch("aragora.cli.training.CritiqueStore")
+    @patch("aragora.ranking.elo.EloSystem")
+    @patch("aragora.memory.store.CritiqueStore")
     def test_stats_shows_data(self, mock_critique, mock_elo, runner):
         """stats command shows training data statistics."""
         mock_critique_instance = MagicMock()

--- a/tests/cli/test_doctor.py
+++ b/tests/cli/test_doctor.py
@@ -6,6 +6,7 @@ Tests health check CLI commands.
 
 from __future__ import annotations
 
+import builtins
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -119,6 +120,32 @@ class TestCheckPackages:
         # At least one integration package should be checked
         int_pkgs = [n for n in names if "(integration)" in n]
         assert len(int_pkgs) >= 1
+
+    def test_optional_packages_are_not_imported(self, monkeypatch):
+        """Optional probes detect presence without importing heavy native stacks."""
+        blocked = {
+            "asyncpg",
+            "boto3",
+            "opentelemetry",
+            "redis",
+            "sentence_transformers",
+            "torch",
+            "transformers",
+        }
+        real_import = builtins.__import__
+
+        def guarded_import(name, *args, **kwargs):
+            if name.split(".", 1)[0] in blocked:
+                raise AssertionError(f"optional package was imported: {name}")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        result = check_packages()
+        names = [name for name, _, _ in result]
+
+        assert "torch (ML)" in names
+        assert "redis (integration)" in names
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

This is a draft repair PR for the #8910 infra-shard blocker observed on #8903.
It is intentionally stacked on the current #8903 head (`22c4070bf7189589c69f986e8f01c83cca8bb8f7`), so it includes #8903's CLI-training fix underneath this commit. Do not merge independently unless the operator chooses to supersede/replace #8903 or retargets this branch.

## Diagnosis

- #8903 attempt 2 reached 99% before cancellation; the last started test in the log was `tests/rbac/test_emergency.py::TestSingleton::test_get_break_glass_access`.
- #8903 attempt 3 reached 99% before cancellation; the last unmatched started test was `tests/observability/test_observability.py::TestTraceHandler::test_trace_handler_decorator`, with cleanup terminating an orphan pytest process.
- Those suspect nodes passed locally on the exact head.
- A CI-shaped local infra-shard run reproduced a concrete worker crash/segfault while running `tests/cli/test_cli_doctor.py::TestDoctorCommand::test_checks_required_packages` / `test_checks_api_keys`.
- The segfault stack was in `aragora/cli/doctor.py::check_packages()` while importing optional `torch`.

## Fix

- Keep required package checks as real imports so broken required dependencies still surface.
- Change optional ML/integration checks to use `importlib.util.find_spec()` presence probes instead of importing native-heavy optional stacks.
- Add a regression test that fails if optional packages such as `torch`, `transformers`, `redis`, `asyncpg`, `boto3`, or `opentelemetry` are imported by the doctor package check.

## Validation

- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH PYTHONPATH=.:aragora-debate/src python -m pytest tests/cli/test_cli_doctor.py::TestDoctorCommand::test_checks_required_packages tests/cli/test_cli_doctor.py::TestDoctorCommand::test_checks_api_keys -q --timeout=120` -> `2 passed`
- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH PYTHONPATH=.:aragora-debate/src python -m pytest tests/cli/test_doctor.py::TestCheckPackages -q --timeout=120` -> `5 passed`
- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH PYTHONPATH=.:aragora-debate/src python -m pytest tests/cli/test_cli_training.py -q --timeout=120` -> `13 passed`
- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH PYTHONPATH=.:aragora-debate/src python -m pytest tests/cli/test_cli_doctor.py tests/cli/test_doctor.py::TestCheckPackages tests/cli/test_cli_training.py -q --timeout=120` -> `30 passed`
- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH python -m ruff check aragora/cli/doctor.py tests/cli/test_doctor.py tests/cli/test_cli_doctor.py tests/cli/test_cli_training.py` -> `All checks passed`
- `PATH=/tmp/aragora-8910-py311-venv/bin:$PATH PYTHONPATH=.:aragora-debate/src python -m pytest tests/cli/test_doctor.py -q --timeout=120` -> `44 passed`
- pre-commit / pre-push hooks passed, including ruff, ruff format, mypy for changed Aragora files, gitleaks, and portability guard.

Refs #8910.
Refs #8903.
