### PR TITLE
fix(governance): tighten charter checker kept-symbol handling

### DIFF
--- a/scripts/check_charter_compliance.py
+++ b/scripts/check_charter_compliance.py
@@ -204,13 +204,18 @@ def _line_reexports_or_defines_symbol(line: str, symbol: str) -> bool:
     return _line_reexports_or_defines_export(line, _symbol_export(symbol))
 
 
-def _line_reexports_or_defines_export(line: str, export: str) -> bool:
+def _line_reexports_or_defines_export(
+    line: str,
+    export: str,
+    *,
+    allow_wildcard: bool = True,
+) -> bool:
     if line[:1].isspace():
         return False
     from_import = _from_import(line)
     if from_import is not None:
         _module, names = from_import
-        return export in names or "*" in names
+        return export in names or (allow_wildcard and "*" in names)
     return bool(
         re.match(rf"^(?:async\s+def|def|class)\s+{re.escape(export)}\b", line)
         or re.match(rf"^{re.escape(export)}\s*=", line)
@@ -219,7 +224,11 @@ def _line_reexports_or_defines_export(line: str, export: str) -> bool:
 
 def _line_reexports_or_defines_kept_symbol(line: str, entry: CharterEntry) -> bool:
     return any(
-        _line_reexports_or_defines_export(line, _symbol_root_export(symbol))
+        _line_reexports_or_defines_export(
+            line,
+            _symbol_root_export(symbol),
+            allow_wildcard=False,
+        )
         for symbol in entry.kept_symbols
     )
 
@@ -294,7 +303,7 @@ def _line_is_kept_only(added_line: AddedLine, entry: CharterEntry) -> bool:
             symbol for symbol in entry.kept_symbols if _symbol_module(symbol) == imported_module
         ]
         if matching_kept:
-            return bool(names) and all(name in kept_exports for name in names)
+            return bool(names) and all(name != "*" and name in kept_exports for name in names)
         return False
     if any(_path_matches(path, added_line.path) for path in entry.paths):
         return _line_reexports_or_defines_kept_symbol(line, entry)

--- a/scripts/check_charter_compliance.py
+++ b/scripts/check_charter_compliance.py
@@ -129,12 +129,17 @@ def _symbol_export(symbol: str) -> str:
     return export.rsplit(".", 1)[-1]
 
 
+def _symbol_root_export(symbol: str) -> str:
+    export = symbol.split(":", 1)[-1]
+    return export.split(".", 1)[0]
+
+
 def _symbol_export_roots(symbols: Iterable[str]) -> set[str]:
     roots: set[str] = set()
     for symbol in symbols:
-        export = symbol.split(":", 1)[-1]
-        parts = [part for part in export.split(".") if part]
-        roots.update(parts)
+        root = _symbol_root_export(symbol)
+        if root:
+            roots.add(root)
     return roots
 
 
@@ -145,7 +150,7 @@ def _parse_imported_names(imports: str) -> list[str]:
     names: list[str] = []
     for part in cleaned.split(","):
         token = part.strip()
-        if not token or token == "*":
+        if not token:
             continue
         names.append(token.split(" as ", 1)[0].strip())
     return names
@@ -196,9 +201,12 @@ def _is_python_path(path: str) -> bool:
 
 
 def _line_reexports_or_defines_symbol(line: str, symbol: str) -> bool:
+    return _line_reexports_or_defines_export(line, _symbol_export(symbol))
+
+
+def _line_reexports_or_defines_export(line: str, export: str) -> bool:
     if line[:1].isspace():
         return False
-    export = _symbol_export(symbol)
     from_import = _from_import(line)
     if from_import is not None:
         _module, names = from_import
@@ -210,7 +218,10 @@ def _line_reexports_or_defines_symbol(line: str, symbol: str) -> bool:
 
 
 def _line_reexports_or_defines_kept_symbol(line: str, entry: CharterEntry) -> bool:
