### PR TITLE
fix(operator): align Docker Go builder version

### DIFF
--- a/aragora-operator/Dockerfile
+++ b/aragora-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.6 AS builder
+FROM golang:1.25.0 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
- align `aragora-operator/Dockerfile` builder image with `aragora-operator/go.mod` by changing `golang:1.21.6` to `golang:1.25.0`
- leave workflow files and all other operator files untouched

Refs #8930.

## Validation
- `awk` static check: `aragora-operator/go.mod` declares `go 1.25.0`; `aragora-operator/Dockerfile` now uses `golang:1.25.0`
- `cd aragora-operator && GOTOOLCHAIN=local go mod download` passes on local `go version go1.26.4 darwin/arm64`
- `bash scripts/automation_pr_preflight.sh --json origin/main HEAD` passes with only `aragora-operator/Dockerfile` changed

## Local Docker blocker
- Full local Docker validation was attempted with `docker build -f aragora-operator/Dockerfile -t test-operator:8930 aragora-operator/`
- It could not run because the Docker daemon socket is unavailable locally: `failed to connect to the docker API at unix:///Users/armand/.docker/run/docker.sock`
- Draft status is intentional until GitHub Actions validates the full `build-operator` image build on hosted Docker.