### PR TITLE
fix(scripts): fall back to gh auth for cancelled-run retrigger

### DIFF
--- a/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
+++ b/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
@@ -131,13 +131,16 @@ that PR branch/event and verifies the run's PR association before considering it
 eligible:
 
 ```bash
-GITHUB_REPOSITORY=synaptent/aragora GITHUB_TOKEN="$GITHUB_TOKEN" \
-  python scripts/retrigger_cancelled_pr_runs.py \
-    --repo synaptent/aragora \
-    --pr <PR_NUMBER> \
-    --ttl-minutes 1440 \
-    --marker-file .aragora/retrigger_cancelled/marker.json
+python scripts/retrigger_cancelled_pr_runs.py \
+  --repo synaptent/aragora \
+  --pr <PR_NUMBER> \
+  --ttl-minutes 1440 \
+  --marker-file .aragora/retrigger_cancelled/marker.json
 ```
+
+The helper uses `GITHUB_TOKEN` when set, otherwise it falls back to
+`gh auth token`; run `gh auth status` first if the local credential state is
+unclear.
 
 If every eligible run is a current-head cancelled PR run and the conductor lane is
 allowed to spend one rerun per run id, repeat with `--apply`. The tool writes a

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -31,6 +31,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,6 +49,22 @@ OPERATOR_ACTION_EXIT = 2
 
 class GitHubApiError(RuntimeError):
     """Raised when GitHub API calls fail."""
+
+
+def _resolve_github_token() -> str:
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        return token
+    completed = subprocess.run(
+        ["gh", "auth", "token"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
 
 
 class GitHubClient:
@@ -672,9 +689,11 @@ def main(argv: list[str] | None = None) -> int:
     if not args.repo:
         print("--repo is required (or set GITHUB_REPOSITORY)", file=sys.stderr)
         return 1
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    token = _resolve_github_token()
     if not token:
-        print("GITHUB_TOKEN is required", file=sys.stderr)
+        print(
+            "GITHUB_TOKEN is required, or authenticate gh so `gh auth token` works", file=sys.stderr
+        )
         return 1
     if args.max_runs < 1:
         print("--max-runs must be >= 1", file=sys.stderr)

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -55,13 +55,16 @@ def _resolve_github_token() -> str:
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if token:
         return token
-    completed = subprocess.run(
-        ["gh", "auth", "token"],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
+    try:
+        completed = subprocess.run(
+            ["gh", "auth", "token"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
     if completed.returncode != 0:
         return ""
     return completed.stdout.strip()

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import datetime, timezone
 from typing import Any
 
@@ -258,6 +259,97 @@ def test_main_scopes_to_pr_and_writes_receipt(tmp_path, monkeypatch, capsys) -> 
     assert receipt["dry_run"] is True
     assert receipt["eligible_run_ids"] == [31]
     assert receipt["head_shas"] == ["sha-a"]
+
+
+def test_main_uses_gh_auth_token_when_env_token_missing(tmp_path, monkeypatch, capsys) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            assert repo == "synaptent/aragora"
+            assert token == "from-gh-auth"
+
+        def list_open_pulls(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "state": "open",
+                    "draft": False,
+                    "head": {"ref": "feat/a", "sha": "sha-a"},
+                }
+            ]
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            return [make_run(id=71, head_branch="feat/a", head_sha="sha-a")]
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert cmd == ["gh", "auth", "token"]
+        assert kwargs["check"] is False
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 10
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="from-gh-auth\n", stderr=""
+        )
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(retrigger.subprocess, "run", fake_run)
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+
+    rc = main(
+        [
+            "--repo",
+            "synaptent/aragora",
+            "--ttl-minutes",
+            "100000",
+            "--receipt-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["eligible"] == 1
+
+
+def test_main_prefers_env_token_without_calling_gh_auth(tmp_path, monkeypatch, capsys) -> None:
+    class FakeClient:
+        def __init__(self, repo: str, token: str) -> None:
+            assert token == "from-env"
+
+        def list_open_pulls(self) -> list[dict[str, Any]]:
+            return []
+
+        def list_recent_workflow_runs(self, max_runs: int) -> list[dict[str, Any]]:
+            return []
+
+    def unexpected_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("gh auth token should not be called when GITHUB_TOKEN is set")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "from-env")
+    monkeypatch.setattr(retrigger.subprocess, "run", unexpected_run)
+    monkeypatch.setattr(retrigger, "GitHubClient", FakeClient)
+
+    rc = main(["--repo", "synaptent/aragora", "--receipt-dir", str(tmp_path)])
+
+    assert rc == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["scanned"] == 0
+
+
+def test_main_reports_missing_token_when_env_and_gh_auth_fail(monkeypatch, capsys) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout="", stderr="not logged in"
+        )
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(retrigger.subprocess, "run", fake_run)
+
+    rc = main(["--repo", "synaptent/aragora"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "GITHUB_TOKEN is required" in captured.err
+    assert "gh auth token" in captured.err
 
 
 def test_main_apply_records_rerun_results_in_receipt(tmp_path, monkeypatch, capsys) -> None:

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -352,6 +352,38 @@ def test_main_reports_missing_token_when_env_and_gh_auth_fail(monkeypatch, capsy
     assert "gh auth token" in captured.err
 
 
+def test_main_reports_missing_token_when_gh_binary_missing(monkeypatch, capsys) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(retrigger.subprocess, "run", fake_run)
+
+    rc = main(["--repo", "synaptent/aragora"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "GITHUB_TOKEN is required" in captured.err
+    assert "gh auth token" in captured.err
+
+
+def test_main_reports_missing_token_when_gh_auth_times_out(monkeypatch, capsys) -> None:
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs["timeout"])
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(retrigger.subprocess, "run", fake_run)
+
+    rc = main(["--repo", "synaptent/aragora"])
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "GITHUB_TOKEN is required" in captured.err
+    assert "gh auth token" in captured.err
+
+
 def test_main_apply_records_rerun_results_in_receipt(tmp_path, monkeypatch, capsys) -> None:
     class FakeClient:
         def __init__(self, repo: str, token: str) -> None:


### PR DESCRIPTION
## Summary

- Lets `scripts/retrigger_cancelled_pr_runs.py` use `GITHUB_TOKEN` when set, otherwise fall back to `gh auth token`.
- Keeps the helper fail-closed when neither credential source is available.
- Updates the cancellation-diagnosis transport-loop docs so operators can run the helper without manually wrapping `GITHUB_TOKEN="$(gh auth token)"`.

Refs #8845.

## Validation

- `pytest -q tests/scripts/test_retrigger_cancelled_pr_runs.py`  
  `19 passed, 8 warnings in 0.47s`
- Live dry-run without `GITHUB_TOKEN`:  
  `env -u GITHUB_TOKEN python3 scripts/retrigger_cancelled_pr_runs.py --repo synaptent/aragora --pr 8946 --ttl-minutes 1440 --receipt-dir /private/tmp/retrigger-gh-token-fallback-receipts --marker-file /private/tmp/retrigger-gh-token-fallback-marker.json`  
  exited 0 through the `gh auth token` fallback, dry-run only, scanned 19 runs, found 3 eligible cancelled advisory runs for #8946, and wrote receipt `/private/tmp/retrigger-gh-token-fallback-receipts/RETRIGGER_CANCELLED_RECEIPT_20260706T153436166536Z_pid95835_pr-8946.json`.

No reruns were applied. No settlement execution, evidence posting, merge, gate mutation, or `--admin` use.