### PR TITLE
docs(architecture): Intended Architecture charter — one definition for all fleets

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -3,8 +3,9 @@
 > **Intent charter:** Where code *belongs* — layer model, per-concern authority modules,
 > and the chartered-removals registry — is defined by
 > [`docs/architecture/INTENDED_ARCHITECTURE.md`](INTENDED_ARCHITECTURE.md)
-> (machine encoding: [`charters.yaml`](charters.yaml)). On any structural conflict, the
-> intent charter supersedes this document; this file remains a descriptive overview.
+> (machine encoding: [`charters.yaml`](charters.yaml)). Once RATIFIED, that charter
+> supersedes this document where they conflict; while DRAFT, see its Binding status block.
+> This file remains a descriptive overview.
 
 > **Last Updated:** 2026-04-24
 >

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,5 +1,11 @@
 # Aragora Architecture
 
+> **Intent charter:** Where code *belongs* — layer model, per-concern authority modules,
+> and the chartered-removals registry — is defined by
+> [`docs/architecture/INTENDED_ARCHITECTURE.md`](INTENDED_ARCHITECTURE.md)
+> (machine encoding: [`charters.yaml`](charters.yaml)). On any structural conflict, the
+> intent charter supersedes this document; this file remains a descriptive overview.
+
 > **Last Updated:** 2026-04-24
 >
 > **Scope:** This document is a hand-curated overview of the **core debate-engine subsystems** (agents, debate, reasoning, verification, memory, evolution, connectors, server, RLM, ops, persistence) — about 13 of the ~169 packages in `aragora/`. For the **full module index** (every package, with one-line descriptions), see [`CLAUDE.md`](../../CLAUDE.md). For per-track deep dives, see the other documents in `docs/architecture/`.

--- a/docs/architecture/INTENDED_ARCHITECTURE.md
+++ b/docs/architecture/INTENDED_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Aragora Intended Architecture Charter
 
-Status: DRAFT v0.2 — pending operator ratification and #8851 adopt-or-retire rulings
+Status: DRAFT v0.3 — pending operator ratification and #8851 adopt-or-retire rulings
 Date: 2026-07-06 | Owner: operator (armand)
 Enforcement targets: merge-gate reviewers, all AI fleets (Claude, Codex, Factory droids, launchd daemons), humans
 
@@ -41,15 +41,18 @@ Before you add a module, package, export, or cross-package import edge:
 2. **Grep your target path and symbols** against `docs/architecture/charters.yaml`
    (the machine encoding of §3). If the path/symbol appears in an entry with state
    `REMOVED` — stop; do not re-add; cite the CHR id. State `PENDING` or `EXPIRING` —
-   no new importers/callers; existing ones keep working. State `EXCLUSION` — never build it.
+   no new importers/callers; existing ones keep working. While this charter's Status is
+   DRAFT, that freeze is OPERATIVE only for the entries listed in the Binding status
+   block; for all other entries it is advisory guidance — flag, don't block.
+   State `EXCLUSION` — never build it.
 3. **Package not in §2 or Appendix A as mapped?** It is **UNMAPPED**: frozen for
    architectural growth (§2d). Fix bugs, don't extend its surface, don't import it anew.
 4. **New top-level `aragora/<pkg>` or new concern?** That requires an operator-approved
    amendment to this charter **in the same PR** (R5).
 5. **Entry says PARKED?** Stop and surface to the operator with the entry ID (R4).
 
-On any structural conflict, **this charter wins over every other file in
-`docs/architecture/`** (see §0 precedence).
+On any structural conflict, once RATIFIED **this charter wins over every other file in
+`docs/architecture/`**; while DRAFT, see the Binding status block (§0 precedence).
 
 ---
 
@@ -67,13 +70,22 @@ Registry entry states (§3): `REMOVED` (edge is gone, do not re-add) | `EXPIRING
 compat exception with an ISO deadline or concrete triggering PR/issue) | `PENDING` (removal or
 absorption chartered, not yet executed — **no new importers/callers**; applies equally to
 EXPIRING per R3) | `EXCLUSION` (never wire this) | `PARKED` (frozen both ways).
+While this charter's Status is DRAFT, the PENDING/EXPIRING no-new-importers/callers rule is
+OPERATIVE only for the entries listed in the Binding status block; for all other entries it
+is advisory guidance — flag, don't block.
 
 **ID permanence rule:** ARCH-ids and CHR-ids are permanent. Never reused, never renumbered.
 Entries are only ever state-transitioned (with date + PR recorded in the entry).
 
-**Precedence:** on any structural or architectural-intent conflict, this charter supersedes
-every other file under `docs/architecture/` (ARCHITECTURE.md, ARCHITECTURE_THREE_LAYER.md,
-SYSTEM_DIAGRAM.md, system-overview.md, GATEWAY_ARCHITECTURE.md, and the rest). Those files
+**Evidence snapshot caveat:** all importer counts and `file:line` anchors in this charter
+(and `charters.yaml`) are a snapshot as of 2026-07-06 — verify by re-running the stated grep
+before citing; a stale anchor is not evidence.
+
+**Precedence:** once RATIFIED, this charter supersedes every other file under
+`docs/architecture/` (ARCHITECTURE.md, ARCHITECTURE_THREE_LAYER.md, SYSTEM_DIAGRAM.md,
+system-overview.md, GATEWAY_ARCHITECTURE.md, and the rest) on any structural or
+architectural-intent conflict; while Status is DRAFT, supersession extends only as far as
+the Binding status block. Those files
 remain useful as description; they are not authority. CHR-X-025 charters their SUPERSEDED-BY
 stamping. On numeric conflict, `docs/METRICS.md` wins (R7). On liveness/feature-status
 conflict with CLAUDE.md's tables, this charter's §1 status marks and §3 states win pending
@@ -184,7 +196,7 @@ legend. **Every row has a permanent ARCH-id; every non-adopt disposition points 
 | ARCH-017 | Idea→execution pipeline | `aragora/pipeline` | `aragora/goals/` (single file, is pipeline stage 2); `aragora/autonomous/` (self-described "Nomic Loop Enhancement") | absorb goals/ into pipeline; fold autonomous/ into nomic (PROPOSED → CHR-X-029) | goals/ = extractor.py only; autonomous importers = handlers + one pipeline util |
 | ARCH-018 | Agent process spawning | `aragora/harnesses` | `swarm/worker_launcher.py` spawns codex/Claude directly (0 harness imports); agent_bridge transports | absorb: worker_launcher becomes a harnesses consumer (PROPOSED → CHR-X-030) | worker_launcher.py:613,685 direct spawn |
 | ARCH-019 | PR settlement | `scripts/settle_tier4_pr.py` + `aragora/cli` review-queue transports | settle_one_pr, tier4_merge_train, auto_merge_quorum_green, settlement_followup (wrapper sprawl) | absorb wrappers, then retire (PROPOSED → CHR-X-008) | settle_tier4_pr imported by 8+ scripts/modules; ~12 fix commits |
-| ARCH-020 | Conductor / goal loop | `scripts/fable_goal_cycle.py` + `scripts/consult_claude.py` | goal_conductor.py (hardcodes nomic_loop.py:310), lane_conductor, overnight_conductor; nomic_loop/self_develop/nomic_staged = legacy **manual** entrypoints | retire old conductors; relabel nomic_loop trio "legacy manual" in CLAUDE.md (PROPOSED → CHR-X-009) | launchd runs swarm boss-loop, nothing runs nomic_loop; fable_goal_cycle merged #8835 |
+| ARCH-020 | Conductor / goal loop | `scripts/fable_goal_cycle.py` + `scripts/consult_claude.py` | goal_conductor.py (its line `scripts/goal_conductor.py:310` hardcodes the `scripts/nomic_loop.py` path), lane_conductor, overnight_conductor; nomic_loop/self_develop/nomic_staged = legacy **manual** entrypoints | adopt authority; retire old conductors; relabel nomic_loop trio "legacy manual" in CLAUDE.md (PROPOSED → CHR-X-009) | launchd runs swarm boss-loop, nothing runs nomic_loop; fable_goal_cycle merged #8835 |
 | ARCH-021 | Worktree lifecycle | `aragora/worktree` (maintainer daemon; `scripts/codex_worktree_autopilot.py` is its implementation detail) | `coordination/worktree_manager.py` (wraps it) | adopt; retire coordination wrapper with coordination/ core (PROPOSED → CHR-X-012) | launchd com.aragora.codex-worktree-maintainer; autopilot.py:49 wrapper |
 | ARCH-022 | Scheduled ops jobs (audits, access reviews, DR drills, token refresh, settlement review) | `aragora/scheduler` | `aragora/schedulers/` — deprecated shim package | adopt; retire shim (PROPOSED → CHR-X-031). Ops-cron is a distinct concern from fleet work-dispatch (ARCH-014) and is NOT covered by exclusion CHR-E-003 | package present with launched jobs; shim self-describes deprecated |
 
@@ -258,7 +270,7 @@ compatibility" is NOT a valid counter-argument to a registry entry.
 | CHR-X-006 | PENDING | `resilience/circuit_breaker_v2.py` shim; top-level `resilience_patterns.py`/`resilience_config.py` | 0 external importers / package-internal only | simple_circuit_breaker.py docstring |
 | CHR-X-007 | PENDING | `aragora/metrics/` shim package (all 7 files) | promised deletion "for one release"; **new imports forbidden effective now** (binding in DRAFT — see Binding status) | metrics/__init__.py DeprecationWarning |
 | CHR-X-008 | PENDING | settlement wrappers `scripts/settle_one_pr.py`, `scripts/tier4_merge_train.py`, `scripts/auto_merge_quorum_green.py` (after absorption into settle_tier4_pr/settle_pr) | one settlement path; wrapper sprawl is where fixes get lost | fleet-ops map |
-| CHR-X-009 | PENDING | conductor scripts `scripts/goal_conductor.py`, `scripts/lane_conductor.py`, `scripts/overnight_conductor.py` | superseded by fable_goal_cycle + consult_claude; goal_conductor still hardcodes legacy nomic_loop | goal_conductor.py:310 |
+| CHR-X-009 | PENDING | conductor scripts `scripts/goal_conductor.py`, `scripts/lane_conductor.py`, `scripts/overnight_conductor.py` | superseded by fable_goal_cycle + consult_claude; goal_conductor still hardcodes legacy nomic_loop | `scripts/goal_conductor.py:310` — hardcodes the `scripts/nomic_loop.py` path |
 | CHR-X-010 | PENDING | zero-importer decision-core modules: `agents/email_agents.py`, `agents/feature_agent.py`, `agents/power_sampling_mixin.py`, `ranking/muse_calibration.py` (email_agents/power_sampling_mixin reachable only via lazy `__init__` re-exports; email_agents' only other mention is a docstring at services/email_prioritization.py:920; debate's PowerSamplingConfig is a separate class, not the mixin). **Explicitly NOT chartered** (real callers verified): `ranking/snapshot.py` (elo.py:96, elo_leaderboard.py:18, elo_matchmaking.py:25), `ranking/redteam.py` (elo.py:90, instantiated elo.py:300,329), `verification/sandbox.py` (formal.py:559 Lean execution, verification/__init__.py:49). `verification/proofs.py` is near-dormant but not chartered here | feature-count inflation; no product or fleet caller for the four listed | zero-importer greps re-verified against critic pass 2026-07-06 |
 | CHR-X-012 | PENDING (per #8851 ruling) | `aragora/coordination/` core: `claims.py`, `task_dispatcher.py`, `registry.py`, `health_watchdog.py`, `worktree_manager.py` — salvage GitReconciler→worktree/, bus→events/ | duplicate of dev_coordination + control_plane concepts; no daemon drives it | orchestration map importer audit |
 | CHR-X-013 | PENDING (per #8851 ruling) | `aragora/fabric/` (flip `ARAGORA_ENABLE_AGENT_FABRIC` default→false first — server import path depends on it) | third agent-pool abstraction; no script/daemon/CI runs a fabric pool | extensions.py:39; instantiation sites only |
@@ -411,7 +423,7 @@ draft). Schema:
 ```yaml
 meta:
   charter: docs/architecture/INTENDED_ARCHITECTURE.md
-  version: "0.2"          # must match this doc's version
+  version: "0.3"          # must match this doc's version
   status: DRAFT           # DRAFT | RATIFIED
 authorities:              # §2 rows
   - id: ARCH-001