-    return any(_line_reexports_or_defines_symbol(line, symbol) for symbol in entry.kept_symbols)
+    return any(
+        _line_reexports_or_defines_export(line, _symbol_root_export(symbol))
+        for symbol in entry.kept_symbols
+    )
 
 
 def _module_is_under(module: str, parent: str) -> bool:

--- a/scripts/check_charter_compliance.py
+++ b/scripts/check_charter_compliance.py
@@ -143,6 +143,10 @@ def _symbol_export_roots(symbols: Iterable[str]) -> set[str]:
     return roots
 
 
+def _is_top_level_symbol(symbol: str) -> bool:
+    return "." not in symbol.split(":", 1)[-1]
+
+
 def _parse_imported_names(imports: str) -> list[str]:
     cleaned = imports.split("#", 1)[0].strip()
     if cleaned.startswith("(") and cleaned.endswith(")"):
@@ -230,6 +234,7 @@ def _line_reexports_or_defines_kept_symbol(line: str, entry: CharterEntry) -> bo
             allow_wildcard=False,
         )
         for symbol in entry.kept_symbols
+        if _is_top_level_symbol(symbol)
     )
 
 

--- a/tests/scripts/test_check_charter_compliance.py
+++ b/tests/scripts/test_check_charter_compliance.py
@@ -123,7 +123,7 @@ def test_kept_symbol_does_not_trip_path_level_park(tmp_path: Path) -> None:
 --- a/aragora/debate/team_selector.py
 +++ b/aragora/debate/team_selector.py
 @@ -1,0 +2,2 @@
