### PR TITLE
docs(action): backfill full action.yml parity + receipt example (misc-docs-tooling-2)

### DIFF
--- a/docs/GITHUB_ACTION_SETUP.md
+++ b/docs/GITHUB_ACTION_SETUP.md
@@ -60,14 +60,26 @@ That's it. The next PR will get an AI code review comment.
 
 ### Action Inputs
 
+The Inputs and Outputs tables below are kept at full parity with
+[`action.yml`](../action.yml) by `tests/scripts/test_github_action_setup_doc.py`
+(exact-match, not just a subset -- a field added to either side without the other
+fails the test).
+
 | Input | Default | Description |
 |-------|---------|-------------|
 | `agents` | `anthropic-api,openai-api` | Comma-separated agent list |
 | `rounds` | `2` | Number of debate rounds (1-5) |
 | `focus` | `security,performance,quality` | Review focus areas |
+| `anthropic-api-key` | (none) | Anthropic API key for Claude |
+| `openai-api-key` | (none) | OpenAI API key for GPT |
+| `openrouter-api-key` | (none) | OpenRouter API key (fallback provider) |
 | `post-comment` | `true` | Post review as PR comment |
 | `fail-on-critical` | `false` | Fail CI if critical issues found |
 | `max-diff-size` | `50000` | Max diff size in bytes |
