### PR TITLE
feat(governance): charter-compliance checker (#8942)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
-| Automated tests | 223,079 test functions | `docs/METRICS.md` |
-| Test files | 5,433 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
+| Automated tests | 223,198 test functions | `docs/METRICS.md` |
+| Test files | 5,437 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions | 5,433 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,079 test functions across 5,433 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,260
-- **Tests**: 223,079 across 5,433 test files
+- **Python files (`aragora/`)**: 4,262
+- **Tests**: 223,198 across 5,437 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,079 tests across 5,433 test files
-- **Source files**: 4,260 Python files under `aragora/`
+- **Test coverage**: 223,198 tests across 5,437 test files
+- **Source files**: 4,262 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,260 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,975,628 | `docs/METRICS.md` |
-| Automated tests | 223,079 test functions | `docs/METRICS.md` |
-| Test files | 5,433 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
+| Automated tests | 223,198 test functions | `docs/METRICS.md` |
+| Test files | 5,437 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,260 tracked Python files | 144 top-level modules | 223,079 test functions across 5,433 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,260
-- **Tests**: 223,079 across 5,433 test files
+- **Python files (`aragora/`)**: 4,262
+- **Tests**: 223,198 across 5,437 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,079 tests across 5,433 test files
-- **Source files**: 4,260 Python files under `aragora/`
+- **Test coverage**: 223,198 tests across 5,437 test files
+- **Source files**: 4,262 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/architecture/CHARTER_COMPLIANCE_CHECKER.md
+++ b/docs/architecture/CHARTER_COMPLIANCE_CHECKER.md
@@ -1,0 +1,31 @@
+# Charter Compliance Checker
+
+`scripts/check_charter_compliance.py` is advisory tooling for issue #8942. It
+reads `docs/architecture/charters.yaml` and a Git diff, then reports citable
+`CHR-*` and related `ARCH-*` rows when a change appears to re-add a chartered
+removed surface, excluded placement, or parked/pending surface that is
+machine-checkable from added lines.
+
+Example:
+
+```bash
+python scripts/check_charter_compliance.py --range origin/main...HEAD
+python scripts/check_charter_compliance.py --range origin/main...HEAD --format json
+```
+
+While the architecture charter remains `DRAFT`, binding violations are limited
+to rows that bind in draft: `CHR-P4A-001`, `CHR-P4A-002`, `CHR-P4A-003`,
+`CHR-P4A-004`, `CHR-X-007`, and any row explicitly marked
+`binding_in_draft: true`. Other detectable rows are reported as proposed-only
+violations so reviewers can see the future charter pressure without treating it
+as ratified policy.
+
+`symbols` and `kept_symbols` provide symbol-level granularity. A path-level
+PARK row can name kept symbols that should not false-positive while the rest of
+the path remains parked or proposed. `CHR-X-040` uses this for the
+`aragora.control_plane.registry` health/liveness API consumed by
+`aragora/debate/team_selector.py`.
+
+This checker is not wired into CI, branch protection, merge gates, settlement,
+or evidence collection. Any required-check integration needs separate operator
+approval.

--- a/docs/architecture/charters.yaml
+++ b/docs/architecture/charters.yaml
@@ -756,6 +756,10 @@ registry:
       - aragora/control_plane/scheduler.py
       - aragora/control_plane/registry.py
     symbols: []
+    kept_symbols:
+      - aragora.control_plane.registry:AgentRegistry
+      - aragora.control_plane.registry:AgentStatus
+      - aragora.control_plane.registry:AgentInfo.is_alive
     deadline: "2026-07-29"
     owner: operator
     evidence: >-

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,260 Python files | 223,079 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/scripts/check_charter_compliance.py
+++ b/scripts/check_charter_compliance.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Advisory checker for chartered architecture removals and exclusions."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+DRAFT_BINDING_IDS = {
+    "CHR-P4A-001",
+    "CHR-P4A-002",
+    "CHR-P4A-003",
+    "CHR-P4A-004",
+    "CHR-X-007",
+}
+ENFORCED_STATES = {"REMOVED", "EXCLUSION", "PENDING", "EXPIRING", "PARKED"}
+FROM_IMPORT_RE = re.compile(r"^\s*from\s+([A-Za-z_][\w.]*)\s+import\s+(.+)$")
+PLAIN_IMPORT_RE = re.compile(r"^\s*import\s+(.+)$")
+HUNK_RE = re.compile(r"@@\s+-\d+(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@")
+WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+@dataclass(frozen=True)
+class CharterEntry:
+    entry_id: str
+    state: str
+    paths: tuple[str, ...]
+    symbols: tuple[str, ...]
+    kept_symbols: tuple[str, ...]
+    binding: str
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    path: str
+    line_no: int | None
+    line: str
+
+
+@dataclass(frozen=True)
+class Violation:
+    binding: str
+    entry_id: str
+    state: str
+    path: str
+    line_no: int | None
+    line: str
+    reason: str
+    authority_ids: list[str]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    ok: bool
+    binding_violations: list[Violation]
+    proposed_violations: list[Violation]
+    violations: list[Violation]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "binding_violations": [asdict(violation) for violation in self.binding_violations],
+            "proposed_violations": [asdict(violation) for violation in self.proposed_violations],
+            "violations": [asdict(violation) for violation in self.violations],
+        }
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _normalize_diff_path(raw: str) -> str | None:
+    raw = raw.strip()
+    if raw == "/dev/null":
+        return None
+    if raw.startswith("a/") or raw.startswith("b/"):
+        raw = raw[2:]
+    if raw.startswith("./"):
+        raw = raw[2:]
+    return raw or None
+
+
+def _path_matches(pattern: str, path: str) -> bool:
+    pattern = pattern.strip()
+    if not pattern:
+        return False
+    if pattern.startswith("./"):
+        pattern = pattern[2:]
+    if pattern.endswith("/"):
+        return path.startswith(pattern)
+    return path == pattern or fnmatch.fnmatch(path, pattern)
+
+
+def _path_to_module(path: str) -> str:
+    if path.endswith("/__init__.py"):
+        path = path[: -len("/__init__.py")]
+    elif path.endswith(".py"):
+        path = path[:-3]
+    return path.replace("/", ".")
+
+
+def _path_pattern_to_modules(pattern: str) -> tuple[str, ...]:
+    pattern = pattern.strip().rstrip("/")
+    if not pattern:
+        return ()
+    if pattern.endswith(".py") or pattern.endswith("/__init__.py"):
+        return (_path_to_module(pattern),)
+    return (pattern.replace("/", "."),)
+
+
+def _symbol_module(symbol: str) -> str | None:
+    if ":" not in symbol:
+        return None
+    return symbol.split(":", 1)[0]
+
+
+def _symbol_export(symbol: str) -> str:
+    export = symbol.split(":", 1)[-1]
+    return export.rsplit(".", 1)[-1]
+
+
+def _symbol_export_roots(symbols: Iterable[str]) -> set[str]:
+    roots: set[str] = set()
+    for symbol in symbols:
+        export = symbol.split(":", 1)[-1]
+        parts = [part for part in export.split(".") if part]
+        roots.update(parts)
+    return roots
+
+
+def _parse_imported_names(imports: str) -> list[str]:
+    cleaned = imports.split("#", 1)[0].strip()
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        cleaned = cleaned[1:-1]
+    names: list[str] = []
+    for part in cleaned.split(","):
+        token = part.strip()
+        if not token or token == "*":
+            continue
+        names.append(token.split(" as ", 1)[0].strip())
+    return names
+
+
+def _from_import(line: str) -> tuple[str, list[str]] | None:
+    match = FROM_IMPORT_RE.match(line)
+    if not match:
+        return None
+    return match.group(1), _parse_imported_names(match.group(2))
+
+
+def _plain_import_modules(line: str) -> list[str]:
+    match = PLAIN_IMPORT_RE.match(line)
+    if not match:
+        return []
+    modules: list[str] = []
+    for part in match.group(1).split(","):
+        token = part.strip()
+        if not token:
+            continue
+        modules.append(token.split(" as ", 1)[0].strip())
+    return modules
+
+
+def _line_mentions_symbol(line: str, symbol: str) -> bool:
+    export = _symbol_export(symbol)
+    return bool(re.search(rf"\b{re.escape(export)}\b", line))
+
+
+def _is_python_path(path: str) -> bool:
+    return path.endswith((".py", ".pyi"))
+
+
+def _line_reexports_or_defines_symbol(line: str, symbol: str) -> bool:
+    if line[:1].isspace():
+        return False
+    export = _symbol_export(symbol)
+    from_import = _from_import(line)
+    if from_import is not None:
+        _module, names = from_import
+        return export in names or "*" in names
+    return bool(
+        re.match(rf"^(?:async\s+def|def|class)\s+{re.escape(export)}\b", line)
+        or re.match(rf"^{re.escape(export)}\s*=", line)
+    )
+
+
+def _module_is_under(module: str, parent: str) -> bool:
+    return module == parent or module.startswith(f"{parent}.")
+
+
+def _line_imports_path(line: str, path_pattern: str) -> bool:
+    modules = _path_pattern_to_modules(path_pattern)
+    if not modules:
+        return False
+    from_import = _from_import(line)
+    if from_import is not None:
+        module, _names = from_import
+        return any(_module_is_under(module, parent) for parent in modules)
+    return any(
+        _module_is_under(imported, parent)
+        for imported in _plain_import_modules(line)
+        for parent in modules
+    )
+
+
+def _line_imports_symbol(line: str, symbol: str) -> bool:
+    module_name = _symbol_module(symbol)
+    export = _symbol_export(symbol)
+    if module_name is None:
+        return _line_mentions_symbol(line, symbol)
+    from_import = _from_import(line)
+    if from_import is not None:
+        imported_module, names = from_import
+        return imported_module == module_name and (export in names or "*" in names)
+    return any(
+        imported == module_name for imported in _plain_import_modules(line)
+    ) and _line_mentions_symbol(
+        line,
+        symbol,
+    )
+
+
+def _line_is_kept_only(line: str, entry: CharterEntry) -> bool:
+    if not entry.kept_symbols:
+        return False
+    kept_exports = _symbol_export_roots(entry.kept_symbols)
+    from_import = _from_import(line)
+    if from_import is not None:
+        imported_module, names = from_import
+        matching_kept = [
+            symbol for symbol in entry.kept_symbols if _symbol_module(symbol) == imported_module
+        ]
+        if matching_kept:
+            return bool(names) and all(name in kept_exports for name in names)
+        return False
+    mentioned_words = set(WORD_RE.findall(line))
+    return bool(mentioned_words & kept_exports) and not (
+        "class " in line and not mentioned_words <= kept_exports
+    )
+
+
+def parse_diff(diff_text: str) -> list[AddedLine]:
+    added: list[AddedLine] = []
+    current_path: str | None = None
+    current_line: int | None = None
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ "):
+            current_path = _normalize_diff_path(raw_line[4:].split("\t", 1)[0])
+            current_line = None
+            continue
+        if raw_line.startswith("@@"):
+            match = HUNK_RE.search(raw_line)
+            current_line = int(match.group(1)) if match else None
+            continue
+        if current_path is None:
+            continue
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            added.append(AddedLine(current_path, current_line, raw_line[1:]))
+            if current_line is not None:
+                current_line += 1
+        elif raw_line.startswith("-"):
+            continue
+        elif current_line is not None:
+            current_line += 1
+    return added
+
+
+def load_charter_entries(
+    charter_path: Path,
+) -> tuple[list[CharterEntry], dict[str, list[str]], str]:
+    data = yaml.safe_load(charter_path.read_text(encoding="utf-8")) or {}
+    meta = data.get("meta") or {}
+    status = str(meta.get("status") or "DRAFT").upper()
+    authority_by_ref: dict[str, list[str]] = {}
+    for authority in data.get("authorities") or []:
+        authority_id = str(authority.get("id") or "")
+        if not authority_id.startswith("ARCH-"):
+            continue
+        for ref in authority.get("registry_refs") or []:
+            authority_by_ref.setdefault(str(ref), []).append(authority_id)
+
+    entries: list[CharterEntry] = []
+    for raw_entry in data.get("registry") or []:
+        entry_id = str(raw_entry.get("id") or "")
+        state = str(raw_entry.get("state") or "").upper()
+        if not entry_id.startswith("CHR-") or state not in ENFORCED_STATES:
+            continue
+        is_binding = (
+            status == "RATIFIED"
+            or bool(raw_entry.get("binding_in_draft"))
+            or entry_id in DRAFT_BINDING_IDS
+        )
+        entries.append(
+            CharterEntry(
+                entry_id=entry_id,
+                state=state,
+                paths=tuple(str(path) for path in raw_entry.get("paths") or []),
+                symbols=tuple(str(symbol) for symbol in raw_entry.get("symbols") or []),
+                kept_symbols=tuple(str(symbol) for symbol in raw_entry.get("kept_symbols") or []),
+                binding="BINDING" if is_binding else "PROPOSED",
+            )
+        )
+    return entries, authority_by_ref, status
+
+
+def _entry_matches_line(entry: CharterEntry, added_line: AddedLine) -> str | None:
+    if _line_is_kept_only(added_line.line, entry):
+        return None
+    if entry.symbols:
+        if not _is_python_path(added_line.path):
+            return None
+        for symbol in entry.symbols:
+            if _line_imports_symbol(added_line.line, symbol) or (
+                any(_path_matches(path, added_line.path) for path in entry.paths)
+                and _line_reexports_or_defines_symbol(added_line.line, symbol)
+            ):
+                return f"re-adds chartered symbol {symbol}"
+        return None
+    if any(_path_matches(path, added_line.path) for path in entry.paths):
+        return f"adds code under chartered {entry.state.lower()} path"
+    for path in entry.paths:
+        if _line_imports_path(added_line.line, path):
+            return f"imports chartered {entry.state.lower()} path {path}"
+    return None
+
+
+def check_diff(diff_text: str, *, charter_path: Path | str) -> CheckResult:
+    entries, authority_by_ref, _status = load_charter_entries(Path(charter_path))
+    added_lines = parse_diff(diff_text)
+    violations: list[Violation] = []
+    seen: set[tuple[str, str, int | None, str]] = set()
+    for added_line in added_lines:
+        for entry in entries:
+            reason = _entry_matches_line(entry, added_line)
+            if reason is None:
+                continue
+            if entry.symbols:
+                key = (
+                    entry.entry_id,
+                    added_line.path,
+                    added_line.line_no,
+                    added_line.line.strip(),
+                )
+            else:
+                key = (entry.entry_id, added_line.path, None, "")
+            if key in seen:
+                continue
+            seen.add(key)
+            violations.append(
+                Violation(
+                    binding=entry.binding,
+                    entry_id=entry.entry_id,
+                    state=entry.state,
+                    path=added_line.path,
+                    line_no=added_line.line_no,
+                    line=added_line.line,
+                    reason=reason,
+                    authority_ids=authority_by_ref.get(entry.entry_id, []),
+                )
+            )
+    binding = [violation for violation in violations if violation.binding == "BINDING"]
+    proposed = [violation for violation in violations if violation.binding == "PROPOSED"]
+    return CheckResult(
+        ok=not violations,
+        binding_violations=binding,
+        proposed_violations=proposed,
+        violations=violations,
+    )
+
+
+def _git_diff(ref_range: str) -> str:
+    proc = subprocess.run(
+        ["git", "diff", "--no-ext-diff", "--unified=0", ref_range, "--"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(f"git diff failed for {ref_range}: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def _read_diff(args: argparse.Namespace) -> str:
+    if args.diff_file:
+        if args.diff_file == "-":
+            return sys.stdin.read()
+        return Path(args.diff_file).read_text(encoding="utf-8")
+    ref_range = args.ref_range or f"{args.base}...{args.head}"
+    return _git_diff(ref_range)
+
+
+def _render_text(result: CheckResult) -> str:
+    if result.ok:
+        return "Charter compliance: PASS\nNo chartered re-adds or enforceable placement violations found."
+    lines = ["Charter compliance: FAIL"]
+    for title, violations in (
+        ("Binding violations", result.binding_violations),
+        ("Proposed violations", result.proposed_violations),
+    ):
+        if not violations:
+            continue
+        lines.append("")
+        lines.append(f"{title}:")
+        for violation in violations:
+            location = violation.path
+            if violation.line_no is not None:
+                location = f"{location}:{violation.line_no}"
+            authorities = ""
+            if violation.authority_ids:
+                authorities = f" authorities={','.join(violation.authority_ids)}"
+            lines.append(
+                f"- {violation.binding} {violation.entry_id} [{violation.state}]"
+                f"{authorities} {location}: {violation.reason}"
+            )
+            lines.append(f"  added: {violation.line.strip()}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--charters",
+        type=Path,
+        default=_repo_root() / "docs" / "architecture" / "charters.yaml",
+        help="Path to docs/architecture/charters.yaml.",
+    )
+    parser.add_argument("--diff-file", help="Unified diff file to inspect; use '-' for stdin.")
+    parser.add_argument(
+        "--range", dest="ref_range", help="Git diff range, for example base...head."
+    )
+    parser.add_argument("--base", default="origin/main", help="Base ref when --range is omitted.")
+    parser.add_argument("--head", default="HEAD", help="Head ref when --range is omitted.")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    diff_text = _read_diff(args)
+    result = check_diff(diff_text, charter_path=args.charters)
+    if args.format == "json":
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(_render_text(result))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_charter_compliance.py
+++ b/scripts/check_charter_compliance.py
@@ -171,6 +171,21 @@ def _plain_import_modules(line: str) -> list[str]:
     return modules
 
 
+def _plain_import_aliases(line: str) -> dict[str, str]:
+    match = PLAIN_IMPORT_RE.match(line)
+    if not match:
+        return {}
+    aliases: dict[str, str] = {}
+    for part in match.group(1).split(","):
+        token = part.strip()
+        if not token or " as " not in token:
+            continue
+        module, alias = [piece.strip() for piece in token.split(" as ", 1)]
+        if module and alias:
+            aliases[alias] = module
+    return aliases
+
+
 def _line_mentions_symbol(line: str, symbol: str) -> bool:
     export = _symbol_export(symbol)
     return bool(re.search(rf"\b{re.escape(export)}\b", line))
@@ -194,6 +209,10 @@ def _line_reexports_or_defines_symbol(line: str, symbol: str) -> bool:
     )
 
 
+def _line_reexports_or_defines_kept_symbol(line: str, entry: CharterEntry) -> bool:
+    return any(_line_reexports_or_defines_symbol(line, symbol) for symbol in entry.kept_symbols)
+
+
 def _module_is_under(module: str, parent: str) -> bool:
     return module == parent or module.startswith(f"{parent}.")
 
@@ -213,7 +232,29 @@ def _line_imports_path(line: str, path_pattern: str) -> bool:
     )
 
 
-def _line_imports_symbol(line: str, symbol: str) -> bool:
+def _line_uses_symbol_reference(
+    line: str,
+    symbol: str,
+    aliases_by_module: dict[str, set[str]],
+) -> bool:
+    module_name = _symbol_module(symbol)
+    if module_name is None:
+        return False
+    export = _symbol_export(symbol)
+    refs = [module_name, *sorted(aliases_by_module.get(module_name, set()))]
+    return any(
+        re.search(rf"(?<![\w.]){re.escape(ref)}\.{re.escape(export)}\b", line) for ref in refs
+    )
+
+
+def _line_imports_symbol(
+    line: str,
+    symbol: str,
+    aliases_by_module: dict[str, set[str]] | None = None,
+) -> bool:
+    aliases_by_module = aliases_by_module or {}
+    if _line_uses_symbol_reference(line, symbol, aliases_by_module):
+        return True
     module_name = _symbol_module(symbol)
     export = _symbol_export(symbol)
     if module_name is None:
@@ -230,9 +271,10 @@ def _line_imports_symbol(line: str, symbol: str) -> bool:
     )
 
 
