### PR TITLE
docs(metrics): regenerate doc_stats metrics blocks to clear origin/main drift (misc-doc-stats-drift-fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
-| Automated tests | 223,079 test functions | `docs/METRICS.md` |
-| Test files | 5,433 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
+| Automated tests | 223,198 test functions | `docs/METRICS.md` |
+| Test files | 5,437 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,260
-- **Tests**: 223,079 across 5,433 test files
+- **Python files (`aragora/`)**: 4,262
+- **Tests**: 223,198 across 5,437 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,079 tests across 5,433 test files
-- **Source files**: 4,260 Python files under `aragora/`
+- **Test coverage**: 223,198 tests across 5,437 test files
+- **Source files**: 4,262 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
-| Automated tests | 223,079 test functions | `docs/METRICS.md` |
-| Test files | 5,433 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
+| Automated tests | 223,198 test functions | `docs/METRICS.md` |
+| Test files | 5,437 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,260
-- **Tests**: 223,079 across 5,433 test files
+- **Python files (`aragora/`)**: 4,262
+- **Tests**: 223,198 across 5,437 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,079 tests across 5,433 test files
-- **Source files**: 4,260 Python files under `aragora/`
+- **Test coverage**: 223,198 tests across 5,437 test files
+- **Source files**: 4,262 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---


### PR DESCRIPTION
## Summary

Clears the pre-existing `doc_stats.py` metric drift on `origin/main` that makes the
**non-required** `build` job (`.github/workflows/docs-build.yml`) fail on every PR
touching `docs/**`. Discovered by `misc-docsite-specs-mirror-boundary` (PR #8953);
that PR's own `build` job failed at the "Ensure docs are synced" step with exactly
this 12-file/24-line drift, confirming the drift is pre-existing on `origin/main`
and not caused by that PR's content.

Confirmed **non-required** via the branch-protection API before starting this fix
(the merge-quorum/required-checks gate does not include `build`).

## What this PR does (STRICTLY mechanical)

Ran the mission docs-sync sequence, in order, on a clean `origin/main` worktree:

```bash
python scripts/doc_stats.py --write
node docs-site/scripts/sync-docs.js
python scripts/check_docs_consistency.py
```

All three completed green. **No manual prose edits were made.** The diff touches
exactly 12 files, and every changed line is *inside* a
`<!-- metrics:begin ... -->` / `<!-- metrics:end -->` delimited block:

- `CLAUDE.md`
- `docs/CANONICAL_GOALS.md`
- `docs/EXTENDED_README.md`
- `docs/STATUS.md`
- `docs/architecture/ARCHITECTURE.md`
- `docs/status/FEATURE_DISCOVERY.md`
- their docs-site mirrors under `docs-site/docs/contributing/**` and
  `docs-site/docs/core-concepts/architecture.md`

Net diff: **12 files changed, 24 insertions(+), 24 deletions(-)** — each file has
one or two numeric-value updates (Python file/line count, test/test-file counts;
these are read from the already-committed `docs/METRICS.md`, not recomputed here).

Verified idempotent: running the same three commands a second time on the
resulting tree produces zero further changes (`doc_stats.py --write` reports
"Updated 0 documentation files"; `git diff` is unchanged).

## Why this is parked, not auto-merged

This diff touches **operator-gated/protected files** (`CLAUDE.md`,
`docs/CANONICAL_GOALS.md` — both listed in `AGENTS.md`/`CLAUDE.md` protected-files
lists). Per mission policy this is a **parked ready PR**, labeled
`operator-review-required`. Auto-merge is **NOT** armed. This mirrors the prior
precedent for this exact class of change (#8783 "docs: sync generated doc
stats... PROTECTED: CLAUDE.md, operator approval required", and #8795).

## Verification

- `python scripts/doc_stats.py --write` → updated 6 files, re-run reports "Updated 0" (idempotent)
- `node docs-site/scripts/sync-docs.js` → synced 260 files (0 skipped); diff limited to the 6 mirror files above
- `python scripts/check_docs_consistency.py` → exit 0, all 4 active checks PASS (gh-hygiene check skipped, as it is everywhere outside `AIRSCRIPT_CHECK_GH=1`)
- `python scripts/check_capability_matrix_sync.py` → "Capability matrix files are up to date." (exit 0)
- `python scripts/check_legacy_entrypoints.py` → "No deprecated entrypoint command patterns found." (exit 0)
- `python scripts/generate_cli_reference.py --check` → "CLI reference files are up to date." (exit 0)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → "preflight: ok" (docs-only diff detected)

These are exactly the steps the `build` job's "Update doc stats" → "Sync
documentation" → "Ensure docs are synced" step sequence runs, so this PR's `build`
job is expected to go green — that is the point of this PR. Will confirm on the
live PR check run and report the result.

## Path-freeze

Checked `gh pr list --state open` for any PR already regenerating these metric
blocks. Found only PR #8823 ("Add epistemic question batteries to receipts and
intake"), a large unrelated feature PR (45 files, 1344 additions) that happens to
touch the same 6 source files (+ mirrors) as an incidental side effect of its own
required docs-sync step, not as a dedicated drift fix. It is not a duplicate of
this PR's scope. No dedicated metric-drift-fix PR is currently open.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
