### PR TITLE
fix(ci): install TypeScript SDK deps in integration job

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -234,6 +234,17 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: sdk/typescript/package-lock.json
+
+      - name: Install TypeScript SDK dependencies
+        working-directory: sdk/typescript
+        run: npm ci
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/ci/test_sdk_test_workflow.py
+++ b/tests/ci/test_sdk_test_workflow.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sdk_integration_installs_typescript_deps_before_pytest() -> None:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/sdk-test.yml").read_text())
+    steps = workflow["jobs"]["sdk-integration"]["steps"]
+
+    pytest_index = next(
+        index for index, step in enumerate(steps) if step.get("name") == "Run SDK integration tests"
+    )
+    setup_steps = steps[:pytest_index]
+
+    assert any(
+        step.get("uses") == "actions/setup-node@v4"
+        and step.get("with", {}).get("cache") == "npm"
+        and step.get("with", {}).get("cache-dependency-path") == "sdk/typescript/package-lock.json"
+        for step in setup_steps
+    )
+    assert any(
+        step.get("working-directory") == "sdk/typescript" and "npm ci" in step.get("run", "")
+        for step in setup_steps
+    )


### PR DESCRIPTION
## Summary
- install Node 20 and sdk/typescript dependencies in the SDK Integration Tests workflow before running the Python SDK suite
- add a workflow regression test so that the integration job keeps TypeScript dependencies available for the tsc compile test

## Validation
- python3 -m pytest tests/ci/test_sdk_test_workflow.py -q
- python3 -m pytest tests/sdk/test_typescript_exports.py::TestTypeScriptCompilation::test_sdk_compiles_cleanly -q
- python3 -m ruff check tests/ci/test_sdk_test_workflow.py
- python3 scripts/check_required_check_priority_policy.py
- python3 -m pytest tests/sdk/ -q --tb=short --timeout=60
