### PR TITLE
fix(review): fall back to in-tree evidence analyzer

### DIFF
--- a/aragora/swarm/review_adjudicator.py
+++ b/aragora/swarm/review_adjudicator.py
@@ -6,8 +6,9 @@ by *adjudicating the findings themselves* instead of hand-refereeing round after
 round. It **composes** existing Aragora primitives (it does NOT reimplement
 them):
 
-* :class:`aragora_debate.evidence.EvidenceQualityAnalyzer` — scores a finding's
-  specificity / concreteness / evidence diversity.
+* :class:`EvidenceQualityAnalyzer` — scores a finding's specificity /
+  concreteness / evidence diversity. Prefer the legacy ``aragora_debate``
+  package when installed, otherwise use Aragora's in-tree analyzer.
 * :func:`aragora.cli.commands.review_queue_comment_verdicts.has_blocking_finding_or_label`
   — the SAME ``[P0]/[P1]`` detector the gate already trusts (the hard bar).
 
@@ -65,6 +66,18 @@ _TRUTHY = {"1", "true", "yes", "on"}
 def review_adjudicator_enabled() -> bool:
     """True when the adjudicator is explicitly enabled (default OFF)."""
     return os.getenv(_ENABLE_FLAG, "").strip().lower() in _TRUTHY
+
+
+def _evidence_quality_analyzer_class() -> Any:
+    """Resolve the evidence analyzer without requiring the legacy package."""
+    try:
+        from aragora_debate.evidence import EvidenceQualityAnalyzer
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"aragora_debate", "aragora_debate.evidence"}:
+            raise
+        from aragora.debate.evidence_quality import EvidenceQualityAnalyzer
+
+    return EvidenceQualityAnalyzer
 
 
 class AdjudicationVerdict(str, Enum):
@@ -202,10 +215,8 @@ def score_groundedness(body: str, *, analyzer: Any | None = None) -> float:
     """
     if analyzer is None:
         # Imported lazily so importing this module never hard-requires the
-        # aragora-debate package (keeps the gate import-light).
-        from aragora_debate.evidence import EvidenceQualityAnalyzer
-
-        analyzer = EvidenceQualityAnalyzer()
+        # legacy aragora-debate package (keeps the gate import-light).
+        analyzer = _evidence_quality_analyzer_class()()
 
     score = analyzer.analyze(body or "", agent="reviewer")
     total_phrases = score.specific_phrase_count + score.vague_phrase_count
@@ -311,9 +322,7 @@ def adjudicate(
     # single analyzer (deferred past both the hard-bar and NOT_APPLICABLE returns
     # — #8749 claude [P3] / openai [P2]).
     if scorer is None:
-        from aragora_debate.evidence import EvidenceQualityAnalyzer
-
-        _analyzer = EvidenceQualityAnalyzer()
+        _analyzer = _evidence_quality_analyzer_class()()
 
         def scorer(body: str) -> float:
             return score_groundedness(body, analyzer=_analyzer)

--- a/tests/swarm/test_review_adjudicator.py
+++ b/tests/swarm/test_review_adjudicator.py
@@ -16,6 +16,7 @@ Default is flag-OFF (byte-identical to today).
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 
 import pytest
@@ -83,6 +84,18 @@ class TestGroundednessScorer:
 
     def test_grounded_above_default_bar(self) -> None:
         assert score_groundedness(_GROUNDED_P2) >= 0.5
+
+    def test_default_scorer_falls_back_to_in_tree_analyzer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "aragora_debate", None)
+        monkeypatch.setitem(sys.modules, "aragora_debate.evidence", None)
+
+        r = adjudicate([_pass("claude"), _Item("openai", _GROUNDED_P2, "changes_requested")])
+        dissent = next(a for a in r.assessments if a.family == "openai")
+
+        assert r.verdict is AdjudicationVerdict.SETTLE
+        assert dissent.groundedness >= 0.5
 
 
 class TestAdjudicate:
@@ -220,12 +233,8 @@ class TestReviewFindingsFixes:
         # claude [P3] round 2: a definite [P0]/[P1] block must not construct (or
         # import) the default analyzer, so a missing aragora_debate never crashes
         # a hard block.
-        import aragora_debate.evidence as ev
-
-        def _explode(*_a: object, **_k: object) -> None:
-            raise ImportError("aragora_debate unavailable")
-
-        monkeypatch.setattr(ev, "EvidenceQualityAnalyzer", _explode)
+        monkeypatch.setitem(sys.modules, "aragora_debate", None)
+        monkeypatch.setitem(sys.modules, "aragora_debate.evidence", None)
         items = [_pass("claude"), _Item("openai", _BLOCKING_P1, "changes_requested")]
         r = adjudicate(items)  # scorer=None default; must not raise
         assert r.verdict is AdjudicationVerdict.BLOCK


### PR DESCRIPTION
## Summary
- let the review adjudicator resolve `EvidenceQualityAnalyzer` from the legacy `aragora_debate` package when present, or fall back to the in-tree `aragora.debate.evidence_quality` analyzer
- keep hard-bar `[P0]/[P1]` adjudication import-light while preserving fail-closed behavior for real scorer failures
- update regression coverage for environments without `aragora_debate`

## Validation
- `uv run pytest tests/swarm/test_review_adjudicator.py tests/swarm/test_quorum_evidence.py -k 'review_adjudicator or adjudication' -q`
- `uv run ruff check aragora/swarm/review_adjudicator.py tests/swarm/test_review_adjudicator.py`
- `git diff --check`
- exact #8948 dry-run replay with `ARAGORA_ENABLE_REVIEW_ADJUDICATOR=1` now emits `adjudicated_escalate` instead of omitting adjudication due `ModuleNotFoundError`

## Context
This unblocks the review-adjudicator path needed by the #8948 no-treadmill conductor cycle without modifying #8948 itself.
