### PR TITLE
fix(tooling): packet App-token rerun failures

### DIFF
--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -39,6 +39,11 @@ from urllib import error, parse, request
 
 
 PR_EVENTS = {"pull_request", "pull_request_target"}
+APP_TOKEN_RERUN_PERMISSION_MESSAGE = "Resource not accessible by integration"
+APP_TOKEN_RERUN_PERMISSION_RESULT = (
+    "app-token-rerun-permission-denied: Resource not accessible by integration"
+)
+OPERATOR_ACTION_EXIT = 2
 
 
 class GitHubApiError(RuntimeError):
@@ -172,6 +177,8 @@ class GitHubClient:
             return True, "rerun_requested"
         except GitHubApiError as exc:
             message = str(exc)
+            if _is_app_token_rerun_permission_failure(message):
+                return False, APP_TOKEN_RERUN_PERMISSION_RESULT
             if "403" in message:
                 return False, "forbidden"
             return False, message
@@ -184,6 +191,10 @@ def _field(run: dict[str, Any], *names: str, default: str = "") -> Any:
         if value not in (None, ""):
             return value
     return default
+
+
+def _is_app_token_rerun_permission_failure(message: str) -> bool:
+    return "403" in message and APP_TOKEN_RERUN_PERMISSION_MESSAGE in message
 
 
 def _parse_iso(ts: str) -> datetime | None:
@@ -344,6 +355,7 @@ def compute_retriggerable_runs(
                 "sha": sha,
                 "run_attempt": run_attempt,
                 "rerun_command": f"gh run rerun {run_id}",
+                "human_rerun_command": f"gh run rerun {run_id} --failed",
             }
         )
 
