### PR TITLE
fix(cli): prefer not-ready blockers before settlement prompts

### DIFF
--- a/aragora/cli/commands/founder_status.py
+++ b/aragora/cli/commands/founder_status.py
@@ -211,15 +211,6 @@ def _queue_next_action(
             "detail": "Use the normal merge gate only; this report is not settlement authority.",
         }
 
-    human_required = queue.get("human_risk_settlement_required") or []
-    if human_required:
-        first = human_required[0]
-        return {
-            "kind": "human_settlement",
-            "summary": f"Record or reject human risk settlement for PR #{first}.",
-            "detail": "Human judgment remains explicit; automate only the receipt/status tail.",
-        }
-
     not_ready = queue.get("not_ready") or []
     not_ready_entries = queue.get("not_ready_entries") or []
     top_entries = queue.get("top_entries") or []
@@ -246,6 +237,15 @@ def _queue_next_action(
                 "summary": f"Work one bounded blocker on PR #{pr} ({status}).",
                 "detail": detail,
             }
+
+    human_required = queue.get("human_risk_settlement_required") or []
+    if human_required:
+        first = human_required[0]
+        return {
+            "kind": "human_settlement",
+            "summary": f"Record or reject human risk settlement for PR #{first}.",
+            "detail": "Human judgment remains explicit; automate only the receipt/status tail.",
+        }
 
     if proof_loop.get("overall_status") in {"stale", "missing"}:
         return {

--- a/tests/cli/test_founder_status.py
+++ b/tests/cli/test_founder_status.py
@@ -139,6 +139,84 @@ def test_founder_status_next_action_uses_not_ready_entry_beyond_top_entries(
     assert "model quorum incomplete" in report["next_action"]["detail"]
 
 
+def test_founder_status_repairs_not_ready_before_human_settlement(tmp_path: Path) -> None:
+    def merge_packet_builder(**_: object) -> dict[str, object]:
+        return {
+            "queue_pressure": {"current_open_prs": 1, "cap": 6, "active": False},
+            "admin_squash_order": [],
+            "human_risk_settlement_required": [8945],
+            "not_ready": [8945],
+            "entries": [
+                {
+                    "pr_number": 8945,
+                    "title": "release workflow post-publish verification",
+                    "url": "https://github.com/synaptent/aragora/pull/8945",
+                    "head_sha": "abc123",
+                    "tier": 4,
+                    "status": "repair_or_wait",
+                    "verdict": "not_ready_for_settlement",
+                    "admin_squash_allowed": False,
+                    "requires_human_risk_settlement": True,
+                    "requires_human_preapproval": True,
+                    "unresolved_dissent": False,
+                    "checks_summary": "3 failing / 32 total",
+                    "counted_model_families": [],
+                    "reasons": [
+                        "workflow/deploy/destructive surface touched",
+                        "checks are failing; repair before settlement",
+                    ],
+                }
+            ],
+        }
+
+    report = gather_founder_status(
+        repo_root=str(tmp_path),
+        health_gatherer=lambda **_: _health(),
+        merge_packet_builder=merge_packet_builder,
+    )
+
+    assert report["next_action"]["kind"] == "queue_blocker"
+    assert "PR #8945" in report["next_action"]["summary"]
+    assert "workflow/deploy/destructive surface touched" in report["next_action"]["detail"]
+
+
+def test_founder_status_keeps_human_settlement_when_ready(tmp_path: Path) -> None:
+    def merge_packet_builder(**_: object) -> dict[str, object]:
+        return {
+            "queue_pressure": {"current_open_prs": 1, "cap": 6, "active": False},
+            "admin_squash_order": [],
+            "human_risk_settlement_required": [8756],
+            "not_ready": [],
+            "entries": [
+                {
+                    "pr_number": 8756,
+                    "title": "operator-approved advisory settlement records",
+                    "url": "https://github.com/synaptent/aragora/pull/8756",
+                    "head_sha": "abc123",
+                    "tier": 4,
+                    "status": "needs_human_settlement",
+                    "verdict": "requires_human_risk_settlement",
+                    "admin_squash_allowed": False,
+                    "requires_human_risk_settlement": True,
+                    "requires_human_preapproval": True,
+                    "unresolved_dissent": False,
+                    "checks_summary": "all non-quorum required checks pass",
+                    "counted_model_families": [],
+                    "reasons": ["human risk settlement required"],
+                }
+            ],
+        }
+
+    report = gather_founder_status(
+        repo_root=str(tmp_path),
+        health_gatherer=lambda **_: _health(),
+        merge_packet_builder=merge_packet_builder,
+    )
+
+    assert report["next_action"]["kind"] == "human_settlement"
+    assert "PR #8756" in report["next_action"]["summary"]
+
+
 def test_founder_status_degrades_on_merge_packet_transport_error(tmp_path: Path) -> None:
     def broken_builder(**_: object) -> dict[str, object]:
         raise RuntimeError("organization access is disabled")


### PR DESCRIPTION
## Summary

- Fixes `status --founder` next-action ordering so `not_ready` PR blockers win before human settlement prompts.
- Preserves the human-settlement prompt when a PR requires settlement and is not otherwise listed as `not_ready`.
- Prevents the founder status surface from asking the operator to settle a PR that still has failing checks or other repair/wait blockers.

Refs #8845.

## Validation

- `pytest -q tests/cli/test_founder_status.py`  
  `8 passed, 8 warnings in 0.41s`
- Live smoke: `python3 -m aragora.cli.main status --founder --json --repo synaptent/aragora --limit 5`  
  returned `next_action.kind=queue_blocker` instead of `human_settlement` while current not-ready PRs include settlement-required #8945.

No settlement execution, evidence posting, rerun, merge, gate mutation, or `--admin` use.