-+from aragora.control_plane.registry import AgentRegistry, AgentStatus
++from aragora.control_plane.registry import AgentRegistry, AgentInfo, AgentStatus
 +registry = AgentRegistry()
 """
 
@@ -149,6 +149,24 @@ def test_kept_symbol_mention_does_not_hide_new_parked_surface(tmp_path: Path) ->
     assert result.binding_violations == []
     assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
     assert result.proposed_violations[0].authority_ids == ["ARCH-014"]
+
+
+def test_dotted_kept_symbol_does_not_exempt_bare_top_level_export(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/control_plane/scheduler.py b/aragora/control_plane/scheduler.py
+--- a/aragora/control_plane/scheduler.py
++++ b/aragora/control_plane/scheduler.py
+@@ -0,0 +1,2 @@
++def is_alive():
++    return True
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+    assert "is_alive" in result.proposed_violations[0].line
 
 
 def test_parked_path_non_kept_surface_is_proposed(tmp_path: Path) -> None:
@@ -202,6 +220,22 @@ def test_removed_symbol_split_alias_use_is_binding(tmp_path: Path) -> None:
     assert result.ok is False
     assert [violation.entry_id for violation in result.binding_violations] == ["CHR-P4A-004"]
     assert "create_default_executor" in result.binding_violations[0].line
+
+
+def test_removed_symbol_wildcard_import_is_binding(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/some.py b/some.py
+--- a/some.py
++++ b/some.py
+@@ -0,0 +1 @@
++from aragora.queue import *
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert [violation.entry_id for violation in result.binding_violations] == ["CHR-P4A-004"]
+    assert "*" in result.binding_violations[0].line
 
 
 def test_exclusion_path_violation_reports_arch_context(tmp_path: Path) -> None:

--- a/tests/scripts/test_check_charter_compliance.py
+++ b/tests/scripts/test_check_charter_compliance.py
@@ -133,6 +133,33 @@ def test_kept_symbol_does_not_trip_path_level_park(tmp_path: Path) -> None:
     assert result.violations == []
 
 
+def test_wildcard_import_is_not_kept_symbol_exemption(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    entries, _authority_by_ref, _status = checker.load_charter_entries(charter_path)
+    entry = next(item for item in entries if item.entry_id == "CHR-X-040")
+
+    assert (
+        checker._line_reexports_or_defines_kept_symbol(
+            "from aragora.control_plane.registry import *",
+            entry,
+        )
+        is False
+    )
+
+    diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
+--- a/aragora/control_plane/registry.py
++++ b/aragora/control_plane/registry.py
+@@ -0,0 +1 @@
++from aragora.control_plane.registry import *
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+
+
 def test_kept_symbol_mention_does_not_hide_new_parked_surface(tmp_path: Path) -> None:
     charter_path = _write_charters(tmp_path, _charters_payload())
     diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
@@ -167,6 +194,23 @@ def test_dotted_kept_symbol_does_not_exempt_bare_top_level_export(tmp_path: Path
     assert result.binding_violations == []
     assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
     assert "is_alive" in result.proposed_violations[0].line
+
+
+def test_wildcard_import_in_parked_path_is_not_kept_only(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
+--- a/aragora/control_plane/registry.py
++++ b/aragora/control_plane/registry.py
+@@ -0,0 +1 @@
++from some_module import *
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+    assert "*" in result.proposed_violations[0].line
 
 
 def test_parked_path_non_kept_surface_is_proposed(tmp_path: Path) -> None:

--- a/tests/scripts/test_check_charter_compliance.py
+++ b/tests/scripts/test_check_charter_compliance.py
@@ -196,6 +196,24 @@ def test_dotted_kept_symbol_does_not_exempt_bare_top_level_export(tmp_path: Path
     assert "is_alive" in result.proposed_violations[0].line
 
 
+def test_dotted_kept_member_does_not_exempt_root_definition(tmp_path: Path) -> None:
+    charter_path = _write_charters(tmp_path, _charters_payload())
+    diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py
+--- a/aragora/control_plane/registry.py
++++ b/aragora/control_plane/registry.py
+@@ -0,0 +1,2 @@
++class AgentInfo:
++    pass
+"""
+
+    result = checker.check_diff(diff_text, charter_path=charter_path)
+
+    assert result.ok is False
+    assert result.binding_violations == []
+    assert [violation.entry_id for violation in result.proposed_violations] == ["CHR-X-040"]
+    assert "AgentInfo" in result.proposed_violations[0].line
+
+
 def test_wildcard_import_in_parked_path_is_not_kept_only(tmp_path: Path) -> None:
     charter_path = _write_charters(tmp_path, _charters_payload())
     diff_text = """diff --git a/aragora/control_plane/registry.py b/aragora/control_plane/registry.py


### PR DESCRIPTION
## Summary

Follow-up to #8968 / issue #8942 and the post-merge blocker noted in https://github.com/synaptent/aragora/pull/8968#issuecomment-4906187421.

This tightens `scripts/check_charter_compliance.py` in two places:

- preserves dotted kept-symbol precision so `AgentInfo.is_alive` does not exempt unrelated bare `is_alive` definitions/imports in parked paths
- preserves `*` in `from ... import *` parsing so wildcard imports of governed modules are reported

## Validation

- `python -m pytest tests/scripts/test_check_charter_compliance.py -q` -> 10 passed, 8 warnings
- `uv run ruff check scripts/check_charter_compliance.py tests/scripts/test_check_charter_compliance.py` -> passed
- `uv run ruff format scripts/check_charter_compliance.py tests/scripts/test_check_charter_compliance.py` -> 2 files left unchanged
- `python scripts/check_charter_compliance.py --range origin/main...HEAD --format json` -> ok true, no violations

Synthetic dogfood artifact: `/tmp/synthetic_8968_followup_20260707T165411Z.json`

```json
{
  "binding_violations": [],
  "ok": false,
  "proposed_violations": [
    {
      "authority_ids": ["ARCH-014"],
      "binding": "PROPOSED",
      "entry_id": "CHR-X-040",
      "line": "def is_alive():",
      "path": "aragora/control_plane/scheduler.py",
      "reason": "adds code under chartered parked path"
    },
    {
      "authority_ids": ["ARCH-014"],
      "binding": "PROPOSED",
      "entry_id": "CHR-X-040",
      "line": "from aragora.control_plane.scheduler import *",
      "path": "synthetic.py",
      "reason": "imports chartered parked path aragora/control_plane/scheduler.py"
    }
  ]
}
```

No settlement evidence was collected or posted in this cycle.
