### PR TITLE
feat(scripts): write prompt handoffs to automation outbox

### DIFF
--- a/scripts/audit_codex_branch_backlog.py
+++ b/scripts/audit_codex_branch_backlog.py
@@ -446,8 +446,35 @@ def _structured_action(value: Any) -> Mapping[str, Any] | None:
     return None
 
 
+def _outbox_requested_action_type(payload: dict[str, Any]) -> str:
+    requested_action = _structured_action(payload.get("requested_action"))
+    if requested_action is not None:
+        return (
+            str(
+                requested_action.get("type")
+                or requested_action.get("action")
+                or requested_action.get("requested_action")
+                or ""
+            )
+            .strip()
+            .lower()
+            .replace("-", "_")
+        )
+    value = payload.get("requested_action")
+    if isinstance(value, str):
+        return value.strip().lower().replace("-", "_")
+    return ""
+
+
+def _is_prompt_handoff_payload(payload: dict[str, Any]) -> bool:
+    return _outbox_requested_action_type(payload) == "prompt_handoff"
+
+
 def _outbox_payload_branches(payload: dict[str, Any]) -> set[str]:
     """Return primary and explicitly superseded branch references from a handoff."""
+
+    if _is_prompt_handoff_payload(payload):
+        return set()
 
     branches: set[str] = set()
     _add_branch_reference(branches, _outbox_payload_branch(payload))
@@ -496,6 +523,9 @@ def _outbox_evidence_head(container: Mapping[str, Any]) -> str | None:
 
 def _outbox_payload_branch_heads(payload: dict[str, Any]) -> dict[str, set[str | None]]:
     """Return branch references with optional explicit head evidence."""
+
+    if _is_prompt_handoff_payload(payload):
+        return {}
 
     refs: dict[str, set[str | None]] = defaultdict(set)
 

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -185,6 +185,7 @@ class Handoff:
     requested_action: str | None = None
     branch: str | None = None
     desired_head: str | None = None
+    prompt_sha256: str | None = None
     prompt_artifact_path: str | None = None
     prompt_artifact_sha256: str | None = None
 
@@ -1083,6 +1084,7 @@ def _load_outbox_handoffs_with_skip_reasons(
             requested_action=requested_action,
             branch=_outbox_evidence_value(payload, "branch") or None,
             desired_head=_outbox_desired_head(payload),
+            prompt_sha256=_outbox_evidence_value(payload, "prompt_sha256") or None,
             prompt_artifact_path=_outbox_prompt_artifact_path(payload),
             prompt_artifact_sha256=_outbox_prompt_artifact_sha256(payload),
         )
@@ -1173,6 +1175,75 @@ def _existing_issue(repo_root: Path, repo: str, title: str) -> dict[str, Any] | 
         existing_title = str(item.get("title") or "")
         if _looks_duplicate(title, existing_title):
             return item
+    return None
+
+
+def _existing_prompt_handoff_issue(
+    repo_root: Path,
+    repo: str,
+    handoff: Handoff,
+) -> dict[str, Any] | None:
+    terms = [
+        str(handoff.idempotency_key or "").strip(),
+        str(handoff.prompt_sha256 or handoff.prompt_artifact_sha256 or "").strip(),
+    ]
+    for term in dict.fromkeys(item for item in terms if item):
+        proc = _run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "all",
+                "--search",
+                term,
+                "--json",
+                "number,title,url,state",
+                "--limit",
+                "50",
+            ],
+            cwd=repo_root,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                proc.stderr.strip() or proc.stdout.strip() or "failed to list prompt issues"
+            )
+        payload = json.loads(proc.stdout or "[]")
+        if not isinstance(payload, list):
+            continue
+        for item in payload:
+            if not isinstance(item, dict):
+                continue
+            number = str(item.get("number") or "").strip()
+            if not number:
+                continue
+            view_proc = _run(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    number,
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,title,url,state,body",
+                ],
+                cwd=repo_root,
+            )
+            if view_proc.returncode != 0:
+                raise RuntimeError(
+                    view_proc.stderr.strip()
+                    or view_proc.stdout.strip()
+                    or "failed to view prompt issue"
+                )
+            viewed = json.loads(view_proc.stdout or "{}")
+            if not isinstance(viewed, dict):
+                continue
+            haystack = "\n".join(str(viewed.get(key) or "") for key in ("title", "body", "url"))
+            if term in haystack:
+                return viewed
     return None
 
 
