### PR TITLE
feat(scripts): read founder decision queue from GitHub issues

### DIFF
--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -11,13 +11,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 UTC = timezone.utc
 DEFAULT_DECISIONS_ROOT = Path(".aragora/founder-decisions")
@@ -61,6 +62,18 @@ class SourceLoadFailure:
     message: str
 
 
+@dataclass(frozen=True)
+class SourceCollection:
+    sources: tuple[DecisionSource, ...]
+    failures: tuple[SourceLoadFailure, ...] = ()
+
+
+@dataclass(frozen=True)
+class DecisionCollection:
+    items: list[DecisionItem]
+    source_failures: tuple[SourceLoadFailure, ...] = ()
+
+
 class SourceCollectionError(RuntimeError):
     def __init__(self, failures: Iterable[SourceLoadFailure]) -> None:
         self.failures = tuple(failures)
@@ -70,6 +83,14 @@ class SourceCollectionError(RuntimeError):
 
 def _warn_source_failure(failure: SourceLoadFailure) -> None:
     print(f"warning: skipped {failure.source}: {failure.message}", file=sys.stderr)
+
+
+def _github_cli_env() -> dict[str, str]:
+    try:
+        from aragora.swarm.github_app_auth import github_cli_env
+    except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+        return dict(os.environ)
+    return github_cli_env(os.environ)
 
 
 def _compact_text(value: str) -> str:
@@ -386,13 +407,27 @@ def _github_issue_comment_sources(
     return sources
 
 
+def _flatten_paginated_items(value: Any) -> list[Mapping[str, Any]]:
+    items: list[Mapping[str, Any]] = []
+    if isinstance(value, list):
+        for page in value:
+            if isinstance(page, list):
+                items.extend(item for item in page if isinstance(item, Mapping))
+            elif isinstance(page, Mapping):
+                items.append(page)
+    elif isinstance(value, Mapping):
+        items.append(value)
+    return items
+
+
 def _load_github_issue_sources(
     *,
     repo: str,
     issue: str,
     timeout_seconds: int = GH_ISSUE_VIEW_TIMEOUT_SECONDS,
 ) -> list[DecisionSource]:
-    command = [
+    env = _github_cli_env()
+    issue_command = [
         "gh",
         "issue",
         "view",
@@ -400,15 +435,31 @@ def _load_github_issue_sources(
         "--repo",
         repo,
         "--json",
-        "state,url,comments",
+        "state,url",
+    ]
+    comments_command = [
+        "gh",
+        "api",
+        "--paginate",
+        "--slurp",
+        f"repos/{repo}/issues/{issue}/comments",
     ]
     try:
-        completed = subprocess.run(
-            command,
+        issue_proc = subprocess.run(
+            issue_command,
             check=False,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,
+            env=env,
+        )
+        comments_proc = subprocess.run(
+            comments_command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=env,
         )
     except FileNotFoundError as exc:
         raise RuntimeError("gh executable not found") from exc
@@ -416,15 +467,24 @@ def _load_github_issue_sources(
         raise RuntimeError(
             f"gh issue view timed out after {timeout_seconds}s for {repo}#{issue}"
         ) from exc
-    if completed.returncode != 0:
-        message = completed.stderr.strip() or completed.stdout.strip() or "unknown gh error"
+    if issue_proc.returncode != 0:
+        message = issue_proc.stderr.strip() or issue_proc.stdout.strip() or "unknown gh error"
         raise RuntimeError(f"gh issue view failed for {repo}#{issue}: {message}")
+    if comments_proc.returncode != 0:
+        message = comments_proc.stderr.strip() or comments_proc.stdout.strip() or "unknown gh error"
+        raise RuntimeError(f"gh issue comments failed for {repo}#{issue}: {message}")
     try:
-        payload = json.loads(completed.stdout)
+        payload = json.loads(issue_proc.stdout)
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"gh issue view returned malformed JSON for {repo}#{issue}") from exc
     if not isinstance(payload, dict):
         return []
+    try:
+        comments_payload = json.loads(comments_proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh issue comments returned malformed JSON for {repo}#{issue}") from exc
+    payload = dict(payload)
+    payload["comments"] = _flatten_paginated_items(comments_payload)
     return _github_issue_comment_sources(repo=repo, issue=issue, payload=payload)
 
 
@@ -447,7 +507,7 @@ def _collect_sources(
     issue_comments_json: Path | None,
     github_issues: Iterable[str],
     repo: str,
-) -> list[DecisionSource]:
+) -> SourceCollection:
     sources: list[DecisionSource] = []
     failures: list[SourceLoadFailure] = []
     if decisions_root.exists():
@@ -486,7 +546,36 @@ def _collect_sources(
             _warn_source_failure(failure)
     if failures and not sources:
         raise SourceCollectionError(failures)
-    return sources
+    return SourceCollection(sources=tuple(sources), failures=tuple(failures))
+
+
+def collect_decision_collection(
+    *,
+    decisions_root: Path = DEFAULT_DECISIONS_ROOT,
+    packet_files: Iterable[Path] = (),
+    issue_comments_json: Path | None = None,
+    github_issues: Iterable[str] = (),
+    repo: str = "synaptent/aragora",
+) -> DecisionCollection:
+    deduped: dict[tuple[str, str, str], DecisionItem] = {}
+    source_collection = _collect_sources(
+        decisions_root=decisions_root,
+        packet_files=packet_files,
+        issue_comments_json=issue_comments_json,
+        github_issues=github_issues,
+        repo=repo,
+    )
+    for source in _newest_sources_by_thread(source_collection.sources):
+        if not source.thread_open:
+            continue
+        for item in parse_decision_packet(source.body, source=source.source):
+            if _item_resolved_after_packet(source, item):
+                continue
+            deduped.setdefault(item.dedupe_key(), item)
+    return DecisionCollection(
+        items=list(deduped.values()),
+        source_failures=source_collection.failures,
+    )
 
 
 def collect_decision_items(
@@ -497,22 +586,13 @@ def collect_decision_items(
     github_issues: Iterable[str] = (),
     repo: str = "synaptent/aragora",
 ) -> list[DecisionItem]:
-    deduped: dict[tuple[str, str, str], DecisionItem] = {}
-    sources = _collect_sources(
+    return collect_decision_collection(
         decisions_root=decisions_root,
         packet_files=packet_files,
         issue_comments_json=issue_comments_json,
         github_issues=github_issues,
         repo=repo,
-    )
-    for source in _newest_sources_by_thread(sources):
-        if not source.thread_open:
-            continue
-        for item in parse_decision_packet(source.body, source=source.source):
-            if _item_resolved_after_packet(source, item):
-                continue
-            deduped.setdefault(item.dedupe_key(), item)
-    return list(deduped.values())
+    ).items
 
 
 def _format_age(item: DecisionItem, *, now: datetime) -> str:
@@ -527,15 +607,26 @@ def _format_age(item: DecisionItem, *, now: datetime) -> str:
     return f"{hours / 24.0:.1f}d"
 
 
-def render_markdown(items: Iterable[DecisionItem], *, now: datetime | None = None) -> str:
+def render_markdown(
+    items: Iterable[DecisionItem],
+    *,
+    now: datetime | None = None,
+    source_failures: Iterable[SourceLoadFailure] = (),
+) -> str:
     now_dt = (now or datetime.now(tz=UTC)).astimezone(UTC)
     rows = list(items)
+    failures = list(source_failures)
     lines = [
         "# Founder Decision Queue",
         "",
         f"Generated: {now_dt.isoformat().replace('+00:00', 'Z')}",
         "",
     ]
+    if failures:
+        lines.extend(["## Source Warnings", ""])
+        for failure in failures:
+            lines.append(f"- Skipped {failure.source}: {failure.message}")
+        lines.append("")
     if not rows:
         lines.append("No pending operator rulings found.")
         return "\n".join(lines) + "\n"
@@ -616,7 +707,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         now = datetime.now(tz=UTC)
     try:
-        items = collect_decision_items(
+        collection = collect_decision_collection(
             decisions_root=Path(args.decisions_root),
             packet_files=[Path(path) for path in args.packet_file],
             issue_comments_json=Path(args.issue_comments_json)
@@ -628,10 +719,15 @@ def main(argv: list[str] | None = None) -> int:
     except SourceCollectionError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
+    items = collection.items
     if args.json:
         payload = {
             "generated_at": now.isoformat().replace("+00:00", "Z"),
             "count": len(items),
+            "source_failures": [
+                {"source": failure.source, "message": failure.message}
+                for failure in collection.source_failures
+            ],
             "items": [
                 {
                     "item": item.item,
@@ -651,7 +747,7 @@ def main(argv: list[str] | None = None) -> int:
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
         return 0
-    print(render_markdown(items, now=now), end="")
+    print(render_markdown(items, now=now, source_failures=collection.source_failures), end="")
     return 0
 
 

--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -223,7 +224,12 @@ def _thread_open_from_comment(comment: dict[str, Any], *, default: bool) -> bool
 
 
 def _comment_created_at(comment: dict[str, Any]) -> datetime | None:
-    value = comment.get("created_at") or comment.get("updated_at")
+    value = (
+        comment.get("created_at")
+        or comment.get("createdAt")
+        or comment.get("updated_at")
+        or comment.get("updatedAt")
+    )
     if not isinstance(value, str):
         return None
     return _parse_datetime(value)
@@ -322,6 +328,73 @@ def _load_issue_comment_sources(path: Path) -> list[DecisionSource]:
     return sources
 
 
+def _github_issue_comment_sources(
+    *,
+    repo: str,
+    issue: str,
+    payload: dict[str, Any],
+) -> list[DecisionSource]:
+    comments_payload = payload.get("comments")
+    if not isinstance(comments_payload, list):
+        return []
+    comments = [comment for comment in comments_payload if isinstance(comment, dict)]
+    thread_open = str(payload.get("state") or "open").lower() == "open"
+    thread_url = str(payload.get("url") or f"https://github.com/{repo}/issues/{issue}")
+    thread_key = f"github-thread:{issue}"
+    sources: list[DecisionSource] = []
+    for index, comment in enumerate(comments):
+        body = comment.get("body")
+        if not isinstance(body, str) or "## Pending Rulings" not in body:
+            continue
+        source = str(comment.get("url") or f"{thread_url}#comment-{index}")
+        created_at = _comment_created_at(comment)
+        later_comments: list[tuple[datetime | None, str]] = []
+        for other in comments:
+            other_body = other.get("body")
+            if not isinstance(other_body, str) or "## Pending Rulings" in other_body:
+                continue
+            later_comments.append((_comment_created_at(other), other_body))
+        sources.append(
+            DecisionSource(
+                source=source,
+                body=body,
+                thread_key=thread_key,
+                source_created_at=created_at,
+                thread_open=thread_open,
+                later_thread_comments=tuple(later_comments),
+            )
+        )
+    return sources
+
+
+def _load_github_issue_sources(*, repo: str, issue: str) -> list[DecisionSource]:
+    completed = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "view",
+            issue,
+            "--repo",
+            repo,
+            "--json",
+            "state,url,comments",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.strip() or completed.stdout.strip() or "unknown gh error"
+        raise RuntimeError(f"gh issue view failed for {repo}#{issue}: {message}")
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh issue view returned malformed JSON for {repo}#{issue}") from exc
+    if not isinstance(payload, dict):
+        return []
+    return _github_issue_comment_sources(repo=repo, issue=issue, payload=payload)
+
+
 def _legacy_load_issue_comment_bodies(path: Path) -> list[tuple[str, str]]:
     """Compatibility shim for tests or callers that imported the private helper."""
 
@@ -339,6 +412,8 @@ def _collect_sources(
     decisions_root: Path,
     packet_files: Iterable[Path],
     issue_comments_json: Path | None,
+    github_issues: Iterable[str],
+    repo: str,
 ) -> list[DecisionSource]:
     sources: list[DecisionSource] = []
     if decisions_root.exists():
@@ -368,6 +443,8 @@ def _collect_sources(
         )
     if issue_comments_json is not None:
         sources.extend(_load_issue_comment_sources(issue_comments_json))
+    for issue in github_issues:
+        sources.extend(_load_github_issue_sources(repo=repo, issue=issue))
     return sources
 
 
@@ -376,12 +453,16 @@ def collect_decision_items(
     decisions_root: Path = DEFAULT_DECISIONS_ROOT,
     packet_files: Iterable[Path] = (),
     issue_comments_json: Path | None = None,
+    github_issues: Iterable[str] = (),
+    repo: str = "synaptent/aragora",
 ) -> list[DecisionItem]:
     deduped: dict[tuple[str, str, str], DecisionItem] = {}
     sources = _collect_sources(
         decisions_root=decisions_root,
         packet_files=packet_files,
         issue_comments_json=issue_comments_json,
+        github_issues=github_issues,
+        repo=repo,
     )
     for source in _newest_sources_by_thread(sources):
         if not source.thread_open:
@@ -466,6 +547,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional JSON export of issue comments containing founder decision packets.",
     )
     parser.add_argument(
+        "--github-issue",
+        action="append",
+        default=[],
+        help="Read-only GitHub issue number to scan for founder decision packet comments.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="synaptent/aragora",
+        help="GitHub repository for --github-issue lookups.",
+    )
+    parser.add_argument(
         "--now",
         default=None,
         help="Override current UTC timestamp for deterministic rendering.",
@@ -486,6 +578,8 @@ def main(argv: list[str] | None = None) -> int:
         decisions_root=Path(args.decisions_root),
         packet_files=[Path(path) for path in args.packet_file],
         issue_comments_json=Path(args.issue_comments_json) if args.issue_comments_json else None,
+        github_issues=args.github_issue,
+        repo=args.repo,
     )
     if args.json:
         payload = {

--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -20,6 +21,7 @@ from typing import Any, Iterable
 
 UTC = timezone.utc
 DEFAULT_DECISIONS_ROOT = Path(".aragora/founder-decisions")
+GH_ISSUE_VIEW_TIMEOUT_SECONDS = 30
 
 
 @dataclass(frozen=True)
@@ -51,6 +53,23 @@ class DecisionSource:
     @property
     def packet_time(self) -> datetime | None:
         return self.source_created_at or _packet_generated_at(self.body)
+
+
+@dataclass(frozen=True)
+class SourceLoadFailure:
+    source: str
+    message: str
+
+
+class SourceCollectionError(RuntimeError):
+    def __init__(self, failures: Iterable[SourceLoadFailure]) -> None:
+        self.failures = tuple(failures)
+        detail = "; ".join(f"{failure.source}: {failure.message}" for failure in self.failures)
+        super().__init__(f"no decision sources could be collected ({detail})")
+
+
+def _warn_source_failure(failure: SourceLoadFailure) -> None:
+    print(f"warning: skipped {failure.source}: {failure.message}", file=sys.stderr)
 
 
 def _compact_text(value: str) -> str:
@@ -367,22 +386,36 @@ def _github_issue_comment_sources(
     return sources
 
 
-def _load_github_issue_sources(*, repo: str, issue: str) -> list[DecisionSource]:
-    completed = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "view",
-            issue,
-            "--repo",
-            repo,
-            "--json",
-            "state,url,comments",
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+def _load_github_issue_sources(
+    *,
+    repo: str,
+    issue: str,
+    timeout_seconds: int = GH_ISSUE_VIEW_TIMEOUT_SECONDS,
+) -> list[DecisionSource]:
+    command = [
+        "gh",
+        "issue",
+        "view",
+        issue,
+        "--repo",
+        repo,
+        "--json",
+        "state,url,comments",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh executable not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"gh issue view timed out after {timeout_seconds}s for {repo}#{issue}"
+        ) from exc
     if completed.returncode != 0:
         message = completed.stderr.strip() or completed.stdout.strip() or "unknown gh error"
         raise RuntimeError(f"gh issue view failed for {repo}#{issue}: {message}")
@@ -416,6 +449,7 @@ def _collect_sources(
     repo: str,
 ) -> list[DecisionSource]:
     sources: list[DecisionSource] = []
+    failures: list[SourceLoadFailure] = []
     if decisions_root.exists():
         for path in sorted(decisions_root.glob("*.md")):
             try:
@@ -444,7 +478,14 @@ def _collect_sources(
     if issue_comments_json is not None:
         sources.extend(_load_issue_comment_sources(issue_comments_json))
     for issue in github_issues:
-        sources.extend(_load_github_issue_sources(repo=repo, issue=issue))
+        try:
+            sources.extend(_load_github_issue_sources(repo=repo, issue=issue))
+        except RuntimeError as exc:
+            failure = SourceLoadFailure(source=f"github issue {repo}#{issue}", message=str(exc))
+            failures.append(failure)
+            _warn_source_failure(failure)
+    if failures and not sources:
+        raise SourceCollectionError(failures)
     return sources
 
 
@@ -574,13 +615,19 @@ def main(argv: list[str] | None = None) -> int:
             raise SystemExit(f"invalid --now timestamp: {args.now}")
     else:
         now = datetime.now(tz=UTC)
-    items = collect_decision_items(
-        decisions_root=Path(args.decisions_root),
-        packet_files=[Path(path) for path in args.packet_file],
-        issue_comments_json=Path(args.issue_comments_json) if args.issue_comments_json else None,
-        github_issues=args.github_issue,
-        repo=args.repo,
-    )
+    try:
+        items = collect_decision_items(
+            decisions_root=Path(args.decisions_root),
+            packet_files=[Path(path) for path in args.packet_file],
+            issue_comments_json=Path(args.issue_comments_json)
+            if args.issue_comments_json
+            else None,
+            github_issues=args.github_issue,
+            repo=args.repo,
+        )
+    except SourceCollectionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if args.json:
         payload = {
             "generated_at": now.isoformat().replace("+00:00", "Z"),

--- a/scripts/founder_decision_queue.py
+++ b/scripts/founder_decision_queue.py
@@ -88,7 +88,7 @@ def _warn_source_failure(failure: SourceLoadFailure) -> None:
 def _github_cli_env() -> dict[str, str]:
     try:
         from aragora.swarm.github_app_auth import github_cli_env
-    except Exception:  # pragma: no cover - fallback for partially bootstrapped script contexts
+    except ImportError:  # pragma: no cover - fallback for partially bootstrapped script contexts
         return dict(os.environ)
     return github_cli_env(os.environ)
 
@@ -386,7 +386,9 @@ def _github_issue_comment_sources(
         body = comment.get("body")
         if not isinstance(body, str) or "## Pending Rulings" not in body:
             continue
-        source = str(comment.get("url") or f"{thread_url}#comment-{index}")
+        source = str(
+            comment.get("html_url") or comment.get("url") or f"{thread_url}#comment-{index}"
+        )
         created_at = _comment_created_at(comment)
         later_comments: list[tuple[datetime | None, str]] = []
         for other in comments:
@@ -453,6 +455,13 @@ def _load_github_issue_sources(
             timeout=timeout_seconds,
             env=env,
         )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh executable not found") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"gh issue view timed out after {timeout_seconds}s for {repo}#{issue}"
+        ) from exc
+    try:
         comments_proc = subprocess.run(
             comments_command,
             check=False,
@@ -465,7 +474,7 @@ def _load_github_issue_sources(
         raise RuntimeError("gh executable not found") from exc
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(
-            f"gh issue view timed out after {timeout_seconds}s for {repo}#{issue}"
+            f"gh issue comments timed out after {timeout_seconds}s for {repo}#{issue}"
         ) from exc
     if issue_proc.returncode != 0:
         message = issue_proc.stderr.strip() or issue_proc.stdout.strip() or "unknown gh error"
@@ -478,7 +487,7 @@ def _load_github_issue_sources(
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"gh issue view returned malformed JSON for {repo}#{issue}") from exc
     if not isinstance(payload, dict):
-        return []
+        raise RuntimeError(f"gh issue view returned non-object JSON for {repo}#{issue}")
     try:
         comments_payload = json.loads(comments_proc.stdout or "[]")
     except json.JSONDecodeError as exc:

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 def _load_module() -> Any:
     here = Path(__file__).resolve()
@@ -454,6 +456,7 @@ def test_collect_decision_items_fetches_github_issue_read_only(
         assert kwargs["check"] is False
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True
+        assert kwargs["timeout"] == fdq.GH_ISSUE_VIEW_TIMEOUT_SECONDS
         return Completed()
 
     monkeypatch.setattr(fdq.subprocess, "run", fake_run)
@@ -478,3 +481,116 @@ def test_collect_decision_items_fetches_github_issue_read_only(
             "state,url,comments",
         ]
     ]
+
+
+def test_collect_decision_items_continues_after_github_issue_failure(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    class Completed:
+        def __init__(self, *, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
+        assert kwargs["timeout"] == fdq.GH_ISSUE_VIEW_TIMEOUT_SECONDS
+        issue = cmd[3]
+        if issue == "8845":
+            return Completed(returncode=1, stderr="temporary API failure")
+        return Completed(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "state": "OPEN",
+                    "url": "https://github.com/synaptent/aragora/issues/8846",
+                    "comments": [
+                        {
+                            "url": "https://github.com/synaptent/aragora/issues/8846#issuecomment-1",
+                            "createdAt": "2026-07-05T10:00:00Z",
+                            "body": _single_item_packet(
+                                generated="2026-07-05T10:00:00Z",
+                                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                                reply="approve",
+                            ),
+                        }
+                    ],
+                }
+            ),
+        )
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        github_issues=["8845", "8846"],
+        repo="synaptent/aragora",
+    )
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "approve"
+    assert "warning: skipped github issue synaptent/aragora#8845" in capsys.readouterr().err
+
+
+def test_collect_decision_items_fails_when_no_sources_collectable(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    class Completed:
+        returncode = 1
+        stdout = ""
+        stderr = "temporary API failure"
+
+    monkeypatch.setattr(fdq.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    with pytest.raises(fdq.SourceCollectionError, match="no decision sources"):
+        fdq.collect_decision_items(
+            decisions_root=tmp_path / "empty",
+            github_issues=["8845"],
+            repo="synaptent/aragora",
+        )
+
+
+def test_github_issue_fetch_reports_timeout(monkeypatch: Any) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        raise fdq.subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="timed out after"):
+        fdq._load_github_issue_sources(repo="synaptent/aragora", issue="8845")
+
+
+def test_github_issue_fetch_reports_missing_gh(monkeypatch: Any) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh executable not found"):
+        fdq._load_github_issue_sources(repo="synaptent/aragora", issue="8845")
+
+
+def test_main_returns_controlled_error_when_no_sources_collectable(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    class Completed:
+        returncode = 1
+        stdout = ""
+        stderr = "temporary API failure"
+
+    monkeypatch.setattr(fdq.subprocess, "run", lambda *args, **kwargs: Completed())
+
+    exit_code = fdq.main(
+        [
+            "--decisions-root",
+            str(tmp_path / "empty"),
+            "--github-issue",
+            "8845",
+            "--repo",
+            "synaptent/aragora",
+        ]
+    )
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "error: no decision sources could be collected" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -385,3 +385,96 @@ def test_collect_decision_items_keeps_open_unruled_packet(tmp_path: Path) -> Non
 
     assert len(items) == 1
     assert items[0].expected_reply == "approve"
+
+
+def test_github_issue_sources_normalize_live_comment_payload() -> None:
+    payload = {
+        "state": "OPEN",
+        "url": "https://github.com/synaptent/aragora/issues/8845",
+        "comments": [
+            {
+                "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+                "createdAt": "2026-07-05T10:00:00Z",
+                "body": _single_item_packet(
+                    generated="2026-07-05T10:00:00Z",
+                    target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                    reply="approve",
+                ),
+            },
+            {
+                "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-2",
+                "createdAt": "2026-07-05T10:05:00Z",
+                "body": "approve",
+            },
+        ],
+    }
+
+    sources = fdq._github_issue_comment_sources(
+        repo="synaptent/aragora",
+        issue="8845",
+        payload=payload,
+    )
+    items = []
+    for source in sources:
+        for item in fdq.parse_decision_packet(source.body, source=source.source):
+            if not fdq._item_resolved_after_packet(source, item):
+                items.append(item)
+
+    assert items == []
+
+
+def test_collect_decision_items_fetches_github_issue_read_only(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    class Completed:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(
+            {
+                "state": "OPEN",
+                "url": "https://github.com/synaptent/aragora/issues/8845",
+                "comments": [
+                    {
+                        "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+                        "createdAt": "2026-07-05T10:00:00Z",
+                        "body": _single_item_packet(
+                            generated="2026-07-05T10:00:00Z",
+                            target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                            reply="approve",
+                        ),
+                    }
+                ],
+            }
+        )
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
+        calls.append(cmd)
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return Completed()
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    items = fdq.collect_decision_items(
+        decisions_root=tmp_path / "empty",
+        github_issues=["8845"],
+        repo="synaptent/aragora",
+    )
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "approve"
+    assert calls == [
+        [
+            "gh",
+            "issue",
+            "view",
+            "8845",
+            "--repo",
+            "synaptent/aragora",
+            "--json",
+            "state,url,comments",
+        ]
+    ]

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -431,25 +431,10 @@ def test_collect_decision_items_fetches_github_issue_read_only(
     calls: list[list[str]] = []
 
     class Completed:
-        returncode = 0
-        stderr = ""
-        stdout = json.dumps(
-            {
-                "state": "OPEN",
-                "url": "https://github.com/synaptent/aragora/issues/8845",
-                "comments": [
-                    {
-                        "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
-                        "createdAt": "2026-07-05T10:00:00Z",
-                        "body": _single_item_packet(
-                            generated="2026-07-05T10:00:00Z",
-                            target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
-                            reply="approve",
-                        ),
-                    }
-                ],
-            }
-        )
+        def __init__(self, *, stdout: str) -> None:
+            self.returncode = 0
+            self.stderr = ""
+            self.stdout = stdout
 
     def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
         calls.append(cmd)
@@ -457,8 +442,35 @@ def test_collect_decision_items_fetches_github_issue_read_only(
         assert kwargs["capture_output"] is True
         assert kwargs["text"] is True
         assert kwargs["timeout"] == fdq.GH_ISSUE_VIEW_TIMEOUT_SECONDS
-        return Completed()
+        assert kwargs["env"] == {"GH_TOKEN": "token"}
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return Completed(
+                stdout=json.dumps(
+                    {
+                        "state": "OPEN",
+                        "url": "https://github.com/synaptent/aragora/issues/8845",
+                    }
+                )
+            )
+        return Completed(
+            stdout=json.dumps(
+                [
+                    [
+                        {
+                            "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+                            "createdAt": "2026-07-05T10:00:00Z",
+                            "body": _single_item_packet(
+                                generated="2026-07-05T10:00:00Z",
+                                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                                reply="approve",
+                            ),
+                        }
+                    ]
+                ]
+            )
+        )
 
+    monkeypatch.setattr(fdq, "_github_cli_env", lambda: {"GH_TOKEN": "token"})
     monkeypatch.setattr(fdq.subprocess, "run", fake_run)
 
     items = fdq.collect_decision_items(
@@ -478,8 +490,15 @@ def test_collect_decision_items_fetches_github_issue_read_only(
             "--repo",
             "synaptent/aragora",
             "--json",
-            "state,url,comments",
-        ]
+            "state,url",
+        ],
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            "repos/synaptent/aragora/issues/8845/comments",
+        ],
     ]
 
 
@@ -494,16 +513,23 @@ def test_collect_decision_items_continues_after_github_issue_failure(
 
     def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
         assert kwargs["timeout"] == fdq.GH_ISSUE_VIEW_TIMEOUT_SECONDS
-        issue = cmd[3]
-        if issue == "8845":
+        if cmd[:3] == ["gh", "issue", "view"] and cmd[3] == "8845":
             return Completed(returncode=1, stderr="temporary API failure")
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return Completed(
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "state": "OPEN",
+                        "url": "https://github.com/synaptent/aragora/issues/8846",
+                    }
+                ),
+            )
         return Completed(
             returncode=0,
             stdout=json.dumps(
-                {
-                    "state": "OPEN",
-                    "url": "https://github.com/synaptent/aragora/issues/8846",
-                    "comments": [
+                [
+                    [
                         {
                             "url": "https://github.com/synaptent/aragora/issues/8846#issuecomment-1",
                             "createdAt": "2026-07-05T10:00:00Z",
@@ -513,22 +539,79 @@ def test_collect_decision_items_continues_after_github_issue_failure(
                                 reply="approve",
                             ),
                         }
-                    ],
-                }
+                    ]
+                ]
             ),
+        )
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    collection = fdq.collect_decision_collection(
+        decisions_root=tmp_path / "empty",
+        github_issues=["8845", "8846"],
+        repo="synaptent/aragora",
+    )
+    items = collection.items
+
+    assert len(items) == 1
+    assert items[0].expected_reply == "approve"
+    assert collection.source_failures[0].source == "github issue synaptent/aragora#8845"
+    assert "warning: skipped github issue synaptent/aragora#8845" in capsys.readouterr().err
+    rendered = fdq.render_markdown(
+        items,
+        now=fdq._parse_datetime("2026-07-05T11:00:00Z"),
+        source_failures=collection.source_failures,
+    )
+    assert "## Source Warnings" in rendered
+    assert "temporary API failure" in rendered
+
+
+def test_collect_decision_items_omits_closed_github_issue_live_path(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    class Completed:
+        def __init__(self, *, stdout: str) -> None:
+            self.returncode = 0
+            self.stderr = ""
+            self.stdout = stdout
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return Completed(
+                stdout=json.dumps(
+                    {
+                        "state": "CLOSED",
+                        "url": "https://github.com/synaptent/aragora/issues/8845",
+                    }
+                )
+            )
+        return Completed(
+            stdout=json.dumps(
+                [
+                    [
+                        {
+                            "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+                            "createdAt": "2026-07-05T10:00:00Z",
+                            "body": _single_item_packet(
+                                generated="2026-07-05T10:00:00Z",
+                                target="PR #8756: https://github.com/synaptent/aragora/pull/8756",
+                                reply="approve",
+                            ),
+                        }
+                    ]
+                ]
+            )
         )
 
     monkeypatch.setattr(fdq.subprocess, "run", fake_run)
 
     items = fdq.collect_decision_items(
         decisions_root=tmp_path / "empty",
-        github_issues=["8845", "8846"],
+        github_issues=["8845"],
         repo="synaptent/aragora",
     )
 
-    assert len(items) == 1
-    assert items[0].expected_reply == "approve"
-    assert "warning: skipped github issue synaptent/aragora#8845" in capsys.readouterr().err
+    assert items == []
 
 
 def test_collect_decision_items_fails_when_no_sources_collectable(

--- a/tests/scripts/test_founder_decision_queue.py
+++ b/tests/scripts/test_founder_decision_queue.py
@@ -458,6 +458,7 @@ def test_collect_decision_items_fetches_github_issue_read_only(
                     [
                         {
                             "url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-1",
+                            "html_url": "https://github.com/synaptent/aragora/issues/8845#issuecomment-browser",
                             "createdAt": "2026-07-05T10:00:00Z",
                             "body": _single_item_packet(
                                 generated="2026-07-05T10:00:00Z",
@@ -481,6 +482,9 @@ def test_collect_decision_items_fetches_github_issue_read_only(
 
     assert len(items) == 1
     assert items[0].expected_reply == "approve"
+    assert (
+        items[0].source == "https://github.com/synaptent/aragora/issues/8845#issuecomment-browser"
+    )
     assert calls == [
         [
             "gh",
@@ -638,7 +642,47 @@ def test_github_issue_fetch_reports_timeout(monkeypatch: Any) -> None:
 
     monkeypatch.setattr(fdq.subprocess, "run", fake_run)
 
-    with pytest.raises(RuntimeError, match="timed out after"):
+    with pytest.raises(RuntimeError, match="gh issue view timed out after"):
+        fdq._load_github_issue_sources(repo="synaptent/aragora", issue="8845")
+
+
+def test_github_issue_fetch_reports_comment_timeout(monkeypatch: Any) -> None:
+    class Completed:
+        returncode = 0
+        stderr = ""
+        stdout = json.dumps(
+            {
+                "state": "OPEN",
+                "url": "https://github.com/synaptent/aragora/issues/8845",
+            }
+        )
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return Completed()
+        raise fdq.subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="gh issue comments timed out after"):
+        fdq._load_github_issue_sources(repo="synaptent/aragora", issue="8845")
+
+
+def test_github_issue_fetch_rejects_non_object_issue_json(monkeypatch: Any) -> None:
+    class Completed:
+        def __init__(self, *, stdout: str) -> None:
+            self.returncode = 0
+            self.stderr = ""
+            self.stdout = stdout
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Completed:
+        if cmd[:3] == ["gh", "issue", "view"]:
+            return Completed(stdout="[]")
+        return Completed(stdout="[]")
+
+    monkeypatch.setattr(fdq.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="non-object JSON"):
         fdq._load_github_issue_sources(repo="synaptent/aragora", issue="8845")
 
 


### PR DESCRIPTION
## Summary

- Adds read-only `--github-issue` and `--repo` sources to `scripts/founder_decision_queue.py`.
- Normalizes live `gh issue view` comment payloads, including camelCase timestamps, into the existing decision-packet parser.
- Keeps existing stale/newest-thread and resolved-after-packet filtering; no posting, reruns, settlement, merge, or gate mutation.

Refs #8845.

## Validation

- `pytest -q tests/scripts/test_founder_decision_queue.py`  
  `14 passed, 8 warnings in 0.44s`
- `python3 scripts/founder_decision_queue.py --github-issue 8845 --json`  
  returned 3 pending rulings from the live #8845 packet: `approve` for #8756, `release` for #8406, and `B` for #8886.