@@ -437,6 +449,12 @@ def _write_receipt(
         "rerun_run_ids": [
             int(item["run_id"]) for item in summary.get("rerun_results", []) if item.get("ok")
         ],
+        "operator_action_required": bool(summary.get("operator_action_required", False)),
+        "permission_denied_run_ids": [
+            int(item["run_id"]) for item in summary.get("permission_denied_reruns", [])
+        ],
+        "human_rerun_commands": list(summary.get("human_rerun_commands", [])),
+        "operator_packet": str(summary.get("operator_packet", "") or ""),
         "head_shas": sorted(
             {
                 str(item.get("sha", "")).strip()
@@ -450,6 +468,107 @@ def _write_receipt(
         json.dump(receipt, handle, indent=2, sort_keys=True)
         handle.write("\n")
     return str(receipt_path)
+
+
+def _human_rerun_items(
+    eligible_runs: list[dict[str, Any]],
+    rerun_results: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    eligible_by_id = {int(item["run_id"]): item for item in eligible_runs}
+    items: list[dict[str, Any]] = []
+    for result in rerun_results:
+        if result.get("ok"):
+            continue
+        message = str(result.get("message", ""))
+        if APP_TOKEN_RERUN_PERMISSION_RESULT not in message:
+            continue
+        run_id = int(result["run_id"])
+        run = eligible_by_id.get(run_id, {"run_id": run_id})
+        item = dict(run)
+        item["run_id"] = run_id
+        item["failure"] = APP_TOKEN_RERUN_PERMISSION_MESSAGE
+        item["human_rerun_command"] = str(
+            item.get("human_rerun_command") or f"gh run rerun {run_id} --failed"
+        )
+        items.append(item)
+    return items
+
+
+def _github_run_url(repo: str, run_id: int) -> str:
+    return f"https://github.com/{repo}/actions/runs/{run_id}"
+
+
+def _write_operator_rerun_packet(
+    *,
+    packet_dir: str,
+    now: datetime,
+    repo: str,
+    scope: str,
+    human_reruns: list[dict[str, Any]],
+    receipt_path: str = "",
+) -> str:
+    path = Path(packet_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    timestamp = now.strftime("%Y%m%dT%H%M%S%fZ")
+    packet_path = path / (
+        f"HUMAN_RERUN_PACKET_{timestamp}_pid{os.getpid()}_{_safe_filename_fragment(scope)}.md"
+    )
+
+    lines = [
+        "# Cancelled Run Human Rerun Packet",
+        "",
+        f"Generated: {now.isoformat()}",
+        "",
+        "Purpose: surface exact human/operator reruns after the GitHub App token "
+        f"failed with `{APP_TOKEN_RERUN_PERMISSION_MESSAGE}`.",
+        "",
+        "This packet does not edit workflow files, mutate PR state, merge, settle, "
+        "post evidence, or rerun checks by itself.",
+        "",
+        "## Pending Reruns",
+        "",
+        "| Priority | Link | Requested Action | Operator Command |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in human_reruns:
+        run_id = int(item["run_id"])
+        command = str(item.get("human_rerun_command") or f"gh run rerun {run_id} --failed")
+        workflow = str(item.get("workflow", "") or "workflow run")
+        branch = str(item.get("branch", "") or "unknown-branch")
+        sha = str(item.get("sha", "") or "unknown-sha")
+        requested = (
+            f"Run exactly `{command}` with human/operator credentials. "
+            f"Proof: `{workflow}` on `{branch}` at `{sha}` was selected as a current "
+            f"cancelled run, but the App-token rerun attempt failed with "
+            f"`{APP_TOKEN_RERUN_PERMISSION_MESSAGE}`."
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    "P1",
+                    _github_run_url(repo, run_id),
+                    requested,
+                    f"`{command}`",
+                ]
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Source",
+            "",
+            f"- Repository: `{repo}`",
+            f"- Scope: `{scope}`",
+        ]
+    )
+    if receipt_path:
+        lines.append(f"- JSON receipt: `{receipt_path}`")
+    lines.append("")
+    packet_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(packet_path)
 
 
 def compute_active_head_map(
@@ -532,6 +651,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=168,
         help="Prune retrigger receipts older than this many hours (<=0 disables pruning)",
+    )
+    parser.add_argument(
+        "--operator-packet-dir",
+        default=os.environ.get(
+            "RETRIGGER_OPERATOR_PACKET_DIR", ".aragora/retrigger_cancelled/operator_packets"
+        ),
+        help="Directory for human rerun packets when App-token reruns are permission-denied",
     )
     parser.add_argument(
         "--apply",
@@ -624,6 +750,8 @@ def main(argv: list[str] | None = None) -> int:
             if args.marker_file:
                 save_marker(args.marker_file, marker_data)
 
+        human_reruns = _human_rerun_items(eligible, rerun_results)
+
         summary = {
             "open_prs_total": len(open_pulls),
             "active_heads_total": len(active_heads),
@@ -642,7 +770,28 @@ def main(argv: list[str] | None = None) -> int:
             "scope": f"pr-{args.pr}" if args.pr is not None else "all-open-prs",
             "scoped_branch": scoped_branch,
             "scoped_sha": scoped_sha,
+            "operator_action_required": bool(human_reruns),
+            "permission_denied_reruns": human_reruns,
+            "human_rerun_commands": [
+                str(item.get("human_rerun_command", "")) for item in human_reruns
+            ],
+            "operator_packet": "",
+            "operator_packet_error": "",
         }
+        operator_packet_error = ""
+        if human_reruns:
+            try:
+                packet_path = _write_operator_rerun_packet(
+                    packet_dir=args.operator_packet_dir,
+                    now=now,
+                    repo=args.repo,
+                    scope=str(summary["scope"]),
+                    human_reruns=human_reruns,
+                )
+                summary["operator_packet"] = packet_path
+            except OSError as exc:
+                operator_packet_error = str(exc)
+                summary["operator_packet_error"] = operator_packet_error
         try:
             receipt_path = _write_receipt(
                 receipt_dir=args.receipt_dir,
@@ -658,6 +807,10 @@ def main(argv: list[str] | None = None) -> int:
             summary["receipt"] = ""
             summary["receipt_error"] = str(exc)
         print(json.dumps(summary))
+        if human_reruns:
+            if operator_packet_error or summary.get("receipt_error"):
+                return 1
+            return OPERATOR_ACTION_EXIT
         return 0
     except (GitHubApiError, ValueError) as exc:
         print(f"Re-trigger error: {exc}", file=sys.stderr)

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -355,7 +355,7 @@ def compute_retriggerable_runs(
                 "sha": sha,
                 "run_attempt": run_attempt,
                 "rerun_command": f"gh run rerun {run_id}",
-                "human_rerun_command": f"gh run rerun {run_id} --failed",
+                "human_rerun_command": f"gh run rerun {run_id}",
             }
         )
 

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -383,19 +383,19 @@ def test_main_apply_permission_denied_writes_human_packet_and_receipt(
     assert summary["apply_failed"] == 1
     assert summary["operator_action_required"] is True
     assert summary["permission_denied_reruns"][0]["run_id"] == 61
-    assert summary["human_rerun_commands"] == ["gh run rerun 61 --failed"]
+    assert summary["human_rerun_commands"] == ["gh run rerun 61"]
 
     packet_path = packet_dir / summary["operator_packet"].split("/")[-1]
     packet = packet_path.read_text(encoding="utf-8")
     assert "Resource not accessible by integration" in packet
     assert "https://github.com/synaptent/aragora/actions/runs/61" in packet
-    assert "`gh run rerun 61 --failed`" in packet
+    assert "`gh run rerun 61`" in packet
 
     receipt_path = receipt_dir / summary["receipt"].split("/")[-1]
     receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
     assert receipt["operator_action_required"] is True
     assert receipt["permission_denied_run_ids"] == [61]
-    assert receipt["human_rerun_commands"] == ["gh run rerun 61 --failed"]
+    assert receipt["human_rerun_commands"] == ["gh run rerun 61"]
     assert receipt["operator_packet"] == summary["operator_packet"]
 
 

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -308,6 +308,97 @@ def test_main_apply_records_rerun_results_in_receipt(tmp_path, monkeypatch, caps
     assert receipt["rerun_run_ids"] == [41]
 
 
+def test_client_classifies_app_token_rerun_permission_failure(monkeypatch) -> None:
+    client = retrigger.GitHubClient(repo="synaptent/aragora", token="token")
+
+    def fail_post(path: str, payload: dict[str, Any] | None = None) -> None:
+        assert path == "/repos/synaptent/aragora/actions/runs/61/rerun"
+        assert payload is None
+        raise retrigger.GitHubApiError(
+            "GitHub API POST /rerun failed: 403 Forbidden\n"
+            '{"message":"Resource not accessible by integration"}'
+        )
+
+    monkeypatch.setattr(client, "post", fail_post)
+
+    ok, message = client.rerun_workflow_run(61)
+
+    assert ok is False
+    assert message == retrigger.APP_TOKEN_RERUN_PERMISSION_RESULT
+
+
+def test_main_apply_permission_denied_writes_human_packet_and_receipt(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            self.repo = repo
+
+        def list_open_pulls(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "feat/a", "sha": "sha-a"},
+                }
+            ]
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            return [
+                make_run(
+                    id=61,
+                    name="Portability Lint",
+                    head_branch="feat/a",
+                    head_sha="sha-a",
+                )
+            ]
+
+        def rerun_workflow_run(self, run_id: int) -> tuple[bool, str]:
+            assert run_id == 61
+            return False, retrigger.APP_TOKEN_RERUN_PERMISSION_RESULT
+
+    receipt_dir = tmp_path / "receipts"
+    packet_dir = tmp_path / "operator-packets"
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+
+    rc = main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--ttl-minutes",
+            "100000",
+            "--apply",
+            "--receipt-dir",
+            str(receipt_dir),
+            "--operator-packet-dir",
+            str(packet_dir),
+        ]
+    )
+
+    assert rc == retrigger.OPERATOR_ACTION_EXIT
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["applied"] == 0
+    assert summary["apply_failed"] == 1
+    assert summary["operator_action_required"] is True
+    assert summary["permission_denied_reruns"][0]["run_id"] == 61
+    assert summary["human_rerun_commands"] == ["gh run rerun 61 --failed"]
+
+    packet_path = packet_dir / summary["operator_packet"].split("/")[-1]
+    packet = packet_path.read_text(encoding="utf-8")
+    assert "Resource not accessible by integration" in packet
+    assert "https://github.com/synaptent/aragora/actions/runs/61" in packet
+    assert "`gh run rerun 61 --failed`" in packet
+
+    receipt_path = receipt_dir / summary["receipt"].split("/")[-1]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert receipt["operator_action_required"] is True
+    assert receipt["permission_denied_run_ids"] == [61]
+    assert receipt["human_rerun_commands"] == ["gh run rerun 61 --failed"]
+    assert receipt["operator_packet"] == summary["operator_packet"]
+
+
 def test_receipt_write_failure_is_reported_without_failing(monkeypatch, capsys) -> None:
     class FakeClient:
         def __init__(self, repo: str, token: str) -> None:


### PR DESCRIPTION
## Summary

- detect GitHub App-token rerun denials that return `Resource not accessible by integration`
- fail closed with exit code 2 when an apply attempt needs human rerun credentials
- write exact `gh run rerun <id> --failed` operator packets plus JSON receipt fields for the fallback

## Context

Uses the fresh founder packet in `.aragora/founder-decisions/20260705T2328Z-mainred-rerun-request.md` and the closed draft #8881 helper work as the live context. This stays scoped to the cancelled-run transport helper and its focused tests.

## Validation

- `python3 -m pytest tests/scripts/test_retrigger_cancelled_pr_runs.py -q` -> 16 passed, 8 warnings
- `python3 -m ruff check scripts/retrigger_cancelled_pr_runs.py tests/scripts/test_retrigger_cancelled_pr_runs.py` -> All checks passed
- `python3 -m ruff format --check scripts/retrigger_cancelled_pr_runs.py tests/scripts/test_retrigger_cancelled_pr_runs.py` -> 2 files already formatted
- `GITHUB_TOKEN="$(gh auth token)" python3 scripts/retrigger_cancelled_pr_runs.py --repo synaptent/aragora --pr 8903 --ttl-minutes 100000 --max-runs 50 --receipt-dir /tmp/aragora-retrigger-smoke-receipts --operator-packet-dir /tmp/aragora-retrigger-smoke-packets` -> dry run, no apply, receipt written
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok
- push hooks passed, including ruff, ruff format, mypy changed-files gate, gitleaks, and portability guard
