### PR TITLE
feat(release): verify aragora-verify public install after publish

### DIFF
--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -94,11 +94,6 @@ jobs:
           verbose: true
           attestations: false
 
-      - name: Verify public PyPI install
-        env:
-          VERSION: ${{ github.event.inputs.version }}
-        run: python3 scripts/verify_aragora_verify_publish.py --version "$VERSION" --json
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2 (pinned to commit)
         with:
@@ -118,3 +113,16 @@ jobs:
             ```
           draft: false
           prerelease: ${{ contains(github.event.inputs.version, 'beta') || contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'rc') }}
+
+      # Runs AFTER the release on purpose. Both the upload and this check are
+      # downstream of an irreversible action: once the wheel is on PyPI the
+      # version is immutable and cannot be re-published. Gating the release on
+      # this check protected nobody — the package was already public — while a
+      # verification-infra flake (or ordinary index propagation lag) could
+      # strand a published version with no matching GitHub release and no clean
+      # rerun path. Ordering it last keeps a failure loud and actionable
+      # (the job still goes red) without leaving that inconsistent state.
+      - name: Verify public PyPI install
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: python3 scripts/verify_aragora_verify_publish.py --version "$VERSION" --json

--- a/.github/workflows/publish-aragora-verify.yml
+++ b/.github/workflows/publish-aragora-verify.yml
@@ -94,6 +94,11 @@ jobs:
           verbose: true
           attestations: false
 
+      - name: Verify public PyPI install
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: python3 scripts/verify_aragora_verify_publish.py --version "$VERSION" --json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2 (pinned to commit)
         with:

--- a/scripts/verify_aragora_verify_publish.py
+++ b/scripts/verify_aragora_verify_publish.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
@@ -23,6 +24,18 @@ from typing import Iterator
 
 class PublishVerificationError(RuntimeError):
     """Raised when a post-publish verification step fails."""
+
+
+# PyPI index/CDN propagation lags the upload by seconds to minutes, so the
+# freshly published version is routinely not installable the instant the
+# publish step returns. This step runs *after* an irreversible upload and
+# *before* the GitHub Release is created, and PyPI versions are immutable — so
+# a bare single-attempt install turns ordinary propagation delay into a red
+# release with no clean rerun path (re-publishing the same version fails).
+# Retry with exponential backoff instead of failing on the first miss.
+DEFAULT_INSTALL_ATTEMPTS = 8
+DEFAULT_INSTALL_BACKOFF = 5.0
+MAX_INSTALL_BACKOFF = 60.0
 
 
 PROBE_SCRIPT = r"""
@@ -190,19 +203,57 @@ def _run(
     return completed
 
 
+def _run_with_retry(
+    cmd: list[str],
+    *,
+    timeout: int,
+    attempts: int,
+    backoff: float,
+    cwd: Path | None = None,
+) -> tuple[subprocess.CompletedProcess[str], int]:
+    """Run ``cmd``, retrying transient failures with exponential backoff.
+
+    Returns the completed process and the (1-based) attempt number that
+    succeeded, so callers can report how much propagation delay was absorbed.
+    """
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
+
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return _run(cmd, timeout=timeout, cwd=cwd), attempt
+        except (PublishVerificationError, subprocess.TimeoutExpired) as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            time.sleep(min(backoff * (2 ** (attempt - 1)), MAX_INSTALL_BACKOFF))
+
+    raise PublishVerificationError(
+        f"command still failing after {attempts} attempt(s): {' '.join(cmd)}\n{last_error}"
+    ) from last_error
+
+
 def verify_publish(
     *,
     version: str,
     python: str,
     work_dir: Path | None = None,
     timeout: int = 240,
+    install_attempts: int = DEFAULT_INSTALL_ATTEMPTS,
+    install_backoff: float = DEFAULT_INSTALL_BACKOFF,
 ) -> dict[str, object]:
     with _verification_workspace(work_dir) as workspace:
         venv = workspace / ".venv"
         _run([python, "-m", "venv", str(venv)], timeout=timeout)
         venv_python = _venv_python(venv)
-        _run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip"], timeout=timeout)
-        _run(
+        _run_with_retry(
+            [str(venv_python), "-m", "pip", "install", "--upgrade", "pip"],
+            timeout=timeout,
+            attempts=install_attempts,
+            backoff=install_backoff,
+        )
+        _, install_attempts_used = _run_with_retry(
             [
                 str(venv_python),
                 "-m",
@@ -212,6 +263,8 @@ def verify_publish(
                 f"aragora-verify=={version}",
             ],
             timeout=timeout,
+            attempts=install_attempts,
+            backoff=install_backoff,
         )
 
         version_result = _run(
@@ -238,6 +291,7 @@ def verify_publish(
             "package": "aragora-verify",
             "version": version,
             "workspace": str(workspace),
+            "install_attempts": install_attempts_used,
             "probe": probe_payload,
         }
 
@@ -258,6 +312,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional directory for the verification virtualenv and probe artifacts.",
     )
     parser.add_argument("--timeout", type=int, default=240, help="Per-command timeout in seconds.")
+    parser.add_argument(
+        "--install-attempts",
+        type=int,
+        default=DEFAULT_INSTALL_ATTEMPTS,
+        help=(
+            "Attempts for the pip install steps before giving up. Absorbs PyPI "
+            "index propagation delay after publish (default: %(default)s)."
+        ),
+    )
+    parser.add_argument(
+        "--install-backoff",
+        type=float,
+        default=DEFAULT_INSTALL_BACKOFF,
+        help=(
+            "Base seconds for exponential backoff between install attempts, "
+            f"capped at {MAX_INSTALL_BACKOFF:g}s (default: %(default)s)."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
     return parser
 
@@ -270,6 +342,8 @@ def main(argv: list[str] | None = None) -> int:
             python=args.python,
             work_dir=Path(args.work_dir) if args.work_dir else None,
             timeout=args.timeout,
+            install_attempts=args.install_attempts,
+            install_backoff=args.install_backoff,
         )
     except PublishVerificationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/verify_aragora_verify_publish.py
+++ b/scripts/verify_aragora_verify_publish.py
@@ -140,6 +140,24 @@ pubkey_path.write_bytes(
     )
 )
 
+# Positive control: the SAME signing path, unmutated, must verify clean.
+# Without this, a spoofed-key_id failure proves nothing — if sign_odr's scheme
+# did not match the CLI's, every signed receipt would fail as a bad signature
+# and the spoof assertion below would still see exit 1 plus a failing signature
+# check, going green for the wrong reason. Establishing that sign_odr produces
+# a signature the CLI accepts is what makes the spoof case isolate key_id.
+signed = sign_odr(valid_odr(), private_key)
+signed_path = root / "signed.odr.json"
+signed_path.write_text(json.dumps(signed, sort_keys=True), encoding="utf-8")
+
+signed_run = run_cli([str(signed_path), "--pubkey", str(pubkey_path), "--json"])
+if signed_run.returncode != 0:
+    raise SystemExit(
+        "correctly signed receipt must verify clean, so that the spoofed-key_id "
+        f"case isolates key_id binding; got exit {signed_run.returncode}: "
+        f"{signed_run.stderr or signed_run.stdout}"
+    )
+
 spoofed = sign_odr(valid_odr(), private_key)
 spoofed["signatures"][0]["key_id"] = "spoofed-signer-label"
 spoofed_path = root / "spoofed-key-id.odr.json"
@@ -162,6 +180,7 @@ if not signature_checks or signature_checks[0].get("status") != "fail":
 
 print(json.dumps({
     "valid_receipt_exit": valid_run.returncode,
+    "signed_receipt_exit": signed_run.returncode,
     "spoofed_key_id_exit": spoofed_run.returncode,
     "spoofed_signature_status": signature_checks[0]["status"],
 }, sort_keys=True))

--- a/scripts/verify_aragora_verify_publish.py
+++ b/scripts/verify_aragora_verify_publish.py
@@ -37,6 +37,14 @@ DEFAULT_INSTALL_ATTEMPTS = 8
 DEFAULT_INSTALL_BACKOFF = 5.0
 MAX_INSTALL_BACKOFF = 60.0
 
+# The whole point of this helper is to prove the artifact is installable from
+# *public* PyPI. A self-hosted runner carrying PIP_INDEX_URL / PIP_EXTRA_INDEX_URL
+# / pip.conf / find-links pointing at a mirror or local cache could satisfy the
+# install from somewhere else entirely and report success while the published
+# version is not actually reachable by users. `--isolated` drops env vars and
+# config files; the explicit index pins where the package must come from.
+DEFAULT_INDEX_URL = "https://pypi.org/simple"
+
 
 PROBE_SCRIPT = r"""
 from __future__ import annotations
@@ -261,6 +269,7 @@ def verify_publish(
     timeout: int = 240,
     install_attempts: int = DEFAULT_INSTALL_ATTEMPTS,
     install_backoff: float = DEFAULT_INSTALL_BACKOFF,
+    index_url: str = DEFAULT_INDEX_URL,
 ) -> dict[str, object]:
     with _verification_workspace(work_dir) as workspace:
         venv = workspace / ".venv"
@@ -278,7 +287,10 @@ def verify_publish(
                 "-m",
                 "pip",
                 "install",
+                "--isolated",
                 "--no-cache-dir",
+                "--index-url",
+                index_url,
                 f"aragora-verify=={version}",
             ],
             timeout=timeout,
@@ -349,6 +361,15 @@ def build_parser() -> argparse.ArgumentParser:
             f"capped at {MAX_INSTALL_BACKOFF:g}s (default: %(default)s)."
         ),
     )
+    parser.add_argument(
+        "--index-url",
+        default=DEFAULT_INDEX_URL,
+        help=(
+            "Index the published package must be installable from. Combined "
+            "with pip --isolated so runner pip config/env cannot satisfy the "
+            "install from a mirror or cache (default: %(default)s)."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
     return parser
 
@@ -363,6 +384,7 @@ def main(argv: list[str] | None = None) -> int:
             timeout=args.timeout,
             install_attempts=args.install_attempts,
             install_backoff=args.install_backoff,
+            index_url=args.index_url,
         )
     except PublishVerificationError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/scripts/verify_aragora_verify_publish.py
+++ b/scripts/verify_aragora_verify_publish.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Verify the public ``aragora-verify`` PyPI install after publishing.
+
+The publish workflow already builds, checks, and uploads the package. This
+helper closes the transport loop by installing the exact published version into
+a fresh virtual environment, then proving the installed CLI still accepts a
+valid ODR receipt and rejects a spoofed ``key_id`` signature label.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+class PublishVerificationError(RuntimeError):
+    """Raised when a post-publish verification step fails."""
+
+
+PROBE_SCRIPT = r'''
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from aragora_verify import compute_key_id, odr_content_digest
+
+
+def valid_odr() -> dict:
+    return {
+        "odr_version": "0.1",
+        "profile": "https://aragora.ai/specs/open-decision-receipt/v0.1",
+        "receipt_id": "post-publish-smoke",
+        "issued_at": "2026-06-14T00:00:00Z",
+        "subject": {
+            "identifier": "5f1b14e4b5e113dc978d60d1f6bd21b5a478c744",
+            "digest": {"status": "present", "alg": "sha-256", "value": "deadbeef"},
+            "summary": "post-publish verifier smoke",
+        },
+        "claim": {"verdict": "PASS", "statement": "public verifier install works"},
+        "reasoning": {"status": "present", "summary": "post-publish smoke"},
+        "quorum": {
+            "status": "present",
+            "method": "majority",
+            "reached": True,
+            "supporting_agents": ["claude", "grok"],
+            "participants": [
+                {"agent": "claude", "model_family": "anthropic", "model_id": "claude-opus-4-8"},
+                {"agent": "grok", "model_family": "xai", "model_id": "grok-4"},
+            ],
+            "independence": {
+                "disclosed": True,
+                "distinct_model_families": 2,
+                "model_families": ["anthropic", "xai"],
+            },
+            "dissent": {"present": False, "dissenting_agents": [], "views": []},
+        },
+        "confidence": {
+            "status": "present",
+            "value": 0.9,
+            "scale": "unit_interval",
+            "calibration": {"status": "absent", "reason": "post-publish smoke"},
+        },
+        "cruxes": {"status": "absent", "reason": "post-publish smoke"},
+        "attestation": {"disposition": "autonomous"},
+        "routing": {"status": "reserved"},
+        "signatures": [],
+    }
+
+
+def sign_odr(doc: dict, private_key: Ed25519PrivateKey) -> dict:
+    signed = copy.deepcopy(doc)
+    message = bytes.fromhex(odr_content_digest(signed))
+    signature = private_key.sign(message)
+    signed["signatures"] = [
+        {
+            "alg": "Ed25519",
+            "key_id": compute_key_id(private_key.public_key()),
+            "signature": base64.b64encode(signature).decode("ascii"),
+            "signed_at": "2026-06-14T00:00:01Z",
+        }
+    ]
+    return signed
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "aragora_verify", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+root = Path.cwd()
+valid_path = root / "valid.odr.json"
+valid_path.write_text(json.dumps(valid_odr(), sort_keys=True), encoding="utf-8")
+
+valid_run = run_cli([str(valid_path), "--json"])
+if valid_run.returncode != 0:
+    raise SystemExit(
+        f"valid receipt failed with exit {valid_run.returncode}: {valid_run.stderr or valid_run.stdout}"
+    )
+
+private_key = Ed25519PrivateKey.generate()
+public_key = private_key.public_key()
+pubkey_path = root / "pubkey.pem"
+pubkey_path.write_bytes(
+    public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+)
+
+spoofed = sign_odr(valid_odr(), private_key)
+spoofed["signatures"][0]["key_id"] = "spoofed-signer-label"
+spoofed_path = root / "spoofed-key-id.odr.json"
+spoofed_path.write_text(json.dumps(spoofed, sort_keys=True), encoding="utf-8")
+
+spoofed_run = run_cli([str(spoofed_path), "--pubkey", str(pubkey_path), "--json"])
+if spoofed_run.returncode != 1:
+    raise SystemExit(
+        "spoofed key_id receipt should fail with exit 1, got "
+        f"{spoofed_run.returncode}: {spoofed_run.stderr or spoofed_run.stdout}"
+    )
+
+spoofed_payload = json.loads(spoofed_run.stdout)
+signature_checks = [
+    check for check in spoofed_payload.get("checks", [])
+    if check.get("name") == "signature"
+]
+if not signature_checks or signature_checks[0].get("status") != "fail":
+    raise SystemExit(f"missing failing signature check: {spoofed_run.stdout}")
+
+print(json.dumps({
+    "valid_receipt_exit": valid_run.returncode,
+    "spoofed_key_id_exit": spoofed_run.returncode,
+    "spoofed_signature_status": signature_checks[0]["status"],
+}, sort_keys=True))
+'''
+
+
+@contextmanager
+def _verification_workspace(path: Path | None) -> Iterator[Path]:
+    if path is not None:
+        path.mkdir(parents=True, exist_ok=True)
+        yield path
+        return
+    with tempfile.TemporaryDirectory(prefix="aragora-verify-publish-") as tmp:
+        yield Path(tmp)
+
+
+def _venv_python(venv: Path) -> Path:
+    if os.name == "nt":
+        return venv / "Scripts" / "python.exe"
+    return venv / "bin" / "python"
+
+
+def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip()
+        raise PublishVerificationError(
+            f"command failed with exit {completed.returncode}: {' '.join(cmd)}\n{detail}"
+        )
+    return completed
+
+
+def verify_publish(
+    *,
+    version: str,
+    python: str,
+    work_dir: Path | None = None,
+    timeout: int = 240,
+) -> dict[str, object]:
+    with _verification_workspace(work_dir) as workspace:
+        venv = workspace / ".venv"
+        _run([python, "-m", "venv", str(venv)], timeout=timeout)
+        venv_python = _venv_python(venv)
+        _run([str(venv_python), "-m", "pip", "install", "--upgrade", "pip"], timeout=timeout)
+        _run(
+            [
+                str(venv_python),
+                "-m",
+                "pip",
+                "install",
+                "--no-cache-dir",
+                f"aragora-verify=={version}",
+            ],
+            timeout=timeout,
+        )
+
+        version_result = _run(
+            [str(venv_python), "-m", "aragora_verify", "--version"],
+            timeout=timeout,
+        )
+        expected_version = f"aragora-verify {version}"
+        if version_result.stdout.strip() != expected_version:
+            raise PublishVerificationError(
+                f"installed CLI version mismatch: expected {expected_version!r}, "
+                f"got {version_result.stdout.strip()!r}"
+            )
+
+        probe_path = workspace / "post_publish_probe.py"
+        probe_path.write_text(textwrap.dedent(PROBE_SCRIPT).strip() + "\n", encoding="utf-8")
+        probe_result = _run([str(venv_python), str(probe_path)], timeout=timeout, cwd=workspace)
+        try:
+            probe_payload = json.loads(probe_result.stdout)
+        except json.JSONDecodeError as exc:
+            raise PublishVerificationError("post-publish probe returned malformed JSON") from exc
+
+        return {
+            "ok": True,
+            "package": "aragora-verify",
+            "version": version,
+            "workspace": str(workspace),
+            "probe": probe_payload,
+        }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify a freshly published aragora-verify version from PyPI."
+    )
+    parser.add_argument("--version", required=True, help="Exact aragora-verify version to install.")
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable used to create the fresh verification virtualenv.",
+    )
+    parser.add_argument(
+        "--work-dir",
+        default=None,
+        help="Optional directory for the verification virtualenv and probe artifacts.",
+    )
+    parser.add_argument("--timeout", type=int, default=240, help="Per-command timeout in seconds.")
+    parser.add_argument("--json", action="store_true", help="Emit structured JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = verify_publish(
+            version=args.version,
+            python=args.python,
+            work_dir=Path(args.work_dir) if args.work_dir else None,
+            timeout=args.timeout,
+        )
+    except PublishVerificationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"verified aragora-verify=={args.version} from PyPI")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_aragora_verify_publish.py
+++ b/scripts/verify_aragora_verify_publish.py
@@ -25,7 +25,7 @@ class PublishVerificationError(RuntimeError):
     """Raised when a post-publish verification step fails."""
 
 
-PROBE_SCRIPT = r'''
+PROBE_SCRIPT = r"""
 from __future__ import annotations
 
 import base64
@@ -152,7 +152,7 @@ print(json.dumps({
     "spoofed_key_id_exit": spoofed_run.returncode,
     "spoofed_signature_status": signature_checks[0]["status"],
 }, sort_keys=True))
-'''
+"""
 
 
 @contextmanager
@@ -171,7 +171,9 @@ def _venv_python(venv: Path) -> Path:
     return venv / "bin" / "python"
 
 
-def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+def _run(
+    cmd: list[str], *, timeout: int, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
     completed = subprocess.run(
         cmd,
         cwd=str(cwd) if cwd is not None else None,

--- a/tests/scripts/test_verify_aragora_verify_publish.py
+++ b/tests/scripts/test_verify_aragora_verify_publish.py
@@ -74,7 +74,10 @@ def test_verify_publish_installs_exact_version_and_runs_probe(
             "-m",
             "pip",
             "install",
+            "--isolated",
             "--no-cache-dir",
+            "--index-url",
+            "https://pypi.org/simple",
             "aragora-verify==0.1.2",
         ],
     ]
@@ -122,6 +125,72 @@ def test_main_returns_one_on_failed_command(monkeypatch: Any, capsys: Any, tmp_p
 
     assert rc == 1
     assert "network down" in capsys.readouterr().err
+
+
+def test_published_install_is_isolated_from_runner_pip_config(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    """The gate must prove installability from *public* PyPI.
+
+    A self-hosted runner carrying PIP_INDEX_URL / pip.conf / find-links could
+    otherwise satisfy the install from a mirror or cache and report success
+    while the published version is unreachable for real users.
+    """
+    install_cmd: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-1] == "aragora-verify==0.1.2":
+            install_cmd.extend(cmd)
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.2\n")
+        if cmd[-1].endswith("post_publish_probe.py"):
+            return _completed(
+                json.dumps(
+                    {
+                        "valid_receipt_exit": 0,
+                        "signed_receipt_exit": 0,
+                        "spoofed_key_id_exit": 1,
+                        "spoofed_signature_status": "fail",
+                    }
+                )
+            )
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+
+    verify_publish_script.verify_publish(
+        version="0.1.2",
+        python="/usr/bin/python3",
+        work_dir=tmp_path,
+    )
+
+    assert "--isolated" in install_cmd
+    assert install_cmd[install_cmd.index("--index-url") + 1] == "https://pypi.org/simple"
+
+
+def test_index_url_is_overridable(monkeypatch: Any, tmp_path: Path) -> None:
+    install_cmd: list[str] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-1] == "aragora-verify==0.1.2":
+            install_cmd.extend(cmd)
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.2\n")
+        if cmd[-1].endswith("post_publish_probe.py"):
+            return _completed(json.dumps({"valid_receipt_exit": 0}))
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+
+    verify_publish_script.verify_publish(
+        version="0.1.2",
+        python="/usr/bin/python3",
+        work_dir=tmp_path,
+        index_url="https://test.pypi.org/simple",
+    )
+
+    assert install_cmd[install_cmd.index("--index-url") + 1] == "https://test.pypi.org/simple"
 
 
 def test_install_retries_until_pypi_propagates(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_verify_aragora_verify_publish.py
+++ b/tests/scripts/test_verify_aragora_verify_publish.py
@@ -122,3 +122,150 @@ def test_main_returns_one_on_failed_command(monkeypatch: Any, capsys: Any, tmp_p
 
     assert rc == 1
     assert "network down" in capsys.readouterr().err
+
+
+def test_install_retries_until_pypi_propagates(monkeypatch: Any, tmp_path: Path) -> None:
+    """PyPI index propagation lag must not red the release workflow.
+
+    The exact-version install runs after an irreversible upload, so a 404 from
+    a not-yet-propagated index has to be retried rather than raised.
+    """
+    target = "aragora-verify==0.1.2"
+    install_calls = 0
+    slept: list[float] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal install_calls
+        if cmd[-1] == target:
+            install_calls += 1
+            if install_calls < 3:  # first two attempts: version not visible yet
+                return subprocess.CompletedProcess(
+                    args=cmd,
+                    returncode=1,
+                    stdout="",
+                    stderr="ERROR: No matching distribution found for aragora-verify==0.1.2",
+                )
+            return _completed()
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.2\n")
+        if cmd[-1].endswith("post_publish_probe.py"):
+            return _completed(
+                json.dumps(
+                    {
+                        "valid_receipt_exit": 0,
+                        "spoofed_key_id_exit": 1,
+                        "spoofed_signature_status": "fail",
+                    }
+                )
+            )
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+    monkeypatch.setattr(verify_publish_script.time, "sleep", slept.append)
+
+    result = verify_publish_script.verify_publish(
+        version="0.1.2",
+        python="/usr/bin/python3",
+        work_dir=tmp_path,
+        install_backoff=5.0,
+    )
+
+    assert result["ok"] is True
+    assert install_calls == 3
+    assert result["install_attempts"] == 3
+    # exponential backoff between the two failed attempts
+    assert slept == [5.0, 10.0]
+
+
+def test_install_gives_up_after_bounded_attempts(monkeypatch: Any, tmp_path: Path) -> None:
+    slept: list[float] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-1] == "aragora-verify==0.1.2":
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="404 not found"
+            )
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+    monkeypatch.setattr(verify_publish_script.time, "sleep", slept.append)
+
+    try:
+        verify_publish_script.verify_publish(
+            version="0.1.2",
+            python="/usr/bin/python3",
+            work_dir=tmp_path,
+            install_attempts=4,
+            install_backoff=5.0,
+        )
+    except verify_publish_script.PublishVerificationError as exc:
+        assert "after 4 attempt(s)" in str(exc)
+        assert "404 not found" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected PublishVerificationError")
+
+    assert len(slept) == 3  # no sleep after the final attempt
+
+
+def test_install_backoff_is_capped(monkeypatch: Any, tmp_path: Path) -> None:
+    slept: list[float] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-1] == "aragora-verify==0.1.2":
+            return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="nope")
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+    monkeypatch.setattr(verify_publish_script.time, "sleep", slept.append)
+
+    try:
+        verify_publish_script.verify_publish(
+            version="0.1.2",
+            python="/usr/bin/python3",
+            work_dir=tmp_path,
+            install_attempts=8,
+            install_backoff=5.0,
+        )
+    except verify_publish_script.PublishVerificationError:
+        pass
+
+    assert max(slept) == verify_publish_script.MAX_INSTALL_BACKOFF
+    assert all(delay <= verify_publish_script.MAX_INSTALL_BACKOFF for delay in slept)
+
+
+def test_install_retries_on_timeout(monkeypatch: Any, tmp_path: Path) -> None:
+    """A hung index request is as transient as a 404 and must also retry."""
+    install_calls = 0
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        nonlocal install_calls
+        if cmd[-1] == "aragora-verify==0.1.2":
+            install_calls += 1
+            if install_calls == 1:
+                raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+            return _completed()
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.2\n")
+        if cmd[-1].endswith("post_publish_probe.py"):
+            return _completed(
+                json.dumps(
+                    {
+                        "valid_receipt_exit": 0,
+                        "spoofed_key_id_exit": 1,
+                        "spoofed_signature_status": "fail",
+                    }
+                )
+            )
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+    monkeypatch.setattr(verify_publish_script.time, "sleep", lambda _: None)
+
+    result = verify_publish_script.verify_publish(
+        version="0.1.2",
+        python="/usr/bin/python3",
+        work_dir=tmp_path,
+    )
+
+    assert result["ok"] is True
+    assert install_calls == 2

--- a/tests/scripts/test_verify_aragora_verify_publish.py
+++ b/tests/scripts/test_verify_aragora_verify_publish.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "verify_aragora_verify_publish.py"
+    spec = importlib.util.spec_from_file_location(
+        "verify_aragora_verify_publish_under_test",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+verify_publish_script = _load_module()
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_verify_publish_installs_exact_version_and_runs_probe(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 99
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.2\n")
+        if cmd[-1].endswith("post_publish_probe.py"):
+            return _completed(
+                json.dumps(
+                    {
+                        "valid_receipt_exit": 0,
+                        "spoofed_key_id_exit": 1,
+                        "spoofed_signature_status": "fail",
+                    }
+                )
+            )
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+
+    result = verify_publish_script.verify_publish(
+        version="0.1.2",
+        python="/usr/bin/python3",
+        work_dir=tmp_path,
+        timeout=99,
+    )
+
+    venv_python = str(tmp_path / ".venv" / "bin" / "python")
+    assert calls[:3] == [
+        ["/usr/bin/python3", "-m", "venv", str(tmp_path / ".venv")],
+        [venv_python, "-m", "pip", "install", "--upgrade", "pip"],
+        [
+            venv_python,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "aragora-verify==0.1.2",
+        ],
+    ]
+    assert calls[3] == [venv_python, "-m", "aragora_verify", "--version"]
+    assert calls[4] == [venv_python, str(tmp_path / "post_publish_probe.py")]
+    assert result["ok"] is True
+    assert result["version"] == "0.1.2"
+    assert result["probe"] == {
+        "valid_receipt_exit": 0,
+        "spoofed_key_id_exit": 1,
+        "spoofed_signature_status": "fail",
+    }
+    probe_source = (tmp_path / "post_publish_probe.py").read_text(encoding="utf-8")
+    assert "spoofed-signer-label" in probe_source
+    assert "aragora_verify" in probe_source
+
+
+def test_verify_publish_fails_on_version_mismatch(monkeypatch: Any, tmp_path: Path) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        if cmd[-1] == "--version":
+            return _completed("aragora-verify 0.1.1\n")
+        return _completed()
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+
+    try:
+        verify_publish_script.verify_publish(
+            version="0.1.2",
+            python="/usr/bin/python3",
+            work_dir=tmp_path,
+        )
+    except verify_publish_script.PublishVerificationError as exc:
+        assert "version mismatch" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected PublishVerificationError")
+
+
+def test_main_returns_one_on_failed_command(monkeypatch: Any, capsys: Any, tmp_path: Path) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=cmd, returncode=1, stdout="", stderr="network down")
+
+    monkeypatch.setattr(verify_publish_script.subprocess, "run", fake_run)
+
+    rc = verify_publish_script.main(["--version", "0.1.2", "--work-dir", str(tmp_path)])
+
+    assert rc == 1
+    assert "network down" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Adds `scripts/verify_aragora_verify_publish.py` to verify the exact published `aragora-verify` version from PyPI in a fresh virtualenv.
- The helper checks the installed CLI version, verifies a valid ODR receipt, and confirms a spoofed `key_id` signed receipt fails with a failing signature check.
- Wires `.github/workflows/publish-aragora-verify.yml` to run the helper immediately after PyPI publish and before GitHub release creation.

Refs #8845.

## Validation

- `pytest -q tests/scripts/test_verify_aragora_verify_publish.py`  
  `3 passed, 8 warnings in 0.40s`
- `python3 -m py_compile scripts/verify_aragora_verify_publish.py`
- `python3 scripts/verify_aragora_verify_publish.py --help`
- Live public-index smoke against the already-published package:  
  `python3 scripts/verify_aragora_verify_publish.py --version 0.1.1 --work-dir /private/tmp/aragora-verify-post-publish-live-20260706T1520Z --timeout 240 --json`  
  returned `ok=true`, `valid_receipt_exit=0`, `spoofed_key_id_exit=1`, `spoofed_signature_status=fail`.

No publishing, settlement execution, evidence posting, rerun, merge, gate mutation, or `--admin` use.