### PR TITLE
fix(tests): repair tenant and gauntlet main-red checks

### DIFF
--- a/tests/cli/test_tenant.py
+++ b/tests/cli/test_tenant.py
@@ -125,7 +125,7 @@ class TestApiRequest:
         mock_response.json.return_value = {"tenants": []}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("aragora.cli.tenant.httpx.request", return_value=mock_response):
+        with patch("aragora.security.safe_http.safe_request", return_value=mock_response):
             result = api_request("GET", "/api/v1/tenants")
 
         assert result == {"tenants": []}
@@ -136,7 +136,7 @@ class TestApiRequest:
         mock_response.json.return_value = {"tenant": {"id": "new-tenant"}}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("aragora.cli.tenant.httpx.request", return_value=mock_response):
+        with patch("aragora.security.safe_http.safe_request", return_value=mock_response):
             result = api_request("POST", "/api/v1/tenants", data={"name": "Test"})
 
         assert result["tenant"]["id"] == "new-tenant"
@@ -149,7 +149,9 @@ class TestApiRequest:
         mock_response.json.return_value = {}
         mock_response.raise_for_status = MagicMock()
 
-        with patch("aragora.cli.tenant.httpx.request", return_value=mock_response) as mock_req:
+        with patch(
+            "aragora.security.safe_http.safe_request", return_value=mock_response
+        ) as mock_req:
             api_request("GET", "/test")
 
         call_kwargs = mock_req.call_args.kwargs
@@ -166,7 +168,7 @@ class TestApiRequest:
         mock_response.raise_for_status.side_effect = mock_error
         mock_response.text = "Not Found"
 
-        with patch("aragora.cli.tenant.httpx.request", return_value=mock_response):
+        with patch("aragora.security.safe_http.safe_request", return_value=mock_response):
             with pytest.raises(RuntimeError) as exc_info:
                 api_request("GET", "/test")
 
@@ -178,7 +180,7 @@ class TestApiRequest:
         request = httpx.Request("GET", "http://test/api")
         mock_error = httpx.RequestError("Connection refused", request=request)
 
-        with patch("aragora.cli.tenant.httpx.request", side_effect=mock_error):
+        with patch("aragora.security.safe_http.safe_request", side_effect=mock_error):
             with pytest.raises(RuntimeError) as exc_info:
                 api_request("GET", "/test")
 

--- a/tests/gauntlet/conftest.py
+++ b/tests/gauntlet/conftest.py
@@ -48,7 +48,13 @@ def _mock_gauntlet_runner_external_calls(monkeypatch):
     from aragora.gauntlet.result import AttackSummary, ProbeSummary, ScenarioSummary
     from aragora.gauntlet.runner import GauntletRunner
 
+    original_run_red_team = GauntletRunner._run_red_team
+
     async def _mock_run_red_team(self, input_content, context, result, report_progress):
+        if self.run_agent_fn is not None:
+            return await original_run_red_team(
+                self, input_content, context, result, report_progress
+            )
         return AttackSummary()
 
     async def _mock_run_probes(self, input_content, context, result, report_progress):

--- a/tests/gauntlet/test_gauntlet_orchestrator.py
+++ b/tests/gauntlet/test_gauntlet_orchestrator.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 from aragora.gauntlet.orchestrator import GauntletOrchestrator
+from aragora.persistence.db_config import get_nomic_dir
 from aragora.gauntlet.config import (
     GauntletConfig,
     GauntletResult,
@@ -30,7 +31,7 @@ class TestGauntletOrchestratorInit:
         orchestrator = GauntletOrchestrator()
 
         assert orchestrator.agents == []
-        assert orchestrator.nomic_dir == Path(".nomic")
+        assert orchestrator.nomic_dir == get_nomic_dir()
         assert orchestrator.on_phase_complete is None
         assert orchestrator.on_finding is None
         assert callable(orchestrator.run_agent_fn)


### PR DESCRIPTION
## Summary

Fixes #8926.

- retarget tenant CLI API helper mocks to the lazy-imported safe HTTP helper actually used by `api_request()`
- let deterministic gauntlet tests with an injected `run_agent_fn` use the real red-team path instead of the suite-wide empty external-call mock
- align the gauntlet orchestrator default `nomic_dir` expectation with `get_nomic_dir()` for linked worktrees

## Validation

- `python3 -m ruff check tests/cli/test_tenant.py tests/gauntlet/conftest.py tests/gauntlet/test_gauntlet_orchestrator.py`
- `env -u OPENROUTER_API_KEY -u XAI_API_KEY -u GROK_API_KEY -u MISTRAL_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY python3 -m pytest tests/cli/test_tenant.py::TestApiRequest::test_includes_auth_header tests/cli/test_tenant.py::TestApiRequest::test_successful_post_request tests/cli/test_tenant.py::TestApiRequest::test_connection_error_raises_runtime_error tests/cli/test_tenant.py::TestApiRequest::test_successful_get_request tests/cli/test_tenant.py::TestApiRequest::test_http_error_raises_runtime_error tests/gauntlet/test_gauntlet_evaluation.py::test_gauntlet_evaluation_fixture_counts -q`
- `env -u OPENROUTER_API_KEY -u XAI_API_KEY -u GROK_API_KEY -u MISTRAL_API_KEY -u GEMINI_API_KEY -u GOOGLE_API_KEY python3 -m pytest tests/cli/test_tenant.py tests/gauntlet -q` (`1937 passed, 2 skipped`)