+| `pr-number` | (empty string) | Pull request number override, for manual/self-test runs (defaults to the triggering PR's number) |
+| `failure-threshold` | `0` | Fail workflow if total issues exceed this count (`0` = disabled) |
+| `output-format` | `none` | Additional output format besides the PR comment (`sarif`, `json`, `none`) |
+| `sarif-upload` | `false` | Upload the generated SARIF file to the GitHub Security tab (requires `output-format: 'sarif'`) |
 | `emit-receipt` | `false` | Emit a verifiable [Open Decision Receipt](specs/OPEN_DECISION_RECEIPT.md) (ODR) for the review and upload it as a build artifact. See [Emitting a Verifiable Decision Receipt](#emitting-a-verifiable-decision-receipt) below. |
 | `receipt-reviewers` | `claude openai` | Space-separated model families for the receipt's merge-quorum pass. You must hold a reachable provider key for every family listed. |
 | `use-secrets-manager` | `false` | Hydrate provider API keys from AWS Secrets Manager instead of the `*-api-key` inputs. Requires AWS credentials in the job env. |
@@ -90,6 +102,7 @@ That's it. The next PR will get an AI code review comment.
 | `risk-areas-count` | Risk areas noted (lower confidence items) |
 | `split-opinions-count` | Split opinions (agent disagreement items) |
 | `agreement-score` | Agent agreement score (0-1) |
+| `sarif-path` | Path to the generated SARIF output file (only set when `output-format: 'sarif'` produced one) |
 | `receipt-path` | Path to the verifiable ODR decision receipt (only set if `emit-receipt: 'true'` and emission succeeded) |
 | `receipt-verdict` | Receipt verdict (`PASS` / `CHANGES_REQUESTED`) |
 | `receipt-digest` | SHA-256 JCS content digest of the receipt -- the value signatures would cover |
@@ -155,6 +168,8 @@ jobs:
           pip install "aragora-verify>=0.1.1"
           aragora-verify "${{ steps.review.outputs.receipt-path }}"
 ```
+
+See `examples/github-action/receipt.yml` for this snippet as a copy-paste workflow file.
 
 Only the **root** `synaptent/aragora` action shown above (this `action.yml`) can emit
 a receipt. The composite actions nested under `.github/actions/` in this repo

--- a/examples/github-action/advanced.yml
+++ b/examples/github-action/advanced.yml
@@ -6,6 +6,9 @@
 # - rich job summary using action outputs
 #
 # For setup instructions, see: docs/GITHUB_ACTION_SETUP.md
+#
+# NOTE: this example predates emit-receipt (#8669); see receipt.yml for the
+# receipt-emitting variant.
 
 name: Aragora AI Code Review (Advanced)
 

--- a/examples/github-action/aragora-review-strict.yml
+++ b/examples/github-action/aragora-review-strict.yml
@@ -4,6 +4,9 @@
 # Use this for repositories where you want AI review to be a required check.
 #
 # Add this file to your repository at: .github/workflows/aragora-review.yml
+#
+# NOTE: this example predates emit-receipt (#8669); see receipt.yml for the
+# receipt-emitting variant.
 
 name: Aragora AI Code Review (Strict)
 

--- a/examples/github-action/aragora-review.yml
+++ b/examples/github-action/aragora-review.yml
@@ -9,6 +9,9 @@
 #   2. Ensure GITHUB_TOKEN has permission to comment on PRs (default for most repos)
 #
 # For full setup instructions, see: docs/GITHUB_ACTION_SETUP.md
+#
+# NOTE: this example predates emit-receipt (#8669); see receipt.yml for the
+# receipt-emitting variant.
 
 name: Aragora AI Code Review
 

--- a/examples/github-action/basic.yml
+++ b/examples/github-action/basic.yml
@@ -3,6 +3,9 @@
 # Add this file to your repository at: .github/workflows/aragora-review.yml
 #
 # For setup instructions, see: docs/GITHUB_ACTION_SETUP.md
+#
+# NOTE: this example predates emit-receipt (#8669); see receipt.yml for the
+# receipt-emitting variant.
 
 name: Aragora AI Code Review (Basic)
 

--- a/examples/github-action/receipt.yml
+++ b/examples/github-action/receipt.yml
@@ -1,0 +1,55 @@
+# Aragora AI Code Review - Decision Receipt Workflow
+#
+# Demonstrates emitting a verifiable Open Decision Receipt (ODR) for the review
+# (landed in #8669) and uploading it as a build artifact.
+#
+# Add this file to your repository at: .github/workflows/aragora-review.yml
+#
+# For full setup instructions, see: docs/GITHUB_ACTION_SETUP.md
+# (section "Emitting a Verifiable Decision Receipt")
+
+name: Aragora AI Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: aragora-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    name: AI Code Review
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Aragora Review
+        id: review
+        uses: synaptent/aragora@8b600a3a8dbf076f4027ae27f3dcbbf48e75409f
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          post-comment: 'true'
+          emit-receipt: 'true'
+          receipt-reviewers: 'claude openai'   # must be families you hold keys for
+
+      - name: Upload the decision receipt
+        if: steps.review.outputs.receipt-verified == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: decision-receipt
+          path: ${{ steps.review.outputs.receipt-path }}
+
+      - name: Verify the receipt offline (optional)
+        if: steps.review.outputs.receipt-verified == 'true'
+        run: |
+          pip install "aragora-verify>=0.1.1"
+          aragora-verify "${{ steps.review.outputs.receipt-path }}"

--- a/tests/scripts/test_github_action_setup_doc.py
+++ b/tests/scripts/test_github_action_setup_doc.py
@@ -21,6 +21,7 @@ DOC_PATH = Path("docs/GITHUB_ACTION_SETUP.md")
 README_PATH = Path("README.md")
 ROOT_ACTION_PATH = Path("action.yml")
 EXAMPLE_RECEIPT_PATH = Path("docs/specs/examples/example-merge-quorum-receipt.odr.json")
+RECEIPT_WORKFLOW_EXAMPLE_PATH = Path("examples/github-action/receipt.yml")
 PINNED_ROOT_ACTION_REF = "synaptent/aragora@8b600a3a8dbf076f4027ae27f3dcbbf48e75409f"
 
 _BACKTICK_TABLE_FIELD_RE = re.compile(r"^\|\s*`([a-zA-Z0-9_-]+)`\s*\|", re.MULTILINE)
@@ -56,7 +57,11 @@ def _first_uses_step(steps: list[dict[str, Any]], prefix: str) -> dict[str, Any]
     raise AssertionError(f"no step with uses starting with {prefix!r} in {steps!r}")
 
 
-def test_documented_input_names_are_a_subset_of_action_yml() -> None:
+def test_documented_input_names_match_action_yml_exactly() -> None:
+    """Exact-parity guard (not a subset check): the doc's Action Inputs table
+    must document every action.yml input and no others, so a future field
+    added to (or removed from) action.yml without a matching doc update fails
+    this test immediately instead of silently drifting."""
     action = _load_yaml(ROOT_ACTION_PATH)
     action_inputs = set(action["inputs"].keys())
 
@@ -64,14 +69,19 @@ def test_documented_input_names_are_a_subset_of_action_yml() -> None:
     documented = set(_table_field_names(_section(doc, "### Action Inputs")))
 
     phantom = documented - action_inputs
-    assert not phantom, f"doc documents inputs action.yml does not have: {phantom}"
+    missing = action_inputs - documented
+    assert documented == action_inputs, (
+        f"doc Action Inputs table is out of parity with action.yml -- "
+        f"phantom (documented but not in action.yml): {phantom or None}; "
+        f"missing (in action.yml but not documented): {missing or None}"
+    )
 
-    receipt_inputs = {"emit-receipt", "receipt-reviewers", "use-secrets-manager", "aws-region"}
-    missing = receipt_inputs - documented
-    assert not missing, f"doc is missing receipt-related inputs: {missing}"
 
-
-def test_documented_output_names_are_a_subset_of_action_yml() -> None:
+def test_documented_output_names_match_action_yml_exactly() -> None:
+    """Exact-parity guard (not a subset check): the doc's Action Outputs table
+    must document every action.yml output and no others, so a future field
+    added to (or removed from) action.yml without a matching doc update fails
+    this test immediately instead of silently drifting."""
     action = _load_yaml(ROOT_ACTION_PATH)
     action_outputs = set(action["outputs"].keys())
 
@@ -79,11 +89,12 @@ def test_documented_output_names_are_a_subset_of_action_yml() -> None:
     documented = set(_table_field_names(_section(doc, "### Action Outputs")))
 
     phantom = documented - action_outputs
-    assert not phantom, f"doc documents outputs action.yml does not have: {phantom}"
-
-    receipt_outputs = {"receipt-path", "receipt-verdict", "receipt-digest", "receipt-verified"}
-    missing = receipt_outputs - documented
-    assert not missing, f"doc is missing receipt-related outputs: {missing}"
+    missing = action_outputs - documented
+    assert documented == action_outputs, (
+        f"doc Action Outputs table is out of parity with action.yml -- "
+        f"phantom (documented but not in action.yml): {phantom or None}; "
+        f"missing (in action.yml but not documented): {missing or None}"
+    )
 
 
 def test_emit_receipt_input_exists_only_on_root_action() -> None:
@@ -128,6 +139,29 @@ def test_minimal_receipt_snippet_is_valid_yaml_and_wires_emit_receipt() -> None:
 
     verify_steps = [s for s in steps if "aragora-verify" in s.get("run", "")]
     assert verify_steps, "expected an optional aragora-verify step in the snippet"
+
+
+def test_doc_points_to_receipt_workflow_example() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    assert str(RECEIPT_WORKFLOW_EXAMPLE_PATH) in doc, (
+        "doc should point at the receipt-emitting example workflow file"
+    )
+
+
+def test_receipt_workflow_example_is_valid_yaml_and_wires_emit_receipt() -> None:
+    workflow = _load_yaml(RECEIPT_WORKFLOW_EXAMPLE_PATH)
+
+    assert "jobs" in workflow
+    steps = next(iter(workflow["jobs"].values()))["steps"]
+
+    aragora_step = _first_uses_step(steps, "synaptent/aragora@")
+    assert "/.github/actions/" not in aragora_step["uses"], (
+        "the receipt example must point at the ROOT action, not a nested composite"
+    )
+    assert aragora_step["with"]["emit-receipt"] == "true"
+
+    upload_step = _first_uses_step(steps, "actions/upload-artifact@")
+    assert "receipt-path" in upload_step["with"]["path"]
 
 
 def test_docs_do_not_recommend_mutable_main_action_ref() -> None:


### PR DESCRIPTION
## Summary

Backfills two non-blocking findings from `m4-action-wedge-doc` (PR #8955):

**(a) Action Inputs/Outputs table parity.** `docs/GITHUB_ACTION_SETUP.md`'s tables
predated the receipt additions and were missing 7 inputs
(`anthropic-api-key`, `openai-api-key`, `openrouter-api-key`, `pr-number`,
`failure-threshold`, `output-format`, `sarif-upload`) and 1 output
(`sarif-path`) that already existed in the root `action.yml`. Backfilled both
tables to full field-for-field parity with the live `action.yml` (verified by
re-deriving the actual gap at execution time, not from the stale mission-brief
list).

Strengthened `tests/scripts/test_github_action_setup_doc.py`'s two subset
assertions (`documented ⊆ action_inputs` / `documented ⊆ action_outputs`) to
exact-parity assertions (`documented == action_inputs` /
`documented == action_outputs`), so a *future* `action.yml` field addition or
removal fails the guard immediately instead of silently drifting again. The
guard was renamed (`..._are_a_subset_of_action_yml` ->
`..._match_action_yml_exactly`) to describe what it now checks.

**(b) Receipt-emitting example.** `examples/github-action/{basic,advanced,
aragora-review,aragora-review-strict}.yml` all predate #8669 and have no
`emit-receipt`. Added `examples/github-action/receipt.yml`, a new complete
workflow example consistent with `GITHUB_ACTION_SETUP.md`'s "Emitting a
Verifiable Decision Receipt" minimal snippet (pinned root-action ref,
`emit-receipt: 'true'`, upload of `receipt-path`, optional `aragora-verify`
step), plus a one-line pointer to it from that doc section. The 4 existing
examples are functionally untouched -- each got only a 3-line header comment
noting it predates receipts and pointing at `receipt.yml` (explicitly allowed
by the feature spec as an optional note).

## Scope

Docs + `tests/scripts/**` + `examples/github-action/**` only. No
`.github/workflows/*`, `action.yml`, or `.github/actions/**` edits (confirmed
by `git diff --stat` below).

## Files changed

```
docs/GITHUB_ACTION_SETUP.md                      | 15 ++++++
examples/github-action/advanced.yml              |  3 ++
examples/github-action/aragora-review-strict.yml |  3 ++
examples/github-action/aragora-review.yml        |  3 ++
examples/github-action/basic.yml                 |  3 ++
examples/github-action/receipt.yml               | 55 ++++++++++++++++++++++
tests/scripts/test_github_action_setup_doc.py    | 58 +++++++++++++++++++-----
7 files changed, 128 insertions(+), 12 deletions(-)
```

## Verification

- `PYTHONPATH=$WT venv/bin/python -m pytest tests/scripts/test_github_action_setup_doc.py -q`
  -> **9 passed** (2 pre-existing tests upgraded to exact-parity + 2 new tests
  covering the receipt example + doc pointer).
- Confirmed the exact-parity guard actually catches drift (not just passes
  vacuously): in-process check with a simulated phantom-documented field and a
  simulated undocumented-new action.yml field both correctly evaluate
  `documented == action_inputs` as `False`.
- `make docs-check` -> Check 1-4 PASS, no findings.
- `python3 scripts/validate_doc_links.py` -> all documentation links valid.
- `venv/bin/python -m ruff check tests/scripts/test_github_action_setup_doc.py` -> all checks passed.
- `venv/bin/python -m mypy --ignore-missing-imports --follow-imports=skip tests/scripts/test_github_action_setup_doc.py` -> no issues.
- `python -c "import yaml"` parse of all 5 `examples/github-action/*.yml` files (including the new `receipt.yml`) -> all parse; pre-commit's `check yaml` hook also passed on the actual commit.
- `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js`: `doc_stats.py --write` only touched the pre-existing known-drifted metric-counter files (`CLAUDE.md`, `docs/CANONICAL_GOALS.md`, `docs/EXTENDED_README.md`, `docs/STATUS.md`, `docs/architecture/ARCHITECTURE.md`, `docs/status/FEATURE_DISCOVERY.md`) that this feature did not cause and `misc-doc-stats-drift-fix` has not yet merged to origin/main -- reverted per the docs-worker skill's known-drift exception. `sync-docs.js` produced zero diff (`docs/GITHUB_ACTION_SETUP.md` is not in the docs-site `DOC_MAP` mirror set).
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`.

## Merge policy

Docs + tests/fixtures only (per the orchestrator's 2026-07-07 ruling on
#8955, a docs change + its focused drift-guard test may combine in one
Tier-0 PR), no frozen/gated paths touched -> **auto-merge eligible**.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