@@ -1540,6 +1611,18 @@ def decide_handoffs(
                         eligible=False,
                         reason="target_open_pr",
                         existing_pr_url=str(target_pr.get("url") or ""),
+                    )
+                )
+                continue
+        if _is_prompt_handoff(handoff):
+            existing_prompt_issue = _existing_prompt_handoff_issue(repo_root, repo, handoff)
+            if existing_prompt_issue:
+                decisions.append(
+                    _decision_for_handoff(
+                        handoff,
+                        eligible=False,
+                        reason="existing_issue",
+                        existing_issue_url=str(existing_prompt_issue.get("url") or ""),
                     )
                 )
                 continue

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1196,7 +1196,7 @@ def _existing_prompt_handoff_issue(
                 "--repo",
                 repo,
                 "--state",
-                "all",
+                "open",
                 "--search",
                 term,
                 "--json",
@@ -1215,6 +1215,8 @@ def _existing_prompt_handoff_issue(
             continue
         for item in payload:
             if not isinstance(item, dict):
+                continue
+            if str(item.get("state") or "").strip().upper() != "OPEN":
                 continue
             number = str(item.get("number") or "").strip()
             if not number:
@@ -1240,6 +1242,8 @@ def _existing_prompt_handoff_issue(
                 )
             viewed = json.loads(view_proc.stdout or "{}")
             if not isinstance(viewed, dict):
+                continue
+            if str(viewed.get("state") or "").strip().upper() != "OPEN":
                 continue
             haystack = "\n".join(str(viewed.get(key) or "") for key in ("title", "body", "url"))
             if term in haystack:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1447,12 +1447,13 @@ def _existing_incomplete_prompt_handoff_issue(
     repo_root: Path,
     repo: str,
     handoff: Handoff,
+    labels: Sequence[str],
 ) -> dict[str, Any] | None:
     return _find_prompt_handoff_issue(
         repo_root,
         repo,
         handoff,
-        predicate=_issue_contains_incomplete_prompt_marker,
+        predicate=lambda issue: not _prompt_issue_is_usable(issue, labels),
     )
 
 
@@ -1676,7 +1677,7 @@ def _publish_prompt_handoff_issue(
     *,
     labels: list[str],
 ) -> str:
-    incomplete_issue = _existing_incomplete_prompt_handoff_issue(repo_root, repo, handoff)
+    incomplete_issue = _existing_incomplete_prompt_handoff_issue(repo_root, repo, handoff, labels)
     if incomplete_issue:
         return _complete_existing_prompt_handoff_issue(
             repo_root,
@@ -1792,7 +1793,7 @@ def _complete_existing_prompt_handoff_issue(
             existing_comment_bodies=existing_comment_bodies,
         )
         _add_issue_labels(repo_root, repo, issue_url, labels)
-        if _issue_contains_incomplete_prompt_marker(issue):
+        if not _issue_contains_marker(issue, COMPLETE_PROMPT_HANDOFF_MARKER):
             _mark_completed_prompt_issue(repo_root, repo, issue_url)
     except RuntimeError as exc:
         try:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1369,7 +1369,12 @@ def _create_issue(
     try:
         _add_prompt_artifact_comments(repo_root, repo, url, prompt_artifact_comment_bodies)
     except RuntimeError as exc:
-        _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
+        try:
+            _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
+        except RuntimeError as close_exc:
+            raise RuntimeError(
+                f"{exc}; additionally failed to close incomplete prompt issue: {close_exc}"
+            ) from close_exc
         raise
     _add_issue_labels(repo_root, repo, url, labels)
     return url
@@ -1382,8 +1387,12 @@ def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[s
     path = _resolve_prompt_artifact_path(repo_root, handoff)
     if path is None:
         return []
-    prompt = path.read_text(encoding="utf-8")
-    artifact_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    artifact_bytes = path.read_bytes()
+    artifact_sha = hashlib.sha256(artifact_bytes).hexdigest()
+    try:
+        prompt = artifact_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("prompt_artifact_not_utf8") from exc
     chunks = [
         prompt[index : index + MAX_PROMPT_ARTIFACT_COMMENT_CHARS]
         for index in range(0, len(prompt), MAX_PROMPT_ARTIFACT_COMMENT_CHARS)
@@ -1436,7 +1445,13 @@ def _close_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, e
         "Closing incomplete prompt handoff issue: required prompt artifact comment "
         f"publication failed before the handoff became usable.\n\nError: {error}"
     )
-    _run(["gh", "issue", "close", number, "--repo", repo, "--comment", body], cwd=repo_root)
+    proc = _run(["gh", "issue", "close", number, "--repo", repo, "--comment", body], cwd=repo_root)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip()
+            or proc.stdout.strip()
+            or "gh issue close failed for incomplete prompt handoff"
+        )
 
 
 def _fit_issue_body(body: str) -> str:
@@ -1496,18 +1511,18 @@ def decide_handoffs(
                     )
                 )
                 continue
-        existing = _existing_issue(repo_root, repo, handoff.task_title)
-        if existing:
-            decisions.append(
-                _decision_for_handoff(
-                    handoff,
-                    eligible=False,
-                    reason="existing_issue",
-                    existing_issue_url=str(existing.get("url") or ""),
-                )
-            )
-            continue
         if not _is_prompt_handoff(handoff):
+            existing = _existing_issue(repo_root, repo, handoff.task_title)
+            if existing:
+                decisions.append(
+                    _decision_for_handoff(
+                        handoff,
+                        eligible=False,
+                        reason="existing_issue",
+                        existing_issue_url=str(existing.get("url") or ""),
+                    )
+                )
+                continue
             referenced_pr = _referenced_pr(repo_root, repo, handoff)
             if referenced_pr and _pr_head_satisfies_handoff(handoff, referenced_pr):
                 decisions.append(

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -431,12 +431,32 @@ def _terminal_receipts_by_key(receipt_dir: Path) -> dict[str, list[dict[str, Any
     return receipts
 
 
+def _receipt_labels(receipt_payload: Mapping[str, Any]) -> list[str]:
+    raw_labels = receipt_payload.get("labels")
+    if isinstance(raw_labels, str):
+        labels = [item.strip() for item in raw_labels.split(",")]
+    elif isinstance(raw_labels, Sequence) and not isinstance(raw_labels, (bytes, bytearray, str)):
+        labels = [str(item).strip() for item in raw_labels]
+    else:
+        labels = []
+    return [label for label in labels if label] or list(DEFAULT_LABELS)
+
+
+def _receipt_issue_url(receipt_payload: Mapping[str, Any]) -> str:
+    for key in ("created_issue_url", "existing_issue_url", "issue_url"):
+        url = str(receipt_payload.get(key) or "").strip()
+        if url:
+            return url
+    return ""
+
+
 def _write_receipt(
     receipt_dir: Path,
     handoff: Handoff,
     decision: PublishDecision,
     *,
     repo: str,
+    labels: Sequence[str] | None = None,
 ) -> None:
     if handoff.source_kind != "outbox" or not handoff.idempotency_key:
         return
@@ -457,6 +477,8 @@ def _write_receipt(
         "existing_pr_url": decision.existing_pr_url,
         "recorded_at": datetime.now(UTC).isoformat(),
     }
+    if _is_prompt_handoff(handoff):
+        payload["labels"] = [label for label in (labels or DEFAULT_LABELS) if label]
     _receipt_path(receipt_dir, handoff.idempotency_key).write_text(
         json.dumps(payload, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
@@ -673,6 +695,10 @@ def _is_pr_open_request(payload: dict[str, Any]) -> bool:
         _normalized_requested_action(payload.get("requested_action"))
         == PR_OPEN_REQUEST_CANONICAL_ACTION
     )
+
+
+def _is_prompt_handoff_payload(payload: Mapping[str, Any]) -> bool:
+    return _normalized_requested_action(payload.get("requested_action")) == "prompt_handoff"
 
 
 def _is_prompt_handoff(handoff: Handoff) -> bool:
@@ -916,6 +942,9 @@ def _receipt_satisfies_outbox(
     payload: dict[str, Any],
     receipt_payload: dict[str, Any],
 ) -> bool:
+    if _is_prompt_handoff_payload(payload):
+        return _prompt_receipt_issue_is_usable(repo_root, payload, receipt_payload)
+
     reason = str(receipt_payload.get("reason") or "").strip().lower()
     if _is_pr_open_request(payload):
         created_issue_url = str(receipt_payload.get("created_issue_url") or "").strip()
@@ -930,6 +959,48 @@ def _receipt_satisfies_outbox(
     if not remote_head:
         return False
     return _head_matches(desired_head, remote_head)
+
+
+def _prompt_receipt_issue_is_usable(
+    repo_root: Path,
+    payload: Mapping[str, Any],
+    receipt_payload: Mapping[str, Any],
+) -> bool:
+    issue_url = _receipt_issue_url(receipt_payload)
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        return False
+    repo = str(receipt_payload.get("repo") or payload.get("repo") or DEFAULT_REPO).strip()
+    if not repo:
+        repo = DEFAULT_REPO
+    proc = _run(
+        [
+            "gh",
+            "issue",
+            "view",
+            number,
+            "--repo",
+            repo,
+            "--json",
+            "number,title,url,state,stateReason,body,labels,comments",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        return False
+    try:
+        issue = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(issue, dict):
+        return False
+    state = str(issue.get("state") or "").strip().upper()
+    state_reason = str(issue.get("stateReason") or "").strip().upper()
+    if state == "CLOSED" and state_reason == "COMPLETED":
+        return not _issue_contains_incomplete_prompt_marker(issue)
+    if state != "OPEN":
+        return False
+    return _prompt_issue_is_usable(issue, _receipt_labels(receipt_payload))
 
 
 def _terminal_outbox_fingerprints(
@@ -1932,7 +2003,7 @@ def publish_handoffs(
             created_issue_url=url,
         )
         if receipt_dir is not None:
-            _write_receipt(receipt_dir, handoff, published_decision, repo=repo)
+            _write_receipt(receipt_dir, handoff, published_decision, repo=repo, labels=labels)
         published.append(published_decision)
     return published
 
@@ -2161,7 +2232,7 @@ def main(argv: list[str] | None = None) -> int:
         for item in results:
             handoff = by_key.get((item.task_title, item.source_file))
             if handoff is not None:
-                _write_receipt(receipt_dir, handoff, item, repo=args.github_repo)
+                _write_receipt(receipt_dir, handoff, item, repo=args.github_repo, labels=labels)
 
     payload = {
         "repo": str(repo_root),

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -47,6 +47,7 @@ MAX_PROMPT_ARTIFACT_CHUNKS = 10
 MAX_PROMPT_ARTIFACT_BYTES = MAX_PROMPT_ARTIFACT_CHUNK_BYTES * MAX_PROMPT_ARTIFACT_CHUNKS
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 INCOMPLETE_PROMPT_HANDOFF_MARKER = "Incomplete prompt handoff issue:"
+COMPLETE_PROMPT_HANDOFF_MARKER = "Completed prompt handoff issue:"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_BASE_REF = "origin/main"
@@ -1226,19 +1227,32 @@ def _issue_label_names(issue: dict[str, Any]) -> set[str]:
     return names
 
 
-def _issue_contains_incomplete_prompt_marker(issue: dict[str, Any]) -> bool:
-    body = str(issue.get("body") or "")
-    if INCOMPLETE_PROMPT_HANDOFF_MARKER in body:
-        return True
+def _issue_comment_bodies(issue: dict[str, Any]) -> list[str]:
     comments = issue.get("comments")
     if not isinstance(comments, list):
-        return False
+        return []
+    bodies: list[str] = []
     for comment in comments:
         if not isinstance(comment, dict):
             continue
-        if INCOMPLETE_PROMPT_HANDOFF_MARKER in str(comment.get("body") or ""):
+        bodies.append(str(comment.get("body") or ""))
+    return bodies
+
+
+def _issue_contains_marker(issue: dict[str, Any], marker: str) -> bool:
+    body = str(issue.get("body") or "")
+    if marker in body:
+        return True
+    for comment_body in _issue_comment_bodies(issue):
+        if marker in comment_body:
             return True
     return False
+
+
+def _issue_contains_incomplete_prompt_marker(issue: dict[str, Any]) -> bool:
+    if _issue_contains_marker(issue, COMPLETE_PROMPT_HANDOFF_MARKER):
+        return False
+    return _issue_contains_marker(issue, INCOMPLETE_PROMPT_HANDOFF_MARKER)
 
 
 def _prompt_issue_is_usable(issue: dict[str, Any], labels: Sequence[str]) -> bool:
@@ -1250,17 +1264,36 @@ def _prompt_issue_is_usable(issue: dict[str, Any], labels: Sequence[str]) -> boo
     return required_labels.issubset(_issue_label_names(issue))
 
 
-def _existing_prompt_handoff_issue(
+def _prompt_identity_terms(handoff: Handoff) -> list[str]:
+    return list(
+        dict.fromkeys(
+            item
+            for item in (
+                str(handoff.idempotency_key or "").strip(),
+                str(handoff.prompt_sha256 or handoff.prompt_artifact_sha256 or "").strip(),
+            )
+            if item
+        )
+    )
+
+
+def _issue_contains_prompt_identity(issue: dict[str, Any], terms: Sequence[str]) -> bool:
+    haystack = "\n".join(
+        [str(issue.get(key) or "") for key in ("title", "body", "url")]
+        + _issue_comment_bodies(issue)
+    )
+    return any(term in haystack for term in terms)
+
+
+def _find_prompt_handoff_issue(
     repo_root: Path,
     repo: str,
     handoff: Handoff,
-    labels: Sequence[str],
+    *,
+    predicate: Callable[[dict[str, Any]], bool],
 ) -> dict[str, Any] | None:
-    terms = [
-        str(handoff.idempotency_key or "").strip(),
-        str(handoff.prompt_sha256 or handoff.prompt_artifact_sha256 or "").strip(),
-    ]
-    for term in dict.fromkeys(item for item in terms if item):
+    terms = _prompt_identity_terms(handoff)
+    for term in terms:
         proc = _run(
             [
                 "gh",
@@ -1318,12 +1351,38 @@ def _existing_prompt_handoff_issue(
                 continue
             if str(viewed.get("state") or "").strip().upper() != "OPEN":
                 continue
-            if not _prompt_issue_is_usable(viewed, labels):
+            if not _issue_contains_prompt_identity(viewed, terms):
                 continue
-            haystack = "\n".join(str(viewed.get(key) or "") for key in ("title", "body", "url"))
-            if term in haystack:
+            if predicate(viewed):
                 return viewed
     return None
+
+
+def _existing_prompt_handoff_issue(
+    repo_root: Path,
+    repo: str,
+    handoff: Handoff,
+    labels: Sequence[str],
+) -> dict[str, Any] | None:
+    return _find_prompt_handoff_issue(
+        repo_root,
+        repo,
+        handoff,
+        predicate=lambda issue: _prompt_issue_is_usable(issue, labels),
+    )
+
+
+def _existing_incomplete_prompt_handoff_issue(
+    repo_root: Path,
+    repo: str,
+    handoff: Handoff,
+) -> dict[str, Any] | None:
+    return _find_prompt_handoff_issue(
+        repo_root,
+        repo,
+        handoff,
+        predicate=_issue_contains_incomplete_prompt_marker,
+    )
 
 
 def _existing_pr(repo_root: Path, repo: str, title: str) -> dict[str, Any] | None:
@@ -1539,6 +1598,25 @@ def _create_issue(
     return url
 
 
+def _publish_prompt_handoff_issue(
+    repo_root: Path,
+    repo: str,
+    handoff: Handoff,
+    *,
+    labels: list[str],
+) -> str:
+    incomplete_issue = _existing_incomplete_prompt_handoff_issue(repo_root, repo, handoff)
+    if incomplete_issue:
+        return _complete_existing_prompt_handoff_issue(
+            repo_root,
+            repo,
+            handoff,
+            incomplete_issue,
+            labels=labels,
+        )
+    return _create_issue(repo_root, repo, handoff, labels=labels)
+
+
 def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[str]:
     artifact = _validated_prompt_artifact_chunks(repo_root, handoff)
     if artifact is None:
@@ -1596,13 +1674,18 @@ def _add_prompt_artifact_comments(
     repo: str,
     issue_url: str,
     bodies: list[str],
+    *,
+    existing_comment_bodies: set[str] | None = None,
 ) -> None:
     number = _issue_number_from_url(issue_url)
     if not number:
         if bodies:
             raise RuntimeError("prompt_artifact_issue_url_unparseable")
         return
+    existing = existing_comment_bodies or set()
     for body in bodies:
+        if body in existing:
+            continue
         proc = _run(
             ["gh", "issue", "comment", number, "--repo", repo, "--body", body],
             cwd=repo_root,
@@ -1613,6 +1696,42 @@ def _add_prompt_artifact_comments(
                 or proc.stdout.strip()
                 or "gh issue comment failed for prompt artifact"
             )
+
+
+def _complete_existing_prompt_handoff_issue(
+    repo_root: Path,
+    repo: str,
+    handoff: Handoff,
+    issue: dict[str, Any],
+    *,
+    labels: list[str],
+) -> str:
+    issue_url = str(issue.get("url") or "").strip()
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        raise RuntimeError("prompt_artifact_issue_url_unparseable")
+    existing_comment_bodies = set(_issue_comment_bodies(issue))
+    prompt_artifact_comment_bodies = _prompt_artifact_comment_bodies(repo_root, handoff)
+    try:
+        _add_prompt_artifact_comments(
+            repo_root,
+            repo,
+            issue_url,
+            prompt_artifact_comment_bodies,
+            existing_comment_bodies=existing_comment_bodies,
+        )
+        _add_issue_labels(repo_root, repo, issue_url, labels)
+        if _issue_contains_incomplete_prompt_marker(issue):
+            _mark_completed_prompt_issue(repo_root, repo, issue_url)
+    except RuntimeError as exc:
+        try:
+            _mark_incomplete_prompt_issue(repo_root, repo, issue_url, str(exc))
+        except RuntimeError as mark_exc:
+            raise RuntimeError(
+                f"{exc}; additionally failed to mark incomplete prompt issue: {mark_exc}"
+            ) from mark_exc
+        raise
+    return issue_url
 
 
 def _mark_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, error: str) -> None:
@@ -1631,6 +1750,24 @@ def _mark_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, er
             proc.stderr.strip()
             or proc.stdout.strip()
             or "gh issue comment failed for incomplete prompt handoff"
+        )
+
+
+def _mark_completed_prompt_issue(repo_root: Path, repo: str, issue_url: str) -> None:
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        raise RuntimeError("prompt_artifact_issue_url_unparseable")
+    body = (
+        f"{COMPLETE_PROMPT_HANDOFF_MARKER} required prompt handoff publication "
+        "finished after a retry resumed this issue. Future publisher checks may "
+        "treat this issue as usable once required labels are present."
+    )
+    proc = _run(["gh", "issue", "comment", number, "--repo", repo, "--body", body], cwd=repo_root)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip()
+            or proc.stdout.strip()
+            or "gh issue comment failed for completed prompt handoff"
         )
 
 
@@ -1783,7 +1920,10 @@ def publish_handoffs(
                 )
             )
             continue
-        url = _create_issue(repo_root, repo, handoff, labels=labels)
+        if _is_prompt_handoff(handoff):
+            url = _publish_prompt_handoff_issue(repo_root, repo, handoff, labels=labels)
+        else:
+            url = _create_issue(repo_root, repo, handoff, labels=labels)
         count += 1
         published_decision = _decision_for_handoff(
             handoff,

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import hashlib
 import json
 import os
 import re
@@ -37,6 +38,7 @@ DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
 MAX_ISSUE_BODY_CHARS = 60_000
+MAX_PROMPT_ARTIFACT_COMMENT_CHARS = 55_000
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_BASE_REF = "origin/main"
@@ -176,6 +178,8 @@ class Handoff:
     source_kind: str = "memory"
     branch: str | None = None
     desired_head: str | None = None
+    prompt_artifact_path: str | None = None
+    prompt_artifact_sha256: str | None = None
 
 
 @dataclass(frozen=True)
@@ -665,7 +669,29 @@ def _outbox_branch_fingerprint(payload: dict[str, Any]) -> str | None:
     branch = _outbox_evidence_value(payload, "branch")
     if not requested_action or not repo or not branch:
         return None
-    return "\0".join((requested_action, repo, branch))
+    parts = [requested_action, repo, branch]
+    if requested_action == "prompt_handoff":
+        prompt_sha = _outbox_evidence_value(payload, "prompt_sha256")
+        if not prompt_sha:
+            return None
+        parts.append(prompt_sha)
+    return "\0".join(parts)
+
+
+def _outbox_prompt_artifact_path(payload: dict[str, Any]) -> str | None:
+    if _normalized_requested_action(payload.get("requested_action")) != "prompt_handoff":
+        return None
+    value = _outbox_evidence_value(payload, "prompt_artifact_path")
+    return value or None
+
+
+def _outbox_prompt_artifact_sha256(payload: dict[str, Any]) -> str | None:
+    if _normalized_requested_action(payload.get("requested_action")) != "prompt_handoff":
+        return None
+    value = _outbox_evidence_value(payload, "prompt_artifact_sha256")
+    if value:
+        return value
+    return _outbox_evidence_value(payload, "prompt_sha256") or None
 
 
 def _outbox_desired_head(payload: dict[str, Any]) -> str | None:
@@ -769,7 +795,39 @@ def _stale_outbox_head(repo_root: Path, handoff: Handoff) -> str | None:
     return branch_tip
 
 
+def _resolve_prompt_artifact_path(repo_root: Path, handoff: Handoff) -> Path | None:
+    if not handoff.prompt_artifact_path:
+        return None
+    path = Path(handoff.prompt_artifact_path).expanduser()
+    if not path.is_absolute():
+        path = repo_root / path
+    return path
+
+
+def _prompt_artifact_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _prompt_artifact_blocker(repo_root: Path, handoff: Handoff) -> str | None:
+    path = _resolve_prompt_artifact_path(repo_root, handoff)
+    if path is None:
+        return None
+    if not path.is_file():
+        return "prompt_artifact_missing"
+    expected_sha = str(handoff.prompt_artifact_sha256 or "").strip()
+    if expected_sha and _prompt_artifact_sha256(path) != expected_sha:
+        return "prompt_artifact_sha_mismatch"
+    return None
+
+
 def _local_handoff_blocker(repo_root: Path, handoff: Handoff) -> PublishDecision | None:
+    prompt_artifact_blocker = _prompt_artifact_blocker(repo_root, handoff)
+    if prompt_artifact_blocker is not None:
+        return _decision_for_handoff(
+            handoff,
+            eligible=False,
+            reason=prompt_artifact_blocker,
+        )
     if _stale_outbox_head(repo_root, handoff):
         return _decision_for_handoff(
             handoff,
@@ -985,6 +1043,8 @@ def _load_outbox_handoffs_with_skip_reasons(
             source_kind="outbox",
             branch=_outbox_evidence_value(payload, "branch") or None,
             desired_head=_outbox_desired_head(payload),
+            prompt_artifact_path=_outbox_prompt_artifact_path(payload),
+            prompt_artifact_sha256=_outbox_prompt_artifact_sha256(payload),
         )
         identity = (
             ("branch", branch_fingerprint)
@@ -1270,8 +1330,59 @@ def _create_issue(
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh issue create failed")
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
+    _add_prompt_artifact_comments(repo_root, repo, url, handoff)
     _add_issue_labels(repo_root, repo, url, labels)
     return url
+
+
+def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[str]:
+    path = _resolve_prompt_artifact_path(repo_root, handoff)
+    if path is None:
+        return []
+    prompt = path.read_text(encoding="utf-8")
+    artifact_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    chunks = [
+        prompt[index : index + MAX_PROMPT_ARTIFACT_COMMENT_CHARS]
+        for index in range(0, len(prompt), MAX_PROMPT_ARTIFACT_COMMENT_CHARS)
+    ] or [""]
+    bodies: list[str] = []
+    total_chunks = len(chunks)
+    cursor = 0
+    for chunk_index, chunk in enumerate(chunks, start=1):
+        start = cursor
+        cursor += len(chunk)
+        header = (
+            "Prompt handoff artifact "
+            f"chunk {chunk_index}/{total_chunks}\n\n"
+            f"Prompt SHA-256: `{artifact_sha}`\n"
+            f"Characters: `{start}-{cursor}` of `{len(prompt)}`\n\n"
+            "-----BEGIN ARAGORA PROMPT CHUNK-----\n"
+        )
+        footer = "\n-----END ARAGORA PROMPT CHUNK-----"
+        bodies.append(header + chunk + footer)
+    return bodies
+
+
+def _add_prompt_artifact_comments(
+    repo_root: Path,
+    repo: str,
+    issue_url: str,
+    handoff: Handoff,
+) -> None:
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        return
+    for body in _prompt_artifact_comment_bodies(repo_root, handoff):
+        proc = _run(
+            ["gh", "issue", "comment", number, "--repo", repo, "--body", body],
+            cwd=repo_root,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                proc.stderr.strip()
+                or proc.stdout.strip()
+                or "gh issue comment failed for prompt artifact"
+            )
 
 
 def _fit_issue_body(body: str) -> str:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -38,7 +38,12 @@ DEFAULT_LIMIT = 2
 DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
 MAX_ISSUE_BODY_CHARS = 60_000
-MAX_PROMPT_ARTIFACT_COMMENT_CHARS = 55_000
+MAX_PROMPT_ARTIFACT_COMMENT_BYTES = 55_000
+PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES = 1_000
+MAX_PROMPT_ARTIFACT_CHUNK_BYTES = (
+    MAX_PROMPT_ARTIFACT_COMMENT_BYTES - PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES
+)
+MAX_PROMPT_ARTIFACT_COMMENT_CHARS = MAX_PROMPT_ARTIFACT_COMMENT_BYTES
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
@@ -1393,10 +1398,7 @@ def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[s
         prompt = artifact_bytes.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise RuntimeError("prompt_artifact_not_utf8") from exc
-    chunks = [
-        prompt[index : index + MAX_PROMPT_ARTIFACT_COMMENT_CHARS]
-        for index in range(0, len(prompt), MAX_PROMPT_ARTIFACT_COMMENT_CHARS)
-    ] or [""]
+    chunks = _split_text_by_utf8_bytes(prompt, MAX_PROMPT_ARTIFACT_CHUNK_BYTES)
     bodies: list[str] = []
     total_chunks = len(chunks)
     cursor = 0
@@ -1411,8 +1413,36 @@ def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[s
             "-----BEGIN ARAGORA PROMPT CHUNK-----\n"
         )
         footer = "\n-----END ARAGORA PROMPT CHUNK-----"
-        bodies.append(header + chunk + footer)
+        body = header + chunk + footer
+        if _utf8_len(body) > MAX_PROMPT_ARTIFACT_COMMENT_BYTES:
+            raise RuntimeError("prompt_artifact_comment_too_large")
+        bodies.append(body)
     return bodies
+
+
+def _utf8_len(value: str) -> int:
+    return len(value.encode("utf-8"))
+
+
+def _split_text_by_utf8_bytes(text: str, max_bytes: int) -> list[str]:
+    if max_bytes <= 0:
+        raise ValueError("max_bytes must be positive")
+    chunks: list[str] = []
+    current: list[str] = []
+    current_bytes = 0
+    for char in text:
+        char_bytes = _utf8_len(char)
+        if char_bytes > max_bytes:
+            raise RuntimeError("prompt_artifact_character_too_large")
+        if current and current_bytes + char_bytes > max_bytes:
+            chunks.append("".join(current))
+            current = []
+            current_bytes = 0
+        current.append(char)
+        current_bytes += char_bytes
+    if current:
+        chunks.append("".join(current))
+    return chunks or [""]
 
 
 def _add_prompt_artifact_comments(
@@ -1423,6 +1453,8 @@ def _add_prompt_artifact_comments(
 ) -> None:
     number = _issue_number_from_url(issue_url)
     if not number:
+        if bodies:
+            raise RuntimeError("prompt_artifact_issue_url_unparseable")
         return
     for body in bodies:
         proc = _run(
@@ -1440,7 +1472,7 @@ def _add_prompt_artifact_comments(
 def _close_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, error: str) -> None:
     number = _issue_number_from_url(issue_url)
     if not number:
-        return
+        raise RuntimeError("prompt_artifact_issue_url_unparseable")
     body = (
         "Closing incomplete prompt handoff issue: required prompt artifact comment "
         f"publication failed before the handoff became usable.\n\nError: {error}"

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -46,6 +46,7 @@ MAX_PROMPT_ARTIFACT_CHUNK_BYTES = (
 MAX_PROMPT_ARTIFACT_CHUNKS = 10
 MAX_PROMPT_ARTIFACT_BYTES = MAX_PROMPT_ARTIFACT_CHUNK_BYTES * MAX_PROMPT_ARTIFACT_CHUNKS
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
+INCOMPLETE_PROMPT_HANDOFF_MARKER = "Incomplete prompt handoff issue:"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_BASE_REF = "origin/main"
@@ -843,21 +844,52 @@ def _prompt_artifact_sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _prompt_artifact_blocker(repo_root: Path, handoff: Handoff) -> str | None:
+def _validated_prompt_artifact_chunks(
+    repo_root: Path,
+    handoff: Handoff,
+) -> tuple[str, list[str]] | None:
     path = _resolve_prompt_artifact_path(repo_root, handoff)
     if path is None:
         if handoff.prompt_artifact_path:
-            return "prompt_artifact_outside_outbox"
+            raise RuntimeError("prompt_artifact_outside_outbox")
         return None
     if not path.is_file():
-        return "prompt_artifact_missing"
+        raise RuntimeError("prompt_artifact_missing")
     expected_sha = str(handoff.prompt_artifact_sha256 or "").strip()
     if not expected_sha:
-        return "prompt_artifact_sha_missing"
+        raise RuntimeError("prompt_artifact_sha_missing")
     if not re.fullmatch(r"[0-9a-fA-F]{64}", expected_sha):
-        return "prompt_artifact_sha_invalid"
-    if _prompt_artifact_sha256(path) != expected_sha.lower():
-        return "prompt_artifact_sha_mismatch"
+        raise RuntimeError("prompt_artifact_sha_invalid")
+    try:
+        artifact_size = path.stat().st_size
+    except OSError as exc:
+        raise RuntimeError("prompt_artifact_unreadable") from exc
+    if artifact_size > MAX_PROMPT_ARTIFACT_BYTES:
+        raise RuntimeError("prompt_artifact_too_large")
+    try:
+        artifact_bytes = path.read_bytes()
+    except OSError as exc:
+        raise RuntimeError("prompt_artifact_unreadable") from exc
+    if len(artifact_bytes) > MAX_PROMPT_ARTIFACT_BYTES:
+        raise RuntimeError("prompt_artifact_too_large")
+    artifact_sha = hashlib.sha256(artifact_bytes).hexdigest()
+    if artifact_sha != expected_sha.lower():
+        raise RuntimeError("prompt_artifact_sha_mismatch")
+    try:
+        prompt = artifact_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("prompt_artifact_not_utf8") from exc
+    chunks = _split_text_by_utf8_bytes(prompt, MAX_PROMPT_ARTIFACT_CHUNK_BYTES)
+    if len(chunks) > MAX_PROMPT_ARTIFACT_CHUNKS:
+        raise RuntimeError("prompt_artifact_too_many_chunks")
+    return artifact_sha, chunks
+
+
+def _prompt_artifact_blocker(repo_root: Path, handoff: Handoff) -> str | None:
+    try:
+        _validated_prompt_artifact_chunks(repo_root, handoff)
+    except RuntimeError as exc:
+        return str(exc) or "prompt_artifact_invalid"
     return None
 
 
@@ -1179,10 +1211,50 @@ def _existing_issue(repo_root: Path, repo: str, title: str) -> dict[str, Any] | 
     return None
 
 
+def _issue_label_names(issue: dict[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    names: set[str] = set()
+    for item in labels:
+        if isinstance(item, dict):
+            name = str(item.get("name") or "").strip()
+        else:
+            name = str(item or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _issue_contains_incomplete_prompt_marker(issue: dict[str, Any]) -> bool:
+    body = str(issue.get("body") or "")
+    if INCOMPLETE_PROMPT_HANDOFF_MARKER in body:
+        return True
+    comments = issue.get("comments")
+    if not isinstance(comments, list):
+        return False
+    for comment in comments:
+        if not isinstance(comment, dict):
+            continue
+        if INCOMPLETE_PROMPT_HANDOFF_MARKER in str(comment.get("body") or ""):
+            return True
+    return False
+
+
+def _prompt_issue_is_usable(issue: dict[str, Any], labels: Sequence[str]) -> bool:
+    if _issue_contains_incomplete_prompt_marker(issue):
+        return False
+    required_labels = {label for label in (label.strip() for label in labels) if label}
+    if not required_labels:
+        return True
+    return required_labels.issubset(_issue_label_names(issue))
+
+
 def _existing_prompt_handoff_issue(
     repo_root: Path,
     repo: str,
     handoff: Handoff,
+    labels: Sequence[str],
 ) -> dict[str, Any] | None:
     terms = [
         str(handoff.idempotency_key or "").strip(),
@@ -1231,7 +1303,7 @@ def _existing_prompt_handoff_issue(
                     "--repo",
                     repo,
                     "--json",
-                    "number,title,url,state,body",
+                    "number,title,url,state,body,labels,comments",
                 ],
                 cwd=repo_root,
             )
@@ -1245,6 +1317,8 @@ def _existing_prompt_handoff_issue(
             if not isinstance(viewed, dict):
                 continue
             if str(viewed.get("state") or "").strip().upper() != "OPEN":
+                continue
+            if not _prompt_issue_is_usable(viewed, labels):
                 continue
             haystack = "\n".join(str(viewed.get(key) or "") for key in ("title", "body", "url"))
             if term in haystack:
@@ -1466,29 +1540,11 @@ def _create_issue(
 
 
 def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[str]:
-    prompt_artifact_blocker = _prompt_artifact_blocker(repo_root, handoff)
-    if prompt_artifact_blocker is not None:
-        raise RuntimeError(prompt_artifact_blocker)
-    path = _resolve_prompt_artifact_path(repo_root, handoff)
-    if path is None:
+    artifact = _validated_prompt_artifact_chunks(repo_root, handoff)
+    if artifact is None:
         return []
-    try:
-        artifact_size = path.stat().st_size
-    except OSError as exc:
-        raise RuntimeError("prompt_artifact_unreadable") from exc
-    if artifact_size > MAX_PROMPT_ARTIFACT_BYTES:
-        raise RuntimeError("prompt_artifact_too_large")
-    artifact_bytes = path.read_bytes()
-    if len(artifact_bytes) > MAX_PROMPT_ARTIFACT_BYTES:
-        raise RuntimeError("prompt_artifact_too_large")
-    artifact_sha = hashlib.sha256(artifact_bytes).hexdigest()
-    try:
-        prompt = artifact_bytes.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise RuntimeError("prompt_artifact_not_utf8") from exc
-    chunks = _split_text_by_utf8_bytes(prompt, MAX_PROMPT_ARTIFACT_CHUNK_BYTES)
-    if len(chunks) > MAX_PROMPT_ARTIFACT_CHUNKS:
-        raise RuntimeError("prompt_artifact_too_many_chunks")
+    artifact_sha, chunks = artifact
+    prompt = "".join(chunks)
     bodies: list[str] = []
     total_chunks = len(chunks)
     cursor = 0
@@ -1564,10 +1620,10 @@ def _mark_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, er
     if not number:
         raise RuntimeError("prompt_artifact_issue_url_unparseable")
     body = (
-        "Incomplete prompt handoff issue: required prompt handoff publication "
+        f"{INCOMPLETE_PROMPT_HANDOFF_MARKER} required prompt handoff publication "
         "failed before the handoff became usable. Leaving this issue open so "
-        "prompt identity dedupe can find it and avoid repeated create/close "
-        f"churn.\n\nError: {error}"
+        "operators can inspect it while publisher retries avoid treating it as "
+        f"a terminal issue record.\n\nError: {error}"
     )
     proc = _run(["gh", "issue", "comment", number, "--repo", repo, "--body", body], cwd=repo_root)
     if proc.returncode != 0:
@@ -1636,7 +1692,7 @@ def decide_handoffs(
                 )
                 continue
         if _is_prompt_handoff(handoff):
-            existing_prompt_issue = _existing_prompt_handoff_issue(repo_root, repo, handoff)
+            existing_prompt_issue = _existing_prompt_handoff_issue(repo_root, repo, handoff, labels)
             if existing_prompt_issue:
                 decisions.append(
                     _decision_for_handoff(

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1449,7 +1449,8 @@ def _create_issue(
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
     try:
         _add_prompt_artifact_comments(repo_root, repo, url, prompt_artifact_comment_bodies)
-        _add_issue_labels(repo_root, repo, url, labels)
+        if defer_labels_until_ready:
+            _add_issue_labels(repo_root, repo, url, labels)
     except RuntimeError as exc:
         if defer_labels_until_ready:
             try:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -43,7 +43,6 @@ PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES = 1_000
 MAX_PROMPT_ARTIFACT_CHUNK_BYTES = (
     MAX_PROMPT_ARTIFACT_COMMENT_BYTES - PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES
 )
-MAX_PROMPT_ARTIFACT_COMMENT_CHARS = MAX_PROMPT_ARTIFACT_COMMENT_BYTES
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
@@ -1450,15 +1449,16 @@ def _create_issue(
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
     try:
         _add_prompt_artifact_comments(repo_root, repo, url, prompt_artifact_comment_bodies)
+        _add_issue_labels(repo_root, repo, url, labels)
     except RuntimeError as exc:
-        try:
-            _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
-        except RuntimeError as close_exc:
-            raise RuntimeError(
-                f"{exc}; additionally failed to close incomplete prompt issue: {close_exc}"
-            ) from close_exc
+        if defer_labels_until_ready:
+            try:
+                _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
+            except RuntimeError as close_exc:
+                raise RuntimeError(
+                    f"{exc}; additionally failed to close incomplete prompt issue: {close_exc}"
+                ) from close_exc
         raise
-    _add_issue_labels(repo_root, repo, url, labels)
     return url
 
 
@@ -1551,7 +1551,7 @@ def _close_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, e
     if not number:
         raise RuntimeError("prompt_artifact_issue_url_unparseable")
     body = (
-        "Closing incomplete prompt handoff issue: required prompt artifact comment "
+        "Closing incomplete prompt handoff issue: required prompt handoff "
         f"publication failed before the handoff became usable.\n\nError: {error}"
     )
     proc = _run(["gh", "issue", "close", number, "--repo", repo, "--comment", body], cwd=repo_root)
@@ -1584,13 +1584,13 @@ def _add_issue_labels(repo_root: Path, repo: str, issue_url: str, labels: list[s
         return
     number = _issue_number_from_url(issue_url)
     if not number:
-        return
+        raise RuntimeError("issue_label_issue_url_unparseable")
     proc = _run(
         ["gh", "issue", "edit", number, "--repo", repo, "--add-label", ",".join(labels)],
         cwd=repo_root,
     )
     if proc.returncode != 0:
-        return
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh issue edit failed")
 
 
 def decide_handoffs(

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1429,6 +1429,7 @@ def _create_issue(
     labels: list[str],
 ) -> str:
     prompt_artifact_comment_bodies = _prompt_artifact_comment_bodies(repo_root, handoff)
+    defer_labels_until_ready = _is_prompt_handoff(handoff) or bool(prompt_artifact_comment_bodies)
     args = [
         "gh",
         "issue",
@@ -1440,7 +1441,8 @@ def _create_issue(
         "--body",
         _fit_issue_body(handoff.body),
     ]
-    for label in labels:
+    labels_at_create = [] if defer_labels_until_ready else labels
+    for label in labels_at_create:
         args.extend(["--label", label])
     proc = _run(args, cwd=repo_root)
     if proc.returncode != 0:

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -1456,11 +1456,11 @@ def _create_issue(
     except RuntimeError as exc:
         if defer_labels_until_ready:
             try:
-                _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
-            except RuntimeError as close_exc:
+                _mark_incomplete_prompt_issue(repo_root, repo, url, str(exc))
+            except RuntimeError as mark_exc:
                 raise RuntimeError(
-                    f"{exc}; additionally failed to close incomplete prompt issue: {close_exc}"
-                ) from close_exc
+                    f"{exc}; additionally failed to mark incomplete prompt issue: {mark_exc}"
+                ) from mark_exc
         raise
     return url
 
@@ -1559,20 +1559,22 @@ def _add_prompt_artifact_comments(
             )
 
 
-def _close_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, error: str) -> None:
+def _mark_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, error: str) -> None:
     number = _issue_number_from_url(issue_url)
     if not number:
         raise RuntimeError("prompt_artifact_issue_url_unparseable")
     body = (
-        "Closing incomplete prompt handoff issue: required prompt handoff "
-        f"publication failed before the handoff became usable.\n\nError: {error}"
+        "Incomplete prompt handoff issue: required prompt handoff publication "
+        "failed before the handoff became usable. Leaving this issue open so "
+        "prompt identity dedupe can find it and avoid repeated create/close "
+        f"churn.\n\nError: {error}"
     )
-    proc = _run(["gh", "issue", "close", number, "--repo", repo, "--comment", body], cwd=repo_root)
+    proc = _run(["gh", "issue", "comment", number, "--repo", repo, "--body", body], cwd=repo_root)
     if proc.returncode != 0:
         raise RuntimeError(
             proc.stderr.strip()
             or proc.stdout.strip()
-            or "gh issue close failed for incomplete prompt handoff"
+            or "gh issue comment failed for incomplete prompt handoff"
         )
 
 

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -43,6 +43,8 @@ PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES = 1_000
 MAX_PROMPT_ARTIFACT_CHUNK_BYTES = (
     MAX_PROMPT_ARTIFACT_COMMENT_BYTES - PROMPT_ARTIFACT_COMMENT_OVERHEAD_BYTES
 )
+MAX_PROMPT_ARTIFACT_CHUNKS = 10
+MAX_PROMPT_ARTIFACT_BYTES = MAX_PROMPT_ARTIFACT_CHUNK_BYTES * MAX_PROMPT_ARTIFACT_CHUNKS
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
@@ -1470,13 +1472,23 @@ def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[s
     path = _resolve_prompt_artifact_path(repo_root, handoff)
     if path is None:
         return []
+    try:
+        artifact_size = path.stat().st_size
+    except OSError as exc:
+        raise RuntimeError("prompt_artifact_unreadable") from exc
+    if artifact_size > MAX_PROMPT_ARTIFACT_BYTES:
+        raise RuntimeError("prompt_artifact_too_large")
     artifact_bytes = path.read_bytes()
+    if len(artifact_bytes) > MAX_PROMPT_ARTIFACT_BYTES:
+        raise RuntimeError("prompt_artifact_too_large")
     artifact_sha = hashlib.sha256(artifact_bytes).hexdigest()
     try:
         prompt = artifact_bytes.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise RuntimeError("prompt_artifact_not_utf8") from exc
     chunks = _split_text_by_utf8_bytes(prompt, MAX_PROMPT_ARTIFACT_CHUNK_BYTES)
+    if len(chunks) > MAX_PROMPT_ARTIFACT_CHUNKS:
+        raise RuntimeError("prompt_artifact_too_many_chunks")
     bodies: list[str] = []
     total_chunks = len(chunks)
     cursor = 0

--- a/scripts/publish_automation_handoffs.py
+++ b/scripts/publish_automation_handoffs.py
@@ -39,6 +39,7 @@ DEFAULT_MAX_OPEN_ISSUES = 12
 DEFAULT_COMMAND_TIMEOUT_SECONDS = 45
 MAX_ISSUE_BODY_CHARS = 60_000
 MAX_PROMPT_ARTIFACT_COMMENT_CHARS = 55_000
+PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_BASE_REF = "origin/main"
@@ -176,6 +177,7 @@ class Handoff:
     expires_at: str | None
     idempotency_key: str | None = None
     source_kind: str = "memory"
+    requested_action: str | None = None
     branch: str | None = None
     desired_head: str | None = None
     prompt_artifact_path: str | None = None
@@ -248,6 +250,7 @@ def summary_only_payload(payload: dict[str, Any]) -> dict[str, Any]:
 
 def _gh_write_op(args: list[str]) -> bool:
     return len(args) >= 2 and (args[0], args[1]) in {
+        ("issue", "close"),
         ("issue", "create"),
         ("issue", "edit"),
         ("issue", "comment"),
@@ -663,6 +666,10 @@ def _is_pr_open_request(payload: dict[str, Any]) -> bool:
     )
 
 
+def _is_prompt_handoff(handoff: Handoff) -> bool:
+    return handoff.source_kind == "outbox" and handoff.requested_action == "prompt_handoff"
+
+
 def _outbox_branch_fingerprint(payload: dict[str, Any]) -> str | None:
     requested_action = _normalized_requested_action(payload.get("requested_action"))
     repo = str(payload.get("repo") or "").strip()
@@ -795,13 +802,34 @@ def _stale_outbox_head(repo_root: Path, handoff: Handoff) -> str | None:
     return branch_tip
 
 
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _prompt_artifact_root(handoff: Handoff) -> Path:
+    return (Path(handoff.source_file).resolve().parent / PROMPT_ARTIFACT_DIR).resolve()
+
+
 def _resolve_prompt_artifact_path(repo_root: Path, handoff: Handoff) -> Path | None:
     if not handoff.prompt_artifact_path:
         return None
-    path = Path(handoff.prompt_artifact_path).expanduser()
-    if not path.is_absolute():
-        path = repo_root / path
-    return path
+    raw_path = Path(handoff.prompt_artifact_path)
+    allowed_root = _prompt_artifact_root(handoff)
+    source_root = Path(handoff.source_file).resolve().parent
+    candidates = (
+        [raw_path]
+        if raw_path.is_absolute()
+        else [repo_root / raw_path, source_root / raw_path, allowed_root / raw_path]
+    )
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if _path_is_relative_to(resolved, allowed_root):
+            return resolved
+    return None
 
 
 def _prompt_artifact_sha256(path: Path) -> str:
@@ -811,11 +839,17 @@ def _prompt_artifact_sha256(path: Path) -> str:
 def _prompt_artifact_blocker(repo_root: Path, handoff: Handoff) -> str | None:
     path = _resolve_prompt_artifact_path(repo_root, handoff)
     if path is None:
+        if handoff.prompt_artifact_path:
+            return "prompt_artifact_outside_outbox"
         return None
     if not path.is_file():
         return "prompt_artifact_missing"
     expected_sha = str(handoff.prompt_artifact_sha256 or "").strip()
-    if expected_sha and _prompt_artifact_sha256(path) != expected_sha:
+    if not expected_sha:
+        return "prompt_artifact_sha_missing"
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", expected_sha):
+        return "prompt_artifact_sha_invalid"
+    if _prompt_artifact_sha256(path) != expected_sha.lower():
         return "prompt_artifact_sha_mismatch"
     return None
 
@@ -828,7 +862,7 @@ def _local_handoff_blocker(repo_root: Path, handoff: Handoff) -> PublishDecision
             eligible=False,
             reason=prompt_artifact_blocker,
         )
-    if _stale_outbox_head(repo_root, handoff):
+    if not _is_prompt_handoff(handoff) and _stale_outbox_head(repo_root, handoff):
         return _decision_for_handoff(
             handoff,
             eligible=False,
@@ -1041,6 +1075,7 @@ def _load_outbox_handoffs_with_skip_reasons(
             expires_at=expires_at,
             idempotency_key=idempotency_key,
             source_kind="outbox",
+            requested_action=requested_action,
             branch=_outbox_evidence_value(payload, "branch") or None,
             desired_head=_outbox_desired_head(payload),
             prompt_artifact_path=_outbox_prompt_artifact_path(payload),
@@ -1313,6 +1348,7 @@ def _create_issue(
     *,
     labels: list[str],
 ) -> str:
+    prompt_artifact_comment_bodies = _prompt_artifact_comment_bodies(repo_root, handoff)
     args = [
         "gh",
         "issue",
@@ -1330,12 +1366,19 @@ def _create_issue(
     if proc.returncode != 0:
         raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh issue create failed")
     url = str(proc.stdout or "").strip().splitlines()[-1].strip()
-    _add_prompt_artifact_comments(repo_root, repo, url, handoff)
+    try:
+        _add_prompt_artifact_comments(repo_root, repo, url, prompt_artifact_comment_bodies)
+    except RuntimeError as exc:
+        _close_incomplete_prompt_issue(repo_root, repo, url, str(exc))
+        raise
     _add_issue_labels(repo_root, repo, url, labels)
     return url
 
 
 def _prompt_artifact_comment_bodies(repo_root: Path, handoff: Handoff) -> list[str]:
+    prompt_artifact_blocker = _prompt_artifact_blocker(repo_root, handoff)
+    if prompt_artifact_blocker is not None:
+        raise RuntimeError(prompt_artifact_blocker)
     path = _resolve_prompt_artifact_path(repo_root, handoff)
     if path is None:
         return []
@@ -1367,12 +1410,12 @@ def _add_prompt_artifact_comments(
     repo_root: Path,
     repo: str,
     issue_url: str,
-    handoff: Handoff,
+    bodies: list[str],
 ) -> None:
     number = _issue_number_from_url(issue_url)
     if not number:
         return
-    for body in _prompt_artifact_comment_bodies(repo_root, handoff):
+    for body in bodies:
         proc = _run(
             ["gh", "issue", "comment", number, "--repo", repo, "--body", body],
             cwd=repo_root,
@@ -1383,6 +1426,17 @@ def _add_prompt_artifact_comments(
                 or proc.stdout.strip()
                 or "gh issue comment failed for prompt artifact"
             )
+
+
+def _close_incomplete_prompt_issue(repo_root: Path, repo: str, issue_url: str, error: str) -> None:
+    number = _issue_number_from_url(issue_url)
+    if not number:
+        return
+    body = (
+        "Closing incomplete prompt handoff issue: required prompt artifact comment "
+        f"publication failed before the handoff became usable.\n\nError: {error}"
+    )
+    _run(["gh", "issue", "close", number, "--repo", repo, "--comment", body], cwd=repo_root)
 
 
 def _fit_issue_body(body: str) -> str:
@@ -1430,17 +1484,18 @@ def decide_handoffs(
         if local_blocker is not None:
             decisions.append(local_blocker)
             continue
-        target_pr = _target_open_pr(repo_root, repo, handoff)
-        if target_pr:
-            decisions.append(
-                _decision_for_handoff(
-                    handoff,
-                    eligible=False,
-                    reason="target_open_pr",
-                    existing_pr_url=str(target_pr.get("url") or ""),
+        if not _is_prompt_handoff(handoff):
+            target_pr = _target_open_pr(repo_root, repo, handoff)
+            if target_pr:
+                decisions.append(
+                    _decision_for_handoff(
+                        handoff,
+                        eligible=False,
+                        reason="target_open_pr",
+                        existing_pr_url=str(target_pr.get("url") or ""),
+                    )
                 )
-            )
-            continue
+                continue
         existing = _existing_issue(repo_root, repo, handoff.task_title)
         if existing:
             decisions.append(
@@ -1452,28 +1507,29 @@ def decide_handoffs(
                 )
             )
             continue
-        referenced_pr = _referenced_pr(repo_root, repo, handoff)
-        if referenced_pr and _pr_head_satisfies_handoff(handoff, referenced_pr):
-            decisions.append(
-                _decision_for_handoff(
-                    handoff,
-                    eligible=False,
-                    reason="existing_pr",
-                    existing_pr_url=str(referenced_pr.get("url") or ""),
+        if not _is_prompt_handoff(handoff):
+            referenced_pr = _referenced_pr(repo_root, repo, handoff)
+            if referenced_pr and _pr_head_satisfies_handoff(handoff, referenced_pr):
+                decisions.append(
+                    _decision_for_handoff(
+                        handoff,
+                        eligible=False,
+                        reason="existing_pr",
+                        existing_pr_url=str(referenced_pr.get("url") or ""),
+                    )
                 )
-            )
-            continue
-        existing_pr = _existing_pr(repo_root, repo, handoff.task_title)
-        if existing_pr and _pr_head_satisfies_handoff(handoff, existing_pr):
-            decisions.append(
-                _decision_for_handoff(
-                    handoff,
-                    eligible=False,
-                    reason="existing_pr",
-                    existing_pr_url=str(existing_pr.get("url") or ""),
+                continue
+            existing_pr = _existing_pr(repo_root, repo, handoff.task_title)
+            if existing_pr and _pr_head_satisfies_handoff(handoff, existing_pr):
+                decisions.append(
+                    _decision_for_handoff(
+                        handoff,
+                        eligible=False,
+                        reason="existing_pr",
+                        existing_pr_url=str(existing_pr.get("url") or ""),
+                    )
                 )
-            )
-            continue
+                continue
         if open_issue_count >= max_open_issues:
             decisions.append(
                 _decision_for_handoff(

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -49,6 +49,7 @@ UTC = timezone.utc
 DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_ARCHIVE_DIR = Path(".aragora/automation-outbox-archive")
+PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 
 # Bounded terminal-archive policy for the existing_issue deadlock:
 # the publisher refuses to open a duplicate PR because a GitHub issue already
@@ -780,6 +781,78 @@ def _is_prompt_handoff_payload(payload: Mapping[str, Any]) -> bool:
         if kind.strip().lower().replace("-", "_") == "prompt_handoff":
             return True
     return False
+
+
+def _path_is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _prompt_artifact_path_value(payload: Mapping[str, Any]) -> str:
+    requested_action = _mapping_from_action(payload.get("requested_action"))
+    if requested_action is not None:
+        value = str(requested_action.get("prompt_artifact_path") or "").strip()
+        if value:
+            return value
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        value = str(local_evidence.get("prompt_artifact_path") or "").strip()
+        if value:
+            return value
+    return str(payload.get("prompt_artifact_path") or "").strip()
+
+
+def _resolve_prompt_artifact_path(
+    *,
+    repo_root: Path,
+    outbox_path: Path,
+    payload: Mapping[str, Any],
+) -> Path | None:
+    raw_value = _prompt_artifact_path_value(payload)
+    if not raw_value:
+        return None
+    raw_path = Path(raw_value)
+    allowed_root = (outbox_path.parent / PROMPT_ARTIFACT_DIR).resolve()
+    candidates = (
+        [raw_path]
+        if raw_path.is_absolute()
+        else [repo_root / raw_path, outbox_path.parent / raw_path, allowed_root / raw_path]
+    )
+    for candidate in candidates:
+        resolved = candidate.resolve(strict=False)
+        if _path_is_relative_to(resolved, allowed_root):
+            return resolved
+    return None
+
+
+def _archive_prompt_handoff_files(
+    *,
+    repo_root: Path,
+    outbox_path: Path,
+    archive_dir: Path,
+    payload: Mapping[str, Any],
+) -> None:
+    artifact_path = _resolve_prompt_artifact_path(
+        repo_root=repo_root,
+        outbox_path=outbox_path,
+        payload=payload,
+    )
+    archived_artifact_path: Path | None = None
+    if artifact_path is not None and artifact_path.exists():
+        archived_artifact_path = archive_dir / PROMPT_ARTIFACT_DIR / artifact_path.name
+        archived_artifact_path.parent.mkdir(parents=True, exist_ok=True)
+        if archived_artifact_path.exists():
+            raise RuntimeError(
+                f"prompt_artifact_archive_destination_exists: {archived_artifact_path}"
+            )
+        shutil.copy2(artifact_path, archived_artifact_path)
+
+    shutil.move(str(outbox_path), str(archive_dir / outbox_path.name))
+
+    if artifact_path is not None and artifact_path.exists():
+        artifact_path.unlink()
 
 
 def _is_pr_publication_request(payload: Mapping[str, Any]) -> bool:
@@ -1665,7 +1738,12 @@ def main(argv: list[str] | None = None) -> int:
                     }
                 )
                 if args.apply:
-                    shutil.move(str(path), str(archive_dir / path.name))
+                    _archive_prompt_handoff_files(
+                        repo_root=root,
+                        outbox_path=path,
+                        archive_dir=archive_dir,
+                        payload=payload,
+                    )
                 continue
             counts["still_protecting_active_work"] += 1
             actions.append(

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -50,6 +50,9 @@ DEFAULT_OUTBOX_DIR = Path(".aragora/automation-outbox")
 DEFAULT_RECEIPT_DIR = Path(".aragora/automation-receipts")
 DEFAULT_ARCHIVE_DIR = Path(".aragora/automation-outbox-archive")
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
+DEFAULT_PROMPT_HANDOFF_LABELS = ("boss-ready",)
+INCOMPLETE_PROMPT_HANDOFF_MARKER = "Incomplete prompt handoff issue:"
+COMPLETE_PROMPT_HANDOFF_MARKER = "Completed prompt handoff issue:"
 
 # Bounded terminal-archive policy for the existing_issue deadlock:
 # the publisher refuses to open a duplicate PR because a GitHub issue already
@@ -1028,6 +1031,17 @@ def _issue_url_from_receipt(receipt: Mapping[str, Any]) -> str:
     return ""
 
 
+def _receipt_labels(receipt: Mapping[str, Any]) -> list[str]:
+    raw_labels = receipt.get("labels")
+    if isinstance(raw_labels, str):
+        labels = [item.strip() for item in raw_labels.split(",")]
+    elif isinstance(raw_labels, Sequence) and not isinstance(raw_labels, (bytes, bytearray, str)):
+        labels = [str(item).strip() for item in raw_labels]
+    else:
+        labels = []
+    return [label for label in labels if label] or list(DEFAULT_PROMPT_HANDOFF_LABELS)
+
+
 def _issue_number_from_url(url: str) -> int | None:
     text = str(url or "").strip().rstrip("/")
     marker = "/issues/"
@@ -1113,7 +1127,7 @@ class _IssueStateChecker:
                     "--repo",
                     repo,
                     "--json",
-                    "number,state,stateReason,url",
+                    "number,state,stateReason,url,body,labels,comments",
                 ],
                 cwd=self._root,
                 text=True,
@@ -1133,6 +1147,73 @@ class _IssueStateChecker:
         if not isinstance(payload, Mapping):
             return None, "gh issue view returned non-mapping JSON"
         return payload, None
+
+
+def _issue_label_names(issue: Mapping[str, Any]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, Sequence) or isinstance(labels, (bytes, bytearray, str)):
+        return set()
+    names: set[str] = set()
+    for item in labels:
+        if isinstance(item, Mapping):
+            name = str(item.get("name") or "").strip()
+        else:
+            name = str(item or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _issue_comment_bodies(issue: Mapping[str, Any]) -> list[str]:
+    comments = issue.get("comments")
+    if not isinstance(comments, Sequence) or isinstance(comments, (bytes, bytearray, str)):
+        return []
+    bodies: list[str] = []
+    for comment in comments:
+        if isinstance(comment, Mapping):
+            bodies.append(str(comment.get("body") or ""))
+    return bodies
+
+
+def _issue_contains_marker(issue: Mapping[str, Any], marker: str) -> bool:
+    if marker in str(issue.get("body") or ""):
+        return True
+    return any(marker in body for body in _issue_comment_bodies(issue))
+
+
+def _issue_contains_incomplete_prompt_marker(issue: Mapping[str, Any]) -> bool:
+    if _issue_contains_marker(issue, COMPLETE_PROMPT_HANDOFF_MARKER):
+        return False
+    return _issue_contains_marker(issue, INCOMPLETE_PROMPT_HANDOFF_MARKER)
+
+
+def _prompt_handoff_receipt_keep_reason(
+    issue_checker: _IssueStateChecker,
+    receipt: Mapping[str, Any],
+) -> str | None:
+    issue_url = _issue_url_from_receipt(receipt)
+    if not issue_url:
+        return "prompt handoff receipt has no linked issue URL"
+    issue_state, error = issue_checker.state(issue_url, receipt)
+    if issue_state is None:
+        return f"prompt handoff receipt issue state unverified ({error})"
+    if _issue_contains_incomplete_prompt_marker(issue_state):
+        return "prompt handoff receipt issue is marked incomplete"
+    state = str(issue_state.get("state") or "").strip().upper()
+    state_reason = str(issue_state.get("stateReason") or "").strip().upper()
+    if state == "CLOSED" and state_reason == "COMPLETED":
+        return None
+    if state != "OPEN":
+        return (
+            f"prompt handoff receipt issue {issue_url} is "
+            f"{state or 'UNKNOWN'}/{state_reason or 'unknown'}, not open or closed-completed"
+        )
+    missing_labels = sorted(set(_receipt_labels(receipt)) - _issue_label_names(issue_state))
+    if missing_labels:
+        return "prompt handoff receipt issue missing required prompt labels: " + ", ".join(
+            missing_labels
+        )
+    return None
 
 
 def _existing_issue_terminal_candidate(
@@ -1727,6 +1808,19 @@ def main(argv: list[str] | None = None) -> int:
         receipt = receipt_payloads_by_key.get(idem)
         if is_prompt_handoff:
             if receipt is not None:
+                keep_reason = _prompt_handoff_receipt_keep_reason(issue_checker, receipt)
+                if keep_reason is not None:
+                    counts["still_protecting_active_work"] += 1
+                    actions.append(
+                        {
+                            "path": str(path),
+                            "branch": branch,
+                            "decision": "keep",
+                            "reason": keep_reason,
+                            "synthetic_receipt": False,
+                        }
+                    )
+                    continue
                 counts["satisfied_by_existing_receipt"] += 1
                 actions.append(
                     {

--- a/scripts/reconcile_automation_outbox.py
+++ b/scripts/reconcile_automation_outbox.py
@@ -761,10 +761,25 @@ def _requested_action_type(payload: Mapping[str, Any]) -> str:
     requested_action = payload.get("requested_action")
     requested_action_mapping = _mapping_from_action(requested_action)
     if requested_action_mapping is not None:
-        return str(requested_action_mapping.get("type") or "").strip().lower()
+        return str(requested_action_mapping.get("type") or "").strip().lower().replace("-", "_")
     if isinstance(requested_action, str):
-        return requested_action.strip().lower()
+        return requested_action.strip().lower().replace("-", "_")
     return ""
+
+
+def _is_prompt_handoff_payload(payload: Mapping[str, Any]) -> bool:
+    if _requested_action_type(payload) == "prompt_handoff":
+        return True
+    for local_evidence in _local_evidence_mappings(payload.get("local_evidence")):
+        kind = str(
+            local_evidence.get("kind")
+            or local_evidence.get("type")
+            or local_evidence.get("requested_action")
+            or ""
+        )
+        if kind.strip().lower().replace("-", "_") == "prompt_handoff":
+            return True
+    return False
 
 
 def _is_pr_publication_request(payload: Mapping[str, Any]) -> bool:
@@ -1630,12 +1645,40 @@ def main(argv: list[str] | None = None) -> int:
         payload["__source_file"] = str(path)
         idem = str(payload.get("idempotency_key") or "").strip()
         branch = _branch_from_payload(payload)
+        is_prompt_handoff = _is_prompt_handoff_payload(payload)
 
-        if not idem or not branch:
+        if not idem or (not branch and not is_prompt_handoff):
             counts["skipped_unparseable"] += 1
             continue
 
         receipt = receipt_payloads_by_key.get(idem)
+        if is_prompt_handoff:
+            if receipt is not None:
+                counts["satisfied_by_existing_receipt"] += 1
+                actions.append(
+                    {
+                        "path": str(path),
+                        "branch": branch,
+                        "decision": "archive",
+                        "reason": "matching prompt handoff receipt exists",
+                        "synthetic_receipt": False,
+                    }
+                )
+                if args.apply:
+                    shutil.move(str(path), str(archive_dir / path.name))
+                continue
+            counts["still_protecting_active_work"] += 1
+            actions.append(
+                {
+                    "path": str(path),
+                    "branch": branch,
+                    "decision": "keep",
+                    "reason": "prompt handoff transport record pending publication",
+                    "synthetic_receipt": False,
+                }
+            )
+            continue
+
         if receipt is not None:
             issue_only_keep_reason = _issue_only_pr_receipt_keep_reason(payload, receipt)
             if issue_only_keep_reason is not None:

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -318,11 +318,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        prompt = _read_prompt(args).strip()
+        prompt = _read_prompt(args)
     except OSError as exc:
         print(f"error: failed to read prompt: {exc}", file=sys.stderr)
         return 2
-    if not prompt:
+    if not prompt.strip():
         print("error: prompt must not be empty", file=sys.stderr)
         return 2
 

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -23,6 +23,9 @@ DEFAULT_OUTBOX_DIR = Path(".aragora") / "automation-outbox"
 DEFAULT_REPO = "synaptent/aragora"
 SCHEMA_VERSION = "aragora-prompt-handoff/1.0"
 MAX_INLINE_PROMPT_CHARS = 40_000
+PUBLISHER_MAX_ISSUE_BODY_BYTES = 60_000
+INLINE_PROMPT_BODY_SAFETY_BYTES = 2_000
+MAX_INLINE_PROMPT_BODY_BYTES = PUBLISHER_MAX_ISSUE_BODY_BYTES - INLINE_PROMPT_BODY_SAFETY_BYTES
 PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
 PROMPT_PREVIEW_CHARS = 2_000
 
@@ -79,8 +82,60 @@ def _default_idempotency_key(
     return f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}-{target_sha[:12]}"
 
 
-def _needs_prompt_artifact(prompt: str) -> bool:
-    return len(prompt) > MAX_INLINE_PROMPT_CHARS
+def _format_json_block(value: Any) -> str:
+    if value is None or value == "":
+        return "NONE"
+    if isinstance(value, str):
+        return value.strip() or "NONE"
+    return json.dumps(value, indent=2, sort_keys=True)
+
+
+def _format_outbox_body(payload: dict[str, Any], source_file: Path) -> str:
+    fields = [
+        ("Task", payload.get("task")),
+        ("Requested Action", payload.get("requested_action")),
+        ("Requires GitHub", payload.get("requires_github")),
+        ("Repo", payload.get("repo")),
+        ("Created At", payload.get("created_at")),
+        ("Idempotency Key", payload.get("idempotency_key")),
+        ("Local Evidence", payload.get("local_evidence")),
+        ("Validation", payload.get("validation")),
+    ]
+    lines: list[str] = []
+    for label, value in fields:
+        formatted = _format_json_block(value)
+        lines.append(f"{label}:")
+        if "\n" in formatted or formatted.startswith("{") or formatted.startswith("["):
+            lines.append("```json" if formatted.startswith(("{", "[")) else "```")
+            lines.append(formatted)
+            lines.append("```")
+        else:
+            lines.append(formatted)
+        lines.append("")
+    lines.append("---")
+    lines.append(f"Published from automation outbox: `{source_file}`")
+    return "\n".join(lines).strip()
+
+
+def _body_utf8_bytes(value: str) -> int:
+    return len(value.encode("utf-8"))
+
+
+def _inline_prompt_body_bytes(payload: dict[str, Any], source_file: Path) -> int:
+    return _body_utf8_bytes(_format_outbox_body(payload, source_file))
+
+
+def _needs_prompt_artifact(
+    prompt: str,
+    *,
+    inline_payload: dict[str, Any] | None = None,
+    source_file: Path | None = None,
+) -> bool:
+    if len(prompt) > MAX_INLINE_PROMPT_CHARS:
+        return True
+    if inline_payload is not None and source_file is not None:
+        return _inline_prompt_body_bytes(inline_payload, source_file) > MAX_INLINE_PROMPT_BODY_BYTES
+    return False
 
 
 def _prompt_artifact_path(outbox_dir: Path, idempotency_key: str, prompt_sha: str) -> Path:
@@ -290,12 +345,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     outbox_dir = args.outbox_dir.expanduser()
     outbox_path = _output_path(outbox_dir, key)
-    prompt_artifact_path = (
-        _prompt_artifact_path(outbox_dir, key, prompt_sha)
-        if _needs_prompt_artifact(prompt)
-        else None
-    )
-    payload = build_payload(
+    inline_payload = build_payload(
         prompt=prompt,
         task=task,
         repo=repo,
@@ -306,7 +356,29 @@ def main(argv: list[str] | None = None) -> int:
         validation=validation,
         target=target,
         idempotency_key=key,
-        prompt_artifact_path=str(prompt_artifact_path) if prompt_artifact_path else None,
+        prompt_artifact_path=None,
+    )
+    prompt_artifact_path = (
+        _prompt_artifact_path(outbox_dir, key, prompt_sha)
+        if _needs_prompt_artifact(prompt, inline_payload=inline_payload, source_file=outbox_path)
+        else None
+    )
+    payload = (
+        build_payload(
+            prompt=prompt,
+            task=task,
+            repo=repo,
+            source=str(args.source),
+            priority=str(args.priority),
+            created_at=created_at,
+            expires_hours=args.expires_hours,
+            validation=validation,
+            target=target,
+            idempotency_key=key,
+            prompt_artifact_path=str(prompt_artifact_path),
+        )
+        if prompt_artifact_path is not None
+        else inline_payload
     )
 
     result: dict[str, Any] = {

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -22,6 +22,9 @@ from typing import Any
 DEFAULT_OUTBOX_DIR = Path(".aragora") / "automation-outbox"
 DEFAULT_REPO = "synaptent/aragora"
 SCHEMA_VERSION = "aragora-prompt-handoff/1.0"
+MAX_INLINE_PROMPT_CHARS = 40_000
+PROMPT_ARTIFACT_DIR = "_prompt-artifacts"
+PROMPT_PREVIEW_CHARS = 2_000
 
 
 def _utc_now() -> datetime:
@@ -60,6 +63,31 @@ def _read_prompt(args: argparse.Namespace) -> str:
     return Path(raw_path).expanduser().read_text(encoding="utf-8")
 
 
+def _prompt_sha(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+
+def _default_idempotency_key(
+    *, task: str, prompt_sha: str, repo: str, target: dict[str, Any]
+) -> str:
+    target_material = json.dumps(
+        {"repo": repo, "target": target},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    target_sha = hashlib.sha256(target_material.encode("utf-8")).hexdigest()
+    return f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}-{target_sha[:12]}"
+
+
+def _needs_prompt_artifact(prompt: str) -> bool:
+    return len(prompt) > MAX_INLINE_PROMPT_CHARS
+
+
+def _prompt_artifact_path(outbox_dir: Path, idempotency_key: str, prompt_sha: str) -> Path:
+    filename = f"{_slug(idempotency_key, limit=100)}-{prompt_sha[:12]}.prompt.md"
+    return outbox_dir / PROMPT_ARTIFACT_DIR / filename
+
+
 def _target_fields(args: argparse.Namespace) -> dict[str, Any]:
     target: dict[str, Any] = {}
     if args.pr is not None:
@@ -85,29 +113,49 @@ def build_payload(
     validation: list[str],
     target: dict[str, Any],
     idempotency_key: str | None = None,
+    prompt_artifact_path: str | None = None,
 ) -> dict[str, Any]:
     """Return a publisher-compatible automation-outbox payload."""
 
-    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    target_material = json.dumps(
-        {"repo": repo, "target": target},
-        sort_keys=True,
-        separators=(",", ":"),
+    prompt_sha = _prompt_sha(prompt)
+    key = idempotency_key or _default_idempotency_key(
+        task=task,
+        prompt_sha=prompt_sha,
+        repo=repo,
+        target=target,
     )
-    target_sha = hashlib.sha256(target_material.encode("utf-8")).hexdigest()
-    key = idempotency_key or f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}-{target_sha[:12]}"
     local_evidence: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "kind": "prompt_handoff",
         "source": source,
         "prompt_sha256": prompt_sha,
         "prompt_chars": len(prompt),
-        "prompt": prompt,
     }
     requested_action: dict[str, Any] = {
         "type": "prompt_handoff",
         "prompt_sha256": prompt_sha,
     }
+    if prompt_artifact_path:
+        prompt_preview = prompt[:PROMPT_PREVIEW_CHARS]
+        prompt_overflow = {
+            "prompt_truncated": True,
+            "prompt_artifact_path": prompt_artifact_path,
+            "prompt_artifact_sha256": prompt_sha,
+            "prompt_preview": prompt_preview,
+            "prompt_preview_chars": len(prompt_preview),
+            "prompt_omitted_chars": max(len(prompt) - len(prompt_preview), 0),
+        }
+        local_evidence.update(prompt_overflow)
+        requested_action.update(
+            {
+                "prompt_truncated": True,
+                "prompt_artifact_path": prompt_artifact_path,
+                "prompt_artifact_sha256": prompt_sha,
+            }
+        )
+    else:
+        local_evidence["prompt"] = prompt
+
     branch = str(target.get("branch") or "").strip()
     expected_head = str(target.get("expected_head") or "").strip()
     target_payload = dict(target)
@@ -228,21 +276,37 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     validation = list(args.validation) or _default_validation(str(args.source))
+    task = args.task or _default_task(prompt)
+    repo = str(args.repo)
+    target = _target_fields(args)
+    prompt_sha = _prompt_sha(prompt)
+    key = args.idempotency_key or _default_idempotency_key(
+        task=task,
+        prompt_sha=prompt_sha,
+        repo=repo,
+        target=target,
+    )
+    outbox_dir = args.outbox_dir.expanduser()
+    outbox_path = _output_path(outbox_dir, key)
+    prompt_artifact_path = (
+        _prompt_artifact_path(outbox_dir, key, prompt_sha)
+        if _needs_prompt_artifact(prompt)
+        else None
+    )
     payload = build_payload(
         prompt=prompt,
-        task=args.task or _default_task(prompt),
-        repo=str(args.repo),
+        task=task,
+        repo=repo,
         source=str(args.source),
         priority=str(args.priority),
         created_at=created_at,
         expires_hours=args.expires_hours,
         validation=validation,
-        target=_target_fields(args),
-        idempotency_key=args.idempotency_key,
+        target=target,
+        idempotency_key=key,
+        prompt_artifact_path=str(prompt_artifact_path) if prompt_artifact_path else None,
     )
 
-    outbox_dir = args.outbox_dir.expanduser()
-    outbox_path = _output_path(outbox_dir, str(payload["idempotency_key"]))
     result: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "apply": bool(args.apply),
@@ -250,12 +314,20 @@ def main(argv: list[str] | None = None) -> int:
         "outbox_path": str(outbox_path),
         "payload": payload,
     }
+    if prompt_artifact_path is not None:
+        result["prompt_artifact_path"] = str(prompt_artifact_path)
 
     if args.apply:
         if outbox_path.exists() and not args.force:
             print(f"error: handoff already exists: {outbox_path}", file=sys.stderr)
             return 2
+        if prompt_artifact_path is not None and prompt_artifact_path.exists() and not args.force:
+            print(f"error: prompt artifact already exists: {prompt_artifact_path}", file=sys.stderr)
+            return 2
         outbox_dir.mkdir(parents=True, exist_ok=True)
+        if prompt_artifact_path is not None:
+            prompt_artifact_path.parent.mkdir(parents=True, exist_ok=True)
+            prompt_artifact_path.write_text(prompt, encoding="utf-8")
         outbox_path.write_text(
             json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Write a generated next prompt as an automation-outbox handoff.
+
+This is transport glue only: it does not call GitHub and it does not decide
+whether a prompt is safe to execute. It converts a prompt that was already
+built by repo-native tooling into the JSON contract consumed by
+``scripts/publish_automation_handoffs.py`` so the existing publisher can move
+prompt handoffs to repo-visible GitHub issues.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OUTBOX_DIR = Path(".aragora") / "automation-outbox"
+DEFAULT_REPO = "synaptent/aragora"
+SCHEMA_VERSION = "aragora-prompt-handoff/1.0"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def _iso_utc(value: datetime) -> str:
+    return value.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_utc(value: str) -> datetime:
+    text = value.strip()
+    if not text:
+        raise ValueError("timestamp must not be empty")
+    parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC).replace(microsecond=0)
+
+
+def _slug(text: str, *, limit: int = 80) -> str:
+    lowered = text.strip().lower()
+    slug = re.sub(r"[^a-z0-9_.-]+", "-", lowered).strip("-._")
+    slug = re.sub(r"-{2,}", "-", slug)
+    if not slug:
+        return "prompt-handoff"
+    return slug[:limit].strip("-._") or "prompt-handoff"
+
+
+def _read_prompt(args: argparse.Namespace) -> str:
+    if args.prompt is not None:
+        return str(args.prompt)
+    raw_path = str(args.prompt_file)
+    if raw_path == "-":
+        return sys.stdin.read()
+    return Path(raw_path).expanduser().read_text(encoding="utf-8")
+
+
+def _target_fields(args: argparse.Namespace) -> dict[str, Any]:
+    target: dict[str, Any] = {}
+    if args.pr is not None:
+        target["pr"] = int(args.pr)
+    if args.branch:
+        target["branch"] = str(args.branch)
+    if args.lane_id:
+        target["lane_id"] = str(args.lane_id)
+    if args.expected_head:
+        target["expected_head"] = str(args.expected_head)
+    return target
+
+
+def build_payload(
+    *,
+    prompt: str,
+    task: str,
+    repo: str,
+    source: str,
+    priority: str,
+    created_at: datetime,
+    expires_hours: float | None,
+    validation: list[str],
+    target: dict[str, Any],
+    idempotency_key: str | None = None,
+) -> dict[str, Any]:
+    """Return a publisher-compatible automation-outbox payload."""
+
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    key = idempotency_key or f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}"
+    local_evidence: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "prompt_handoff",
+        "source": source,
+        "prompt_sha256": prompt_sha,
+        "prompt_chars": len(prompt),
+        "prompt": prompt,
+    }
+    if target:
+        local_evidence["target"] = target
+
+    requested_action: dict[str, Any] = {
+        "type": "prompt_handoff",
+        "prompt_sha256": prompt_sha,
+    }
+    if target:
+        requested_action["target"] = target
+
+    payload: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "task": task,
+        "requires_github": True,
+        "requested_action": requested_action,
+        "repo": repo,
+        "priority": priority,
+        "created_at": _iso_utc(created_at),
+        "idempotency_key": key,
+        "local_evidence": local_evidence,
+        "validation": validation,
+    }
+    if expires_hours is not None and expires_hours > 0:
+        payload["expires_at"] = _iso_utc(created_at + timedelta(hours=expires_hours))
+    return payload
+
+
+def _output_path(outbox_dir: Path, idempotency_key: str) -> Path:
+    return outbox_dir / f"{_slug(idempotency_key, limit=140)}.json"
+
+
+def _default_task(prompt: str) -> str:
+    first_line = next((line.strip() for line in prompt.splitlines() if line.strip()), "")
+    if not first_line:
+        return "Prompt handoff"
+    return f"Prompt handoff: {first_line[:96]}"
+
+
+def _default_validation(source: str) -> list[str]:
+    return [
+        f"Prompt source: {source}",
+        "python3 scripts/publish_automation_handoffs.py --summary-only --json",
+    ]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt", help="Prompt text to store in the handoff")
+    prompt_group.add_argument(
+        "--prompt-file",
+        help="Path to prompt text, or '-' to read from stdin",
+    )
+    parser.add_argument("--task", help="GitHub issue task title for the handoff")
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Target GitHub OWNER/REPO")
+    parser.add_argument(
+        "--source",
+        default="manual-prompt",
+        help="Human-readable source command or artifact path for the prompt",
+    )
+    parser.add_argument("--priority", default="automation-quality")
+    parser.add_argument("--pr", type=int, help="Optional PR target carried as metadata")
+    parser.add_argument("--branch", help="Optional branch target carried as metadata")
+    parser.add_argument("--lane-id", help="Optional lane target carried as metadata")
+    parser.add_argument("--expected-head", help="Optional exact head carried as metadata")
+    parser.add_argument(
+        "--validation",
+        action="append",
+        default=[],
+        help="Validation or publication command to include; repeatable",
+    )
+    parser.add_argument(
+        "--expires-hours",
+        type=float,
+        default=72.0,
+        help="Expiry horizon for stale prompts; <=0 omits expires_at",
+    )
+    parser.add_argument(
+        "--outbox-dir",
+        type=Path,
+        default=DEFAULT_OUTBOX_DIR,
+        help="Automation outbox directory to write under with --apply",
+    )
+    parser.add_argument("--idempotency-key", help="Override deterministic handoff key")
+    parser.add_argument("--created-at", help=argparse.SUPPRESS)
+    parser.add_argument("--apply", action="store_true", help="Write the JSON handoff")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing handoff file")
+    parser.add_argument("--json", action="store_true", help="Emit JSON result")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        prompt = _read_prompt(args).strip()
+    except OSError as exc:
+        print(f"error: failed to read prompt: {exc}", file=sys.stderr)
+        return 2
+    if not prompt:
+        print("error: prompt must not be empty", file=sys.stderr)
+        return 2
+
+    try:
+        created_at = _parse_utc(args.created_at) if args.created_at else _utc_now()
+    except ValueError as exc:
+        print(f"error: invalid --created-at: {exc}", file=sys.stderr)
+        return 2
+
+    validation = list(args.validation) or _default_validation(str(args.source))
+    payload = build_payload(
+        prompt=prompt,
+        task=args.task or _default_task(prompt),
+        repo=str(args.repo),
+        source=str(args.source),
+        priority=str(args.priority),
+        created_at=created_at,
+        expires_hours=args.expires_hours,
+        validation=validation,
+        target=_target_fields(args),
+        idempotency_key=args.idempotency_key,
+    )
+
+    outbox_dir = args.outbox_dir.expanduser()
+    outbox_path = _output_path(outbox_dir, str(payload["idempotency_key"]))
+    result: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "apply": bool(args.apply),
+        "wrote": False,
+        "outbox_path": str(outbox_path),
+        "payload": payload,
+    }
+
+    if args.apply:
+        if outbox_path.exists() and not args.force:
+            print(f"error: handoff already exists: {outbox_path}", file=sys.stderr)
+            return 2
+        outbox_dir.mkdir(parents=True, exist_ok=True)
+        outbox_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        result["wrote"] = True
+
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        action = "wrote" if result["wrote"] else "would write"
+        print(f"{action}: {outbox_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -104,15 +104,28 @@ def build_payload(
         "prompt_chars": len(prompt),
         "prompt": prompt,
     }
-    if target:
-        local_evidence["target"] = target
-
     requested_action: dict[str, Any] = {
         "type": "prompt_handoff",
         "prompt_sha256": prompt_sha,
     }
-    if target:
-        requested_action["target"] = target
+    branch = str(target.get("branch") or "").strip()
+    expected_head = str(target.get("expected_head") or "").strip()
+    target_payload = dict(target)
+    if branch:
+        local_evidence["branch"] = branch
+        requested_action["branch"] = branch
+    if expected_head:
+        local_evidence["desired_head_sha"] = expected_head
+        local_evidence["head_sha"] = expected_head
+        requested_action["desired_head_sha"] = expected_head
+        requested_action["head_sha"] = expected_head
+        target_payload.setdefault("desired_head_sha", expected_head)
+        target_payload.setdefault("head_sha", expected_head)
+    if target_payload:
+        local_evidence["target"] = target_payload
+
+    if target_payload:
+        requested_action["target"] = target_payload
 
     payload: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -89,7 +89,13 @@ def build_payload(
     """Return a publisher-compatible automation-outbox payload."""
 
     prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
-    key = idempotency_key or f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}"
+    target_material = json.dumps(
+        {"repo": repo, "target": target},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    target_sha = hashlib.sha256(target_material.encode("utf-8")).hexdigest()
+    key = idempotency_key or f"prompt-handoff-{_slug(task)}-{prompt_sha[:12]}-{target_sha[:12]}"
     local_evidence: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "kind": "prompt_handoff",

--- a/scripts/write_prompt_handoff_outbox.py
+++ b/scripts/write_prompt_handoff_outbox.py
@@ -141,6 +141,7 @@ def build_payload(
             "prompt_truncated": True,
             "prompt_artifact_path": prompt_artifact_path,
             "prompt_artifact_sha256": prompt_sha,
+            "prompt_artifact_publication": "github_issue_comments",
             "prompt_preview": prompt_preview,
             "prompt_preview_chars": len(prompt_preview),
             "prompt_omitted_chars": max(len(prompt) - len(prompt_preview), 0),
@@ -151,6 +152,7 @@ def build_payload(
                 "prompt_truncated": True,
                 "prompt_artifact_path": prompt_artifact_path,
                 "prompt_artifact_sha256": prompt_sha,
+                "prompt_artifact_publication": "github_issue_comments",
             }
         )
     else:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -3122,6 +3122,7 @@ def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path)
 def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
+    operations: list[str] = []
     issue_bodies: list[str] = []
     comment_bodies: list[str] = []
     prompt = "Start from live repo truth.\n" + ("x" * 1000) + "END-OF-PROMPT"
@@ -3132,14 +3133,20 @@ def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
 
     def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
+            operations.append("create")
+            assert "--label" not in args
             issue_bodies.append(args[args.index("--body") + 1])
             return subprocess.CompletedProcess(
                 args, 0, "https://github.com/synaptent/aragora/issues/6002\n", ""
             )
         if args[:3] == ["gh", "issue", "comment"]:
+            operations.append("comment")
             comment_bodies.append(args[args.index("--body") + 1])
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ["gh", "issue", "edit"]:
+            operations.append("edit")
+            assert args[3] == "6002"
+            assert args[args.index("--add-label") + 1] == "boss-ready"
             return subprocess.CompletedProcess(args, 0, "", "")
         return subprocess.CompletedProcess(args, 0, "", "")
 
@@ -3162,6 +3169,7 @@ def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
     )
 
     assert url == "https://github.com/synaptent/aragora/issues/6002"
+    assert operations == ["create", "comment", "edit"]
     assert issue_bodies == ["Prompt preview only"]
     assert len(comment_bodies) == 1
     assert prompt_sha in comment_bodies[0]
@@ -3276,6 +3284,7 @@ def test_close_incomplete_prompt_issue_rejects_unparseable_issue_url(tmp_path: P
 def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
+    created: list[list[str]] = []
     closed: list[list[str]] = []
     prompt = "Start from live repo truth."
     artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
@@ -3285,6 +3294,7 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
 
     def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
+            created.append(args)
             return subprocess.CompletedProcess(
                 args, 0, "https://github.com/synaptent/aragora/issues/6003\n", ""
             )
@@ -3293,6 +3303,8 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
         if args[:3] == ["gh", "issue", "close"]:
             closed.append(args)
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "edit"]:
+            raise AssertionError("incomplete prompt issue must not be labeled")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
@@ -3314,6 +3326,8 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
             labels=["boss-ready"],
         )
 
+    assert created
+    assert "--label" not in created[0]
     assert closed
     assert closed[0][:3] == ["gh", "issue", "close"]
     assert closed[0][3] == "6003"

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -3333,6 +3333,54 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
     assert closed[0][3] == "6003"
 
 
+def test_create_issue_closes_incomplete_prompt_issue_when_label_add_fails(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    closed: list[list[str]] = []
+    prompt = "Start from live repo truth."
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/6004\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "edit"]:
+            return subprocess.CompletedProcess(args, 1, "", "label add failed")
+        if args[:3] == ["gh", "issue", "close"]:
+            closed.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    with pytest.raises(RuntimeError, match="label add failed"):
+        mod._create_issue(
+            tmp_path,
+            "synaptent/aragora",
+            Handoff(
+                source_file=str(tmp_path / "handoff.json"),
+                task_title="Long prompt handoff",
+                priority="HIGH",
+                body="Prompt preview only",
+                labels={},
+                expires_at=None,
+                prompt_artifact_path=str(artifact),
+                prompt_artifact_sha256=prompt_sha,
+            ),
+            labels=["boss-ready"],
+        )
+
+    assert closed
+    assert closed[0][:3] == ["gh", "issue", "close"]
+    assert closed[0][3] == "6004"
+
+
 def test_create_issue_surfaces_incomplete_issue_close_failure(
     monkeypatch: Any, tmp_path: Path
 ) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2953,6 +2953,41 @@ def test_prompt_artifact_comment_sha_uses_validated_bytes(tmp_path: Path) -> Non
     assert "line one\r\nline two" in comments[0]
 
 
+def test_prompt_artifact_comments_chunk_by_utf8_byte_limit(tmp_path: Path) -> None:
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    prompt = "🙂" * ((mod.MAX_PROMPT_ARTIFACT_CHUNK_BYTES // 4) + 250)
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    comments = mod._prompt_artifact_comment_bodies(
+        tmp_path,
+        Handoff(
+            source_file=str(tmp_path / "handoff.json"),
+            task_title="Unicode prompt handoff",
+            priority="HIGH",
+            body="Prompt preview only",
+            labels={},
+            expires_at=None,
+            prompt_artifact_path=str(artifact),
+            prompt_artifact_sha256=prompt_sha,
+        ),
+    )
+
+    assert len(comments) > 1
+    assert all(
+        len(comment.encode("utf-8")) <= mod.MAX_PROMPT_ARTIFACT_COMMENT_BYTES
+        for comment in comments
+    )
+    recovered = "".join(
+        body.split("-----BEGIN ARAGORA PROMPT CHUNK-----\n", 1)[1].rsplit(
+            "\n-----END ARAGORA PROMPT CHUNK-----", 1
+        )[0]
+        for body in comments
+    )
+    assert recovered == prompt
+
+
 def test_prompt_artifact_comment_rejects_non_utf8_as_runtime_blocker(
     tmp_path: Path,
 ) -> None:
@@ -2975,6 +3010,26 @@ def test_prompt_artifact_comment_rejects_non_utf8_as_runtime_blocker(
                 prompt_artifact_path=str(artifact),
                 prompt_artifact_sha256=prompt_sha,
             ),
+        )
+
+
+def test_add_prompt_artifact_comments_rejects_unparseable_issue_url(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="prompt_artifact_issue_url_unparseable"):
+        mod._add_prompt_artifact_comments(
+            tmp_path,
+            "synaptent/aragora",
+            "not-a-github-issue-url",
+            ["required prompt artifact body"],
+        )
+
+
+def test_close_incomplete_prompt_issue_rejects_unparseable_issue_url(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="prompt_artifact_issue_url_unparseable"):
+        mod._close_incomplete_prompt_issue(
+            tmp_path,
+            "synaptent/aragora",
+            "not-a-github-issue-url",
+            "comment failed",
         )
 
 

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -718,6 +719,111 @@ def test_load_outbox_handoffs_skips_terminal_receipt_for_same_branch(
     )
 
     assert mod.load_outbox_handoffs(tmp_path) == []
+
+
+def _prompt_handoff_payload(
+    *,
+    branch: str,
+    prompt_sha: str,
+    idempotency_key: str,
+    task: str = "Publish prompt handoff",
+) -> dict[str, Any]:
+    return _outbox_payload(
+        task=task,
+        requested_action={
+            "type": "prompt_handoff",
+            "branch": branch,
+            "prompt_sha256": prompt_sha,
+        },
+        idempotency_key=idempotency_key,
+        local_evidence={
+            "kind": "prompt_handoff",
+            "branch": branch,
+            "prompt_sha256": prompt_sha,
+            "prompt": f"prompt body {prompt_sha}",
+        },
+    )
+
+
+def test_load_outbox_handoffs_keeps_distinct_prompt_handoffs_for_same_branch(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    older = outbox / "older-prompt.json"
+    newer = outbox / "newer-prompt.json"
+    older.write_text(
+        json.dumps(
+            _prompt_handoff_payload(
+                branch="codex/example",
+                prompt_sha="a" * 64,
+                idempotency_key="prompt-handoff-old",
+                task="Publish older prompt handoff",
+            )
+        ),
+        encoding="utf-8",
+    )
+    newer.write_text(
+        json.dumps(
+            _prompt_handoff_payload(
+                branch="codex/example",
+                prompt_sha="b" * 64,
+                idempotency_key="prompt-handoff-new",
+                task="Publish newer prompt handoff",
+            )
+        ),
+        encoding="utf-8",
+    )
+    os.utime(older, (1_000, 1_000))
+    os.utime(newer, (2_000, 2_000))
+
+    handoffs = mod.load_outbox_handoffs(tmp_path)
+
+    assert [handoff.idempotency_key for handoff in handoffs] == [
+        "prompt-handoff-new",
+        "prompt-handoff-old",
+    ]
+
+
+def test_terminal_prompt_handoff_receipt_does_not_skip_distinct_prompt_same_branch(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    old_key = "prompt-handoff-old"
+    (outbox / "old-prompt.json").write_text(
+        json.dumps(
+            _prompt_handoff_payload(
+                branch="codex/example",
+                prompt_sha="a" * 64,
+                idempotency_key=old_key,
+                task="Publish older prompt handoff",
+            )
+        ),
+        encoding="utf-8",
+    )
+    (outbox / "new-prompt.json").write_text(
+        json.dumps(
+            _prompt_handoff_payload(
+                branch="codex/example",
+                prompt_sha="b" * 64,
+                idempotency_key="prompt-handoff-new",
+                task="Publish newer prompt handoff",
+            )
+        ),
+        encoding="utf-8",
+    )
+    (receipts / f"{old_key}.json").write_text(
+        json.dumps({"idempotency_key": old_key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    handoffs = mod.load_outbox_handoffs(tmp_path)
+
+    assert len(handoffs) == 1
+    assert handoffs[0].idempotency_key == "prompt-handoff-new"
 
 
 def test_load_outbox_handoffs_skips_already_merged_branch_head(tmp_path: Path) -> None:
@@ -2608,6 +2714,54 @@ def test_create_issue_truncates_oversized_body(monkeypatch: Any, tmp_path: Path)
 
     assert len(bodies[0]) <= mod.MAX_ISSUE_BODY_CHARS
     assert "truncated this issue body" in bodies[0]
+
+
+def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    issue_bodies: list[str] = []
+    comment_bodies: list[str] = []
+    prompt = "Start from live repo truth.\n" + ("x" * 1000) + "END-OF-PROMPT"
+    artifact = tmp_path / "prompt.md"
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            issue_bodies.append(args[args.index("--body") + 1])
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/6002\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            comment_bodies.append(args[args.index("--body") + 1])
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "edit"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    url = mod._create_issue(
+        tmp_path,
+        "synaptent/aragora",
+        Handoff(
+            source_file=str(tmp_path / "handoff.json"),
+            task_title="Long prompt handoff",
+            priority="HIGH",
+            body="Prompt preview only",
+            labels={},
+            expires_at=None,
+            prompt_artifact_path=str(artifact),
+            prompt_artifact_sha256=prompt_sha,
+        ),
+        labels=["boss-ready"],
+    )
+
+    assert url == "https://github.com/synaptent/aragora/issues/6002"
+    assert issue_bodies == ["Prompt preview only"]
+    assert len(comment_bodies) == 1
+    assert prompt_sha in comment_bodies[0]
+    assert "END-OF-PROMPT" in comment_bodies[0]
 
 
 def test_create_issue_preserves_boundary_sized_body(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -885,6 +885,84 @@ def test_prompt_artifact_blocker_requires_hash_for_outbox_artifact(
     assert blocker == "prompt_artifact_sha_missing"
 
 
+def test_prompt_artifact_blocker_rejects_non_utf8_before_publish(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact_bytes = b"\xff\xfe"
+    artifact.write_bytes(artifact_bytes)
+    prompt_sha = hashlib.sha256(artifact_bytes).hexdigest()
+
+    blocker = mod._prompt_artifact_blocker(
+        tmp_path,
+        Handoff(
+            source_file=str(tmp_path / "handoff.json"),
+            task_title="Binary prompt handoff",
+            priority="HIGH",
+            body="Prompt preview only",
+            labels={},
+            expires_at=None,
+            prompt_artifact_path=str(artifact),
+            prompt_artifact_sha256=prompt_sha,
+        ),
+    )
+
+    assert blocker == "prompt_artifact_not_utf8"
+
+
+def test_decide_handoffs_blocks_oversized_prompt_artifact_before_publish(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    outbox_file = tmp_path / ".aragora" / "automation-outbox" / "prompt.json"
+    artifact = outbox_file.parent / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir(parents=True)
+    prompt = "x" * (mod.MAX_PROMPT_ARTIFACT_BYTES + 1)
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    handoff = Handoff(
+        source_file=str(outbox_file),
+        task_title="Oversized prompt handoff",
+        priority="HIGH",
+        body="Idempotency Key:\nprompt-handoff-too-large\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-too-large",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_artifact_path=str(artifact),
+        prompt_artifact_sha256=prompt_sha,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        raise AssertionError(f"oversized prompt artifact should not query dedupe: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="prompt_artifact_too_large",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+
 def test_decide_handoffs_keeps_prompt_handoff_actionable_for_open_branch_pr(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
@@ -1044,6 +1122,8 @@ def test_decide_handoffs_dedupes_prompt_handoff_by_idempotency_key(
                             "Local Evidence:\n"
                             f"{'c' * 64}\n"
                         ),
+                        "labels": [{"name": "boss-ready"}],
+                        "comments": [],
                     }
                 ),
                 "",
@@ -1069,6 +1149,84 @@ def test_decide_handoffs_dedupes_prompt_handoff_by_idempotency_key(
             branch="codex/active-repair",
             desired_head="abc1234",
             existing_issue_url="https://github.com/synaptent/aragora/issues/6006",
+        )
+    ]
+
+
+def test_decide_handoffs_ignores_unlabeled_prompt_handoff_identity_match(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "prompt.json"),
+        task_title="Prompt handoff after label failure",
+        priority="HIGH",
+        body="Idempotency Key:\nprompt-handoff-label-failed\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-label-failed",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256="f" * 64,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 6009,
+                            "title": "Prompt handoff after label failure",
+                            "url": "https://github.com/synaptent/aragora/issues/6009",
+                            "state": "OPEN",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 6009,
+                        "title": "Prompt handoff after label failure",
+                        "url": "https://github.com/synaptent/aragora/issues/6009",
+                        "state": "OPEN",
+                        "body": "Idempotency Key:\nprompt-handoff-label-failed\n",
+                        "labels": [],
+                        "comments": [],
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected prompt dedupe command: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
         )
     ]
 
@@ -2249,7 +2407,7 @@ def test_publish_handoffs_writes_outbox_receipt(monkeypatch: Any, tmp_path: Path
     assert receipt["created_issue_url"] == "https://github.com/synaptent/aragora/issues/7000"
 
 
-def test_publish_handoffs_leaves_failed_prompt_issue_discoverable(
+def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     prompt_sha = hashlib.sha256(b"large prompt body").hexdigest()
@@ -2325,6 +2483,8 @@ def test_publish_handoffs_leaves_failed_prompt_issue_discoverable(
                             "Local Evidence:\n"
                             f"{prompt_sha}\n"
                         ),
+                        "labels": [{"name": "boss-ready"}],
+                        "comments": [{"body": marker_comments[0]}] if marker_comments else [],
                     }
                 ),
                 "",
@@ -2365,11 +2525,10 @@ def test_publish_handoffs_leaves_failed_prompt_issue_discoverable(
         PublishDecision(
             task_title=handoff.task_title,
             source_file=handoff.source_file,
-            eligible=False,
-            reason="existing_issue",
+            eligible=True,
+            reason="eligible",
             branch="codex/active-repair",
             desired_head="abc1234",
-            existing_issue_url="https://github.com/synaptent/aragora/issues/7001",
         )
     ]
 

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2827,6 +2827,122 @@ def test_publish_handoffs_resumes_after_deferred_label_failure_without_duplicate
     assert any(comment.startswith("Completed prompt handoff issue:") for comment in issue_comments)
 
 
+def test_publish_handoffs_reuses_unmarked_prompt_identity_orphan(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt_sha = "d" * 64
+    outbox_file = tmp_path / ".aragora" / "automation-outbox" / "prompt.json"
+    handoff = Handoff(
+        source_file=str(outbox_file),
+        task_title="Prompt handoff after marker failure",
+        priority="HIGH",
+        body=f"Idempotency Key:\nprompt-handoff-marker-failed\n\nLocal Evidence:\n{prompt_sha}\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-marker-failed",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256=prompt_sha,
+    )
+    issue_comments: list[str] = []
+    label_edits: list[str] = []
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            raise AssertionError("orphaned prompt identity issue should be reused")
+        if args[:3] == ["gh", "issue", "comment"]:
+            issue_comments.append(args[args.index("--body") + 1])
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "edit"]:
+            label_edits.extend(args[args.index("--add-label") + 1].split(","))
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 7003,
+                            "title": "Prompt handoff after marker failure",
+                            "url": "https://github.com/synaptent/aragora/issues/7003",
+                            "state": "OPEN",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 7003,
+                        "title": "Prompt handoff after marker failure",
+                        "url": "https://github.com/synaptent/aragora/issues/7003",
+                        "state": "OPEN",
+                        "body": (
+                            "Idempotency Key:\n"
+                            "prompt-handoff-marker-failed\n\n"
+                            "Local Evidence:\n"
+                            f"{prompt_sha}\n"
+                        ),
+                        "labels": [{"name": label} for label in label_edits],
+                        "comments": [{"body": body} for body in issue_comments],
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    published = mod.publish_handoffs(
+        [handoff],
+        [
+            PublishDecision(
+                task_title=handoff.task_title,
+                source_file=handoff.source_file,
+                eligible=True,
+                reason="eligible",
+            )
+        ],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        limit=1,
+    )
+
+    assert published[0].reason == "published"
+    assert published[0].created_issue_url == "https://github.com/synaptent/aragora/issues/7003"
+    assert label_edits == ["boss-ready"]
+    assert any(comment.startswith("Completed prompt handoff issue:") for comment in issue_comments)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="existing_issue",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+            existing_issue_url="https://github.com/synaptent/aragora/issues/7003",
+        )
+    ]
+
+
 def test_main_preview_does_not_write_outbox_receipt(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -826,6 +826,110 @@ def test_terminal_prompt_handoff_receipt_does_not_skip_distinct_prompt_same_bran
     assert handoffs[0].idempotency_key == "prompt-handoff-new"
 
 
+def test_prompt_artifact_blocker_rejects_absolute_path_outside_outbox(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    outbox.mkdir(parents=True)
+    source = outbox / "prompt.json"
+    source.write_text("{}", encoding="utf-8")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("do not publish", encoding="utf-8")
+    secret_sha = hashlib.sha256(secret.read_bytes()).hexdigest()
+
+    blocker = mod._prompt_artifact_blocker(
+        tmp_path,
+        Handoff(
+            source_file=str(source),
+            task_title="Publish prompt handoff",
+            priority="HIGH",
+            body="body",
+            labels={},
+            expires_at=None,
+            source_kind="outbox",
+            requested_action="prompt_handoff",
+            prompt_artifact_path=str(secret),
+            prompt_artifact_sha256=secret_sha,
+        ),
+    )
+
+    assert blocker == "prompt_artifact_outside_outbox"
+
+
+def test_prompt_artifact_blocker_requires_hash_for_outbox_artifact(
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    artifact_root = outbox / mod.PROMPT_ARTIFACT_DIR
+    artifact_root.mkdir(parents=True)
+    source = outbox / "prompt.json"
+    source.write_text("{}", encoding="utf-8")
+    artifact = artifact_root / "prompt.md"
+    artifact.write_text("prompt", encoding="utf-8")
+
+    blocker = mod._prompt_artifact_blocker(
+        tmp_path,
+        Handoff(
+            source_file=str(source),
+            task_title="Publish prompt handoff",
+            priority="HIGH",
+            body="body",
+            labels={},
+            expires_at=None,
+            source_kind="outbox",
+            requested_action="prompt_handoff",
+            prompt_artifact_path=str(artifact),
+        ),
+    )
+
+    assert blocker == "prompt_artifact_sha_missing"
+
+
+def test_decide_handoffs_keeps_prompt_handoff_actionable_for_open_branch_pr(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Prompt handoff for active repair branch",
+        priority="HIGH",
+        body="body",
+        labels={},
+        expires_at=None,
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args and args[0] in {"gh", "git"}:
+            raise AssertionError(f"prompt handoff should not use branch/PR blocker: {args}")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+
 def test_load_outbox_handoffs_skips_already_merged_branch_head(tmp_path: Path) -> None:
     repo, head = _repo_with_merged_codex_branch(tmp_path)
     outbox = repo / ".aragora" / "automation-outbox"
@@ -2722,7 +2826,8 @@ def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
     issue_bodies: list[str] = []
     comment_bodies: list[str] = []
     prompt = "Start from live repo truth.\n" + ("x" * 1000) + "END-OF-PROMPT"
-    artifact = tmp_path / "prompt.md"
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
     artifact.write_text(prompt, encoding="utf-8")
     prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
 
@@ -2762,6 +2867,52 @@ def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
     assert len(comment_bodies) == 1
     assert prompt_sha in comment_bodies[0]
     assert "END-OF-PROMPT" in comment_bodies[0]
+
+
+def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    closed: list[list[str]] = []
+    prompt = "Start from live repo truth."
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/6003\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(args, 1, "", "comment failed")
+        if args[:3] == ["gh", "issue", "close"]:
+            closed.append(args)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    with pytest.raises(RuntimeError, match="comment failed"):
+        mod._create_issue(
+            tmp_path,
+            "synaptent/aragora",
+            Handoff(
+                source_file=str(tmp_path / "handoff.json"),
+                task_title="Long prompt handoff",
+                priority="HIGH",
+                body="Prompt preview only",
+                labels={},
+                expires_at=None,
+                prompt_artifact_path=str(artifact),
+                prompt_artifact_sha256=prompt_sha,
+            ),
+            labels=["boss-ready"],
+        )
+
+    assert closed
+    assert closed[0][:3] == ["gh", "issue", "close"]
+    assert closed[0][3] == "6003"
 
 
 def test_create_issue_preserves_boundary_sized_body(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -1073,6 +1073,162 @@ def test_decide_handoffs_dedupes_prompt_handoff_by_idempotency_key(
     ]
 
 
+def test_decide_handoffs_ignores_closed_prompt_handoff_identity_match(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt_sha = "d" * 64
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "prompt.json"),
+        task_title="Prompt handoff for retry after incomplete issue",
+        priority="HIGH",
+        body="Idempotency Key:\nprompt-handoff-retry-closed\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-retry-closed",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256=prompt_sha,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            assert args[args.index("--state") + 1] == "open"
+            search = args[args.index("--search") + 1]
+            if search == "prompt-handoff-retry-closed":
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    json.dumps(
+                        [
+                            {
+                                "number": 6007,
+                                "title": "Prompt handoff for retry after incomplete issue",
+                                "url": "https://github.com/synaptent/aragora/issues/6007",
+                                "state": "CLOSED",
+                            }
+                        ]
+                    ),
+                    "",
+                )
+            assert search == prompt_sha
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "view"]:
+            raise AssertionError("closed prompt issue should not be viewed as delivered")
+        raise AssertionError(f"unexpected prompt dedupe command: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+
+def test_decide_handoffs_ignores_prompt_issue_closed_between_list_and_view(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt_sha = "e" * 64
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "prompt.json"),
+        task_title="Prompt handoff for retry after race",
+        priority="HIGH",
+        body="Idempotency Key:\nprompt-handoff-race\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-race",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256=prompt_sha,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            search = args[args.index("--search") + 1]
+            if search == "prompt-handoff-race":
+                return subprocess.CompletedProcess(
+                    args,
+                    0,
+                    json.dumps(
+                        [
+                            {
+                                "number": 6008,
+                                "title": "Prompt handoff for retry after race",
+                                "url": "https://github.com/synaptent/aragora/issues/6008",
+                                "state": "OPEN",
+                            }
+                        ]
+                    ),
+                    "",
+                )
+            assert search == prompt_sha
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "view"]:
+            assert args[3] == "6008"
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 6008,
+                        "title": "Prompt handoff for retry after race",
+                        "url": "https://github.com/synaptent/aragora/issues/6008",
+                        "state": "CLOSED",
+                        "body": (
+                            "Idempotency Key:\n"
+                            "prompt-handoff-race\n\n"
+                            "Local Evidence:\n"
+                            f"{prompt_sha}\n"
+                        ),
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected prompt dedupe command: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+
 def test_load_outbox_handoffs_skips_already_merged_branch_head(tmp_path: Path) -> None:
     repo, head = _repo_with_merged_codex_branch(tmp_path)
     outbox = repo / ".aragora" / "automation-outbox"

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2249,6 +2249,131 @@ def test_publish_handoffs_writes_outbox_receipt(monkeypatch: Any, tmp_path: Path
     assert receipt["created_issue_url"] == "https://github.com/synaptent/aragora/issues/7000"
 
 
+def test_publish_handoffs_leaves_failed_prompt_issue_discoverable(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt_sha = hashlib.sha256(b"large prompt body").hexdigest()
+    outbox_file = tmp_path / ".aragora" / "automation-outbox" / "prompt.json"
+    artifact = outbox_file.parent / "_prompt-artifacts" / "prompt.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("large prompt body", encoding="utf-8")
+    handoff = Handoff(
+        source_file=str(outbox_file),
+        task_title="Prompt handoff for repeated artifact failure",
+        priority="HIGH",
+        body=(
+            f"Idempotency Key:\nprompt-handoff-repeated-failure\n\nLocal Evidence:\n{prompt_sha}\n"
+        ),
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-repeated-failure",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256=prompt_sha,
+        prompt_artifact_path=str(artifact),
+        prompt_artifact_sha256=prompt_sha,
+    )
+    created: list[str] = []
+    marker_comments: list[str] = []
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            created.append("https://github.com/synaptent/aragora/issues/7001")
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/7001\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            body = args[args.index("--body") + 1]
+            if body.startswith("Prompt handoff artifact"):
+                return subprocess.CompletedProcess(args, 1, "", "artifact comment failed")
+            marker_comments.append(body)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            assert len(created) == 1
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 7001,
+                            "title": "Prompt handoff for repeated artifact failure",
+                            "url": "https://github.com/synaptent/aragora/issues/7001",
+                            "state": "OPEN",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 7001,
+                        "title": "Prompt handoff for repeated artifact failure",
+                        "url": "https://github.com/synaptent/aragora/issues/7001",
+                        "state": "OPEN",
+                        "body": (
+                            "Idempotency Key:\n"
+                            "prompt-handoff-repeated-failure\n\n"
+                            "Local Evidence:\n"
+                            f"{prompt_sha}\n"
+                        ),
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    with pytest.raises(RuntimeError, match="artifact comment failed"):
+        mod.publish_handoffs(
+            [handoff],
+            [
+                PublishDecision(
+                    task_title=handoff.task_title,
+                    source_file=handoff.source_file,
+                    eligible=True,
+                    reason="eligible",
+                )
+            ],
+            repo_root=tmp_path,
+            repo="synaptent/aragora",
+            labels=["boss-ready"],
+            limit=1,
+        )
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert len(created) == 1
+    assert len(marker_comments) == 1
+    assert marker_comments[0].startswith("Incomplete prompt handoff issue")
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="existing_issue",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+            existing_issue_url="https://github.com/synaptent/aragora/issues/7001",
+        )
+    ]
+
+
 def test_main_preview_does_not_write_outbox_receipt(
     monkeypatch: Any, tmp_path: Path, capsys
 ) -> None:
@@ -3285,9 +3410,9 @@ def test_add_prompt_artifact_comments_rejects_unparseable_issue_url(tmp_path: Pa
         )
 
 
-def test_close_incomplete_prompt_issue_rejects_unparseable_issue_url(tmp_path: Path) -> None:
+def test_mark_incomplete_prompt_issue_rejects_unparseable_issue_url(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="prompt_artifact_issue_url_unparseable"):
-        mod._close_incomplete_prompt_issue(
+        mod._mark_incomplete_prompt_issue(
             tmp_path,
             "synaptent/aragora",
             "not-a-github-issue-url",
@@ -3295,11 +3420,11 @@ def test_close_incomplete_prompt_issue_rejects_unparseable_issue_url(tmp_path: P
         )
 
 
-def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails(
+def test_create_issue_marks_incomplete_issue_when_prompt_artifact_comment_fails(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     created: list[list[str]] = []
-    closed: list[list[str]] = []
+    marker_comments: list[str] = []
     prompt = "Start from live repo truth."
     artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
     artifact.parent.mkdir()
@@ -3313,10 +3438,13 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
                 args, 0, "https://github.com/synaptent/aragora/issues/6003\n", ""
             )
         if args[:3] == ["gh", "issue", "comment"]:
-            return subprocess.CompletedProcess(args, 1, "", "comment failed")
-        if args[:3] == ["gh", "issue", "close"]:
-            closed.append(args)
+            body = args[args.index("--body") + 1]
+            if body.startswith("Prompt handoff artifact"):
+                return subprocess.CompletedProcess(args, 1, "", "comment failed")
+            marker_comments.append(body)
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "close"]:
+            raise AssertionError("incomplete prompt issue must not be closed")
         if args[:3] == ["gh", "issue", "edit"]:
             raise AssertionError("incomplete prompt issue must not be labeled")
         raise AssertionError(f"unexpected args: {args}")
@@ -3342,15 +3470,14 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
 
     assert created
     assert "--label" not in created[0]
-    assert closed
-    assert closed[0][:3] == ["gh", "issue", "close"]
-    assert closed[0][3] == "6003"
+    assert marker_comments
+    assert marker_comments[0].startswith("Incomplete prompt handoff issue")
 
 
-def test_create_issue_closes_incomplete_prompt_issue_when_label_add_fails(
+def test_create_issue_marks_incomplete_prompt_issue_when_label_add_fails(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    closed: list[list[str]] = []
+    marker_comments: list[str] = []
     prompt = "Start from live repo truth."
     artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
     artifact.parent.mkdir()
@@ -3363,12 +3490,14 @@ def test_create_issue_closes_incomplete_prompt_issue_when_label_add_fails(
                 args, 0, "https://github.com/synaptent/aragora/issues/6004\n", ""
             )
         if args[:3] == ["gh", "issue", "comment"]:
+            body = args[args.index("--body") + 1]
+            if body.startswith("Incomplete prompt handoff issue"):
+                marker_comments.append(body)
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ["gh", "issue", "edit"]:
             return subprocess.CompletedProcess(args, 1, "", "label add failed")
         if args[:3] == ["gh", "issue", "close"]:
-            closed.append(args)
-            return subprocess.CompletedProcess(args, 0, "", "")
+            raise AssertionError("incomplete prompt issue must not be closed")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
@@ -3390,12 +3519,11 @@ def test_create_issue_closes_incomplete_prompt_issue_when_label_add_fails(
             labels=["boss-ready"],
         )
 
-    assert closed
-    assert closed[0][:3] == ["gh", "issue", "close"]
-    assert closed[0][3] == "6004"
+    assert marker_comments
+    assert marker_comments[0].startswith("Incomplete prompt handoff issue")
 
 
-def test_create_issue_surfaces_incomplete_issue_close_failure(
+def test_create_issue_surfaces_incomplete_issue_marker_failure(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
     prompt = "Start from live repo truth."
@@ -3412,12 +3540,12 @@ def test_create_issue_surfaces_incomplete_issue_close_failure(
         if args[:3] == ["gh", "issue", "comment"]:
             return subprocess.CompletedProcess(args, 1, "", "comment failed")
         if args[:3] == ["gh", "issue", "close"]:
-            return subprocess.CompletedProcess(args, 1, "", "close failed")
+            raise AssertionError("incomplete prompt issue must not be closed")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
 
-    with pytest.raises(RuntimeError, match="failed to close incomplete prompt issue"):
+    with pytest.raises(RuntimeError, match="failed to mark incomplete prompt issue"):
         mod._create_issue(
             tmp_path,
             "synaptent/aragora",

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -930,6 +930,65 @@ def test_decide_handoffs_keeps_prompt_handoff_actionable_for_open_branch_pr(
     ]
 
 
+def test_decide_handoffs_ignores_title_duplicate_issue_for_prompt_handoff(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / "outbox.json"),
+        task_title="Prompt handoff for active repair branch",
+        priority="HIGH",
+        body="body",
+        labels={},
+        expires_at=None,
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 6004,
+                            "title": "Prompt handoff for active repair branch",
+                            "url": "https://github.com/synaptent/aragora/issues/6004",
+                            "state": "CLOSED",
+                        }
+                    ]
+                ),
+                "",
+            )
+        raise AssertionError(f"prompt handoff should not title-dedup issues: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+
 def test_load_outbox_handoffs_skips_already_merged_branch_head(tmp_path: Path) -> None:
     repo, head = _repo_with_merged_codex_branch(tmp_path)
     outbox = repo / ".aragora" / "automation-outbox"
@@ -2869,6 +2928,56 @@ def test_create_issue_posts_prompt_artifact_as_repo_visible_comment(
     assert "END-OF-PROMPT" in comment_bodies[0]
 
 
+def test_prompt_artifact_comment_sha_uses_validated_bytes(tmp_path: Path) -> None:
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact_bytes = b"line one\r\nline two\r\n"
+    artifact.write_bytes(artifact_bytes)
+    prompt_sha = hashlib.sha256(artifact_bytes).hexdigest()
+
+    comments = mod._prompt_artifact_comment_bodies(
+        tmp_path,
+        Handoff(
+            source_file=str(tmp_path / "handoff.json"),
+            task_title="CRLF prompt handoff",
+            priority="HIGH",
+            body="Prompt preview only",
+            labels={},
+            expires_at=None,
+            prompt_artifact_path=str(artifact),
+            prompt_artifact_sha256=prompt_sha,
+        ),
+    )
+
+    assert prompt_sha in comments[0]
+    assert "line one\r\nline two" in comments[0]
+
+
+def test_prompt_artifact_comment_rejects_non_utf8_as_runtime_blocker(
+    tmp_path: Path,
+) -> None:
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact_bytes = b"\xff\xfe"
+    artifact.write_bytes(artifact_bytes)
+    prompt_sha = hashlib.sha256(artifact_bytes).hexdigest()
+
+    with pytest.raises(RuntimeError, match="prompt_artifact_not_utf8"):
+        mod._prompt_artifact_comment_bodies(
+            tmp_path,
+            Handoff(
+                source_file=str(tmp_path / "handoff.json"),
+                task_title="Binary prompt handoff",
+                priority="HIGH",
+                body="Prompt preview only",
+                labels={},
+                expires_at=None,
+                prompt_artifact_path=str(artifact),
+                prompt_artifact_sha256=prompt_sha,
+            ),
+        )
+
+
 def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
@@ -2913,6 +3022,46 @@ def test_create_issue_closes_incomplete_issue_when_prompt_artifact_comment_fails
     assert closed
     assert closed[0][:3] == ["gh", "issue", "close"]
     assert closed[0][3] == "6003"
+
+
+def test_create_issue_surfaces_incomplete_issue_close_failure(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt = "Start from live repo truth."
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/6005\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            return subprocess.CompletedProcess(args, 1, "", "comment failed")
+        if args[:3] == ["gh", "issue", "close"]:
+            return subprocess.CompletedProcess(args, 1, "", "close failed")
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    with pytest.raises(RuntimeError, match="failed to close incomplete prompt issue"):
+        mod._create_issue(
+            tmp_path,
+            "synaptent/aragora",
+            Handoff(
+                source_file=str(tmp_path / "handoff.json"),
+                task_title="Long prompt handoff",
+                priority="HIGH",
+                body="Prompt preview only",
+                labels={},
+                expires_at=None,
+                prompt_artifact_path=str(artifact),
+                prompt_artifact_sha256=prompt_sha,
+            ),
+            labels=["boss-ready"],
+        )
 
 
 def test_create_issue_preserves_boundary_sized_body(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -786,6 +786,7 @@ def test_load_outbox_handoffs_keeps_distinct_prompt_handoffs_for_same_branch(
 
 
 def test_terminal_prompt_handoff_receipt_does_not_skip_distinct_prompt_same_branch(
+    monkeypatch: Any,
     tmp_path: Path,
 ) -> None:
     outbox = tmp_path / ".aragora" / "automation-outbox"
@@ -816,14 +817,104 @@ def test_terminal_prompt_handoff_receipt_does_not_skip_distinct_prompt_same_bran
         encoding="utf-8",
     )
     (receipts / f"{old_key}.json").write_text(
-        json.dumps({"idempotency_key": old_key, "status": "published"}),
+        json.dumps(
+            {
+                "idempotency_key": old_key,
+                "status": "published",
+                "reason": "published",
+                "created_issue_url": "https://github.com/synaptent/aragora/issues/7001",
+                "labels": ["boss-ready"],
+            }
+        ),
         encoding="utf-8",
     )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 7001,
+                        "state": "OPEN",
+                        "stateReason": "",
+                        "url": "https://github.com/synaptent/aragora/issues/7001",
+                        "body": "Idempotency Key:\nprompt-handoff-old\n",
+                        "labels": [{"name": "boss-ready"}],
+                        "comments": [],
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
 
     handoffs = mod.load_outbox_handoffs(tmp_path)
 
     assert len(handoffs) == 1
     assert handoffs[0].idempotency_key == "prompt-handoff-new"
+
+
+def test_prompt_handoff_receipt_does_not_suppress_unlabeled_issue(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    outbox = tmp_path / ".aragora" / "automation-outbox"
+    receipts = tmp_path / ".aragora" / "automation-receipts"
+    outbox.mkdir(parents=True)
+    receipts.mkdir(parents=True)
+    key = "prompt-handoff-label-failed"
+    (outbox / "prompt.json").write_text(
+        json.dumps(
+            _prompt_handoff_payload(
+                branch="codex/example",
+                prompt_sha="c" * 64,
+                idempotency_key=key,
+                task="Publish prompt after failed label admission",
+            )
+        ),
+        encoding="utf-8",
+    )
+    (receipts / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "reason": "published",
+                "created_issue_url": "https://github.com/synaptent/aragora/issues/7002",
+                "labels": ["boss-ready"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 7002,
+                        "state": "OPEN",
+                        "stateReason": "",
+                        "url": "https://github.com/synaptent/aragora/issues/7002",
+                        "body": "Idempotency Key:\nprompt-handoff-label-failed\n",
+                        "labels": [],
+                        "comments": [],
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    handoffs = mod.load_outbox_handoffs(tmp_path)
+
+    assert [handoff.idempotency_key for handoff in handoffs] == [key]
 
 
 def test_prompt_artifact_blocker_rejects_absolute_path_outside_outbox(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -3252,6 +3252,29 @@ def test_prompt_artifact_comment_rejects_non_utf8_as_runtime_blocker(
         )
 
 
+def test_prompt_artifact_comment_rejects_oversized_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / mod.PROMPT_ARTIFACT_DIR / "prompt.md"
+    artifact.parent.mkdir()
+    prompt = "x" * (mod.MAX_PROMPT_ARTIFACT_BYTES + 1)
+    artifact.write_text(prompt, encoding="utf-8")
+    prompt_sha = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+
+    with pytest.raises(RuntimeError, match="prompt_artifact_too_large"):
+        mod._prompt_artifact_comment_bodies(
+            tmp_path,
+            Handoff(
+                source_file=str(tmp_path / "handoff.json"),
+                task_title="Oversized prompt handoff",
+                priority="HIGH",
+                body="Prompt preview only",
+                labels={},
+                expires_at=None,
+                prompt_artifact_path=str(artifact),
+                prompt_artifact_sha256=prompt_sha,
+            ),
+        )
+
+
 def test_add_prompt_artifact_comments_rejects_unparseable_issue_url(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="prompt_artifact_issue_url_unparseable"):
         mod._add_prompt_artifact_comments(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2407,14 +2407,15 @@ def test_publish_handoffs_writes_outbox_receipt(monkeypatch: Any, tmp_path: Path
     assert receipt["created_issue_url"] == "https://github.com/synaptent/aragora/issues/7000"
 
 
-def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
+def test_publish_handoffs_resumes_incomplete_prompt_issue_without_duplicate(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    prompt_sha = hashlib.sha256(b"large prompt body").hexdigest()
+    prompt_text = "large prompt body"
+    prompt_sha = hashlib.sha256(prompt_text.encode("utf-8")).hexdigest()
     outbox_file = tmp_path / ".aragora" / "automation-outbox" / "prompt.json"
     artifact = outbox_file.parent / "_prompt-artifacts" / "prompt.txt"
     artifact.parent.mkdir(parents=True)
-    artifact.write_text("large prompt body", encoding="utf-8")
+    artifact.write_text(prompt_text, encoding="utf-8")
     handoff = Handoff(
         source_file=str(outbox_file),
         task_title="Prompt handoff for repeated artifact failure",
@@ -2433,8 +2434,15 @@ def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
         prompt_artifact_path=str(artifact),
         prompt_artifact_sha256=prompt_sha,
     )
+    artifact_comments = [
+        "Prompt handoff artifact chunk 1/2\nchunk-one",
+        "Prompt handoff artifact chunk 2/2\nchunk-two",
+    ]
     created: list[str] = []
-    marker_comments: list[str] = []
+    issue_comments: list[str] = []
+    posted_artifact_comments: list[str] = []
+    label_edits: list[str] = []
+    second_chunk_failed = False
 
     def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         if args[:3] == ["gh", "issue", "create"]:
@@ -2443,15 +2451,20 @@ def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
                 args, 0, "https://github.com/synaptent/aragora/issues/7001\n", ""
             )
         if args[:3] == ["gh", "issue", "comment"]:
+            nonlocal second_chunk_failed
             body = args[args.index("--body") + 1]
+            if body == artifact_comments[1] and not second_chunk_failed:
+                second_chunk_failed = True
+                return subprocess.CompletedProcess(args, 1, "", "artifact chunk failed")
+            issue_comments.append(body)
             if body.startswith("Prompt handoff artifact"):
-                return subprocess.CompletedProcess(args, 1, "", "artifact comment failed")
-            marker_comments.append(body)
+                posted_artifact_comments.append(body)
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ["gh", "issue", "list"] and "--label" in args:
             return subprocess.CompletedProcess(args, 0, "[]", "")
         if args[:3] == ["gh", "issue", "list"]:
-            assert len(created) == 1
+            if not created:
+                return subprocess.CompletedProcess(args, 0, "[]", "")
             return subprocess.CompletedProcess(
                 args,
                 0,
@@ -2483,17 +2496,25 @@ def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
                             "Local Evidence:\n"
                             f"{prompt_sha}\n"
                         ),
-                        "labels": [{"name": "boss-ready"}],
-                        "comments": [{"body": marker_comments[0]}] if marker_comments else [],
+                        "labels": [{"name": label} for label in label_edits],
+                        "comments": [{"body": body} for body in issue_comments],
                     }
                 ),
                 "",
             )
+        if args[:3] == ["gh", "issue", "edit"]:
+            label_edits.extend(args[args.index("--add-label") + 1].split(","))
+            return subprocess.CompletedProcess(args, 0, "", "")
         raise AssertionError(f"unexpected args: {args}")
 
     monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(
+        mod,
+        "_prompt_artifact_comment_bodies",
+        lambda repo_root, target: artifact_comments if target == handoff else [],
+    )
 
-    with pytest.raises(RuntimeError, match="artifact comment failed"):
+    with pytest.raises(RuntimeError, match="artifact chunk failed"):
         mod.publish_handoffs(
             [handoff],
             [
@@ -2519,8 +2540,6 @@ def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
     )
 
     assert len(created) == 1
-    assert len(marker_comments) == 1
-    assert marker_comments[0].startswith("Incomplete prompt handoff issue")
     assert decisions == [
         PublishDecision(
             task_title=handoff.task_title,
@@ -2531,6 +2550,190 @@ def test_publish_handoffs_does_not_treat_failed_prompt_issue_as_satisfied(
             desired_head="abc1234",
         )
     ]
+    published = mod.publish_handoffs(
+        [handoff],
+        decisions,
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        limit=1,
+        receipt_dir=tmp_path / ".aragora" / "automation-receipts",
+    )
+    assert published == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="published",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+            created_issue_url="https://github.com/synaptent/aragora/issues/7001",
+        )
+    ]
+    assert len(created) == 1
+    assert posted_artifact_comments == artifact_comments
+    assert label_edits == ["boss-ready"]
+    assert any(comment.startswith("Incomplete prompt handoff issue:") for comment in issue_comments)
+    assert any(comment.startswith("Completed prompt handoff issue:") for comment in issue_comments)
+    satisfied_decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+    assert satisfied_decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="existing_issue",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+            existing_issue_url="https://github.com/synaptent/aragora/issues/7001",
+        )
+    ]
+
+
+def test_publish_handoffs_resumes_after_deferred_label_failure_without_duplicate(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    prompt_sha = "b" * 64
+    outbox_file = tmp_path / ".aragora" / "automation-outbox" / "prompt.json"
+    handoff = Handoff(
+        source_file=str(outbox_file),
+        task_title="Prompt handoff for label retry",
+        priority="HIGH",
+        body=f"Idempotency Key:\nprompt-handoff-label-retry\n\nLocal Evidence:\n{prompt_sha}\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-label-retry",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256=prompt_sha,
+    )
+    created: list[str] = []
+    issue_comments: list[str] = []
+    label_edits: list[str] = []
+    label_failed_once = False
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "create"]:
+            created.append("https://github.com/synaptent/aragora/issues/7002")
+            return subprocess.CompletedProcess(
+                args, 0, "https://github.com/synaptent/aragora/issues/7002\n", ""
+            )
+        if args[:3] == ["gh", "issue", "comment"]:
+            issue_comments.append(args[args.index("--body") + 1])
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "edit"]:
+            nonlocal label_failed_once
+            if not label_failed_once:
+                label_failed_once = True
+                return subprocess.CompletedProcess(args, 1, "", "label add failed")
+            label_edits.extend(args[args.index("--add-label") + 1].split(","))
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            if not created:
+                return subprocess.CompletedProcess(args, 0, "[]", "")
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 7002,
+                            "title": "Prompt handoff for label retry",
+                            "url": "https://github.com/synaptent/aragora/issues/7002",
+                            "state": "OPEN",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 7002,
+                        "title": "Prompt handoff for label retry",
+                        "url": "https://github.com/synaptent/aragora/issues/7002",
+                        "state": "OPEN",
+                        "body": (
+                            "Idempotency Key:\n"
+                            "prompt-handoff-label-retry\n\n"
+                            "Local Evidence:\n"
+                            f"{prompt_sha}\n"
+                        ),
+                        "labels": [{"name": label} for label in label_edits],
+                        "comments": [{"body": body} for body in issue_comments],
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    first_decisions = [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+        )
+    ]
+    with pytest.raises(RuntimeError, match="label add failed"):
+        mod.publish_handoffs(
+            [handoff],
+            first_decisions,
+            repo_root=tmp_path,
+            repo="synaptent/aragora",
+            labels=["boss-ready"],
+            limit=1,
+        )
+
+    retry_decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert len(created) == 1
+    assert any(comment.startswith("Incomplete prompt handoff issue:") for comment in issue_comments)
+    assert retry_decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=True,
+            reason="eligible",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+        )
+    ]
+
+    published = mod.publish_handoffs(
+        [handoff],
+        retry_decisions,
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        limit=1,
+    )
+
+    assert published[0].reason == "published"
+    assert published[0].created_issue_url == "https://github.com/synaptent/aragora/issues/7002"
+    assert len(created) == 1
+    assert label_edits == ["boss-ready"]
+    assert any(comment.startswith("Completed prompt handoff issue:") for comment in issue_comments)
 
 
 def test_main_preview_does_not_write_outbox_receipt(

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -2194,18 +2194,9 @@ def test_publish_handoffs_creates_issue_with_labels(monkeypatch: Any, tmp_path: 
 
     assert published[0].reason == "published"
     assert published[0].created_issue_url == "https://github.com/synaptent/aragora/issues/5890"
+    assert len(created) == 1
     assert created[0][:3] == ["gh", "issue", "create"]
     assert created[0].count("--label") == 2
-    assert created[1] == [
-        "gh",
-        "issue",
-        "edit",
-        "5890",
-        "--repo",
-        "synaptent/aragora",
-        "--add-label",
-        "boss-ready,autonomous",
-    ]
 
 
 def test_publish_handoffs_writes_outbox_receipt(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/scripts/test_publish_automation_handoffs.py
+++ b/tests/scripts/test_publish_automation_handoffs.py
@@ -989,6 +989,90 @@ def test_decide_handoffs_ignores_title_duplicate_issue_for_prompt_handoff(
     ]
 
 
+def test_decide_handoffs_dedupes_prompt_handoff_by_idempotency_key(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    handoff = Handoff(
+        source_file=str(tmp_path / ".aragora" / "automation-outbox" / "prompt.json"),
+        task_title="Prompt handoff for active repair branch",
+        priority="HIGH",
+        body="Idempotency Key:\nprompt-handoff-retry-abc123\n",
+        labels={},
+        expires_at=None,
+        idempotency_key="prompt-handoff-retry-abc123",
+        source_kind="outbox",
+        requested_action="prompt_handoff",
+        branch="codex/active-repair",
+        desired_head="abc1234",
+        prompt_sha256="c" * 64,
+    )
+
+    def fake_run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "issue", "list"] and "--label" in args:
+            return subprocess.CompletedProcess(args, 0, "[]", "")
+        if args[:3] == ["gh", "issue", "list"]:
+            assert args[args.index("--search") + 1] == "prompt-handoff-retry-abc123"
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    [
+                        {
+                            "number": 6006,
+                            "title": "Prompt handoff for active repair branch",
+                            "url": "https://github.com/synaptent/aragora/issues/6006",
+                            "state": "OPEN",
+                        }
+                    ]
+                ),
+                "",
+            )
+        if args[:3] == ["gh", "issue", "view"]:
+            assert args[3] == "6006"
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(
+                    {
+                        "number": 6006,
+                        "title": "Prompt handoff for active repair branch",
+                        "url": "https://github.com/synaptent/aragora/issues/6006",
+                        "state": "OPEN",
+                        "body": (
+                            "Idempotency Key:\n"
+                            "prompt-handoff-retry-abc123\n\n"
+                            "Local Evidence:\n"
+                            f"{'c' * 64}\n"
+                        ),
+                    }
+                ),
+                "",
+            )
+        raise AssertionError(f"unexpected prompt dedupe command: {args}")
+
+    monkeypatch.setattr(mod, "_run", fake_run)
+
+    decisions = mod.decide_handoffs(
+        [handoff],
+        repo_root=tmp_path,
+        repo="synaptent/aragora",
+        labels=["boss-ready"],
+        max_open_issues=12,
+    )
+
+    assert decisions == [
+        PublishDecision(
+            task_title=handoff.task_title,
+            source_file=handoff.source_file,
+            eligible=False,
+            reason="existing_issue",
+            branch="codex/active-repair",
+            desired_head="abc1234",
+            existing_issue_url="https://github.com/synaptent/aragora/issues/6006",
+        )
+    ]
+
+
 def test_load_outbox_handoffs_skips_already_merged_branch_head(tmp_path: Path) -> None:
     repo, head = _repo_with_merged_codex_branch(tmp_path)
     outbox = repo / ".aragora" / "automation-outbox"

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -777,6 +777,62 @@ def test_prompt_handoff_branch_metadata_is_preserved_not_archived(
     assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
 
 
+def test_apply_archives_prompt_handoff_artifact_with_terminal_receipt(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "prompt-handoff-codex-published-abc123"
+    prompt_sha = "a" * 64
+    artifact = outbox_dir / mod.PROMPT_ARTIFACT_DIR / "prompt-handoff.prompt.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("Start from live repo truth.", encoding="utf-8")
+    handoff = outbox_dir / f"{key}.json"
+    handoff.write_text(
+        json.dumps(
+            {
+                "task": "Prompt handoff already published",
+                "requires_github": True,
+                "requested_action": {
+                    "type": "prompt_handoff",
+                    "branch": "codex/published",
+                    "prompt_sha256": prompt_sha,
+                    "prompt_artifact_path": str(artifact),
+                    "prompt_artifact_sha256": prompt_sha,
+                },
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "kind": "prompt_handoff",
+                    "branch": "codex/published",
+                    "prompt_sha256": prompt_sha,
+                    "prompt_artifact_path": str(artifact),
+                    "prompt_artifact_sha256": prompt_sha,
+                },
+                "idempotency_key": key,
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps({"idempotency_key": key, "status": "published"}),
+        encoding="utf-8",
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    archive_dir = tmp_path / ".aragora" / "automation-outbox-archive"
+    archived_artifact = archive_dir / mod.PROMPT_ARTIFACT_DIR / artifact.name
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 1
+    assert payload["archived"] == 1
+    assert handoff.exists() is False
+    assert artifact.exists() is False
+    assert (archive_dir / handoff.name).exists()
+    assert archived_artifact.read_text(encoding="utf-8") == "Start from live repo truth."
+
+
 @pytest.mark.parametrize(
     ("status", "reason", "issue_key"),
     [

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -779,6 +779,7 @@ def test_prompt_handoff_branch_metadata_is_preserved_not_archived(
 
 def test_apply_archives_prompt_handoff_artifact_with_terminal_receipt(
     tmp_path: Path,
+    monkeypatch: Any,
     capsys: Any,
 ) -> None:
     outbox_dir = tmp_path / ".aragora" / "automation-outbox"
@@ -816,9 +817,33 @@ def test_apply_archives_prompt_handoff_artifact_with_terminal_receipt(
     )
     receipt_dir.mkdir(parents=True)
     (receipt_dir / f"{key}.json").write_text(
-        json.dumps({"idempotency_key": key, "status": "published"}),
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "reason": "published",
+                "created_issue_url": "https://github.com/synaptent/aragora/issues/7001",
+                "labels": ["boss-ready"],
+            }
+        ),
         encoding="utf-8",
     )
+
+    def fake_fetch(self: Any, repo: str, number: int) -> tuple[dict[str, Any], None]:
+        return (
+            {
+                "number": number,
+                "state": "OPEN",
+                "stateReason": "",
+                "url": f"https://github.com/{repo}/issues/{number}",
+                "body": "Idempotency Key:\nprompt-handoff-codex-published-abc123\n",
+                "labels": [{"name": "boss-ready"}],
+                "comments": [],
+            },
+            None,
+        )
+
+    monkeypatch.setattr(mod._IssueStateChecker, "_fetch", fake_fetch)
 
     assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
 
@@ -831,6 +856,86 @@ def test_apply_archives_prompt_handoff_artifact_with_terminal_receipt(
     assert artifact.exists() is False
     assert (archive_dir / handoff.name).exists()
     assert archived_artifact.read_text(encoding="utf-8") == "Start from live repo truth."
+
+
+def test_reconcile_keeps_prompt_handoff_receipt_when_issue_unlabeled(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    receipt_dir = tmp_path / ".aragora" / "automation-receipts"
+    key = "prompt-handoff-label-failed-abc123"
+    prompt_sha = "b" * 64
+    artifact = outbox_dir / mod.PROMPT_ARTIFACT_DIR / "prompt-handoff.prompt.md"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("Start from live repo truth.", encoding="utf-8")
+    handoff = outbox_dir / f"{key}.json"
+    handoff.write_text(
+        json.dumps(
+            {
+                "task": "Prompt handoff with failed label admission",
+                "requires_github": True,
+                "requested_action": {
+                    "type": "prompt_handoff",
+                    "branch": "codex/label-failed",
+                    "prompt_sha256": prompt_sha,
+                    "prompt_artifact_path": str(artifact),
+                    "prompt_artifact_sha256": prompt_sha,
+                },
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "kind": "prompt_handoff",
+                    "branch": "codex/label-failed",
+                    "prompt_sha256": prompt_sha,
+                    "prompt_artifact_path": str(artifact),
+                    "prompt_artifact_sha256": prompt_sha,
+                },
+                "idempotency_key": key,
+            }
+        ),
+        encoding="utf-8",
+    )
+    receipt_dir.mkdir(parents=True)
+    (receipt_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "idempotency_key": key,
+                "status": "published",
+                "reason": "published",
+                "created_issue_url": "https://github.com/synaptent/aragora/issues/7002",
+                "labels": ["boss-ready"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_fetch(self: Any, repo: str, number: int) -> tuple[dict[str, Any], None]:
+        return (
+            {
+                "number": number,
+                "state": "OPEN",
+                "stateReason": "",
+                "url": f"https://github.com/{repo}/issues/{number}",
+                "body": "Idempotency Key:\nprompt-handoff-label-failed-abc123\n",
+                "labels": [],
+                "comments": [],
+            },
+            None,
+        )
+
+    monkeypatch.setattr(mod._IssueStateChecker, "_fetch", fake_fetch)
+
+    assert mod.main(["--repo", str(tmp_path), "--apply", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["archived"] == 0
+    assert payload["counts"]["satisfied_by_existing_receipt"] == 0
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert "missing required prompt labels" in payload["actions"][0]["reason"]
+    assert handoff.exists()
+    assert artifact.exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_reconcile_automation_outbox.py
+++ b/tests/scripts/test_reconcile_automation_outbox.py
@@ -711,6 +711,72 @@ def test_reconcile_existing_receipt_uses_structured_requested_action_branch(
     assert payload["actions"][0]["branch"] == "codex/structured-action"
 
 
+def test_prompt_handoff_branch_metadata_is_preserved_not_archived(
+    tmp_path: Path,
+    monkeypatch: Any,
+    capsys: Any,
+) -> None:
+    outbox_dir = tmp_path / ".aragora" / "automation-outbox"
+    outbox_dir.mkdir(parents=True)
+    key = "prompt-handoff-codex-landed-abc123"
+    (outbox_dir / f"{key}.json").write_text(
+        json.dumps(
+            {
+                "task": "Prompt handoff for landed branch",
+                "requires_github": True,
+                "requested_action": {
+                    "type": "prompt_handoff",
+                    "branch": "codex/landed",
+                    "prompt_sha256": "a" * 64,
+                },
+                "repo": "synaptent/aragora",
+                "local_evidence": {
+                    "kind": "prompt_handoff",
+                    "branch": "codex/landed",
+                    "prompt_sha256": "a" * 64,
+                    "prompt": "continue the landed branch review",
+                },
+                "idempotency_key": key,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        mod,
+        "run_git",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("prompt handoff should not enter branch archival checks")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "check_github_cli_health",
+        lambda _root: (_ for _ in ()).throw(
+            AssertionError("prompt handoff should not query GitHub PR state")
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "open_pr_heads",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("prompt handoff should not load open PR state")
+        ),
+    )
+
+    assert mod.main(["--repo", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["archived"] == 0
+    assert payload["kept"] == 1
+    assert payload["counts"]["still_protecting_active_work"] == 1
+    assert payload["actions"][0]["decision"] == "keep"
+    assert payload["actions"][0]["branch"] == "codex/landed"
+    assert payload["actions"][0]["reason"] == "prompt handoff transport record pending publication"
+    assert (outbox_dir / f"{key}.json").exists()
+    assert not (tmp_path / ".aragora" / "automation-outbox-archive").exists()
+
+
 @pytest.mark.parametrize(
     ("status", "reason", "issue_key"),
     [

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -1,0 +1,159 @@
+"""Tests for ``scripts/write_prompt_handoff_outbox.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_script(script_name: str, module_name: str) -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / script_name
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_script("write_prompt_handoff_outbox.py", "write_prompt_handoff_outbox_under_test")
+
+
+def test_dry_run_emits_publisher_compatible_payload(tmp_path: Path, capsys: Any) -> None:
+    rc = mod.main(
+        [
+            "--prompt",
+            "Start from live repo truth.\nDo exactly one bounded unit.",
+            "--task",
+            "Prompt handoff for queue routing",
+            "--source",
+            "python3 scripts/build_next_prompt.py --json",
+            "--pr",
+            "8845",
+            "--expected-head",
+            "abc123",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:41:00Z",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["wrote"] is False
+    assert not Path(result["outbox_path"]).exists()
+
+    payload = result["payload"]
+    for required in (
+        "task",
+        "requires_github",
+        "requested_action",
+        "repo",
+        "local_evidence",
+        "validation",
+        "idempotency_key",
+        "created_at",
+    ):
+        assert payload[required]
+    assert payload["requires_github"] is True
+    assert payload["requested_action"]["type"] == "prompt_handoff"
+    assert payload["requested_action"]["target"] == {"pr": 8845, "expected_head": "abc123"}
+    assert payload["local_evidence"]["kind"] == "prompt_handoff"
+    assert (
+        payload["local_evidence"]["prompt_sha256"] == payload["requested_action"]["prompt_sha256"]
+    )
+    assert payload["local_evidence"]["prompt"].startswith("Start from live repo truth")
+    assert payload["expires_at"] == "2026-07-09T15:41:00Z"
+
+
+def test_apply_writes_deterministic_outbox_file(tmp_path: Path, capsys: Any) -> None:
+    rc = mod.main(
+        [
+            "--prompt",
+            "Route this through the existing publisher.",
+            "--task",
+            "Publish prompt handoff",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:42:00Z",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    outbox_path = Path(result["outbox_path"])
+    assert result["wrote"] is True
+    assert outbox_path.exists()
+    saved = json.loads(outbox_path.read_text(encoding="utf-8"))
+    assert saved == result["payload"]
+    assert saved["idempotency_key"].startswith("prompt-handoff-publish-prompt-handoff-")
+
+
+def test_written_payload_is_loadable_by_automation_handoff_publisher(
+    tmp_path: Path, capsys: Any
+) -> None:
+    rc = mod.main(
+        [
+            "--prompt",
+            "Start from live repo truth and read the handoff issue.",
+            "--task",
+            "Publish prompt handoff through existing publisher",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:44:00Z",
+            "--apply",
+            "--json",
+        ]
+    )
+    assert rc == 0
+    capsys.readouterr()
+
+    publisher = _load_script(
+        "publish_automation_handoffs.py", "publish_automation_handoffs_for_prompt_test"
+    )
+    handoffs, skipped = publisher._load_outbox_handoffs_with_skip_reasons(
+        tmp_path,
+        outbox_dir=tmp_path,
+        receipt_dir=tmp_path / "receipts",
+        now=publisher.datetime(2026, 7, 6, 15, 45, tzinfo=publisher.UTC),
+    )
+
+    assert skipped == {}
+    assert len(handoffs) == 1
+    assert handoffs[0].task_title == "Publish prompt handoff through existing publisher"
+    assert "Requested Action:" in handoffs[0].body
+    assert "prompt_handoff" in handoffs[0].body
+
+
+def test_apply_refuses_existing_file_without_force(tmp_path: Path, capsys: Any) -> None:
+    args = [
+        "--prompt",
+        "Same prompt.",
+        "--task",
+        "Same task",
+        "--outbox-dir",
+        str(tmp_path),
+        "--created-at",
+        "2026-07-06T15:43:00Z",
+        "--apply",
+    ]
+    assert mod.main(args) == 0
+    assert mod.main(args) == 2
+    assert "handoff already exists" in capsys.readouterr().err
+
+
+def test_empty_prompt_returns_2(capsys: Any) -> None:
+    rc = mod.main(["--prompt", "  "])
+    assert rc == 2
+    assert "prompt must not be empty" in capsys.readouterr().err

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -153,6 +153,31 @@ def test_apply_refuses_existing_file_without_force(tmp_path: Path, capsys: Any) 
     assert "handoff already exists" in capsys.readouterr().err
 
 
+def test_default_idempotency_key_includes_target_metadata(tmp_path: Path, capsys: Any) -> None:
+    base_args = [
+        "--prompt",
+        "Same prompt for different targets.",
+        "--task",
+        "Same task",
+        "--outbox-dir",
+        str(tmp_path),
+        "--created-at",
+        "2026-07-06T15:43:00Z",
+        "--apply",
+        "--json",
+    ]
+
+    assert mod.main([*base_args, "--pr", "100"]) == 0
+    first = json.loads(capsys.readouterr().out)
+    assert mod.main([*base_args, "--pr", "101"]) == 0
+    second = json.loads(capsys.readouterr().out)
+
+    assert first["payload"]["idempotency_key"] != second["payload"]["idempotency_key"]
+    assert first["outbox_path"] != second["outbox_path"]
+    assert Path(first["outbox_path"]).exists()
+    assert Path(second["outbox_path"]).exists()
+
+
 def test_empty_prompt_returns_2(capsys: Any) -> None:
     rc = mod.main(["--prompt", "  "])
     assert rc == 2

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -191,6 +191,8 @@ def test_long_prompt_uses_artifact_and_keeps_published_body_recoverable(
     assert payload["requested_action"]["prompt_artifact_path"] == str(artifact_path)
     assert payload["local_evidence"]["prompt_artifact_sha256"] == full_sha
     assert payload["requested_action"]["prompt_artifact_sha256"] == full_sha
+    assert payload["local_evidence"]["prompt_artifact_publication"] == "github_issue_comments"
+    assert payload["requested_action"]["prompt_artifact_publication"] == "github_issue_comments"
     assert payload["local_evidence"]["prompt_sha256"] == full_sha
     assert "prompt" not in payload["local_evidence"]
     assert marker not in payload["local_evidence"]["prompt_preview"]
@@ -213,6 +215,10 @@ def test_long_prompt_uses_artifact_and_keeps_published_body_recoverable(
     assert str(artifact_path) in issue_body
     assert full_sha in issue_body
     assert marker not in issue_body
+    artifact_comments = publisher._prompt_artifact_comment_bodies(tmp_path, handoffs[0])
+    assert len(artifact_comments) == 1
+    assert full_sha in artifact_comments[0]
+    assert marker in artifact_comments[0]
 
 
 def test_written_payload_round_trips_through_outbox_consumers(tmp_path: Path, capsys: Any) -> None:
@@ -256,10 +262,8 @@ def test_written_payload_round_trips_through_outbox_consumers(tmp_path: Path, ca
     ]
 
     audit = _load_script("audit_codex_branch_backlog.py", "audit_backlog_for_prompt_test")
-    assert audit._outbox_payload_branches(payload) == {"codex/prompt-handoff-outbox"}
-    assert audit._outbox_payload_branch_heads(payload) == {
-        "codex/prompt-handoff-outbox": {"070f6aaffccaf726cd6d3c93eff7c88b933fc65f"}
-    }
+    assert audit._outbox_payload_branches(payload) == set()
+    assert audit._outbox_payload_branch_heads(payload) == {}
 
 
 def test_apply_refuses_existing_file_without_force(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -35,6 +35,8 @@ def test_dry_run_emits_publisher_compatible_payload(tmp_path: Path, capsys: Any)
             "python3 scripts/build_next_prompt.py --json",
             "--pr",
             "8845",
+            "--branch",
+            "codex/prompt-handoff",
             "--expected-head",
             "abc123",
             "--outbox-dir",
@@ -64,8 +66,20 @@ def test_dry_run_emits_publisher_compatible_payload(tmp_path: Path, capsys: Any)
         assert payload[required]
     assert payload["requires_github"] is True
     assert payload["requested_action"]["type"] == "prompt_handoff"
-    assert payload["requested_action"]["target"] == {"pr": 8845, "expected_head": "abc123"}
+    assert payload["requested_action"]["branch"] == "codex/prompt-handoff"
+    assert payload["requested_action"]["desired_head_sha"] == "abc123"
+    assert payload["requested_action"]["head_sha"] == "abc123"
+    assert payload["requested_action"]["target"] == {
+        "pr": 8845,
+        "branch": "codex/prompt-handoff",
+        "expected_head": "abc123",
+        "desired_head_sha": "abc123",
+        "head_sha": "abc123",
+    }
     assert payload["local_evidence"]["kind"] == "prompt_handoff"
+    assert payload["local_evidence"]["branch"] == "codex/prompt-handoff"
+    assert payload["local_evidence"]["desired_head_sha"] == "abc123"
+    assert payload["local_evidence"]["head_sha"] == "abc123"
     assert (
         payload["local_evidence"]["prompt_sha256"] == payload["requested_action"]["prompt_sha256"]
     )
@@ -134,6 +148,53 @@ def test_written_payload_is_loadable_by_automation_handoff_publisher(
     assert handoffs[0].task_title == "Publish prompt handoff through existing publisher"
     assert "Requested Action:" in handoffs[0].body
     assert "prompt_handoff" in handoffs[0].body
+
+
+def test_written_payload_round_trips_through_outbox_consumers(tmp_path: Path, capsys: Any) -> None:
+    rc = mod.main(
+        [
+            "--prompt",
+            "Resume the current-head prompt handoff task.",
+            "--task",
+            "Prompt handoff for current branch",
+            "--branch",
+            "codex/prompt-handoff-outbox",
+            "--expected-head",
+            "070f6aaffccaf726cd6d3c93eff7c88b933fc65f",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:45:00Z",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    payload = json.loads(Path(result["outbox_path"]).read_text(encoding="utf-8"))
+
+    reconcile = _load_script(
+        "reconcile_automation_outbox.py", "reconcile_automation_outbox_for_prompt_test"
+    )
+    assert reconcile._branch_from_payload(payload) == "codex/prompt-handoff-outbox"
+    assert (
+        reconcile._desired_head_from_payload(payload) == "070f6aaffccaf726cd6d3c93eff7c88b933fc65f"
+    )
+    records = reconcile._lane_records_from_payload(payload, reconcile._branch_from_payload(payload))
+    assert records == [
+        {
+            "branch": "codex/prompt-handoff-outbox",
+            "desired_head_sha": "070f6aaffccaf726cd6d3c93eff7c88b933fc65f",
+            "head_sha": "070f6aaffccaf726cd6d3c93eff7c88b933fc65f",
+        }
+    ]
+
+    audit = _load_script("audit_codex_branch_backlog.py", "audit_backlog_for_prompt_test")
+    assert audit._outbox_payload_branches(payload) == {"codex/prompt-handoff-outbox"}
+    assert audit._outbox_payload_branch_heads(payload) == {
+        "codex/prompt-handoff-outbox": {"070f6aaffccaf726cd6d3c93eff7c88b933fc65f"}
+    }
 
 
 def test_apply_refuses_existing_file_without_force(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -80,6 +80,8 @@ def test_dry_run_emits_publisher_compatible_payload(tmp_path: Path, capsys: Any)
     assert payload["local_evidence"]["branch"] == "codex/prompt-handoff"
     assert payload["local_evidence"]["desired_head_sha"] == "abc123"
     assert payload["local_evidence"]["head_sha"] == "abc123"
+    assert "prompt_truncated" not in payload["local_evidence"]
+    assert "prompt_artifact_path" not in payload["local_evidence"]
     assert (
         payload["local_evidence"]["prompt_sha256"] == payload["requested_action"]["prompt_sha256"]
     )
@@ -148,6 +150,69 @@ def test_written_payload_is_loadable_by_automation_handoff_publisher(
     assert handoffs[0].task_title == "Publish prompt handoff through existing publisher"
     assert "Requested Action:" in handoffs[0].body
     assert "prompt_handoff" in handoffs[0].body
+
+
+def test_long_prompt_uses_artifact_and_keeps_published_body_recoverable(
+    tmp_path: Path, capsys: Any
+) -> None:
+    marker = "END-OF-LONG-PROMPT-MARKER"
+    long_prompt = "Start from live repo truth.\n" + ("x" * mod.MAX_INLINE_PROMPT_CHARS) + marker
+    full_sha = mod._prompt_sha(long_prompt)
+
+    rc = mod.main(
+        [
+            "--prompt",
+            long_prompt,
+            "--task",
+            "Publish long prompt handoff",
+            "--branch",
+            "codex/long-prompt-handoff",
+            "--expected-head",
+            "abc123",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:46:00Z",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    payload = json.loads(Path(result["outbox_path"]).read_text(encoding="utf-8"))
+    artifact_path = Path(result["prompt_artifact_path"])
+
+    assert artifact_path.exists()
+    assert artifact_path.read_text(encoding="utf-8") == long_prompt
+    assert payload["local_evidence"]["prompt_truncated"] is True
+    assert payload["requested_action"]["prompt_truncated"] is True
+    assert payload["local_evidence"]["prompt_artifact_path"] == str(artifact_path)
+    assert payload["requested_action"]["prompt_artifact_path"] == str(artifact_path)
+    assert payload["local_evidence"]["prompt_artifact_sha256"] == full_sha
+    assert payload["requested_action"]["prompt_artifact_sha256"] == full_sha
+    assert payload["local_evidence"]["prompt_sha256"] == full_sha
+    assert "prompt" not in payload["local_evidence"]
+    assert marker not in payload["local_evidence"]["prompt_preview"]
+
+    publisher = _load_script(
+        "publish_automation_handoffs.py", "publish_automation_handoffs_for_long_prompt_test"
+    )
+    handoffs, skipped = publisher._load_outbox_handoffs_with_skip_reasons(
+        tmp_path,
+        outbox_dir=tmp_path,
+        receipt_dir=tmp_path / "receipts",
+        now=publisher.datetime(2026, 7, 6, 15, 47, tzinfo=publisher.UTC),
+    )
+
+    assert skipped == {}
+    assert len(handoffs) == 1
+    issue_body = publisher._fit_issue_body(handoffs[0].body)
+    assert issue_body == handoffs[0].body
+    assert len(issue_body) < publisher.MAX_ISSUE_BODY_CHARS
+    assert str(artifact_path) in issue_body
+    assert full_sha in issue_body
+    assert marker not in issue_body
 
 
 def test_written_payload_round_trips_through_outbox_consumers(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -221,6 +221,59 @@ def test_long_prompt_uses_artifact_and_keeps_published_body_recoverable(
     assert marker in artifact_comments[0]
 
 
+def test_escaping_heavy_prompt_uses_artifact_before_issue_body_truncation(
+    tmp_path: Path, capsys: Any
+) -> None:
+    prompt = "Start from live repo truth.\n" + ('"\\' * 18_000)
+    full_sha = mod._prompt_sha(prompt)
+    assert len(prompt) < mod.MAX_INLINE_PROMPT_CHARS
+
+    rc = mod.main(
+        [
+            "--prompt",
+            prompt,
+            "--task",
+            "Publish escaping-heavy prompt handoff",
+            "--branch",
+            "codex/escaping-heavy-prompt",
+            "--expected-head",
+            "abc123",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:46:00Z",
+            "--apply",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    payload = json.loads(Path(result["outbox_path"]).read_text(encoding="utf-8"))
+    artifact_path = Path(result["prompt_artifact_path"])
+
+    assert artifact_path.read_text(encoding="utf-8") == prompt
+    assert payload["local_evidence"]["prompt_truncated"] is True
+    assert payload["local_evidence"]["prompt_artifact_sha256"] == full_sha
+    assert "prompt" not in payload["local_evidence"]
+
+    publisher = _load_script(
+        "publish_automation_handoffs.py", "publish_automation_handoffs_for_escaped_prompt_test"
+    )
+    handoffs, skipped = publisher._load_outbox_handoffs_with_skip_reasons(
+        tmp_path,
+        outbox_dir=tmp_path,
+        receipt_dir=tmp_path / "receipts",
+        now=publisher.datetime(2026, 7, 6, 15, 47, tzinfo=publisher.UTC),
+    )
+
+    assert skipped == {}
+    assert len(handoffs) == 1
+    issue_body = publisher._fit_issue_body(handoffs[0].body)
+    assert issue_body == handoffs[0].body
+    assert len(issue_body.encode("utf-8")) < publisher.MAX_ISSUE_BODY_CHARS
+
+
 def test_written_payload_round_trips_through_outbox_consumers(tmp_path: Path, capsys: Any) -> None:
     rc = mod.main(
         [

--- a/tests/scripts/test_write_prompt_handoff_outbox.py
+++ b/tests/scripts/test_write_prompt_handoff_outbox.py
@@ -89,6 +89,31 @@ def test_dry_run_emits_publisher_compatible_payload(tmp_path: Path, capsys: Any)
     assert payload["expires_at"] == "2026-07-09T15:41:00Z"
 
 
+def test_prompt_content_is_preserved_verbatim(tmp_path: Path, capsys: Any) -> None:
+    prompt = "\n```text\nStart from live repo truth.\n```\n\n"
+    rc = mod.main(
+        [
+            "--prompt",
+            prompt,
+            "--task",
+            "Preserve prompt bytes",
+            "--outbox-dir",
+            str(tmp_path),
+            "--created-at",
+            "2026-07-06T15:41:00Z",
+            "--json",
+        ]
+    )
+
+    assert rc == 0
+    result = json.loads(capsys.readouterr().out)
+    payload = result["payload"]
+    assert payload["local_evidence"]["prompt"] == prompt
+    assert payload["local_evidence"]["prompt_chars"] == len(prompt)
+    assert payload["local_evidence"]["prompt_sha256"] == mod._prompt_sha(prompt)
+    assert payload["requested_action"]["prompt_sha256"] == mod._prompt_sha(prompt)
+
+
 def test_apply_writes_deterministic_outbox_file(tmp_path: Path, capsys: Any) -> None:
     rc = mod.main(
         [


### PR DESCRIPTION
Summary:
- Add scripts/write_prompt_handoff_outbox.py to convert generated next prompts into publisher-compatible automation-outbox JSON.
- Keep the helper dry-run by default; --apply writes one deterministic, idempotent outbox handoff for the existing publisher to move to GitHub issues.
- Add tests for dry-run/apply behavior, duplicate protection, empty prompt rejection, and downstream publish_automation_handoffs loader compatibility.

Validation:
- python3 -m py_compile scripts/write_prompt_handoff_outbox.py
- uv run ruff check scripts/write_prompt_handoff_outbox.py tests/scripts/test_write_prompt_handoff_outbox.py
- uv run ruff format --check scripts/write_prompt_handoff_outbox.py tests/scripts/test_write_prompt_handoff_outbox.py
- uv run pytest -q tests/scripts/test_write_prompt_handoff_outbox.py
- push hooks passed, including ruff, ruff format, mypy, gitleaks, and portability guard

Transport scope:
- Covers the prompt-shuttling portion of #8845 without changing judgment gates: this helper only writes a local handoff; GitHub publication still goes through scripts/publish_automation_handoffs.py.