### PR TITLE
fix(tests): repair debate-am main-red shard

### DIFF
--- a/aragora/debate/memory_manager.py
+++ b/aragora/debate/memory_manager.py
@@ -988,7 +988,9 @@ class MemoryManager:
                     )
                 except (ConnectionError, TimeoutError, StopIteration, ImportError) as e:
                     logger.warning("  [continuum] Failed to update memory %s: %s", mem_id, e)
-                except Exception as e:
+                except BaseException as e:
+                    if not isinstance(e, Exception):
+                        raise
                     logger.warning("  [continuum] Failed to update memory %s: %s", mem_id, e)
 
             if updated_count > 0:
@@ -1305,7 +1307,9 @@ class MemoryManager:
             except (OSError, RuntimeError, ValueError, KeyError) as e:
                 # Spectator delivery must never break debate execution.
                 logger.warning("Unexpected spectator notification error: %s", e)
-            except Exception as e:
+            except BaseException as e:
+                if not isinstance(e, Exception):
+                    raise
                 logger.warning("Unexpected spectator notification error: %s", e)
 
     def track_retrieved_ids(

--- a/aragora/debate/memory_manager.py
+++ b/aragora/debate/memory_manager.py
@@ -988,6 +988,8 @@ class MemoryManager:
                     )
                 except (ConnectionError, TimeoutError, StopIteration, ImportError) as e:
                     logger.warning("  [continuum] Failed to update memory %s: %s", mem_id, e)
+                except Exception as e:
+                    logger.warning("  [continuum] Failed to update memory %s: %s", mem_id, e)
 
             if updated_count > 0:
                 logger.info(
@@ -1302,6 +1304,8 @@ class MemoryManager:
                 logger.debug("Spectator notification error: %s", e)
             except (OSError, RuntimeError, ValueError, KeyError) as e:
                 # Spectator delivery must never break debate execution.
+                logger.warning("Unexpected spectator notification error: %s", e)
+            except Exception as e:
                 logger.warning("Unexpected spectator notification error: %s", e)
 
     def track_retrieved_ids(


### PR DESCRIPTION
## Summary

- Fixes the `test-fast (debate-am, debate-am, debate, 30)` main-red shard by containing optional memory/spectator sink failures.
- Keeps the change scoped to `aragora/debate/memory_manager.py`.
- Opens as draft for CI validation; no merge, settlement, evidence posting, workflow edit, or branch-protection mutation is requested.

## Main-Red Reproduction

Source run: `28763292849` on PR #8912 head `c73f03587e05dbc6f724a77a87f868a80e7b9efc`.

Failed job repaired here:

- `test-fast (debate-am, debate-am, debate, 30)`
- job id: `85283737571`

Failing node IDs from that job:

- `tests/debate/test_memory_manager_extended.py::TestEventEmission::test_handles_notification_failures_gracefully`
- `tests/debate/test_memory_manager_extended.py::TestOutcomeUpdates::test_partial_update_failures_handled`

Pristine `origin/main` reproduction worktree:

- path: `/tmp/aragora-mainred-20260706T0535`
- starting head: `c69d7dea36fdabe5370897b6ace7f1b2ab68b6d0`

Reproduction command:

```bash
/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest \
  tests/debate/test_memory_manager_extended.py::TestEventEmission::test_handles_notification_failures_gracefully \
  tests/debate/test_memory_manager_extended.py::TestOutcomeUpdates::test_partial_update_failures_handled \
  --tb=short -q
```

Before the fix, both nodes failed on pristine `origin/main`:

- `Exception: Notification failed`
- `Exception: Database error`

## Fix Rationale

Both failing tests exercise optional/best-effort sinks:

- spectator notification emission
- continuum-memory outcome updates

Those sinks should not crash the debate/memory path when an implementation raises a generic delivery/storage exception. The fix logs and contains generic `Exception` at the two optional sink boundaries while still allowing `BaseException` subclasses such as `KeyboardInterrupt` and `SystemExit` to propagate.

## Validation

```bash
/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest \
  tests/debate/test_memory_manager_extended.py::TestEventEmission::test_handles_notification_failures_gracefully \
  tests/debate/test_memory_manager_extended.py::TestOutcomeUpdates::test_partial_update_failures_handled \
  --tb=short -q
```

Result: `2 passed`.

```bash
/Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest \
  tests/debate/test_memory_manager_extended.py --tb=short -q
```

Result: `22 passed`.

```bash
/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check \
  aragora/debate/memory_manager.py tests/debate/test_memory_manager_extended.py
```

Result: `All checks passed`.

```bash
/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check \
  aragora/debate/memory_manager.py tests/debate/test_memory_manager_extended.py
```

Result: `2 files already formatted`.

```bash
git diff --check
```

Result: passed.

```bash
bash scripts/automation_pr_preflight.sh origin/main HEAD
```

Result: passed; preflight noted this is a source-only change and the relevant validation is included above.

## Remaining Red From The Source Run

This PR repairs only the debate-am shard. The same source run also showed:

- `test-fast (server-rest, server-rest, server_rest, 30)`:
  - `tests/server/fastapi/routes/test_swarm_status.py::test_register_routes_adds_swarm_status_endpoints`
  - error: `AttributeError: '_IncludedRouter' object has no attribute 'path'`
- `Integration Smoke (handlers)`:
  - `tests/handlers/test_handlers_social_publishing.py::TestOAuthStateCapacity::test_max_states_eviction`
  - error: `AssertionError: assert 'new-state' in {}`

Those remain for separate bounded cycles.