-def _line_is_kept_only(line: str, entry: CharterEntry) -> bool:
+def _line_is_kept_only(added_line: AddedLine, entry: CharterEntry) -> bool:
     if not entry.kept_symbols:
         return False
+    line = added_line.line
     kept_exports = _symbol_export_roots(entry.kept_symbols)
     from_import = _from_import(line)
     if from_import is not None:
@@ -243,10 +285,9 @@ def _line_is_kept_only(line: str, entry: CharterEntry) -> bool:
         if matching_kept:
             return bool(names) and all(name in kept_exports for name in names)
         return False
-    mentioned_words = set(WORD_RE.findall(line))
-    return bool(mentioned_words & kept_exports) and not (
-        "class " in line and not mentioned_words <= kept_exports
-    )
+    if any(_path_matches(path, added_line.path) for path in entry.paths):
+        return _line_reexports_or_defines_kept_symbol(line, entry)
+    return False
 
 
 def parse_diff(diff_text: str) -> list[AddedLine]:
@@ -313,14 +354,18 @@ def load_charter_entries(
     return entries, authority_by_ref, status
 
 
-def _entry_matches_line(entry: CharterEntry, added_line: AddedLine) -> str | None:
-    if _line_is_kept_only(added_line.line, entry):
+def _entry_matches_line(
+    entry: CharterEntry,
+    added_line: AddedLine,
+    aliases_by_module: dict[str, set[str]],
+) -> str | None:
+    if _line_is_kept_only(added_line, entry):
         return None
     if entry.symbols:
         if not _is_python_path(added_line.path):
             return None
         for symbol in entry.symbols:
-            if _line_imports_symbol(added_line.line, symbol) or (
+            if _line_imports_symbol(added_line.line, symbol, aliases_by_module) or (
                 any(_path_matches(path, added_line.path) for path in entry.paths)
                 and _line_reexports_or_defines_symbol(added_line.line, symbol)
             ):
@@ -337,11 +382,19 @@ def _entry_matches_line(entry: CharterEntry, added_line: AddedLine) -> str | Non
 def check_diff(diff_text: str, *, charter_path: Path | str) -> CheckResult:
     entries, authority_by_ref, _status = load_charter_entries(Path(charter_path))
     added_lines = parse_diff(diff_text)
+    aliases_by_path: dict[str, dict[str, set[str]]] = {}
+    for added_line in added_lines:
+        for alias, module in _plain_import_aliases(added_line.line).items():
+            aliases_by_path.setdefault(added_line.path, {}).setdefault(module, set()).add(alias)
     violations: list[Violation] = []
     seen: set[tuple[str, str, int | None, str]] = set()
     for added_line in added_lines:
         for entry in entries:
-            reason = _entry_matches_line(entry, added_line)
+            reason = _entry_matches_line(
+                entry,
+                added_line,
+                aliases_by_path.get(added_line.path, {}),
+            )
             if reason is None:
                 continue
             if entry.symbols:

--- a/tests/scripts/test_check_charter_compliance.py
+++ b/tests/scripts/test_check_charter_compliance.py
@@ -133,6 +133,24 @@ def test_kept_symbol_does_not_trip_path_level_park(tmp_path: Path) -> None:
     assert result.violations == []
 
 
+def test_kept_symbol_mention_does_not_hide_new_parked_surface(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
+--- a/aragora/control_plane/registry.py
++++ b/aragora/control_plane/registry.py
+@@ -0,0 +1,2 @@
++def new_surface():
++    return AgentRegistry()
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+    assert result.proposed_violations[0].authority_ids == ["ARCH-014"]
+
+
 def test_parked_path_non_kept_surface_is_proposed(tmp_path: Path) -> None:
     charter_path = _write_charters(tmp_path, _charters_payload())
     diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
@@ -150,6 +168,40 @@ def test_parked_path_non_kept_surface_is_proposed(tmp_path: Path) -> None:
     assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
     assert result.proposed_violations[0].binding == "PROPOSED"
     assert result.proposed_violations[0].authority_ids == ["ARCH-014"]
+
+
+def test_removed_symbol_split_fully_qualified_use_is_binding(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/some.py b/some.py
+--- a/some.py
++++ b/some.py
+@@ -0,0 +1,2 @@
++import aragora.queue
++executor = aragora.queue.create_default_executor()
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert [violation.entry_id for violation in result.binding_violations] == ["CHR-P4A-004"]
+    assert "create_default_executor" in result.binding_violations[0].line
+
+
+def test_removed_symbol_split_alias_use_is_binding(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/some.py b/some.py
+--- a/some.py
++++ b/some.py
+@@ -0,0 +1,2 @@
++import aragora.queue as queue_mod
++executor = queue_mod.create_default_executor()
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert [violation.entry_id for violation in result.binding_violations] == ["CHR-P4A-004"]
+    assert "create_default_executor" in result.binding_violations[0].line
 
 
 def test_exclusion_path_violation_reports_arch_context(tmp_path: Path) -> None:

--- a/tests/scripts/test_check_charter_compliance.py
+++ b/tests/scripts/test_check_charter_compliance.py
@@ -1,0 +1,200 @@
+"""Tests for ``scripts/check_charter_compliance.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "check_charter_compliance.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_charter_compliance_under_test",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load_module()
+
+
+def _write_charters(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    path = tmp_path / "charters.yaml"
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return path
+
+
+def _charters_payload() -> dict[str, Any]:
+    return {
+        "meta": {
+            "charter": "docs/architecture/INTENDED_ARCHITECTURE.md",
+            "version": "0.4",
+            "status": "DRAFT",
+        },
+        "authorities": [
+            {
+                "id": "ARCH-015",
+                "concern": "durable-server-jobs",
+                "authority": "aragora/queue",
+                "registry_refs": ["CHR-P4A-004"],
+            },
+            {
+                "id": "ARCH-014",
+                "concern": "fleet-task-scheduling",
+                "authority": "aragora/swarm",
+                "registry_refs": ["CHR-X-040"],
+            },
+            {
+                "id": "ARCH-029",
+                "concern": "observability",
+                "authority": "aragora/observability",
+                "registry_refs": ["CHR-E-004"],
+            },
+        ],
+        "registry": [
+            {
+                "id": "CHR-P4A-004",
+                "state": "REMOVED",
+                "binding_in_draft": True,
+                "paths": ["aragora/queue/__init__.py"],
+                "symbols": ["aragora.queue:create_default_executor"],
+                "evidence": "Removed by #8890, re-removed by #8909.",
+            },
+            {
+                "id": "CHR-X-040",
+                "state": "PARKED",
+                "paths": [
+                    "aragora/control_plane/scheduler.py",
+                    "aragora/control_plane/registry.py",
+                ],
+                "symbols": [],
+                "kept_symbols": [
+                    "aragora.control_plane.registry:AgentRegistry",
+                    "aragora.control_plane.registry:AgentStatus",
+                    "aragora.control_plane.registry:AgentInfo.is_alive",
+                ],
+                "evidence": "registry health/liveness surface is KEPT.",
+            },
+            {
+                "id": "CHR-E-004",
+                "state": "EXCLUSION",
+                "paths": ["aragora/server/"],
+                "symbols": [],
+                "evidence": "no server-local metrics/tracing/http-pool homes.",
+            },
+        ],
+    }
+
+
+def test_removed_symbol_readd_is_binding_and_cites_authority(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/some.py b/some.py
+--- a/some.py
++++ b/some.py
+@@ -0,0 +1,2 @@
++from aragora.queue import create_default_executor
++executor = create_default_executor()
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert [violation.entry_id for violation in result.binding_violations] == ["CHR-P4A-004"]
+    violation = result.binding_violations[0]
+    assert violation.binding == "BINDING"
+    assert violation.authority_ids == ["ARCH-015"]
+    assert "create_default_executor" in violation.line
+
+
+def test_kept_symbol_does_not_trip_path_level_park(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/debate/team_selector.py b/aragora/debate/team_selector.py
+--- a/aragora/debate/team_selector.py
++++ b/aragora/debate/team_selector.py
+@@ -1,0 +2,2 @@
++from aragora.control_plane.registry import AgentRegistry, AgentStatus
++registry = AgentRegistry()
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is True
+    assert result.violations == []
+
+
+def test_parked_path_non_kept_surface_is_proposed(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
+--- a/aragora/control_plane/registry.py
++++ b/aragora/control_plane/registry.py
+@@ -0,0 +1,2 @@
++class RegionalLoadBalancer:
++    pass
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+    assert result.proposed_violations[0].binding == "PROPOSED"
+    assert result.proposed_violations[0].authority_ids == ["ARCH-014"]
+
+
+def test_exclusion_path_violation_reports_arch_context(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/server/metrics_pool.py b/aragora/server/metrics_pool.py
+--- /dev/null
++++ b/aragora/server/metrics_pool.py
+@@ -0,0 +1,2 @@
++def record_metric(name: str) -> None:
++    pass
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-E-004"]
+    assert result.proposed_violations[0].authority_ids == ["ARCH-029"]
+
+
+def test_cli_json_exits_nonzero_with_citable_ids(tmp_path: Path, capsys: Any) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_path = tmp_path / "diff.patch"
+    diff_path.write_text(
+        """diff --git a/some.py b/some.py
+--- a/some.py
++++ b/some.py
+@@ -0,0 +1 @@
++from aragora.queue import create_default_executor
+""",
+        encoding="utf-8",
+    )
+
+    rc = checker.main(
+        [
+            "--charters",
+            str(charter_path),
+            "--diff-file",
+            str(diff_path),
+            "--format",
+            "json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 1
+    assert payload["ok"] is False
+    assert payload["binding_violations"][0]["entry_id"] == "CHR-P4A-004"
+    assert payload["binding_violations"][0]["authority_ids"] == ["ARCH-015"]


### PR DESCRIPTION
## Summary

Refs #8942.

Adds advisory charter-compliance tooling for `docs/architecture/charters.yaml`:

- `scripts/check_charter_compliance.py` checks a unified diff or git ref range for machine-detectable charter violations.
- `docs/architecture/CHARTER_COMPLIANCE_CHECKER.md` documents usage and current DRAFT behavior.
- `docs/architecture/charters.yaml` gets minimal `kept_symbols` metadata for CHR-X-040 so the kept registry health/liveness API does not false-positive.
- Focused tests cover binding/proposed split, CHR symbol re-adds, ARCH context citation, and CHR-X-040 symbol-level kept surface handling.

## Binding vs proposed today

The charter is still `DRAFT` in `docs/architecture/charters.yaml`. This checker reports violations separately:

- Binding today: `CHR-P4A-001`, `CHR-P4A-002`, `CHR-P4A-003`, `CHR-P4A-004`, `CHR-X-007`.
- Proposed-only today: all other detectable `REMOVED`, `EXCLUSION`, `PENDING`, `EXPIRING`, and `PARKED` rows remain advisory until ratification or explicit draft binding.

This PR does not ratify the charter.

## Exact IDs currently enforced or cited

Binding CHR IDs:

`CHR-P4A-001`, `CHR-P4A-002`, `CHR-P4A-003`, `CHR-P4A-004`, `CHR-X-007`

Proposed CHR IDs currently detectable from added lines:

`CHR-X-001`, `CHR-X-002`, `CHR-X-003`, `CHR-X-004`, `CHR-X-005`, `CHR-X-006`, `CHR-X-008`, `CHR-X-009`, `CHR-X-010`, `CHR-X-012`, `CHR-X-013`, `CHR-X-014`, `CHR-X-015`, `CHR-X-016`, `CHR-X-017`, `CHR-X-018`, `CHR-X-019`, `CHR-X-025`, `CHR-X-026`, `CHR-X-027`, `CHR-X-028`, `CHR-X-029`, `CHR-X-030`, `CHR-X-031`, `CHR-X-032`, `CHR-X-033`, `CHR-X-034`, `CHR-X-035`, `CHR-X-036`, `CHR-X-037`, `CHR-X-038`, `CHR-X-041`, `CHR-X-042`, `CHR-X-043`, `CHR-X-011`, `CHR-X-020`, `CHR-X-021`, `CHR-X-022`, `CHR-X-023`, `CHR-X-024`, `CHR-X-039`, `CHR-X-040`, `CHR-E-001`, `CHR-E-002`, `CHR-E-003`, `CHR-E-004`, `CHR-E-005`, `CHR-E-006`, `CHR-E-007`, `CHR-E-008`

ARCH IDs cited as authority context when linked through `registry_refs`:

`ARCH-002`, `ARCH-003`, `ARCH-004`, `ARCH-006`, `ARCH-007`, `ARCH-008`, `ARCH-009`, `ARCH-010`, `ARCH-012`, `ARCH-013`, `ARCH-014`, `ARCH-015`, `ARCH-016`, `ARCH-017`, `ARCH-018`, `ARCH-019`, `ARCH-020`, `ARCH-021`, `ARCH-022`, `ARCH-023`, `ARCH-024`, `ARCH-025`, `ARCH-026`, `ARCH-027`, `ARCH-029`, `ARCH-030`, `ARCH-031`, `ARCH-032`, `ARCH-033`, `ARCH-034`

## Validation

```bash
pytest -q tests/scripts/test_check_charter_compliance.py
# 5 passed, 8 warnings

ruff check scripts/check_charter_compliance.py tests/scripts/test_check_charter_compliance.py
# All checks passed!

git diff --check
# passed

python3 - <<'PY'
import yaml
from pathlib import Path
path = Path('docs/architecture/charters.yaml')
data = yaml.safe_load(path.read_text())
print(f'{path}: ok status={data["meta"]["status"]} registry={len(data.get("registry", []))}')
PY
# docs/architecture/charters.yaml: ok status=DRAFT registry=55

python3 scripts/check_charter_compliance.py --range origin/main...HEAD
# Charter compliance: PASS
# No chartered re-adds or enforceable placement violations found.
```

Known chartered re-removal range, merged PR #8909:

```bash
python3 scripts/check_charter_compliance.py --range 787a9562eb5f72438df23af3784f6d069b0ca00f^..787a9562eb5f72438df23af3784f6d069b0ca00f
# Charter compliance: PASS
# No chartered re-adds or enforceable placement violations found.
```

Benign docs-only range, merged PR #8868:

```bash
python3 scripts/check_charter_compliance.py --range 589d955ea5fc55afba7f184c32ac5f428ad7650f^..589d955ea5fc55afba7f184c32ac5f428ad7650f
# Charter compliance: PASS
# No chartered re-adds or enforceable placement violations found.
```

Pre-push hooks also passed, including ruff, ruff format, gitleaks, portability guard, and changed-surface mypy.

## Explicitly out of scope

This PR intentionally does not wire the checker into CI, required checks, branch protection, merge gates, settlement tooling, or evidence tooling. Any required-check integration needs separate operator approval.

## Post-merge validation audit

Final PR head: `e13b16e9f2eaec62334ebbaef0cbb668964b8b6a`.
Merge commit on `main`: `1390b9a27aaa6ffa04800fa20728e53ee51ac1a3`.
Branch lease status after publish/merge: `scripts/check_work_lease.py codex/charter-compliance-checker-8942 --verify-only --work-id pr:8968 --json` reports `ok=false`, `reason=missing_lease`, `detail="no active lease held for branch 'codex/charter-compliance-checker-8942' and work_id 'pr:8968'"`.

Post-merge validation on `origin/main` in disposable worktree `/private/tmp/aragora-charter-audit-97149`:

```bash
python3 -m pytest -q tests/scripts/test_check_charter_compliance.py
# 8 passed, 8 warnings in 0.52s

python3 -m ruff check scripts/check_charter_compliance.py tests/scripts/test_check_charter_compliance.py
# All checks passed!

git diff --check
# passed

python3 - <<'PY'
from pathlib import Path
import yaml
path = Path('docs/architecture/charters.yaml')
data = yaml.safe_load(path.read_text())
print(f'{path}: ok status={data["meta"]["status"]} registry={len(data.get("registry", []))}')
PY
# docs/architecture/charters.yaml: ok status=DRAFT registry=55

python3 scripts/check_charter_compliance.py --range 787a9562eb5f72438df23af3784f6d069b0ca00f^..787a9562eb5f72438df23af3784f6d069b0ca00f
# Charter compliance: PASS
# No chartered re-adds or enforceable placement violations found.

python3 scripts/check_charter_compliance.py --range 589d955ea5fc55afba7f184c32ac5f428ad7650f^..589d955ea5fc55afba7f184c32ac5f428ad7650f
# Charter compliance: PASS
# No chartered re-adds or enforceable placement violations found.
```