@@ -464,6 +476,7 @@ registry:                 # §3 entries
 |---|---|---|---|---|
 | v0.1 | 2026-07-05 | (scratchpad draft, never binding) | operator-commissioned | initial: CHR-P4A-001..004, CHR-X-001..024, CHR-E-001..008 |
 | v0.2 | 2026-07-06 | this PR (draft) | operator-commissioned; adversarial critic pass applied | added ARCH-001..036 ids; CHR-P4A-004 → REMOVED (#8909); CHR-X-002 split (→ CHR-X-038); CHR-X-010 corrected (snapshot/redteam/sandbox de-chartered); added CHR-X-025..039; parked entries got owners+dates; exclusions got operational tests; UNMAPPED default + Appendix A; R3 covers EXPIRING; R7 date source; R7b; R8 → preconditions |
+| v0.3 | 2026-07-06 | this PR (draft) | gate round 1: adversarial review findings applied | DRAFT carve-outs for placement protocol/§0 entry states/precedence (banner + §0); ARCH-020 disposition fix (retire → adopt; retirement confined to CHR-X-009); evidence snapshot caveat (§0); ARCH-020/CHR-X-009 anchor disambiguated (`scripts/goal_conductor.py:310` hardcodes the `scripts/nomic_loop.py` path) |
 
 ---
 

--- a/docs/architecture/INTENDED_ARCHITECTURE.md
+++ b/docs/architecture/INTENDED_ARCHITECTURE.md
@@ -1,0 +1,633 @@
+# Aragora Intended Architecture Charter
+
+Status: DRAFT v0.2 — pending operator ratification and #8851 adopt-or-retire rulings
+Date: 2026-07-06 | Owner: operator (armand)
+Enforcement targets: merge-gate reviewers, all AI fleets (Claude, Codex, Factory droids, launchd daemons), humans
+
+Provenance: authored by the conductor via orchestrated multi-agent review on 2026-07-06
+(draft v0.1 2026-07-05 from 8 evidence-grounded cluster maps; v0.2 incorporates an adversarial
+critic pass — see Amendment log, §6). Operator-commissioned. Amendments require an
+operator-approved PR touching this file.
+
+---
+
+## Binding status (read this first)
+
+**Ratification condition (machine-checkable):** this charter is RATIFIED **iff** this file
+exists at `docs/architecture/INTENDED_ARCHITECTURE.md` on `main` with a first-section header
+line `Status: RATIFIED vN.N`, landed via an operator-approved PR. Any other copy — scratchpad,
+branch, gist, PR body — is a proposal, not a charter.
+
+**While Status is DRAFT, the ONLY binding entries are those backed by a pre-existing
+operator-approved artifact:**
+
+| Entry | Binding because |
+|---|---|
+| CHR-P4A-001..004 | operator-approved `P4A_LAYERING_DISPOSITION.md` / `P4A_EVENTS_QUEUE_INVERSION.md` + merged PRs #8712 #8717 #8719 #8890 #8909 |
+| CHR-X-007 (no new `aragora.metrics` imports) | the shim's own published deprecation contract (`aragora/metrics/__init__.py` DeprecationWarning, "for one release") |
+
+Everything else in this document is PROPOSED and becomes binding only at ratification.
+This file lives in the repo precisely so that diff-grounded reviewers and quarantining
+adjudicators can see it; a charter that lives in a scratchpad binds nobody.
+
+---
+
+## Placement protocol (the 2-minute version for a fresh agent)
+
+Before you add a module, package, export, or cross-package import edge:
+
+1. **Identify the concern** your code implements. Look it up in the Authority Table (§2)
+   by ARCH-id. Code for a chartered concern may be added **only** to its authority module.
+2. **Grep your target path and symbols** against `docs/architecture/charters.yaml`
+   (the machine encoding of §3). If the path/symbol appears in an entry with state
+   `REMOVED` — stop; do not re-add; cite the CHR id. State `PENDING` or `EXPIRING` —
+   no new importers/callers; existing ones keep working. State `EXCLUSION` — never build it.
+3. **Package not in §2 or Appendix A as mapped?** It is **UNMAPPED**: frozen for
+   architectural growth (§2d). Fix bugs, don't extend its surface, don't import it anew.
+4. **New top-level `aragora/<pkg>` or new concern?** That requires an operator-approved
+   amendment to this charter **in the same PR** (R5).
+5. **Entry says PARKED?** Stop and surface to the operator with the entry ID (R4).
+
+On any structural conflict, **this charter wins over every other file in
+`docs/architecture/`** (see §0 precedence).
+
+---
+
+## 0. Ratification legend, precedence, and entry states
+
+Legend used throughout (referenced from §2 and §3):
+
+- **RATIFIED** — operator-approved charter exists (P4a docs, merged downshift PRs). Binding now.
+- **PROPOSED** — this draft's disposition, traceable to cluster-map evidence. Binding only
+  after operator/#8851 sign-off (see Binding status block).
+- **PARKED** — deliberately undecided; has a named owner and a calendar review date.
+  Do not act either way.
+
+Registry entry states (§3): `REMOVED` (edge is gone, do not re-add) | `EXPIRING` (temporary
+compat exception with an ISO deadline or concrete triggering PR/issue) | `PENDING` (removal or
+absorption chartered, not yet executed — **no new importers/callers**; applies equally to
+EXPIRING per R3) | `EXCLUSION` (never wire this) | `PARKED` (frozen both ways).
+
+**ID permanence rule:** ARCH-ids and CHR-ids are permanent. Never reused, never renumbered.
+Entries are only ever state-transitioned (with date + PR recorded in the entry).
+
+**Precedence:** on any structural or architectural-intent conflict, this charter supersedes
+every other file under `docs/architecture/` (ARCHITECTURE.md, ARCHITECTURE_THREE_LAYER.md,
+SYSTEM_DIAGRAM.md, system-overview.md, GATEWAY_ARCHITECTURE.md, and the rest). Those files
+remain useful as description; they are not authority. CHR-X-025 charters their SUPERSEDED-BY
+stamping. On numeric conflict, `docs/METRICS.md` wins (R7). On liveness/feature-status
+conflict with CLAUDE.md's tables, this charter's §1 status marks and §3 states win pending
+the approved CLAUDE.md edit (R7b).
+
+---
+
+## 1. Layer Model — the Decision Integrity Platform in six layers
+
+Product story: *adversarial multi-model vetting that produces verifiable decision receipts,
+delivered to any channel, on a platform that also develops itself.* Each layer names its
+AUTHORITY modules; anything else implementing that layer's concern is a duplicate (see §2).
+
+```
+ L6  INTENT          docs/METRICS.md, CLAUDE.md/AGENTS.md/AGENT_OPERATING_CONTRACT,
+     (charters)      THIS CHARTER + removals registry (§3) + charters.yaml
+ ───────────────────────────────────────────────────────────────────────────────
+ L5  FLEET           nomic/dev_coordination (leases) → swarm (boss/merge daemons)
+     (dev-side only) → worktree/ → settle_tier4_pr + review-queue transports;
+                      agent_bridge, consult_claude/fable_goal_cycle, harnesses
+ ───────────────────────────────────────────────────────────────────────────────
+ L4  EDGE            IN: connectors/ (Gmail, GitHub, chat, web)
+     (in/out)        OUT: channels/ (transport) + notifications/service (policy)
+                      + webhooks/retry_queue; mcp/ (agent tool surface); broadcast/
+ ───────────────────────────────────────────────────────────────────────────────
+ L3  PRODUCT         server/unified_server + handler_registry + stream/;
+     SURFACE         aragora CLI; sdk/python + sdk/typescript (parity-gated);
+                      pipeline/ (idea→goal→workflow→execution) + workflow/ (DAG lib)
+                      + queue/ (durable jobs)
+ ───────────────────────────────────────────────────────────────────────────────
+ L2  KNOWLEDGE       knowledge/mound (durable org knowledge + receipt sink);
+     & MEMORY        memory/continuum+consensus (session memory); rlm/ (context
+                      navigation); evidence/ + documents/ (ingestion); insights/
+ ───────────────────────────────────────────────────────────────────────────────
+ L1  DECISION CORE   debate/ (Arena — the ONLY deliberation engine); agents/
+     (the product)   (heterogeneous roster); reasoning/ (claims/provenance base);
+                      verification/, explainability/, evaluation/, ranking/;
+                      gauntlet/ (the ONLY receipt emitter; receipts/ is a facade
+                      over it — see ARCH-002); aragora-verify PyPI pkg (the ONLY
+                      external verifier)
+ ───────────────────────────────────────────────────────────────────────────────
+ L0  PLATFORM        storage/ (persistence), rbac/+auth/ (authn/z), observability/
+     SUBSTRATE       (P4a single authority), resilience/, billing/, compliance/,
+                      privacy/, security/, backup/, scheduler/ (ops cron jobs)
+```
+
+Five-minute read for an outside engineering manager: a question enters at L3/L4, the L1 core
+debates it across heterogeneous models, grounds it in L2 knowledge, and emits a
+cryptographically verifiable **decision receipt** (gauntlet → ODR schema → `aragora-verify`).
+L0 makes that auditable and access-controlled. L5 is the same machinery pointed at the repo
+itself: fleets take **work leases**, ship PRs through a receipt-gated merge quorum, and settle.
+L6 is where intent lives so reviewers can cite it.
+
+**L5 packaging note:** fleet machinery (nomic/, swarm/, worktree/, harnesses/) currently ships
+inside the `aragora` package namespace and therefore inside the customer wheel. "Dev-side only"
+is intent the artifact does not yet enforce. Whether fleet code is excluded from the customer
+distribution via the packaging manifest is a chartered open decision: CHR-X-039 (PARKED,
+owner: operator, review by 2026-09-01).
+
+### Layer status (honest marks — do not over-claim)
+
+| Layer | Status | Notes |
+|---|---|---|
+| L1 Decision core | **core/stable**, under-consolidation | debate/ ≈230 modules, 14 `orchestrator_*.py` + 8 `arena_*.py` shards; **three** receipt class lineages pending reconciliation (gauntlet, export/decision_receipt "Legacy", receipts/ lane+operational — see ARCH-002, CHR-X-001/037) |
+| L2 Knowledge/memory | **core/stable**, under-consolidation | mound is live hub (159 external importers); 4 embedding stacks; unified-memory gateway flag-off limbo |
+| L3 Product surface | **core/stable** | 327 handler modules register clean; any handler module not registered is **dormant** per R6 (see ARCH-023 disposition); sdk-parity CI-gated; second FastAPI stack PARKED (CHR-X-011) |
+| L4 Edge | **under-consolidation** | Slack exists in ~7 stacks; two live Telegram clients; two live notification services |
+| L0 Platform substrate | **core/stable** with prod-dormant lanes | Postgres/Redis-HA/multi-tenant paths are **code-live, prod-dormant** (prod = sqlite + `ARAGORA_SINGLE_INSTANCE=true`) — never cite them as exercised |
+| L5 Fleet machinery | **adopted-machinery** | live via launchd (swarm-boss-loop, ctl-merge-executor, worktree-maintainer); `check_work_lease.py` still fail-open (v0); packaging ruling parked (CHR-X-039) |
+| L6 Intent | **under-consolidation** | METRICS.md drift-gated; `scripts/ci/check_import_contracts.py` is UNWIRED (no workflow/Makefile caller) — wiring it is a ratification precondition (R8) |
+
+---
+
+## 2. Authority Table — one authority per concern
+
+Rules of the table: the **single authority** column is the only module where code for that
+concern may be added. "Duplicates found" are evidence-grounded, not exhaustive. Dispositions:
+**adopt** (keep as authority) / **absorb** (fold into authority, then delete) / **retire**
+(delete after registry entry) / **park** (frozen, owner + review date). Ratification per §0
+legend. **Every row has a permanent ARCH-id; every non-adopt disposition points at a §3 CHR-id**
+— reviewers and gates cite rows by these ids, never by prose.
+
+### 2a. Decision core & knowledge
+
+| ID | Concern | Single authority | Duplicates found | Disposition | Evidence |
+|---|---|---|---|---|---|
+| ARCH-001 | Deliberation orchestration | `aragora/debate` (Arena) | workflow/coordination/queue must not grow rival debate loops; debate-internal `graph_orchestrator`/`molecule_orchestrator` overlap pipeline staged execution | adopt; consolidation budget on debate/ (PROPOSED) | 194 non-test importers; entrypoints nomic_loop, triage_runner, server handlers |
+| ARCH-002 | Receipt emission | `aragora/gauntlet` | **Three receipt class lineages exist:** (1) gauntlet's DecisionReceipt (authority); (2) `aragora/export/decision_receipt.py`, re-exported by `aragora/receipts/__init__.py:9` as `LegacyDecisionReceipt`; (3) `aragora/receipts/` itself emits lane/operational receipts (`emit_lane_receipt`, `emit_operational_receipt`). pipeline `receipt_*` + nomic `dev_receipts` are downstream consumers/fleet mirrors, not emitters | adopt gauntlet (RATIFIED by product story); `receipts/` becomes a **sanctioned facade over gauntlet** — re-exports only, no independent receipt classes; LegacyDecisionReceipt absorbed-or-retired per RECEIPT_LINEAGE_RECONCILIATION (PROPOSED → CHR-X-037); fleet lane/operational receipts are the L5 analogue and must be schema-reconciled in the same spec | 83 gauntlet importers; receipts/__init__.py:9,12-13 |
+| ARCH-003 | External receipt verification | `aragora-verify` PyPI pkg (ODR schema) | `aragora/gauntlet/odr_verify.py` — self-documented "no shipped CLI/route calls it" | absorb-or-retire odr_verify per `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` (PROPOSED → CHR-X-001) | odr_verify.py docstring; aragora-verify v0.1.1 in-repo |
+| ARCH-004 | Quality scoring / eval metrics | `aragora/evaluation` | `aragora/metrics/` — 7-file deprecated re-export shim "for one release" | retire shim on schedule; **new imports of `aragora.metrics` forbidden now** (RATIFIED by shim's own contract → CHR-X-007) | metrics/__init__.py DeprecationWarning |
+| ARCH-005 | Claims/evidence base layer | `aragora/reasoning` | — (aragora/evidence imports reasoning; correct layering) | adopt; reasoning is the base, evidence/ the ingestion front-end | 124 importers; evidence/collector.py imports reasoning |
+| ARCH-006 | Agent calibration | `aragora/ranking` (calibration_engine et al.) | `aragora/agents/calibration.py` | absorb into ranking (PROPOSED → CHR-X-026) | dual calibration paths risk team-selection schema drift |
+| ARCH-007 | Durable knowledge store | `aragora/knowledge/mound` | knowledge top-level legacy surface, **two classes**: (a) `fact_extractor.py`, `migration.py`, `mound_store.py`, `unified/unified_store.py` — verified 0 external importers; (b) `vector_store.py` and `search/` — **live mound-internal importers** (mound/core.py:306 imports KnowledgeVectorStore/KnowledgeVectorConfig — live Weaviate connect path; knowledge/embeddings.py:14 and mound/vector_abstraction/memory.py:27 import search/bm25) | retire class (a) (PROPOSED → CHR-X-002); **absorb** class (b) into mound — re-home the modules or re-point the imports first, delete top-level only after (PROPOSED → CHR-X-038) | rg counts: mound 159 external files; class-(a) 0 importers each; class-(b) importers cited inline |
+| ARCH-008 | Debate-session memory | `aragora/memory` (continuum, consensus) | Unified Memory Gateway (gateway/retention_gate/dedup/titans) flag-off by default | park gateway pending explicit adopt-or-retire alongside #8851 (PARKED → CHR-X-020) | orchestrator_config.py:421 `enable_unified_memory=False` |
+| ARCH-009 | Outcome→confidence feedback | `aragora/debate/km_outcome_bridge.py` | `memory/outcome_bridge.py` (test-only), `openclaw_bridge.py`, `claude_mem_km_sync.py` (test-only) | retire test-only bridges (PROPOSED → CHR-X-003) | rg: only tests import them |
+| ARCH-010 | Embeddings | `aragora/core` embeddings service | `knowledge/embeddings.py`, `memory/embeddings.py`, `ml/embeddings.py` | absorb: demote to provider plugins behind core (PROPOSED → CHR-X-027; coordinate with CHR-X-038 — knowledge/embeddings imports search/bm25) | 4 stacks; mixed 256/1536-dim rows already caused a prod KM crash |
+| ARCH-011 | Context navigation | `aragora/rlm` | — | adopt (product + fleet shared) | 17 debate files, nomic/context_builder, `aragora rlm` CLI |
+
+### 2b. Orchestration & fleet
+
+| ID | Concern | Single authority | Duplicates found | Disposition | Evidence |
+|---|---|---|---|---|---|
+| ARCH-012 | Work ownership / leases | `aragora/nomic/dev_coordination` (SQLite at `<git-common-dir>/aragora-agent-state/dev_coordination.db`; preflight `scripts/check_work_lease.py`) | `coordination/claims.py`; `control_plane/registry.py` heartbeats; `worktree/fleet.py` FleetCoordinationStore | adopt (RATIFIED by #8851 mandate); worktree/fleet stays a **mirror, never a second truth**; retire coordination/claims with coordination/ core (PROPOSED → CHR-X-012) | check_work_lease.py docstring cites #8851 "single ownership truth" |
+| ARCH-013 | Bead/convoy stores | `aragora/nomic/stores` | `aragora/workspace` (already a delegating wrapper), Gastown dialect (refinery/rig) | finish convergence; retire Gastown dialect (PROPOSED → CHR-X-028) | workspace/bead.py imports NomicBeadStore |
+| ARCH-014 | Fleet task scheduling | swarm boss loop + dev_coordination dispatch | `control_plane/scheduler.py` (Redis-only; returns None **with a warning log** in prod — invisible unless logs are inspected), `coordination/task_dispatcher.py`, `fabric/scheduler.py`, `workflow/scheduler.py`, `tasks/router.py` | retire control_plane scheduler/registry, coordination dispatch, fabric, tasks/ (PROPOSED → CHR-X-012/013/014/015, per #8851; API deprecation path required for control_plane handlers) | startup/control_plane.py:55-58 warn-then-None; prod is sqlite single-instance. Complete scheduler inventory: these five + ARCH-022's ops-cron scheduler (a distinct, sanctioned concern) |
+| ARCH-015 | Durable server-side jobs | `aragora/queue` (Redis Streams workers) | control_plane scheduler (above) | adopt — queue is LIVE, not a #8851 dormant (GauntletWorker default-on, TestFixerWorker) | startup/workers.py:185-210,315 |
+| ARCH-016 | Product DAG workflows | `aragora/workflow` as **library** consumed by pipeline | debate-internal staged execution (see ARCH-001) | adopt as library; must not grow a rival scheduler or debate loop | WorkflowEngine instantiated by pipeline/executor, canvas, mcp, CLI |
+| ARCH-017 | Idea→execution pipeline | `aragora/pipeline` | `aragora/goals/` (single file, is pipeline stage 2); `aragora/autonomous/` (self-described "Nomic Loop Enhancement") | absorb goals/ into pipeline; fold autonomous/ into nomic (PROPOSED → CHR-X-029) | goals/ = extractor.py only; autonomous importers = handlers + one pipeline util |
+| ARCH-018 | Agent process spawning | `aragora/harnesses` | `swarm/worker_launcher.py` spawns codex/Claude directly (0 harness imports); agent_bridge transports | absorb: worker_launcher becomes a harnesses consumer (PROPOSED → CHR-X-030) | worker_launcher.py:613,685 direct spawn |
+| ARCH-019 | PR settlement | `scripts/settle_tier4_pr.py` + `aragora/cli` review-queue transports | settle_one_pr, tier4_merge_train, auto_merge_quorum_green, settlement_followup (wrapper sprawl) | absorb wrappers, then retire (PROPOSED → CHR-X-008) | settle_tier4_pr imported by 8+ scripts/modules; ~12 fix commits |
+| ARCH-020 | Conductor / goal loop | `scripts/fable_goal_cycle.py` + `scripts/consult_claude.py` | goal_conductor.py (hardcodes nomic_loop.py:310), lane_conductor, overnight_conductor; nomic_loop/self_develop/nomic_staged = legacy **manual** entrypoints | retire old conductors; relabel nomic_loop trio "legacy manual" in CLAUDE.md (PROPOSED → CHR-X-009) | launchd runs swarm boss-loop, nothing runs nomic_loop; fable_goal_cycle merged #8835 |
+| ARCH-021 | Worktree lifecycle | `aragora/worktree` (maintainer daemon; `scripts/codex_worktree_autopilot.py` is its implementation detail) | `coordination/worktree_manager.py` (wraps it) | adopt; retire coordination wrapper with coordination/ core (PROPOSED → CHR-X-012) | launchd com.aragora.codex-worktree-maintainer; autopilot.py:49 wrapper |
+| ARCH-022 | Scheduled ops jobs (audits, access reviews, DR drills, token refresh, settlement review) | `aragora/scheduler` | `aragora/schedulers/` — deprecated shim package | adopt; retire shim (PROPOSED → CHR-X-031). Ops-cron is a distinct concern from fleet work-dispatch (ARCH-014) and is NOT covered by exclusion CHR-E-003 | package present with launched jobs; shim self-describes deprecated |
+
+### 2c. Surface, edge, substrate
+
+| ID | Concern | Single authority | Duplicates found | Disposition | Evidence |
+|---|---|---|---|---|---|
+| ARCH-023 | HTTP/WS ingress | `server/unified_server` + `handler_registry` + the 4 instantiated stream servers | `server/fastapi` /api/v2 stack (default-off, no deploy/CI reference); dead `server/extensions.py` init path; unregistered handler modules | park FastAPI with hard deadline (PARKED → CHR-X-011); delete-or-wire extensions init (PROPOSED → CHR-X-016); **blanket rule: any handler module not registered in handler_registry is dormant per R6** — it may not be cited as a feature and needs no removal entry to be treated as dead; triage list is Appendix-A follow-up | unified_server.py:1313 flag; rg: init_extensions has zero callers; 327 modules register vs "700+" advertised |
+| ARCH-024 | Python client | `sdk/python/aragora_sdk` (parity-gated) | `aragora/client/` (37 resources, ungated, kept alive only by CLI) | absorb: CLI migrates to the SDK, or client comes under the parity gate — never two ungated (PROPOSED → CHR-X-033) | check_sdk_parity.py:280 hardcodes sdk/python only |
+| ARCH-025 | Inbound connectors | `aragora/connectors` | `integrations/{slack,telegram,teams,whatsapp}` platform clients (both Telegram clients LIVE today) | absorb integrations clients into connectors/chat via staged migration (PROPOSED → CHR-X-032); vertical catalog (~132 unreferenced files) tiered "catalog: dynamic-load only, no direct import" (PARKED → CHR-X-023) | runtime_registry.py:424 importlib load; both telegram stacks wired |
+| ARCH-026 | Outbound delivery | `aragora/channels` (transport/rendering) + `aragora/notifications/service.py` (policy/routing) | `control_plane/notifications.py` (live, split-brain), `bots/slack_bot.py`+`teams_bot.py` (0 importers), integrations dispatcher | absorb control_plane notifications (P4a downshift pattern, PROPOSED → CHR-X-015 keep-list note); retire dead bots (PROPOSED → CHR-X-004) | dual live services confirmed by importer rg; bots rg = handlers/bots/{discord,zoom} only |
+| ARCH-027 | Retry / dead-letter | `aragora/webhooks/retry_queue.py` | `notifications/retry_queue.py`, `events/dead_letter_queue.py`, `integrations/webhooks.py` dispatcher | absorb onto one transport (PROPOSED → CHR-X-034) | 4 implementations, all reachable |
+| ARCH-028 | Agent-facing tools | `aragora/mcp` | — | adopt (product + fleet shared) | CLI delegated.py:221; harnesses/claude_code.py:570 |
+| ARCH-029 | Observability | `aragora/observability` | `aragora/telemetry/` (0 importers, shim), `aragora/monitoring/` (1 importer), any server-local metrics/tracing home | adopt (**RATIFIED** — P4a); retire shims (PROPOSED → CHR-X-005); server re-adds are charter violations (CHR-P4A-001..003) | P4A_LAYERING_DISPOSITION.md; PRs #8712/#8717/#8719 |
+| ARCH-030 | Persistence API | `aragora/storage` | `aragora/db/` (1 importer, near-identical docstring); `aragora/persistence/` (nomic-loop-serving) | absorb db/ (PROPOSED → CHR-X-019); park persistence/ adjudication (PARKED → CHR-X-022) | db sole importer = control_plane/health handler |
+| ARCH-031 | Schema migrations | **interim authority: `aragora/persistence/migrations`** — what `auto_migrations` actually runs today; consolidation of the three systems is PARKED → CHR-X-021 | `aragora/migrations` (Postgres), `storage/migrations`, `db/migrate.py` | interim adopt persistence.migrations (its default stands); consolidation parked with owner + date (CHR-X-021). An authority row must always point at code that exists — "to be named" is not an authority | auto_migrations.py defaults to persistence.migrations.runner |
+| ARCH-032 | Circuit breaking / retry | `aragora/resilience` | `circuit_breaker_v2.py` (0 importers, self-described shim); top-level `resilience_patterns.py`/`resilience_config.py` | retire v2 shim; absorb top-level files (PROPOSED → CHR-X-006) | simple_circuit_breaker.py docstring; rg 0 external v2 importers |
+| ARCH-033 | AuthN/AuthZ | `aragora/rbac` + `aragora/auth` | `security/token_rotation.py` vs `auth/token_rotation.py` | adopt; absorb token_rotation duplication (PROPOSED → CHR-X-035); rbac = Tier 3-4 blast radius, no autonomous refactor | rbac 353 importers |
+| ARCH-034 | Key rotation | **interim authority: the existing per-provider rotators as wired by `aragora/server/startup/security.py`** (the code that exists and runs); end-state: one table-driven registry in `aragora/security` | 8 per-provider `*_rotator.py` boilerplate files, each with exactly 1 importer | interim adopt current rotators; absorb into one registry when built (PROPOSED → CHR-X-036). No new per-provider rotator files meanwhile | each rotator's sole importer = startup/security.py |
+| ARCH-035 | Numeric truth | `docs/METRICS.md` (generated, drift-gated) | hand-written counts anywhere else | adopt (RATIFIED — "this doc wins") | metrics-drift.yml weekly + per-PR |
+| ARCH-036 | Removal intent | **§3 of this charter + `charters.yaml`** | PR threads, stale plans, dormant ADRs | adopt — the #8905 fix | issue #8905 acceptance criteria |
+
+### 2d. Default state for everything else: UNMAPPED
+
+The repo has 144 top-level `aragora/*` packages; §2 dispositions roughly half. **Any package
+without a MAPPED row in Appendix A is UNMAPPED, and UNMAPPED is a state, not a gap:**
+
+- **Frozen for architectural growth**: no new cross-package importers of it, no new exports
+  consumed from other packages, no new subpackages, and it must not grow an implementation
+  of any chartered concern (§2).
+- Bug fixes, existing-caller maintenance, and test work continue normally.
+- Escaping UNMAPPED requires triage into a layer via charter amendment (R5) — one table row,
+  operator-approved.
+
+Appendix A is the generated one-line-per-package triage table (layer + status per package).
+Known UNMAPPED packages the v0.1 draft never mentioned include: `receipts` (now mapped,
+ARCH-002), `scheduler`/`schedulers` (now mapped, ARCH-022), `epistemic`, `prediction`,
+`markets`, `missions`, `ralph`, `gti`, `factory`, `brief_engine`, `advocates`,
+`heterogeneity`, and ~60 more — see Appendix A for the full inventory.
+
+---
+
+## 3. Chartered Removals & Exclusions Registry
+
+Machine-citable. Reviewers and gates cite entries by ID. **The normative machine encoding of
+this section is `docs/architecture/charters.yaml`, committed alongside this file and updated
+in the same PR as any §3 change** — every REMOVED/PENDING/EXPIRING entry carries explicit
+`paths` (exact repo-relative paths or well-formed globs) and `symbols`
+(`module:export_name`) fields there. A PR that re-adds anything listed as **REMOVED** must
+receive a grounded finding citing the entry (per #8905 acceptance criteria) — "backward
+compatibility" is NOT a valid counter-argument to a registry entry.
+
+### 3a. Executed (RATIFIED — operator-approved charters, merged PRs)
+
+| ID | State | What | Why | Date | PR/Doc |
+|---|---|---|---|---|---|
+| CHR-P4A-001 | REMOVED | Server-local metrics/prometheus surface in `aragora/server` (paths/symbols in charters.yaml: `aragora/server/metrics.py` shim, `aragora.observability.server_metrics` is home) | `aragora/observability` is single metrics authority | 2026-06 | #8712, P4A_LAYERING_DISPOSITION.md |
+| CHR-P4A-002 | REMOVED | Server tracing/correlation middleware as a server-owned surface (`aragora/server/middleware/tracing.py` shim; home `aragora.observability.middleware.tracing`) | downshifted to observability | 2026-06 | #8717 |
+| CHR-P4A-003 | REMOVED | Server `http_client_pool` as a server-owned surface (`aragora/server/http_client_pool.py` shim; home `aragora.observability.http_client_pool`) | downshifted to observability | 2026-06/07 | #8719 |
+| CHR-P4A-004 | REMOVED | `create_default_executor` re-export on `aragora.queue`. History: removed by P4a Q1 (#8890); **re-added charter-blind by merged PR #8893** — the first specimen of the charter-blind approval class (#8905); **re-removed, executed, by #8909 (merged 2026-07-05)**. Standing rule: `aragora.queue` must not re-export `create_default_executor`; its home is `aragora/debate/queue_executor.py` (queue stays domain-free). Any re-add is a charter violation citing this entry | queue/events inversion; blast-radius containment | removed #8890, re-added 2026-07-05 #8893, re-removed 2026-07-05 #8909 | #8890, #8893, #8905, #8909, P4A_EVENTS_QUEUE_INVERSION.md |
+
+### 3b. Chartered by this draft (PROPOSED — no new dependents at ratification; execute after ratification/#8851)
+
+| ID | State | What (paths/symbols normative in charters.yaml) | Why | Evidence anchor |
+|---|---|---|---|---|
+| CHR-X-001 | PENDING | `aragora/gauntlet/odr_verify.py` (second receipt-**verifier** lineage) | `aragora-verify` package is the sole external verifier; two lineages can silently diverge on canonicalization and destroy the receipt claim | odr_verify.py docstring ("no shipped CLI/route calls it"); docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md |
+| CHR-X-002 | PENDING | knowledge legacy surface, zero-importer class only: `knowledge/fact_extractor.py`, `knowledge/migration.py`, `knowledge/mound_store.py`, `knowledge/unified/unified_store.py` | superseded by `knowledge/mound`; verified 0 external importers each. (`vector_store.py` and `search/` are NOT here — they have live internal importers; see CHR-X-038) | cluster-map rg counts, re-verified 2026-07-06 |
+| CHR-X-003 | PENDING | `memory/outcome_bridge.py`, `memory/openclaw_bridge.py`, `memory/claude_mem_km_sync.py` | test-only; live edge is `debate/km_outcome_bridge.py` | rg: importers are tests only |
+| CHR-X-004 | PENDING | `bots/slack_bot.py`, `bots/teams_bot.py` | 0 importers; Slack already served by connectors/chat + handlers + channels dock | rg 'aragora.bots' → discord/zoom handlers only |
+| CHR-X-005 | PENDING | `aragora/telemetry/` (0 importers), `aragora/monitoring/` (1 importer) re-export shims | observability is P4a single authority | shim docstrings |
+| CHR-X-006 | PENDING | `resilience/circuit_breaker_v2.py` shim; top-level `resilience_patterns.py`/`resilience_config.py` | 0 external importers / package-internal only | simple_circuit_breaker.py docstring |
+| CHR-X-007 | PENDING | `aragora/metrics/` shim package (all 7 files) | promised deletion "for one release"; **new imports forbidden effective now** (binding in DRAFT — see Binding status) | metrics/__init__.py DeprecationWarning |
+| CHR-X-008 | PENDING | settlement wrappers `scripts/settle_one_pr.py`, `scripts/tier4_merge_train.py`, `scripts/auto_merge_quorum_green.py` (after absorption into settle_tier4_pr/settle_pr) | one settlement path; wrapper sprawl is where fixes get lost | fleet-ops map |
+| CHR-X-009 | PENDING | conductor scripts `scripts/goal_conductor.py`, `scripts/lane_conductor.py`, `scripts/overnight_conductor.py` | superseded by fable_goal_cycle + consult_claude; goal_conductor still hardcodes legacy nomic_loop | goal_conductor.py:310 |
+| CHR-X-010 | PENDING | zero-importer decision-core modules: `agents/email_agents.py`, `agents/feature_agent.py`, `agents/power_sampling_mixin.py`, `ranking/muse_calibration.py` (email_agents/power_sampling_mixin reachable only via lazy `__init__` re-exports; email_agents' only other mention is a docstring at services/email_prioritization.py:920; debate's PowerSamplingConfig is a separate class, not the mixin). **Explicitly NOT chartered** (real callers verified): `ranking/snapshot.py` (elo.py:96, elo_leaderboard.py:18, elo_matchmaking.py:25), `ranking/redteam.py` (elo.py:90, instantiated elo.py:300,329), `verification/sandbox.py` (formal.py:559 Lean execution, verification/__init__.py:49). `verification/proofs.py` is near-dormant but not chartered here | feature-count inflation; no product or fleet caller for the four listed | zero-importer greps re-verified against critic pass 2026-07-06 |
+| CHR-X-012 | PENDING (per #8851 ruling) | `aragora/coordination/` core: `claims.py`, `task_dispatcher.py`, `registry.py`, `health_watchdog.py`, `worktree_manager.py` — salvage GitReconciler→worktree/, bus→events/ | duplicate of dev_coordination + control_plane concepts; no daemon drives it | orchestration map importer audit |
+| CHR-X-013 | PENDING (per #8851 ruling) | `aragora/fabric/` (flip `ARAGORA_ENABLE_AGENT_FABRIC` default→false first — server import path depends on it) | third agent-pool abstraction; no script/daemon/CI runs a fabric pool | extensions.py:39; instantiation sites only |
+| CHR-X-014 | PENDING (per #8851 ruling) | `aragora/tasks/` — one implementation module (`router.py`), one caller (`server/handlers/tasks/execution.py:39`) | inline into its handler or route via workflow templates | rg 'from aragora.tasks' |
+| CHR-X-015 | PENDING (per #8851 ruling) | `control_plane/scheduler.py`, `control_plane/registry.py` + speculative enterprise modules (`auto_scaling`, `federation`, `blockchain_identity`, `regional_sync`). **Keep-list (explicit paths): `control_plane/policy.py` + policy store/sync/cache, `control_plane/notifications.py` (until absorbed per CHR-X-015-note/ARCH-026), deliberation worker** | Redis-only; returns None with a warning log in the actual prod deployment; public-API deprecation path REQUIRED (handlers are served surface) | startup/control_plane.py:55-58 |
+| CHR-X-016 | PENDING | dead `server/extensions.py` init path + its None-returning consumers, OR wire `init_extensions()` at startup — one or the other, no limbo | ENABLE_MOLTBOT/ENABLE_GASTOWN flags are cosmetic today; docs over-claim | rg: init_extensions has zero callers |
+| CHR-X-017 | PENDING | `aragora/gateway` never-started LocalGateway/device-node/federation server story (registered gateway HTTP handlers stay) | no non-test code starts LocalGateway; untested-in-prod security surface | rg 'LocalGateway' non-test |
+| CHR-X-018 | PENDING | docs: root `docs/STATUS.md` mirror, `docs/COORDINATION.md` (frozen 2026-04-28, folds into AGENT_OPERATING_CONTRACT), stale positioning snapshots → `docs/archive/` | intent layer must not contradict itself; CLAUDE.md still points agents at the stale file | docs-charters map git-log dates |
+| CHR-X-019 | PENDING | `aragora/db/` (fold into `aragora/storage`) | duplicate get_database abstraction, 1 importer | db/__init__.py docstring |
+| CHR-X-025 | PENDING | Superseded sibling architecture docs: stamp `SUPERSEDED-BY: docs/architecture/INTENDED_ARCHITECTURE.md` headers on (or archive to `docs/archive/`) `ARCHITECTURE.md`, `ARCHITECTURE_THREE_LAYER.md`, `SYSTEM_DIAGRAM.md`, `system-overview.md`, `GATEWAY_ARCHITECTURE.md`, `CODEBASE_ANALYSIS.md`, `ANALYSIS.md`, `ground-up-assessment-2026-01-29.md` — executed as part of the ratification PR | rival layer models must not be citable against the charter (§0 precedence) | docs/architecture/ ls 2026-07-06 |
+| CHR-X-026 | PENDING | `agents/calibration.py` → absorb into `aragora/ranking` | dual calibration paths (ARCH-006) | ARCH-006 evidence |
+| CHR-X-027 | PENDING | `knowledge/embeddings.py`, `memory/embeddings.py`, `ml/embeddings.py` → demote to provider plugins behind `aragora/core` embeddings service | 4 embedding stacks; dimension-mix prod crash (ARCH-010); coordinate with CHR-X-038 | ARCH-010 evidence |
+| CHR-X-028 | PENDING | Gastown bead/convoy dialect (`extensions/gastown` refinery/rig store surfaces) | `aragora/nomic/stores` is the single bead/convoy truth (ARCH-013) | workspace/bead.py delegation |
+| CHR-X-029 | PENDING | `aragora/goals/` → absorb into `aragora/pipeline`; `aragora/autonomous/` → fold into `aragora/nomic` | single idea→execution pipeline (ARCH-017) | goals/ = extractor.py only |
+| CHR-X-030 | PENDING | `swarm/worker_launcher.py` direct process spawning → becomes a `aragora/harnesses` consumer | one spawning authority (ARCH-018) | worker_launcher.py:613,685 |
+| CHR-X-031 | PENDING | `aragora/schedulers/` deprecated shim package (home: `aragora/scheduler`) | shim-retirement family with CHR-X-005/006/007 (ARCH-022) | shim self-describes deprecated |
+| CHR-X-032 | PENDING | `integrations/slack.py`, `integrations/telegram.py`, `integrations/teams.py`, `integrations/whatsapp.py` platform clients → staged migration into `connectors/chat` | one inbound-connector home (ARCH-025); both Telegram stacks live today | runtime wiring rg |
+| CHR-X-033 | PENDING | `aragora/client/` ungated Python client → CLI migrates to `sdk/python/aragora_sdk`, or client comes under the parity gate; never two ungated | ungated clients drift silently (ARCH-024, CHR-E-007) | check_sdk_parity.py:280 |
+| CHR-X-034 | PENDING | `notifications/retry_queue.py`, `events/dead_letter_queue.py`, `integrations/webhooks.py` dispatcher → consolidate onto `webhooks/retry_queue.py` | 4 retry/dead-letter implementations (ARCH-027) | all reachable per rg |
+| CHR-X-035 | PENDING | `security/token_rotation.py` vs `auth/token_rotation.py` — absorb into one (ARCH-033 rules which at execution) | duplicated token rotation | importer rg |
+| CHR-X-036 | PENDING | 8 per-provider `security/*_rotator.py` boilerplate files → one table-driven registry in `aragora/security`; no NEW per-provider rotator files meanwhile | each has exactly 1 importer (startup/security.py) (ARCH-034) | startup/security.py wiring |
+| CHR-X-037 | PENDING | `aragora/export/decision_receipt.py` (`LegacyDecisionReceipt`) → absorb-or-retire per RECEIPT_LINEAGE_RECONCILIATION; `aragora/receipts/` chartered as **facade-only** over gauntlet (re-exports + fleet lane/operational receipts; no independent product receipt classes) | three receipt lineages is exactly the believability failure the charter exists to prevent (ARCH-002, CHR-E-002) | receipts/__init__.py:9 |
+| CHR-X-038 | PENDING | `knowledge/vector_store.py` + `knowledge/search/` → **absorb into `knowledge/mound`** (move under mound or re-point imports first; delete top-level only after). Live internal importers: mound/core.py:306 (KnowledgeVectorStore/KnowledgeVectorConfig — live Weaviate connect path), knowledge/embeddings.py:14 (bm25), mound/vector_abstraction/memory.py:27 (bm25) | deleting in place breaks knowledge/mound — the v0.1 "0 external importers" claim was wrong for these two; corrected per critic pass | import sites cited inline, verified 2026-07-06 |
+
+### 3c. Parked (deliberately undecided — named owner + calendar date; do not act either way)
+
+| ID | State | What | Owner | Review by | Condition |
+|---|---|---|---|---|---|
+| CHR-X-011 | PARKED | `server/fastapi` /api/v2 second HTTP stack | operator | 2026-09-01 | make it THE stack or delete; carrying two indefinitely is the worst option |
+| CHR-X-020 | PARKED | Unified Memory Gateway (`memory/gateway` + retention/dedup/titans) | operator | 2026-08-15 (backstop; earlier if #8851 rules) | adopt as sanctioned fan-out API or remove; meanwhile no new callers beyond existing flag paths |
+| CHR-X-021 | PARKED | migration-system consolidation (3 systems; interim authority = persistence.migrations per ARCH-031) | operator | 2026-09-01 | pick one system; auto_migrations' persistence.migrations default stands until then |
+| CHR-X-022 | PARKED | `aragora/persistence/` vs storage adjudication | operator | 2026-09-01 (backstop; earlier once CHR-X-019 lands) | serves the nomic loop; rule after CHR-X-019 executes |
+| CHR-X-023 | PARKED | connector vertical catalog (~132 dynamically-loaded files) | operator | 2026-10-01 | keep as "catalog tier" with contract tests, or prune; grep-based dead-code claims are invalid here (importlib load, runtime_registry.py:424) |
+| CHR-X-024 | PARKED | debate flag-only exotica (chaos_theater, blackbox, witness, immune_system) | operator | 2026-09-15 | live caller by the review date or move to an experiments namespace |
+| CHR-X-039 | PARKED | L5 fleet-machinery packaging: ships in customer wheel vs excluded via packaging manifest (nomic/, swarm/, worktree/, harnesses/) | operator | 2026-09-01 | P3 pip packaging is proven (#8517); "dev-side only" is currently intent the artifact does not enforce |
+
+Parking rule (§5 vocabulary): a park without an owner is abandonment; an expiry without a date
+has no teeth. Every PARKED/EXPIRING entry carries a named owner and an ISO date (or a concrete
+triggering PR/issue **plus** a backstop date at which it auto-escalates to the operator).
+
+### 3d. Exclusions (never build / never wire) — each with an operational test
+
+| ID | What is excluded | Operational test | Why |
+|---|---|---|---|
+| CHR-E-001 | New debate/deliberation loops outside `aragora/debate` | any module outside `aragora/debate` that sends a prompt to more than one agent/model and aggregates their outputs into a verdict, vote, consensus, or ranking is a deliberation loop — excluded. (Calling Arena as a library is fine; that is the point.) | one deliberation engine (L1) |
+| CHR-E-002 | New receipt emitters outside `aragora/gauntlet`; new external verifiers besides `aragora-verify` | any new class/function outside gauntlet that constructs a decision-receipt artifact (product) — excluded; `receipts/` facade re-exports and dev_coordination fleet receipts (the chartered L5 analogue, ARCH-002) are the closed set of exceptions | receipt integrity is the product claim |
+| CHR-E-003 | New schedulers, work-claim/lease stores, or agent registries | allowed dispatch surfaces are the closed list: `aragora/nomic/dev_coordination`, `aragora/queue`, and the swarm boss-loop dispatch inside `aragora/swarm` (supervisor/reconciler). Anything else that assigns work to agents or claims ownership is excluded. Ops-cron (`aragora/scheduler`, ARCH-022) is a distinct sanctioned concern, not a dispatch surface. Complete duplicate inventory: ARCH-014 | six schedulers and three claims systems already; #8851 |
+| CHR-E-004 | Server-local metrics/tracing/http-pool homes in `aragora/server` | any new module under `aragora/server` exporting prometheus metrics, tracing middleware, or an HTTP client pool — excluded | P4a; see CHR-P4A-001..003 |
+| CHR-E-005 | New KM adapters wrapping PENDING-retire subsystems | no new adapter may wrap anything named in registry entries CHR-X-001..CHR-X-038 while in state PENDING (machine check: adapter target path ∈ charters.yaml pending paths) | adapters manufacture fake "integration" evidence |
+| CHR-E-006 | New platform delivery clients outside `connectors/chat` + channels dock | closed platform list: Slack, Teams, Telegram, WhatsApp, Discord, Zoom, Email. A client for any of these outside connectors/chat + channels is excluded; a NEW platform requires a charter amendment (R5) | ~7 Slack stacks is the cautionary tale |
+| CHR-E-007 | Second Python client surfaces beyond the parity-gated SDK | any new module presenting a typed Python API-client resource surface outside `sdk/python/aragora_sdk` — excluded (pending CHR-X-033 client absorption) | ungated clients drift silently |
+| CHR-E-008 | Standing admin credentials / API keys in local env | any PR adding a standing credential to `.env*`, launchd plists, or shell profiles — excluded; AWS Secrets Manager only | credential architecture (post-incident) |
+
+---
+
+## 4. Fleet Rules — consulting this charter
+
+Binding per the Binding status block (top of file): all rules bind at ratification; while
+DRAFT, only the entries listed there bind. These compose with, and do not replace,
+`docs/AGENT_OPERATING_CONTRACT.md` (approval matrix, main-red mode) and the lease rule
+(`scripts/check_work_lease.py`).
+
+**R1 — Check before you add.** Before creating a module, package, export, or cross-package
+import edge, find the concern's ARCH-row in §2 (or the package's Appendix-A state). Code for
+a chartered concern goes in its authority module. Adding it to a non-authority module is a
+**charter violation**, even if the code is good, tested, and green. Packages with no row are
+UNMAPPED and frozen for growth (§2d).
+
+**R2 — Removed means removed.** Re-adding anything in a §3 `REMOVED` entry — including
+"compat re-exports", "temporary shims", or flipping a charter end-state test — is a charter
+violation. Reviewers must cite the entry ID in their finding. The #8893 pattern
+("preserving backward compatibility" for a chartered removal) is explicitly named invalid.
+
+**R3 — Pending and Expiring mean frozen.** `PENDING` **and `EXPIRING`** entries accept
+**no new importers/callers** from ratification (or from the entry's own pre-existing
+contract, where noted). Existing callers keep working until the removal executes; for
+EXPIRING, existing callers must migrate before the stated deadline. Extending a deadline
+requires operator approval **and** a registry-entry update in the same PR. This is how we
+avoid growing the blast radius while #8851 rulings land.
+
+**R4 — Parked means hands off.** Do not wire, extend, or delete `PARKED` items. If your task
+seems to require one, stop and surface it to the operator with the entry ID.
+
+**R5 — New subsystems need a charter amendment.** A new top-level `aragora/<pkg>`, a new
+concern row, or promoting an UNMAPPED package requires an operator-approved amendment to this
+document in the same PR (Tier 3+ by the operating contract). "It exists so I wired it" is not
+an integration argument — check §2 dispositions and §3 states first (control_plane's
+warn-then-None startup is the cautionary precedent for wired-but-dead claims).
+
+**R6 — Evidence standard.** Claims of liveness must cite an entrypoint (daemon, CI workflow,
+registered handler, CLI command, script with callers) — not the existence of tests or of a KM
+adapter (CHR-E-005). Claims about code under this charter must distinguish
+**live product / adopted fleet machinery / code-live-prod-dormant / dormant** (§1 status marks).
+An unregistered server handler module is dormant (ARCH-023).
+
+**R7 — Doc citability.** A doc claim is citable only if it is generated (doc_stats/METRICS)
+or CI-checked. Recency is guidance, not a rule: where recency matters, the date source is
+`git log -1 --format=%cs -- <path>` (last commit touching the file), not header dates —
+and a mass-format commit does not refresh substance. On numeric conflict, `docs/METRICS.md`
+wins.
+
+**R7b — Charter wins on liveness.** On conflict between CLAUDE.md's feature/status tables (or
+any marketing/status doc) and this charter's §1 status marks or §3 states, the charter wins
+pending the approved CLAUDE.md edit (protected file; queued in the ratification checklist, §6).
+
+**R8 — Gate integration (ratification preconditions, currently honest-red).** The
+reviewer/gate grounding must include this registry (#8905 acceptance): a PR touching a
+chartered-removed symbol yields a grounded finding citing the CHR id. **Preconditions of
+flipping Status to RATIFIED — not follow-ups:**
+(a) wire `scripts/ci/check_import_contracts.py` + `scripts/baselines/import_contracts_baseline.json`
+into a required check (today: zero callers in workflows/Makefile/pre-commit);
+(b) `docs/architecture/charters.yaml` committed and current (done in the PR that landed this
+draft — schema in §6);
+(c) add #8893 as the charter-blind specimen to the adjudicator eval fixtures.
+Until (a) is live, **no §3b entry may transition PENDING → REMOVED** — executing removals a
+gate cannot cite reproduces the failure this charter was written to close.
+
+---
+
+## 5. Vocabulary — one language for all fleets
+
+| Term | Canonical meaning | Not to be confused with |
+|---|---|---|
+| **mission** | A bounded goal given to the fleet, entering via mission intake and decomposed into leased work (fleet spine, L5) | product "debate task"; a mission may spawn many debates |
+| **feature** | A shipped, *reachable* capability with a live entrypoint (R6 evidence standard) | tested-but-unwired code; flag-off code; catalog code |
+| **work lease** | Exclusive, time-bounded ownership of a branch/lane recorded in `nomic/dev_coordination` (preflight: `check_work_lease.py`) | worktree existence; a git branch; `worktree/fleet.py` mirrors leases, never grants them |
+| **receipt** | Verifiable decision artifact emitted by `aragora/gauntlet` (ODR schema), externally checkable by `aragora-verify`; fleet completion receipts in dev_coordination are the L5 analogue | logs, summaries, PR descriptions |
+| **gate** | A merge-blocking check: the 5 required CI checks + the tiered quorum (#8638). Severity-gated P2/P3 dissent is advisory: non-blocking but **non-counting** | code review comments generally |
+| **settle** | Drive a PR through quorum to a terminal state via `settle_tier4_pr.py`; Tier 1-2 settle on ONE western-frontier PASS | merging by hand; approving |
+| **quorum** | The configured reviewer set whose PASS/FAIL verdicts the tiered gate counts (western-frontier = {claude, openai}) | any collection of LLM opinions; Fugu never counts as diversity |
+| **charter** | An operator-ratified statement of intended structure (this doc, P4a docs) with a citable registry | plans, proposals, PR-thread decisions |
+| **chartered removal** | A §3 entry with an ID; removal intent that survives the PR that executed it | ordinary refactor deletions |
+| **authority (module)** | The single module allowed to own a concern (§2) | the module with the most code for that concern |
+| **duplicate / dormant** | Second implementation of a chartered concern / code with no live entrypoint per R6 | "unused" by grep alone (see CHR-X-023 importlib caveat) |
+| **park** | Deliberate non-decision with a named owner + calendar review date (§3c) | abandonment; parking still freezes wiring |
+| **UNMAPPED** | Default state for packages with no §2/Appendix-A mapping: frozen for architectural growth, maintenance allowed (§2d) | "unowned, do what you want" |
+| **spine** | The two chartered execution paths: **fleet spine** (missions → dev_coordination → swarm → pipeline → approvals/receipts) and **product spine** (surface → debate core → knowledge → receipt → channels) | any long import chain |
+| **tier** | Change-risk class 0-4 from the operating contract driving gate strictness and auto-merge eligibility | RBAC roles; handler tiers (`ARAGORA_HANDLER_TIERS`) |
+
+---
+
+## 6. Amendment & maintenance
+
+### charters.yaml schema (normative)
+
+`docs/architecture/charters.yaml` is generated from §2/§3 and committed in the same PR as any
+change to them (R8b made it a ratification precondition; the seed was committed with this
+draft). Schema:
+
+```yaml
+meta:
+  charter: docs/architecture/INTENDED_ARCHITECTURE.md
+  version: "0.2"          # must match this doc's version
+  status: DRAFT           # DRAFT | RATIFIED
+authorities:              # §2 rows
+  - id: ARCH-001
+    concern: <short name>
+    authority: <repo-relative module path(s)>
+    layer: L0..L6
+    disposition: adopt | absorb | retire | park | interim-adopt
+    registry_refs: [CHR-...]   # every non-adopt disposition points at ≥1 entry
+registry:                 # §3 entries
+  - id: CHR-X-001
+    state: REMOVED | EXPIRING | PENDING | PARKED | EXCLUSION
+    paths: [<exact repo-relative paths or well-formed globs>]
+    symbols: [<module:export_name>]   # may be empty for whole-path entries
+    deadline: <ISO date>              # required for EXPIRING and PARKED
+    owner: <name>                     # required for PARKED
+    evidence: <one-line anchor>
+    superseded_by: <id or null>
+```
+
+### Rules
+
+- This charter lives at `docs/architecture/INTENDED_ARCHITECTURE.md`; it and `charters.yaml`
+  change only together.
+- Amendments: operator approval required (governance-doc class, per operating contract).
+  Fleets may PROPOSE entries via PR; entries take effect only when state is set by the operator.
+- **Any change to §2, §3, or §4 bumps the charter version** and appends an Amendment-log row.
+- IDs are permanent: never reused, never renumbered; entries are only ever state-transitioned.
+- Every §3b/§3c execution PR must reference its CHR id in the PR body; the registry entry is
+  then updated with date + PR in the same change.
+- Review cadence: with the #8762 close-the-loop checkpoint (next: 2026-07-29), reconcile this
+  charter against #8851 rulings and newly merged downshifts.
+
+### Ratification checklist (all are preconditions of `Status: RATIFIED`)
+
+1. Operator approves this PR (or a successor) — charter + charters.yaml land on main.
+2. R8a: `check_import_contracts.py` wired as a required check.
+3. R8c: #8893 added to the adjudicator eval fixtures as the charter-blind specimen.
+4. CHR-X-025 executed: sibling architecture docs stamped SUPERSEDED-BY or archived.
+5. Pointer lines added to `CLAUDE.md` and `AGENTS.md` (protected files — explicit
+   operator-approved edit): "Architecture intent: `docs/architecture/INTENDED_ARCHITECTURE.md`
+   + `charters.yaml` — check before adding modules/imports." Includes fixing CLAUDE.md's
+   144-row table advertising §3b PENDING subsystems as features with no liveness column (R7b
+   governs the interim).
+6. The queue-drain cleanup plan lands on main so it is citable
+   (`docs/plans/2026-06-30-queue-drain-diagnosis-and-cleanup-plan.md`).
+
+### Amendment log
+
+| Version | Date | PR | Approval evidence | Entries changed |
+|---|---|---|---|---|
+| v0.1 | 2026-07-05 | (scratchpad draft, never binding) | operator-commissioned | initial: CHR-P4A-001..004, CHR-X-001..024, CHR-E-001..008 |
+| v0.2 | 2026-07-06 | this PR (draft) | operator-commissioned; adversarial critic pass applied | added ARCH-001..036 ids; CHR-P4A-004 → REMOVED (#8909); CHR-X-002 split (→ CHR-X-038); CHR-X-010 corrected (snapshot/redteam/sandbox de-chartered); added CHR-X-025..039; parked entries got owners+dates; exclusions got operational tests; UNMAPPED default + Appendix A; R3 covers EXPIRING; R7 date source; R7b; R8 → preconditions |
+
+---
+
+*Drafted 2026-07-05 from 8 evidence-grounded cluster maps (decision-core, knowledge-memory,
+orchestration-substrate, server-api, fleet-ops, integrations-channels, enterprise-platform,
+docs-charters); revised 2026-07-06 after an adversarial critic pass that re-verified importer
+claims against the repo. Every disposition traces to an evidence line; where maps, priors, or
+the v0.1 draft disagreed with the code (queue/ and workflow/ are live, not dormant; vector_store
+and search/ have live mound-internal importers; snapshot/redteam/sandbox have real ELO and
+formal-verification callers; #8909 already executed the queue re-removal), the code evidence won.*
+
+## Appendix A. Top-level package triage (generated 2026-07-06)
+
+One line per `aragora/*` package. MAPPED rows cite their ARCH/CHR ids; UNMAPPED rows are
+frozen for architectural growth per §2d until triaged by charter amendment (R5). This table is
+descriptive inventory — the normative machine encoding is `charters.yaml`.
+
+| Package | Layer | State | Charter refs / notes |
+|---|---|---|---|
+| `aragora/advocates` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/agents` | L1 | MAPPED | ARCH-001 roster; CHR-X-010 dead modules; CHR-X-026 calibration absorb |
+| `aragora/analysis` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/analytics` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/approvals` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/audience` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/audit` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/auth` | L0 | MAPPED | ARCH-033 authority; CHR-X-035 token_rotation |
+| `aragora/autonomous` | L5 | MAPPED | CHR-X-029 fold into nomic |
+| `aragora/backup` | L0 | MAPPED | L0 |
+| `aragora/billing` | L0 | MAPPED | L0 |
+| `aragora/blockchain` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/bots` | L4 | MAPPED | CHR-X-004 slack/teams retire; discord/zoom handlers stay |
+| `aragora/brief_engine` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/broadcast` | L4 | MAPPED | L4 out |
+| `aragora/caching` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/canvas` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/channels` | L4 | MAPPED | ARCH-026 authority (transport) |
+| `aragora/cli` | L3 | MAPPED | ARCH-019/024 (migrates to SDK per CHR-X-033) |
+| `aragora/client` | L3 | MAPPED | ARCH-024 duplicate; CHR-X-033 absorb |
+| `aragora/codex` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/compat` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/compliance` | L0 | MAPPED | L0 |
+| `aragora/computer_use` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/config` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/connectors` | L4 | MAPPED | ARCH-025 authority; CHR-X-023 catalog parked |
+| `aragora/control_plane` | L0 | MAPPED | CHR-X-015 partial retire; policy/notifications keep-list |
+| `aragora/coordination` | L5 | MAPPED | CHR-X-012 retire (core); salvage GitReconciler/bus |
+| `aragora/core` | L1 | MAPPED | ARCH-010 embeddings authority; core types |
+| `aragora/db` | L0 | MAPPED | CHR-X-019 fold into storage |
+| `aragora/debate` | L1 | MAPPED | ARCH-001 authority; ARCH-009; CHR-X-024 exotica parked |
+| `aragora/deliberation` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/documents` | L2 | MAPPED | L2 ingestion |
+| `aragora/embeddings` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/epistemic` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/essay` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/evaluation` | L1 | MAPPED | ARCH-004 authority |
+| `aragora/events` | L0 | MAPPED | dispatcher stays; dead_letter_queue → CHR-X-034 |
+| `aragora/evidence` | L2 | MAPPED | ARCH-005 ingestion front-end |
+| `aragora/evolution` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/explainability` | L1 | MAPPED | L1 authority |
+| `aragora/export` | L1 | MAPPED | decision_receipt.py → CHR-X-037; rest of export/ UNMAPPED-adjacent, see note |
+| `aragora/extensions` | L5 | MAPPED | CHR-X-016 (init path); CHR-X-028 gastown dialect |
+| `aragora/fabric` | L5 | MAPPED | CHR-X-013 retire |
+| `aragora/factory` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/fixtures` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/gateway` | L4 | MAPPED | CHR-X-017 (LocalGateway story); registered handlers stay |
+| `aragora/gauntlet` | L1 | MAPPED | ARCH-002 authority (receipt emission); CHR-X-001 odr_verify |
+| `aragora/genesis` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/goals` | L3 | MAPPED | CHR-X-029 absorb into pipeline |
+| `aragora/gti` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/harnesses` | L5 | MAPPED | ARCH-018 authority |
+| `aragora/heterogeneity` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/hooks` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/ideacloud` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/implement` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/inbox` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/insights` | L2 | MAPPED | L2 |
+| `aragora/integrations` | L4 | MAPPED | CHR-X-032 clients absorb into connectors; CHR-X-034 dispatcher |
+| `aragora/interrogation` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/introspection` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/knowledge` | L2 | MAPPED | ARCH-007 authority (mound); CHR-X-002/027/038 |
+| `aragora/learning` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/live` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/maintenance` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/marketplace` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/markets` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/mcp` | L4 | MAPPED | ARCH-028 authority |
+| `aragora/memory` | L2 | MAPPED | ARCH-008 authority; CHR-X-003/020/027 |
+| `aragora/metrics` | L1 | MAPPED | CHR-X-007 shim retire; new imports forbidden now |
+| `aragora/migrations` | L0 | MAPPED | ARCH-031/CHR-X-021 parked consolidation |
+| `aragora/missions` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/ml` | L2 | MAPPED | CHR-X-027 embeddings demote; rest UNMAPPED-adjacent |
+| `aragora/moderation` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/modes` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/monitoring` | L0 | MAPPED | CHR-X-005 shim retire |
+| `aragora/nomic` | L5 | MAPPED | ARCH-012 authority (dev_coordination); ARCH-013 stores; CHR-X-039 packaging park |
+| `aragora/notifications` | L4 | MAPPED | ARCH-026 authority (policy); CHR-X-034 retry consolidation |
+| `aragora/observability` | L0 | MAPPED | ARCH-029 authority (P4a RATIFIED) |
+| `aragora/onboarding` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/operations` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/ops` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/pdb` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/performance` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/persistence` | L0 | MAPPED | ARCH-031 interim migrations authority; CHR-X-022 parked |
+| `aragora/pipeline` | L3 | MAPPED | ARCH-017 authority |
+| `aragora/playbooks` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/plugins` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/policy` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/prediction` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/privacy` | L0 | MAPPED | L0 |
+| `aragora/prompt_engine` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/prompts` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/protocols` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/pulse` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/queue` | L3 | MAPPED | ARCH-015 authority; CHR-P4A-004 |
+| `aragora/ralph` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/ranking` | L1 | MAPPED | ARCH-006 authority; CHR-X-010 muse_calibration only |
+| `aragora/rbac` | L0 | MAPPED | ARCH-033 authority |
+| `aragora/reasoning` | L1 | MAPPED | ARCH-005 authority |
+| `aragora/receipts` | L1 | MAPPED | ARCH-002 facade over gauntlet; CHR-X-037 |
+| `aragora/replay` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/reports` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/reputation` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/resilience` | L0 | MAPPED | ARCH-032 authority; CHR-X-006 |
+| `aragora/review` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/rlm` | L2 | MAPPED | ARCH-011 authority |
+| `aragora/routing` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/runtime` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/sandbox` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/scheduler` | L0 | MAPPED | ARCH-022 authority (ops cron) |
+| `aragora/schedulers` | L0 | MAPPED | CHR-X-031 shim retire |
+| `aragora/security` | L0 | MAPPED | ARCH-034 authority (interim rotators); CHR-X-035/036 |
+| `aragora/server` | L3 | MAPPED | ARCH-023 authority; CHR-X-011 park; CHR-X-016; CHR-P4A-001..003 |
+| `aragora/services` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/shared` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/skills` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/spectate` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/storage` | L0 | MAPPED | ARCH-030 authority |
+| `aragora/stores` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/streaming` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/swarm` | L5 | MAPPED | ARCH-014 authority (boss loop); CHR-X-030 worker_launcher absorb |
+| `aragora/sync` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/tasks` | L3 | MAPPED | CHR-X-014 retire |
+| `aragora/telemetry` | L0 | MAPPED | CHR-X-005 shim retire |
+| `aragora/templates` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/tenancy` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/tools` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/tournaments` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/trail` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/training` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/transcription` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/triage` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/types` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/uncertainty` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/utils` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/verification` | L1 | MAPPED | L1 authority; sandbox.py retained (CHR-X-010 note) |
+| `aragora/verticals` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/visualization` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/webhooks` | L4 | MAPPED | ARCH-027 authority |
+| `aragora/work` | — | UNMAPPED | frozen for architectural growth (§2d); triage via R5 amendment |
+| `aragora/workflow` | L3 | MAPPED | ARCH-016 authority (library) |
+| `aragora/workspace` | L5 | MAPPED | ARCH-013 delegating wrapper over nomic/stores |
+| `aragora/worktree` | L5 | MAPPED | ARCH-021 authority; fleet.py mirror-only (ARCH-012) |
+
+Totals: 144 top-level packages — 64 MAPPED, 80 UNMAPPED.
+(Top-level single-file modules under `aragora/*.py` follow their nearest package's state; `resilience_patterns.py`/`resilience_config.py` are chartered in CHR-X-006.)
+

--- a/docs/architecture/charters.yaml
+++ b/docs/architecture/charters.yaml
@@ -1,0 +1,714 @@
+# charters.yaml — machine-readable encoding of docs/architecture/INTENDED_ARCHITECTURE.md
+# Normative for gate/reviewer grounding (charter §3, R8b). Regenerate/update in the SAME PR
+# as any change to charter §2/§3. IDs are permanent: never reused, never renumbered.
+meta:
+  charter: docs/architecture/INTENDED_ARCHITECTURE.md
+  version: "0.2"
+  status: DRAFT
+  # Ratified iff the charter file exists on main with 'Status: RATIFIED vN.N' via an
+  # operator-approved PR. While DRAFT, only entries with binding_in_draft: true bind.
+  generated: "2026-07-06"
+
+authorities:
+  - id: ARCH-001
+    concern: deliberation-orchestration
+    authority: aragora/debate
+    layer: L1
+    disposition: adopt
+    registry_refs: []
+  - id: ARCH-002
+    concern: receipt-emission
+    authority: aragora/gauntlet
+    layer: L1
+    disposition: adopt
+    registry_refs: [CHR-X-037]
+    notes: aragora/receipts is a sanctioned facade over gauntlet; no independent receipt classes
+  - id: ARCH-003
+    concern: external-receipt-verification
+    authority: aragora-verify (PyPI package, ODR schema)
+    layer: L1
+    disposition: adopt
+    registry_refs: [CHR-X-001]
+  - id: ARCH-004
+    concern: quality-scoring-eval-metrics
+    authority: aragora/evaluation
+    layer: L1
+    disposition: adopt
+    registry_refs: [CHR-X-007]
+  - id: ARCH-005
+    concern: claims-evidence-base
+    authority: aragora/reasoning
+    layer: L1
+    disposition: adopt
+    registry_refs: []
+  - id: ARCH-006
+    concern: agent-calibration
+    authority: aragora/ranking
+    layer: L1
+    disposition: absorb
+    registry_refs: [CHR-X-026]
+  - id: ARCH-007
+    concern: durable-knowledge-store
+    authority: aragora/knowledge/mound
+    layer: L2
+    disposition: adopt
+    registry_refs: [CHR-X-002, CHR-X-038]
+  - id: ARCH-008
+    concern: debate-session-memory
+    authority: aragora/memory
+    layer: L2
+    disposition: adopt
+    registry_refs: [CHR-X-003, CHR-X-020]
+  - id: ARCH-009
+    concern: outcome-confidence-feedback
+    authority: aragora/debate/km_outcome_bridge.py
+    layer: L1
+    disposition: adopt
+    registry_refs: [CHR-X-003]
+  - id: ARCH-010
+    concern: embeddings
+    authority: aragora/core
+    layer: L1
+    disposition: absorb
+    registry_refs: [CHR-X-027]
+  - id: ARCH-011
+    concern: context-navigation
+    authority: aragora/rlm
+    layer: L2
+    disposition: adopt
+    registry_refs: []
+  - id: ARCH-012
+    concern: work-ownership-leases
+    authority: aragora/nomic/dev_coordination
+    layer: L5
+    disposition: adopt
+    registry_refs: [CHR-X-012]
+    notes: worktree/fleet.py is a mirror, never a second truth
+  - id: ARCH-013
+    concern: bead-convoy-stores
+    authority: aragora/nomic/stores
+    layer: L5
+    disposition: adopt
+    registry_refs: [CHR-X-028]
+  - id: ARCH-014
+    concern: fleet-task-scheduling
+    authority: aragora/swarm (boss loop) + aragora/nomic/dev_coordination dispatch
+    layer: L5
+    disposition: adopt
+    registry_refs: [CHR-X-012, CHR-X-013, CHR-X-014, CHR-X-015]
+  - id: ARCH-015
+    concern: durable-server-jobs
+    authority: aragora/queue
+    layer: L3
+    disposition: adopt
+    registry_refs: [CHR-P4A-004]
+  - id: ARCH-016
+    concern: product-dag-workflows
+    authority: aragora/workflow
+    layer: L3
+    disposition: adopt
+    registry_refs: []
+    notes: library consumed by pipeline; must not grow a rival scheduler or debate loop
+  - id: ARCH-017
+    concern: idea-to-execution-pipeline
+    authority: aragora/pipeline
+    layer: L3
+    disposition: absorb
+    registry_refs: [CHR-X-029]
+  - id: ARCH-018
+    concern: agent-process-spawning
+    authority: aragora/harnesses
+    layer: L5
+    disposition: absorb
+    registry_refs: [CHR-X-030]
+  - id: ARCH-019
+    concern: pr-settlement
+    authority: scripts/settle_tier4_pr.py + aragora/cli review-queue transports
+    layer: L5
+    disposition: absorb
+    registry_refs: [CHR-X-008]
+  - id: ARCH-020
+    concern: conductor-goal-loop
+    authority: scripts/fable_goal_cycle.py + scripts/consult_claude.py
+    layer: L5
+    disposition: retire
+    registry_refs: [CHR-X-009]
+  - id: ARCH-021
+    concern: worktree-lifecycle
+    authority: aragora/worktree
+    layer: L5
+    disposition: adopt
+    registry_refs: [CHR-X-012]
+  - id: ARCH-022
+    concern: scheduled-ops-jobs
+    authority: aragora/scheduler
+    layer: L0
+    disposition: adopt
+    registry_refs: [CHR-X-031]
+    notes: ops-cron is distinct from fleet work-dispatch (ARCH-014); not covered by CHR-E-003
+  - id: ARCH-023
+    concern: http-ws-ingress
+    authority: aragora/server/unified_server.py + handler_registry + stream servers
+    layer: L3
+    disposition: adopt
+    registry_refs: [CHR-X-011, CHR-X-016]
+    notes: unregistered handler modules are dormant per R6
+  - id: ARCH-024
+    concern: python-client
+    authority: sdk/python/aragora_sdk
+    layer: L3
+    disposition: absorb
+    registry_refs: [CHR-X-033]
+  - id: ARCH-025
+    concern: inbound-connectors
+    authority: aragora/connectors
+    layer: L4
+    disposition: absorb
+    registry_refs: [CHR-X-032, CHR-X-023]
+  - id: ARCH-026
+    concern: outbound-delivery
+    authority: aragora/channels + aragora/notifications/service.py
+    layer: L4
+    disposition: absorb
+    registry_refs: [CHR-X-004, CHR-X-015]
+  - id: ARCH-027
+    concern: retry-dead-letter
+    authority: aragora/webhooks/retry_queue.py
+    layer: L4
+    disposition: absorb
+    registry_refs: [CHR-X-034]
+  - id: ARCH-028
+    concern: agent-facing-tools
+    authority: aragora/mcp
+    layer: L4
+    disposition: adopt
+    registry_refs: []
+  - id: ARCH-029
+    concern: observability
+    authority: aragora/observability
+    layer: L0
+    disposition: adopt
+    registry_refs: [CHR-X-005, CHR-P4A-001, CHR-P4A-002, CHR-P4A-003]
+    notes: RATIFIED by P4a
+  - id: ARCH-030
+    concern: persistence-api
+    authority: aragora/storage
+    layer: L0
+    disposition: absorb
+    registry_refs: [CHR-X-019, CHR-X-022]
+  - id: ARCH-031
+    concern: schema-migrations
+    authority: aragora/persistence/migrations
+    layer: L0
+    disposition: interim-adopt
+    registry_refs: [CHR-X-021]
+    notes: interim authority (what auto_migrations runs); consolidation parked
+  - id: ARCH-032
+    concern: circuit-breaking-retry
+    authority: aragora/resilience
+    layer: L0
+    disposition: adopt
+    registry_refs: [CHR-X-006]
+  - id: ARCH-033
+    concern: authn-authz
+    authority: aragora/rbac + aragora/auth
+    layer: L0
+    disposition: adopt
+    registry_refs: [CHR-X-035]
+    notes: Tier 3-4 blast radius; no autonomous refactor
+  - id: ARCH-034
+    concern: key-rotation
+    authority: aragora/security per-provider rotators wired by aragora/server/startup/security.py
+    layer: L0
+    disposition: interim-adopt
+    registry_refs: [CHR-X-036]
+    notes: end-state is one table-driven registry in aragora/security; no new rotator files
+  - id: ARCH-035
+    concern: numeric-truth
+    authority: docs/METRICS.md
+    layer: L6
+    disposition: adopt
+    registry_refs: []
+  - id: ARCH-036
+    concern: removal-intent
+    authority: docs/architecture/INTENDED_ARCHITECTURE.md#3 + docs/architecture/charters.yaml
+    layer: L6
+    disposition: adopt
+    registry_refs: []
+
+registry:
+  # --- 3a. Executed (RATIFIED) ---
+  - id: CHR-P4A-001
+    state: REMOVED
+    binding_in_draft: true
+    paths: [aragora/server/metrics.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "PR #8712; P4A_LAYERING_DISPOSITION.md; home is aragora.observability.server_metrics"
+    superseded_by: null
+  - id: CHR-P4A-002
+    state: REMOVED
+    binding_in_draft: true
+    paths: [aragora/server/middleware/tracing.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "PR #8717; home is aragora.observability.middleware.tracing"
+    superseded_by: null
+  - id: CHR-P4A-003
+    state: REMOVED
+    binding_in_draft: true
+    paths: [aragora/server/http_client_pool.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "PR #8719; home is aragora.observability.http_client_pool"
+    superseded_by: null
+  - id: CHR-P4A-004
+    state: REMOVED
+    binding_in_draft: true
+    paths: [aragora/queue/__init__.py]
+    symbols: ["aragora.queue:create_default_executor"]
+    deadline: null
+    owner: null
+    evidence: "removed #8890; re-added charter-blind #8893 (specimen, #8905); re-removed #8909 (2026-07-05). Home: aragora/debate/queue_executor.py"
+    superseded_by: null
+
+  # --- 3b. PENDING (no new importers/callers; execute after ratification/#8851) ---
+  - id: CHR-X-001
+    state: PENDING
+    paths: [aragora/gauntlet/odr_verify.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "odr_verify.py docstring 'no shipped CLI/route calls it'; docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md"
+    superseded_by: null
+  - id: CHR-X-002
+    state: PENDING
+    paths:
+      - aragora/knowledge/fact_extractor.py
+      - aragora/knowledge/migration.py
+      - aragora/knowledge/mound_store.py
+      - aragora/knowledge/unified/unified_store.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "0 external importers each (re-verified 2026-07-06); vector_store/search are CHR-X-038, NOT here"
+    superseded_by: null
+  - id: CHR-X-003
+    state: PENDING
+    paths:
+      - aragora/memory/outcome_bridge.py
+      - aragora/memory/openclaw_bridge.py
+      - aragora/memory/claude_mem_km_sync.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "test-only importers; live edge is aragora/debate/km_outcome_bridge.py"
+    superseded_by: null
+  - id: CHR-X-004
+    state: PENDING
+    paths: [aragora/bots/slack_bot.py, aragora/bots/teams_bot.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "0 importers; Slack served by connectors/chat + handlers + channels dock"
+    superseded_by: null
+  - id: CHR-X-005
+    state: PENDING
+    paths: [aragora/telemetry/, aragora/monitoring/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "re-export shims; observability is P4a single authority"
+    superseded_by: null
+  - id: CHR-X-006
+    state: PENDING
+    paths:
+      - aragora/resilience/circuit_breaker_v2.py
+      - aragora/resilience_patterns.py
+      - aragora/resilience_config.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "0 external importers / package-internal only"
+    superseded_by: null
+  - id: CHR-X-007
+    state: PENDING
+    binding_in_draft: true
+    paths: [aragora/metrics/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "shim's own DeprecationWarning contract ('for one release'); new imports of aragora.metrics forbidden now"
+    superseded_by: null
+  - id: CHR-X-008
+    state: PENDING
+    paths:
+      - scripts/settle_one_pr.py
+      - scripts/tier4_merge_train.py
+      - scripts/auto_merge_quorum_green.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "wrapper sprawl around settle_tier4_pr; absorb then retire"
+    superseded_by: null
+  - id: CHR-X-009
+    state: PENDING
+    paths:
+      - scripts/goal_conductor.py
+      - scripts/lane_conductor.py
+      - scripts/overnight_conductor.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "superseded by fable_goal_cycle + consult_claude (#8835); goal_conductor.py:310 hardcodes nomic_loop"
+    superseded_by: null
+  - id: CHR-X-010
+    state: PENDING
+    paths:
+      - aragora/agents/email_agents.py
+      - aragora/agents/feature_agent.py
+      - aragora/agents/power_sampling_mixin.py
+      - aragora/ranking/muse_calibration.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "zero-importer (lazy __init__ re-exports only). NOT chartered: ranking/snapshot.py, ranking/redteam.py, verification/sandbox.py (real callers: elo.py:90,96; elo_leaderboard.py:18; elo_matchmaking.py:25; formal.py:559; verification/__init__.py:49)"
+    superseded_by: null
+  - id: CHR-X-012
+    state: PENDING
+    paths:
+      - aragora/coordination/claims.py
+      - aragora/coordination/task_dispatcher.py
+      - aragora/coordination/registry.py
+      - aragora/coordination/health_watchdog.py
+      - aragora/coordination/worktree_manager.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "per #8851 ruling; salvage GitReconciler->worktree/, bus->events/"
+    superseded_by: null
+  - id: CHR-X-013
+    state: PENDING
+    paths: [aragora/fabric/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "per #8851 ruling; flip ARAGORA_ENABLE_AGENT_FABRIC default->false first (extensions.py:39)"
+    superseded_by: null
+  - id: CHR-X-014
+    state: PENDING
+    paths: [aragora/tasks/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "one implementation module (router.py), one caller (server/handlers/tasks/execution.py:39)"
+    superseded_by: null
+  - id: CHR-X-015
+    state: PENDING
+    paths:
+      - aragora/control_plane/scheduler.py
+      - aragora/control_plane/registry.py
+      - aragora/control_plane/auto_scaling.py
+      - aragora/control_plane/federation.py
+      - aragora/control_plane/blockchain_identity.py
+      - aragora/control_plane/regional_sync.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "warn-then-None in prod (startup/control_plane.py:55-58). KEEP: policy store/sync/cache, notifications.py (until ARCH-026 absorb), deliberation worker. Public-API deprecation path required"
+    superseded_by: null
+  - id: CHR-X-016
+    state: PENDING
+    paths: [aragora/server/extensions.py]
+    symbols: ["aragora.server.extensions:init_extensions"]
+    deadline: null
+    owner: null
+    evidence: "zero callers; delete the init path or wire it at startup - no limbo"
+    superseded_by: null
+  - id: CHR-X-017
+    state: PENDING
+    paths: [aragora/gateway/]
+    symbols: ["aragora.gateway.server:LocalGateway"]
+    deadline: null
+    owner: null
+    evidence: "no non-test code starts LocalGateway; registered gateway HTTP handlers stay"
+    superseded_by: null
+  - id: CHR-X-018
+    state: PENDING
+    paths: [docs/STATUS.md, docs/COORDINATION.md]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "COORDINATION.md frozen 2026-04-28, folds into AGENT_OPERATING_CONTRACT; archive stale positioning snapshots"
+    superseded_by: null
+  - id: CHR-X-019
+    state: PENDING
+    paths: [aragora/db/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "duplicate get_database abstraction; 1 importer (control_plane/health handler); fold into aragora/storage"
+    superseded_by: null
+  - id: CHR-X-025
+    state: PENDING
+    paths:
+      - docs/architecture/ARCHITECTURE.md
+      - docs/architecture/ARCHITECTURE_THREE_LAYER.md
+      - docs/architecture/SYSTEM_DIAGRAM.md
+      - docs/architecture/system-overview.md
+      - docs/architecture/GATEWAY_ARCHITECTURE.md
+      - docs/architecture/CODEBASE_ANALYSIS.md
+      - docs/architecture/ANALYSIS.md
+      - docs/architecture/ground-up-assessment-2026-01-29.md
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "stamp SUPERSEDED-BY header or archive as part of the ratification PR (charter s0 precedence)"
+    superseded_by: null
+  - id: CHR-X-026
+    state: PENDING
+    paths: [aragora/agents/calibration.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "absorb into aragora/ranking (ARCH-006); dual calibration paths risk schema drift"
+    superseded_by: null
+  - id: CHR-X-027
+    state: PENDING
+    paths:
+      - aragora/knowledge/embeddings.py
+      - aragora/memory/embeddings.py
+      - aragora/ml/embeddings.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "demote to provider plugins behind aragora/core (ARCH-010); coordinate with CHR-X-038 (knowledge/embeddings imports search/bm25)"
+    superseded_by: null
+  - id: CHR-X-028
+    state: PENDING
+    paths: [aragora/extensions/gastown/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "Gastown bead/convoy dialect (refinery/rig); aragora/nomic/stores is the single truth (ARCH-013)"
+    superseded_by: null
+  - id: CHR-X-029
+    state: PENDING
+    paths: [aragora/goals/, aragora/autonomous/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "goals/ = extractor.py only (pipeline stage 2); autonomous/ self-describes 'Nomic Loop Enhancement' (ARCH-017)"
+    superseded_by: null
+  - id: CHR-X-030
+    state: PENDING
+    paths: [aragora/swarm/worker_launcher.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "direct spawn at worker_launcher.py:613,685; becomes a harnesses consumer (ARCH-018)"
+    superseded_by: null
+  - id: CHR-X-031
+    state: PENDING
+    paths: [aragora/schedulers/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "deprecated shim package; home is aragora/scheduler (ARCH-022); shim family with CHR-X-005/006/007"
+    superseded_by: null
+  - id: CHR-X-032
+    state: PENDING
+    paths:
+      - aragora/integrations/slack.py
+      - aragora/integrations/telegram.py
+      - aragora/integrations/teams.py
+      - aragora/integrations/whatsapp.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "platform clients absorb into connectors/chat via staged migration (ARCH-025); both Telegram stacks live today"
+    superseded_by: null
+  - id: CHR-X-033
+    state: PENDING
+    paths: [aragora/client/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "ungated 37-resource client kept alive by CLI; CLI migrates to sdk/python/aragora_sdk or client joins parity gate (ARCH-024, check_sdk_parity.py:280)"
+    superseded_by: null
+  - id: CHR-X-034
+    state: PENDING
+    paths:
+      - aragora/notifications/retry_queue.py
+      - aragora/events/dead_letter_queue.py
+      - aragora/integrations/webhooks.py
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "4 retry/dead-letter implementations, all reachable; consolidate onto aragora/webhooks/retry_queue.py (ARCH-027)"
+    superseded_by: null
+  - id: CHR-X-035
+    state: PENDING
+    paths: [aragora/security/token_rotation.py, aragora/auth/token_rotation.py]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "duplicated token rotation; absorb into one (ARCH-033 rules which at execution)"
+    superseded_by: null
+  - id: CHR-X-036
+    state: PENDING
+    paths: ["aragora/security/*_rotator.py"]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "8 per-provider rotator files, each with 1 importer (startup/security.py); absorb into one table-driven registry; no NEW rotator files meanwhile (ARCH-034)"
+    superseded_by: null
+  - id: CHR-X-037
+    state: PENDING
+    paths: [aragora/export/decision_receipt.py]
+    symbols: ["aragora.receipts:LegacyDecisionReceipt"]
+    deadline: null
+    owner: null
+    evidence: "third receipt lineage (receipts/__init__.py:9); absorb-or-retire per RECEIPT_LINEAGE_RECONCILIATION; receipts/ chartered facade-only over gauntlet (ARCH-002)"
+    superseded_by: null
+  - id: CHR-X-038
+    state: PENDING
+    paths: [aragora/knowledge/vector_store.py, aragora/knowledge/search/]
+    symbols:
+      - "aragora.knowledge.vector_store:KnowledgeVectorStore"
+      - "aragora.knowledge.vector_store:KnowledgeVectorConfig"
+    deadline: null
+    owner: null
+    evidence: "ABSORB into knowledge/mound, do NOT delete in place - live internal importers: mound/core.py:306 (Weaviate connect path), knowledge/embeddings.py:14 (bm25), mound/vector_abstraction/memory.py:27 (bm25). Corrects v0.1's wrong '0 external importers' claim"
+    superseded_by: null
+
+  # --- 3c. PARKED (named owner + calendar date; frozen both ways) ---
+  - id: CHR-X-011
+    state: PARKED
+    paths: [aragora/server/fastapi/]
+    symbols: []
+    deadline: "2026-09-01"
+    owner: operator
+    evidence: "second HTTP stack, default-off, no deploy/CI reference (unified_server.py:1313); make it THE stack or delete"
+    superseded_by: null
+  - id: CHR-X-020
+    state: PARKED
+    paths: [aragora/memory/gateway/]
+    symbols: []
+    deadline: "2026-08-15"
+    owner: operator
+    evidence: "Unified Memory Gateway flag-off (orchestrator_config.py:421); adopt or remove with #8851; backstop date auto-escalates"
+    superseded_by: null
+  - id: CHR-X-021
+    state: PARKED
+    paths: [aragora/migrations/, aragora/storage/migrations/, aragora/db/migrate.py]
+    symbols: []
+    deadline: "2026-09-01"
+    owner: operator
+    evidence: "3 migration systems; interim authority = aragora/persistence/migrations (ARCH-031, what auto_migrations runs)"
+    superseded_by: null
+  - id: CHR-X-022
+    state: PARKED
+    paths: [aragora/persistence/]
+    symbols: []
+    deadline: "2026-09-01"
+    owner: operator
+    evidence: "vs storage adjudication; serves the nomic loop; rule after CHR-X-019 executes; backstop date"
+    superseded_by: null
+  - id: CHR-X-023
+    state: PARKED
+    paths: [aragora/connectors/verticals/]
+    symbols: []
+    deadline: "2026-10-01"
+    owner: operator
+    evidence: "~132 dynamically-loaded catalog files; grep-based dead-code claims invalid (runtime_registry.py:424 importlib)"
+    superseded_by: null
+  - id: CHR-X-024
+    state: PARKED
+    paths:
+      - aragora/debate/chaos_theater.py
+      - aragora/debate/blackbox.py
+      - aragora/debate/witness.py
+      - aragora/debate/immune_system.py
+    symbols: []
+    deadline: "2026-09-15"
+    owner: operator
+    evidence: "flag-only exotica; live caller by review date or move to an experiments namespace"
+    superseded_by: null
+  - id: CHR-X-039
+    state: PARKED
+    paths: [aragora/nomic/, aragora/swarm/, aragora/worktree/, aragora/harnesses/]
+    symbols: []
+    deadline: "2026-09-01"
+    owner: operator
+    evidence: "L5 packaging ruling: fleet machinery ships in customer wheel today vs exclusion via packaging manifest (P3 packaging proven, #8517)"
+    superseded_by: null
+
+  # --- 3d. EXCLUSIONS (never build / never wire; operational tests in charter s3d) ---
+  - id: CHR-E-001
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no deliberation loops outside aragora/debate: any module that prompts >1 agent/model and aggregates outputs into a verdict/vote/consensus/ranking"
+    superseded_by: null
+  - id: CHR-E-002
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no receipt emitters outside aragora/gauntlet; no external verifiers besides aragora-verify; exceptions closed-set: receipts/ facade re-exports + dev_coordination fleet receipts (ARCH-002)"
+    superseded_by: null
+  - id: CHR-E-003
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no new schedulers/lease-stores/agent-registries; allowed dispatch surfaces closed list: aragora/nomic/dev_coordination, aragora/queue, aragora/swarm boss-loop (supervisor/reconciler); ops-cron ARCH-022 is distinct"
+    superseded_by: null
+  - id: CHR-E-004
+    state: EXCLUSION
+    paths: [aragora/server/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no server-local metrics/tracing/http-pool homes (P4a; CHR-P4A-001..003)"
+    superseded_by: null
+  - id: CHR-E-005
+    state: EXCLUSION
+    paths: [aragora/knowledge/mound/adapters/]
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no new KM adapters wrapping registry entries CHR-X-001..CHR-X-038 while state=PENDING (machine check: adapter target path in pending paths)"
+    superseded_by: null
+  - id: CHR-E-006
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no platform delivery clients outside connectors/chat + channels dock; closed platform list: Slack, Teams, Telegram, WhatsApp, Discord, Zoom, Email; new platform = R5 amendment"
+    superseded_by: null
+  - id: CHR-E-007
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no second Python client surfaces beyond sdk/python/aragora_sdk (pending CHR-X-033)"
+    superseded_by: null
+  - id: CHR-E-008
+    state: EXCLUSION
+    paths: []
+    symbols: []
+    deadline: null
+    owner: null
+    evidence: "no standing admin credentials/API keys in local env, launchd plists, or shell profiles; AWS Secrets Manager only"
+    superseded_by: null

--- a/docs/architecture/charters.yaml
+++ b/docs/architecture/charters.yaml
@@ -3,7 +3,7 @@
 # as any change to charter §2/§3. IDs are permanent: never reused, never renumbered.
 meta:
   charter: docs/architecture/INTENDED_ARCHITECTURE.md
-  version: "0.2"
+  version: "0.3"
   status: DRAFT
   # Ratified iff the charter file exists on main with 'Status: RATIFIED vN.N' via an
   # operator-approved PR. While DRAFT, only entries with binding_in_draft: true bind.
@@ -131,7 +131,9 @@ authorities:
     concern: conductor-goal-loop
     authority: scripts/fable_goal_cycle.py + scripts/consult_claude.py
     layer: L5
-    disposition: retire
+    disposition: adopt
+    # retirement of the superseded conductor duplicates is chartered in CHR-X-009,
+    # not against this authority
     registry_refs: [CHR-X-009]
   - id: ARCH-021
     concern: worktree-lifecycle
@@ -363,7 +365,7 @@ registry:
     symbols: []
     deadline: null
     owner: null
-    evidence: "superseded by fable_goal_cycle + consult_claude (#8835); goal_conductor.py:310 hardcodes nomic_loop"
+    evidence: "superseded by fable_goal_cycle + consult_claude (#8835); scripts/goal_conductor.py:310 hardcodes the scripts/nomic_loop.py path"
     superseded_by: null
   - id: CHR-X-010
     state: PENDING


### PR DESCRIPTION
## What this is

The **Intended Architecture charter** — one repo-resident definition of *where code belongs* and *what is deliberately excluded* — plus its machine-readable seed registry:

- `docs/architecture/INTENDED_ARCHITECTURE.md` — DRAFT v0.2. Layer model (L0–L6), an authority table (**36 ARCH-id rows**, one authority module per concern), a chartered-removals & exclusions registry (**51 CHR-id entries**: 4 REMOVED, 32 PENDING, 7 PARKED, 8 EXCLUSION), fleet rules R1–R8, a shared vocabulary, and a generated 144-package triage appendix (64 mapped, 80 UNMAPPED-frozen).
- `docs/architecture/charters.yaml` — the normative machine encoding (id, state, paths, symbols, deadline, owner, evidence). Parses clean; every authority-row `registry_refs` resolves.
- `docs/architecture/ARCHITECTURE.md` — banner pointing at the charter as intent authority (descriptive doc unchanged otherwise).

Status is **DRAFT**: per the binding-status block, only CHR-P4A-001..004 (operator-approved P4a artifacts, PRs #8712/#8717/#8719/#8890/#8909) and the `aragora.metrics` shim contract (CHR-X-007) bind today. Everything else binds at ratification — the ratification condition is machine-checkable (`Status: RATIFIED vN.N` on main via operator-approved PR), and R8 makes gate wiring (`check_import_contracts.py`) + this yaml **preconditions** of ratification, not follow-ups.

## Why: the charter-blind approval class (#8905)

PR #8893 re-added a chartered-removed export (`create_default_executor` on `aragora.queue`) and **merged**, because "preserving backward compatibility" looks unambiguously good to a reviewer who cannot see the decided architecture. #8909 re-removed it. Issue #8905 names this failure class; §3 of this charter plus `charters.yaml` is the citable registry that closes it — a reviewer or gate can now ground a finding in a CHR id instead of archaeology.

## The four consumers

1. **Codex fleets** — placement protocol at the top of the doc: look up the concern's ARCH row, grep the target path/symbol against `charters.yaml`, stop on REMOVED/PENDING/PARKED.
2. **Factory droids / quarantining adjudicators** — binding-status block + machine-checkable ratification condition mean an adjudicator can determine what binds *today* without judgment calls.
3. **Merge-gate reviewers** — diff-grounded reviewers can finally *see* the decided architecture (the draft previously lived in a scratchpad, enforceable on nobody); R2/R3 name the #8893 pattern invalid and require CHR-id citations in findings.
4. **Humans** — the five-minute layer-model read, honest per-layer status marks (no over-claiming: prod-dormant lanes marked, unwired enforcement marked honest-red), and Appendix A as the full package inventory.

## Revisions in v0.2 (adversarial critic pass, all P1/P2 incorporated)

- **Corrected falsifiable claims against the repo:** CHR-X-002 split (vector_store/search have live mound-internal importers — now CHR-X-038 absorb, not delete); CHR-X-010 de-charters ranking/snapshot, ranking/redteam, verification/sandbox (real ELO/formal-verification callers); CHR-P4A-004 updated to REMOVED-executed via #8909.
- **Third receipt lineage catalogued:** `aragora/receipts` + `export/decision_receipt.py` (LegacyDecisionReceipt) added to ARCH-002 with facade-only disposition (CHR-X-037).
- **Mechanical citability:** every §2 row has an ARCH id; every §3 entry has paths/symbols in yaml; PARKED entries all have owner + calendar date; exclusions have operational tests; EXPIRING is frozen like PENDING (R3).
- **Coverage:** UNMAPPED default state + generated 144-package appendix; `aragora/scheduler` chartered (ARCH-022), `aragora/schedulers` shim → CHR-X-031; interim authorities named for migrations/key-rotation (no row points at code that doesn't exist).
- **Supremacy + discoverability:** precedence clause over sibling `docs/architecture/` files (CHR-X-025 stamps them at ratification); CLAUDE.md/AGENTS.md pointer lines queued in the ratification checklist (protected files).

## Pointers

- #8905 — charter-blind approval class (motivation; acceptance criteria drive R8)
- #8851 — convergence audit: adopt-or-retire rulings gate the `PENDING (per #8851)` entries
- #8890 / #8893 / #8909 — the specimen removal → charter-blind re-add → re-removal arc
- `P4A_LAYERING_DISPOSITION.md`, `P4A_EVENTS_QUEUE_INVERSION.md` — the ratified P4a inputs

**Not requesting merge as-is** — this is the draft for operator review; ratification flips `Status:` via a follow-up operator-approved change per the binding-status block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
