### PR TITLE
feat(scripts): add steering conductor cycle

### DIFF
--- a/scripts/steering_conductor.py
+++ b/scripts/steering_conductor.py
@@ -26,9 +26,13 @@ if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 
 import send_operator_steering
+import identify_lane_owner as owner_lookup
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_LEDGER_PATH = Path.home() / ".aragora" / "steering_conductor_ledger.json"
+LANE_REGISTRY_DEFAULT = owner_lookup.LANE_REGISTRY_DEFAULT
+STEERING_INBOX_ROOT_DEFAULT = owner_lookup.STEERING_INBOX_ROOT_DEFAULT
+USER_LANE_REGISTRY_DEFAULT = send_operator_steering.USER_LANE_REGISTRY_DEFAULT
 DEFAULT_RECENT_TARGET_CYCLES = 3
 DEFAULT_RECENT_TARGET_HOURS = 2.0
 DEFAULT_MAX_LANE_AGE_MINUTES = 120.0
@@ -93,8 +97,8 @@ class Candidate:
 class CycleConfig:
     repo_root: Path = REPO_ROOT
     ledger_path: Path = DEFAULT_LEDGER_PATH
-    lane_registry_path: Path = send_operator_steering.LANE_REGISTRY_DEFAULT
-    steering_inbox_root: Path = send_operator_steering.STEERING_INBOX_ROOT_DEFAULT
+    lane_registry_path: Path = LANE_REGISTRY_DEFAULT
+    steering_inbox_root: Path = STEERING_INBOX_ROOT_DEFAULT
     recent_target_cycles: int = DEFAULT_RECENT_TARGET_CYCLES
     recent_target_hours: float = DEFAULT_RECENT_TARGET_HOURS
     max_lane_age_minutes: float = DEFAULT_MAX_LANE_AGE_MINUTES
@@ -207,14 +211,14 @@ def _load_lane_records_file(path: Path) -> list[dict[str, Any]]:
 
 
 def load_lane_records(path: Path) -> list[dict[str, Any]]:
-    if path != send_operator_steering.LANE_REGISTRY_DEFAULT:
+    if path != LANE_REGISTRY_DEFAULT:
         return _load_lane_records_file(path)
 
     records: list[dict[str, Any]] = []
     seen: set[Path] = set()
     for candidate in (
-        send_operator_steering.USER_LANE_REGISTRY_DEFAULT,
-        send_operator_steering.LANE_REGISTRY_DEFAULT,
+        USER_LANE_REGISTRY_DEFAULT,
+        LANE_REGISTRY_DEFAULT,
     ):
         try:
             resolved = candidate.resolve()
@@ -762,16 +766,28 @@ def _run_cycle_locked(
         return result
 
     latest_records = load_lane_records(config.lane_registry_path)
+    latest_owner_conflicts = _active_owner_conflicts(
+        latest_records,
+        open_prs=open_prs,
+        now=now,
+        max_lane_age_minutes=config.max_lane_age_minutes,
+        steering_inbox_root=config.steering_inbox_root,
+    )
+    current_conflict_owners = latest_owner_conflicts.get(candidate.target_key)
     current_record = _find_current_record(latest_records, candidate)
     current_blocker = (
-        "candidate disappeared before send"
-        if current_record is None
-        else _current_record_blocker(
-            current_record,
-            candidate,
-            open_prs=open_prs,
-            now=now,
-            max_lane_age_minutes=config.max_lane_age_minutes,
+        "multiple active owners"
+        if current_conflict_owners
+        else (
+            "candidate disappeared before send"
+            if current_record is None
+            else _current_record_blocker(
+                current_record,
+                candidate,
+                open_prs=open_prs,
+                now=now,
+                max_lane_age_minutes=config.max_lane_age_minutes,
+            )
         )
     )
     if current_blocker is not None:
@@ -782,6 +798,8 @@ def _run_cycle_locked(
             "owner_session": candidate.owner_session,
             "skip_reason": current_blocker,
         }
+        if current_conflict_owners:
+            entry["owner_sessions"] = current_conflict_owners
         ledger = _append_ledger_entry(ledger, entry, sent=False)
         if ledger["consecutive_no_send"] >= 3:
             result["stop"] = True
@@ -792,6 +810,7 @@ def _run_cycle_locked(
             {
                 "selected": {"target_key": candidate.target_key, "reason": candidate.reason},
                 "no_send_reason": current_blocker,
+                "owner_sessions": current_conflict_owners,
                 "ledger_consecutive_no_send": ledger["consecutive_no_send"],
                 "ledger_updated": not config.dry_run,
                 "next_prompt": _next_prompt(config.repo_root),
@@ -937,12 +956,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--lane-registry-path",
         type=Path,
-        default=send_operator_steering.LANE_REGISTRY_DEFAULT,
+        default=LANE_REGISTRY_DEFAULT,
     )
     parser.add_argument(
         "--steering-inbox-root",
         type=Path,
-        default=send_operator_steering.STEERING_INBOX_ROOT_DEFAULT,
+        default=STEERING_INBOX_ROOT_DEFAULT,
     )
     parser.add_argument("--recent-target-cycles", type=int, default=DEFAULT_RECENT_TARGET_CYCLES)
     parser.add_argument("--recent-target-hours", type=float, default=DEFAULT_RECENT_TARGET_HOURS)

--- a/scripts/steering_conductor.py
+++ b/scripts/steering_conductor.py
@@ -1,0 +1,791 @@
+#!/usr/bin/env python3
+"""Run one bounded operator-steering conductor cycle.
+
+The conductor chooses at most one live lane and writes at most one
+operator-steering mailbox message.  It never mutates GitHub or PR branches.
+Repeated runs are de-duplicated through a small JSON ledger, plus unread
+mailbox detection for the target owner_session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import send_operator_steering
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_LEDGER_PATH = Path("/tmp/aragora_steering_conductor_ledger.json")
+DEFAULT_RECENT_TARGET_CYCLES = 3
+DEFAULT_RECENT_TARGET_HOURS = 2.0
+DEFAULT_MAX_LANE_AGE_MINUTES = 120.0
+SCHEMA_VERSION = "aragora-steering-conductor-ledger/1.0"
+
+ACTIVE_STATUSES = {
+    "active",
+    "running",
+    "pending",
+    "queued",
+    "claimed",
+    "working",
+    "waiting_for_steering",
+    "acknowledged",
+}
+TERMINAL_STATUSES = {
+    "completed",
+    "released",
+    "superseded",
+    "expired",
+    "dead",
+    "stale",
+}
+EXCLUDED_PR_NUMBERS = {8456}
+EXCLUDED_BRANCH_PREFIXES = ("claude/fusion-",)
+HIGH_LEVERAGE_TERMS = (
+    "duplicate",
+    "collision",
+    "head drift",
+    "drift",
+    "breaker",
+    "treadmill",
+    "owner",
+    "human-gated",
+    "tier 3",
+    "tier 4",
+    "stop",
+    "blocked",
+)
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    record: dict[str, Any]
+    target_key: str
+    owner_session: str
+    score: tuple[int, float, str]
+    reason: str
+
+
+@dataclass(frozen=True)
+class CycleConfig:
+    repo_root: Path = REPO_ROOT
+    ledger_path: Path = DEFAULT_LEDGER_PATH
+    lane_registry_path: Path = send_operator_steering.LANE_REGISTRY_DEFAULT
+    steering_inbox_root: Path = send_operator_steering.STEERING_INBOX_ROOT_DEFAULT
+    recent_target_cycles: int = DEFAULT_RECENT_TARGET_CYCLES
+    recent_target_hours: float = DEFAULT_RECENT_TARGET_HOURS
+    max_lane_age_minutes: float = DEFAULT_MAX_LANE_AGE_MINUTES
+    dry_run: bool = False
+    skip_fetch: bool = False
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+
+
+def _iso(ts: dt.datetime) -> str:
+    return ts.astimezone(dt.UTC).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def _run(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    command_runner: CommandRunner = subprocess.run,
+    timeout: int = 30,
+) -> subprocess.CompletedProcess[str]:
+    return command_runner(
+        list(command),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _run_json(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    command_runner: CommandRunner = subprocess.run,
+    timeout: int = 30,
+) -> dict[str, Any] | list[Any] | None:
+    proc = _run(command, cwd=cwd, command_runner=command_runner, timeout=timeout)
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout or "null")
+    except json.JSONDecodeError:
+        return None
+
+
+def _load_json_file(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def load_ledger(path: Path) -> dict[str, Any]:
+    data = _load_json_file(path, {})
+    if not isinstance(data, dict):
+        data = {}
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        entries = []
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "consecutive_no_send": int(data.get("consecutive_no_send") or 0),
+        "entries": [entry for entry in entries if isinstance(entry, dict)],
+    }
+
+
+def write_ledger(path: Path, ledger: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_lane_records(path: Path) -> list[dict[str, Any]]:
+    data = _load_json_file(path, [])
+    return [record for record in data if isinstance(record, dict)] if isinstance(data, list) else []
+
+
+def _target_key(record: dict[str, Any]) -> str:
+    pr_number = record.get("pr_number")
+    if pr_number is not None:
+        try:
+            return f"pr:{int(pr_number)}"
+        except (TypeError, ValueError):
+            pass
+    branch = str(record.get("branch") or "").strip()
+    if branch:
+        return f"branch:{branch}"
+    return f"lane:{record.get('lane_id') or record.get('owner_session') or 'unknown'}"
+
+
+def _lane_age_minutes(record: dict[str, Any], now: dt.datetime) -> float | None:
+    stamp = _parse_timestamp(record.get("last_heartbeat_at") or record.get("updated_at"))
+    if stamp is None:
+        return None
+    return max(0.0, (now - stamp).total_seconds() / 60.0)
+
+
+def _is_excluded_record(
+    record: dict[str, Any], now: dt.datetime, max_age_minutes: float
+) -> str | None:
+    status = str(record.get("status") or "").strip().lower()
+    if status in TERMINAL_STATUSES:
+        return f"terminal status {status}"
+    if status not in ACTIVE_STATUSES:
+        return f"non-active status {status or '<missing>'}"
+    try:
+        if int(record.get("pr_number") or 0) in EXCLUDED_PR_NUMBERS:
+            return "excluded PR"
+    except (TypeError, ValueError):
+        pass
+    branch = str(record.get("branch") or "")
+    if branch.startswith(EXCLUDED_BRANCH_PREFIXES):
+        return "excluded branch prefix"
+    if record.get("possible_unpushed_work") is True:
+        return "possible_unpushed_work"
+    age = _lane_age_minutes(record, now)
+    if age is None:
+        return "missing freshness timestamp"
+    if age > max_age_minutes:
+        return f"stale lane age {age:.1f}m"
+    if not str(record.get("owner_session") or "").strip():
+        return "missing owner_session"
+    return None
+
+
+def _open_pr_lookup(open_prs_payload: Any) -> dict[int, dict[str, Any]]:
+    if not isinstance(open_prs_payload, list):
+        return {}
+    out: dict[int, dict[str, Any]] = {}
+    for row in open_prs_payload:
+        if not isinstance(row, dict):
+            continue
+        try:
+            number = int(row.get("number"))
+        except (TypeError, ValueError):
+            continue
+        out[number] = row
+    return out
+
+
+def _message_body(
+    record: dict[str, Any], *, repo_root: Path, open_pr: dict[str, Any] | None = None
+) -> str:
+    pr_number = record.get("pr_number")
+    branch = str(record.get("branch") or "").strip()
+    lane_id = str(record.get("lane_id") or "").strip()
+    owner_session = str(record.get("owner_session") or "").strip()
+    target = (
+        f"PR #{pr_number}" if pr_number else f"branch {branch}" if branch else f"lane {lane_id}"
+    )
+    head = ""
+    if open_pr:
+        head_oid = str(open_pr.get("headRefOid") or "").strip()
+        if head_oid:
+            head = f" at live observed head {head_oid}"
+    next_action = str(
+        record.get("next_action")
+        or "re-ground from live state and choose exactly one bounded action"
+    ).strip()
+    last_observed = (
+        f"lane {lane_id or '<unknown>'} status={record.get('status') or '<unknown>'}, "
+        f"updated_at={record.get('updated_at') or '<unknown>'}, owner_session={owner_session}."
+    )
+    return "\n".join(
+        [
+            f"Start from live repo truth in {repo_root}. Do not trust prior transcript state.",
+            "Operating contract: re-read docs/AGENT_OPERATING_CONTRACT.md §Conductor and docs/REVIEW_AUTHORITY_PRINCIPLES.md this cycle.",
+            "",
+            f"Target: {target}{head}; owner_session {owner_session}.",
+            f"Last observed: {last_observed}",
+            f"Next bounded action: {next_action}",
+            "Do not merge, settle Tier 3/4, rerun workflows, use --admin, change branch protection, post duplicate evidence, delete worktrees, or touch unrelated PRs unless separately exact-head authorized.",
+            "If blocked: stop and report the exact blocker plus the safest next authorization prompt.",
+        ]
+    )
+
+
+def _body_hash(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _recent_target_keys(
+    ledger: dict[str, Any],
+    *,
+    now: dt.datetime,
+    recent_cycles: int,
+    recent_hours: float,
+) -> set[str]:
+    entries = [entry for entry in ledger.get("entries", []) if isinstance(entry, dict)]
+    recent_entries = entries[-max(0, recent_cycles) :]
+    cutoff = now - dt.timedelta(hours=recent_hours)
+    keys: set[str] = {
+        str(entry.get("target_key")) for entry in recent_entries if entry.get("target_key")
+    }
+    for entry in entries:
+        target_key = str(entry.get("target_key") or "")
+        if not target_key:
+            continue
+        stamp = _parse_timestamp(entry.get("timestamp"))
+        if stamp is not None and stamp >= cutoff:
+            keys.add(target_key)
+    return keys
+
+
+def _receipt_keys(receipt_dir: Path) -> tuple[set[str], set[str]]:
+    filenames: set[str] = set()
+    shas: set[str] = set()
+    if not receipt_dir.is_dir():
+        return filenames, shas
+    for path in receipt_dir.glob("*.json"):
+        payload = _load_json_file(path, {})
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("message_filename"):
+            filenames.add(str(payload["message_filename"]))
+        if payload.get("message_sha256"):
+            shas.add(str(payload["message_sha256"]))
+    return filenames, shas
+
+
+def unread_messages(owner_session: str, *, steering_inbox_root: Path) -> list[dict[str, Any]]:
+    inbox = send_operator_steering.validate_to_session(
+        owner_session, steering_inbox_root=steering_inbox_root
+    )
+    if not inbox.is_dir():
+        return []
+    receipt_filenames, receipt_shas = _receipt_keys(inbox / "_read_receipts")
+    unread: list[dict[str, Any]] = []
+    for path in sorted(p for p in inbox.glob("*.json") if p.is_file()):
+        payload = _load_json_file(path, {})
+        if not isinstance(payload, dict):
+            unread.append({"path": str(path), "reason": "unreadable"})
+            continue
+        sha = str(payload.get("message_sha256") or "")
+        if path.name not in receipt_filenames and (not sha or sha not in receipt_shas):
+            unread.append(
+                {
+                    "path": str(path),
+                    "subject": payload.get("subject"),
+                    "sent_at_utc": payload.get("sent_at_utc"),
+                    "message_sha256": sha,
+                }
+            )
+    return unread
+
+
+def _score_candidate(
+    record: dict[str, Any],
+    *,
+    open_prs: dict[int, dict[str, Any]],
+    now: dt.datetime,
+) -> Candidate:
+    target_key = _target_key(record)
+    owner_session = str(record.get("owner_session") or "").strip()
+    next_action = str(record.get("next_action") or "").lower()
+    priority = 40
+    reason = "active non-PR lane"
+    pr_number: int | None = None
+    try:
+        pr_number = int(record.get("pr_number")) if record.get("pr_number") is not None else None
+    except (TypeError, ValueError):
+        pr_number = None
+    if pr_number is not None and pr_number in open_prs:
+        priority = 10
+        reason = "active owner on open PR"
+        if any(term in next_action for term in HIGH_LEVERAGE_TERMS):
+            priority = 0
+            reason = "active open PR lane with molasses-prevention signal"
+    elif any(term in next_action for term in HIGH_LEVERAGE_TERMS):
+        priority = 30
+        reason = "active lane with stop/coordination signal"
+    age = _lane_age_minutes(record, now)
+    return Candidate(
+        record=record,
+        target_key=target_key,
+        owner_session=owner_session,
+        score=(priority, age if age is not None else 999999.0, target_key),
+        reason=reason,
+    )
+
+
+def choose_candidate(
+    records: list[dict[str, Any]],
+    *,
+    open_prs: dict[int, dict[str, Any]],
+    ledger: dict[str, Any],
+    now: dt.datetime,
+    recent_target_cycles: int,
+    recent_target_hours: float,
+    max_lane_age_minutes: float,
+    steering_inbox_root: Path,
+) -> tuple[Candidate | None, list[dict[str, Any]]]:
+    skips: list[dict[str, Any]] = []
+    candidates: list[Candidate] = []
+    for record in records:
+        target_key = _target_key(record)
+        excluded = _is_excluded_record(record, now, max_lane_age_minutes)
+        if excluded:
+            skips.append({"target_key": target_key, "reason": excluded})
+            continue
+        owner_session = str(record.get("owner_session") or "").strip()
+        unread = unread_messages(owner_session, steering_inbox_root=steering_inbox_root)
+        if unread:
+            skips.append(
+                {
+                    "target_key": target_key,
+                    "owner_session": owner_session,
+                    "reason": "unread pending steering",
+                    "unread_count": len(unread),
+                }
+            )
+            continue
+        candidates.append(_score_candidate(record, open_prs=open_prs, now=now))
+
+    if not candidates:
+        return None, skips
+
+    recent_keys = _recent_target_keys(
+        ledger,
+        now=now,
+        recent_cycles=recent_target_cycles,
+        recent_hours=recent_target_hours,
+    )
+    fresh_candidates = [
+        candidate for candidate in candidates if candidate.target_key not in recent_keys
+    ]
+    if fresh_candidates:
+        candidates = fresh_candidates
+    return sorted(candidates, key=lambda candidate: candidate.score)[0], skips
+
+
+def _find_current_record(
+    records: list[dict[str, Any]], candidate: Candidate
+) -> dict[str, Any] | None:
+    lane_id = candidate.record.get("lane_id")
+    owner_session = candidate.record.get("owner_session")
+    for record in records:
+        if record.get("lane_id") == lane_id and record.get("owner_session") == owner_session:
+            return record
+    return None
+
+
+def _append_ledger_entry(
+    ledger: dict[str, Any],
+    entry: dict[str, Any],
+    *,
+    sent: bool,
+) -> dict[str, Any]:
+    entries = [e for e in ledger.get("entries", []) if isinstance(e, dict)]
+    entries.append(entry)
+    ledger["entries"] = entries[-200:]
+    ledger["consecutive_no_send"] = 0 if sent else int(ledger.get("consecutive_no_send") or 0) + 1
+    ledger["schema_version"] = SCHEMA_VERSION
+    return ledger
+
+
+def collect_live_state(
+    config: CycleConfig,
+    *,
+    command_runner: CommandRunner = subprocess.run,
+) -> dict[str, Any]:
+    repo_root = config.repo_root
+    fetch_result: dict[str, Any] | None = None
+    if not config.skip_fetch:
+        proc = _run(
+            ["git", "fetch", "origin", "main", "--quiet"],
+            cwd=repo_root,
+            command_runner=command_runner,
+            timeout=60,
+        )
+        fetch_result = {"returncode": proc.returncode, "stderr": proc.stderr.strip()}
+    status = _run(
+        ["git", "status", "--short", "--branch", "--untracked-files=all"],
+        cwd=repo_root,
+        command_runner=command_runner,
+    )
+    rev = _run(
+        ["git", "rev-parse", "HEAD", "origin/main"],
+        cwd=repo_root,
+        command_runner=command_runner,
+    )
+    rev_lines = (rev.stdout or "").splitlines()
+    pr_payload = _run_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,headRefName,headRefOid,isDraft,mergeStateStatus,title,url",
+        ],
+        cwd=repo_root,
+        command_runner=command_runner,
+    )
+    sessions_payload = _run_json(
+        ["python3", "scripts/list_active_agent_sessions.py", "--json"],
+        cwd=repo_root,
+        command_runner=command_runner,
+        timeout=45,
+    )
+    snapshot_payload = _run_json(
+        ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
+        cwd=repo_root,
+        command_runner=command_runner,
+        timeout=45,
+    )
+    sentinel_payload = _run_json(
+        ["python3", "scripts/fleet_sentinel.py", "--json"],
+        cwd=repo_root,
+        command_runner=command_runner,
+        timeout=45,
+    )
+    return {
+        "fetch": fetch_result,
+        "status": status.stdout,
+        "head": rev_lines[0] if len(rev_lines) >= 1 else None,
+        "origin_main": rev_lines[1] if len(rev_lines) >= 2 else None,
+        "open_prs": pr_payload if isinstance(pr_payload, list) else [],
+        "open_pr_count": len(pr_payload) if isinstance(pr_payload, list) else None,
+        "sessions_summary": sessions_payload if isinstance(sessions_payload, dict) else None,
+        "operator_snapshot_summary": snapshot_payload
+        if isinstance(snapshot_payload, dict)
+        else None,
+        "fleet_sentinel_summary": sentinel_payload if isinstance(sentinel_payload, dict) else None,
+    }
+
+
+def run_cycle(
+    config: CycleConfig,
+    *,
+    command_runner: CommandRunner = subprocess.run,
+    now: dt.datetime | None = None,
+) -> dict[str, Any]:
+    now = now or _utc_now()
+    live_state = collect_live_state(config, command_runner=command_runner)
+    ledger = load_ledger(config.ledger_path)
+    records = load_lane_records(config.lane_registry_path)
+    open_prs = _open_pr_lookup(live_state.get("open_prs"))
+    candidate, skips = choose_candidate(
+        records,
+        open_prs=open_prs,
+        ledger=ledger,
+        now=now,
+        recent_target_cycles=config.recent_target_cycles,
+        recent_target_hours=config.recent_target_hours,
+        max_lane_age_minutes=config.max_lane_age_minutes,
+        steering_inbox_root=config.steering_inbox_root,
+    )
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "sent": False,
+        "dry_run": config.dry_run,
+        "timestamp": _iso(now),
+        "origin_main": live_state.get("origin_main"),
+        "open_pr_count": live_state.get("open_pr_count"),
+        "candidate_skips": skips[:25],
+        "selected": None,
+        "message_path": None,
+        "stop": False,
+        "stop_reason": None,
+    }
+
+    if candidate is None:
+        entry = {
+            "timestamp": _iso(now),
+            "sent": False,
+            "skip_reason": "no eligible live owner target",
+        }
+        ledger = _append_ledger_entry(ledger, entry, sent=False)
+        result["ledger_consecutive_no_send"] = ledger["consecutive_no_send"]
+        if ledger["consecutive_no_send"] >= 3:
+            result["stop"] = True
+            result["stop_reason"] = "three consecutive no-send cycles"
+        if not config.dry_run:
+            write_ledger(config.ledger_path, ledger)
+        result["ledger_updated"] = not config.dry_run
+        result["no_send_reason"] = "no eligible live owner target"
+        result["next_prompt"] = _next_prompt(config.repo_root)
+        return result
+
+    latest_records = load_lane_records(config.lane_registry_path)
+    current_record = _find_current_record(latest_records, candidate)
+    if current_record is None or current_record != candidate.record:
+        entry = {
+            "timestamp": _iso(now),
+            "sent": False,
+            "target_key": candidate.target_key,
+            "owner_session": candidate.owner_session,
+            "skip_reason": "candidate drifted before send",
+        }
+        ledger = _append_ledger_entry(ledger, entry, sent=False)
+        if not config.dry_run:
+            write_ledger(config.ledger_path, ledger)
+        result.update(
+            {
+                "selected": {"target_key": candidate.target_key, "reason": candidate.reason},
+                "no_send_reason": "candidate drifted before send",
+                "ledger_consecutive_no_send": ledger["consecutive_no_send"],
+                "ledger_updated": not config.dry_run,
+                "next_prompt": _next_prompt(config.repo_root),
+            }
+        )
+        return result
+
+    open_pr: dict[str, Any] | None = None
+    try:
+        pr_number = (
+            int(candidate.record.get("pr_number"))
+            if candidate.record.get("pr_number") is not None
+            else None
+        )
+    except (TypeError, ValueError):
+        pr_number = None
+    if pr_number is not None:
+        open_pr = open_prs.get(pr_number)
+    body = _message_body(candidate.record, repo_root=config.repo_root, open_pr=open_pr)
+    body_hash = _body_hash(body)
+    route = send_operator_steering.direct_route_payload(
+        candidate.owner_session, steering_inbox_root=config.steering_inbox_root
+    )
+    message = send_operator_steering.build_message(
+        to_session=candidate.owner_session,
+        body=body,
+        from_label="steering-conductor",
+        lane_id_hint=str(candidate.record.get("lane_id") or "") or None,
+        pr_hint=pr_number,
+        priority="normal",
+    )
+
+    written_path: Path | None = None
+    if not config.dry_run:
+        written_path = send_operator_steering.write_message(
+            message, steering_inbox_root=config.steering_inbox_root
+        )
+
+    entry = {
+        "timestamp": _iso(now),
+        "sent": not config.dry_run,
+        "dry_run": config.dry_run,
+        "target_key": candidate.target_key,
+        "owner_session": candidate.owner_session,
+        "lane_id": candidate.record.get("lane_id"),
+        "pr_number": pr_number,
+        "branch": candidate.record.get("branch"),
+        "body_sha256": body_hash,
+        "message_sha256": message["message_sha256"],
+        "message_path": str(written_path) if written_path is not None else None,
+        "selection_reason": candidate.reason,
+    }
+    ledger = _append_ledger_entry(ledger, entry, sent=not config.dry_run)
+    if not config.dry_run:
+        write_ledger(config.ledger_path, ledger)
+
+    result.update(
+        {
+            "sent": not config.dry_run,
+            "selected": {
+                "target_key": candidate.target_key,
+                "owner_session": candidate.owner_session,
+                "lane_id": candidate.record.get("lane_id"),
+                "pr_number": pr_number,
+                "branch": candidate.record.get("branch"),
+                "reason": candidate.reason,
+                "body_sha256": body_hash,
+            },
+            "diagnose_result": {
+                "safe_to_send": True,
+                "route": route,
+                "unread_pending_count": 0,
+            },
+            "message_path": str(written_path) if written_path is not None else None,
+            "message_preview": body,
+            "ledger_consecutive_no_send": ledger["consecutive_no_send"],
+            "ledger_updated": not config.dry_run,
+            "next_prompt": _next_prompt(config.repo_root),
+        }
+    )
+    return result
+
+
+def _next_prompt(repo_root: Path = REPO_ROOT) -> str:
+    return (
+        "Run one long-lived Aragora STEERING-CONDUCTOR cycle from live repo truth in "
+        f"{repo_root}. Do not trust prior transcript state. "
+        "Operating contract: re-read docs/AGENT_OPERATING_CONTRACT.md §Conductor, "
+        "docs/REVIEW_AUTHORITY_PRINCIPLES.md, and AGENTS.md this cycle. Send at most "
+        "one local operator-steering message via scripts/steering_conductor.py, "
+        "respecting /tmp/aragora_steering_conductor_ledger.json rotation and all "
+        "hard exclusions. Do not mutate GitHub, PR branches, evidence, settlements, "
+        "workflows, branch protection, or repo-tracked files."
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="steering_conductor.py",
+        description="Send at most one idempotent operator-steering message to a live lane.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable output.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Select and validate without writing."
+    )
+    parser.add_argument(
+        "--skip-fetch", action="store_true", help="Skip git fetch for tests/offline use."
+    )
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--ledger-path", type=Path, default=DEFAULT_LEDGER_PATH)
+    parser.add_argument(
+        "--lane-registry-path",
+        type=Path,
+        default=send_operator_steering.LANE_REGISTRY_DEFAULT,
+    )
+    parser.add_argument(
+        "--steering-inbox-root",
+        type=Path,
+        default=send_operator_steering.STEERING_INBOX_ROOT_DEFAULT,
+    )
+    parser.add_argument("--recent-target-cycles", type=int, default=DEFAULT_RECENT_TARGET_CYCLES)
+    parser.add_argument("--recent-target-hours", type=float, default=DEFAULT_RECENT_TARGET_HOURS)
+    parser.add_argument("--max-lane-age-minutes", type=float, default=DEFAULT_MAX_LANE_AGE_MINUTES)
+    return parser
+
+
+def _format_text(result: dict[str, Any]) -> str:
+    lines = [
+        f"origin/main: {result.get('origin_main') or '<unknown>'}",
+        f"open PR count: {result.get('open_pr_count') if result.get('open_pr_count') is not None else '<unknown>'}",
+    ]
+    selected = result.get("selected")
+    if selected:
+        lines.append(
+            "selected: "
+            f"{selected.get('target_key')} owner={selected.get('owner_session')} "
+            f"reason={selected.get('reason')}"
+        )
+    else:
+        lines.append(f"selected: none ({result.get('no_send_reason')})")
+    lines.append(f"sent: {result.get('sent')}")
+    if result.get("message_path"):
+        lines.append(f"message path: {result['message_path']}")
+    lines.append(f"ledger consecutive no-send: {result.get('ledger_consecutive_no_send')}")
+    if result.get("stop"):
+        lines.append(f"STOP: {result.get('stop_reason')}")
+    lines.append("")
+    lines.append("Next prompt:")
+    lines.append(str(result.get("next_prompt") or _next_prompt()))
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    config = CycleConfig(
+        repo_root=args.repo_root,
+        ledger_path=args.ledger_path,
+        lane_registry_path=args.lane_registry_path,
+        steering_inbox_root=args.steering_inbox_root,
+        recent_target_cycles=args.recent_target_cycles,
+        recent_target_hours=args.recent_target_hours,
+        max_lane_age_minutes=args.max_lane_age_minutes,
+        dry_run=args.dry_run,
+        skip_fetch=args.skip_fetch,
+    )
+    try:
+        result = run_cycle(config)
+    except Exception as exc:
+        out = {"ok": False, "error": f"{exc.__class__.__name__}: {exc}"}
+        if args.json:
+            print(json.dumps(out, indent=2, sort_keys=True))
+        else:
+            print(f"ERROR: {out['error']}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(_format_text(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/steering_conductor.py
+++ b/scripts/steering_conductor.py
@@ -51,6 +51,14 @@ TERMINAL_STATUSES = {
     "dead",
     "stale",
 }
+RESOLVED_STEERING_OUTCOMES = {
+    "obeyed",
+    "held",
+    "stale",
+    "superseded",
+    "blocked",
+    "completed",
+}
 EXCLUDED_PR_NUMBERS = {8456}
 EXCLUDED_BRANCH_PREFIXES = ("claude/fusion-",)
 HIGH_LEVERAGE_TERMS = (
@@ -177,9 +185,30 @@ def write_ledger(path: Path, ledger: dict[str, Any]) -> None:
     path.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def load_lane_records(path: Path) -> list[dict[str, Any]]:
+def _load_lane_records_file(path: Path) -> list[dict[str, Any]]:
     data = _load_json_file(path, [])
     return [record for record in data if isinstance(record, dict)] if isinstance(data, list) else []
+
+
+def load_lane_records(path: Path) -> list[dict[str, Any]]:
+    if path != send_operator_steering.LANE_REGISTRY_DEFAULT:
+        return _load_lane_records_file(path)
+
+    records: list[dict[str, Any]] = []
+    seen: set[Path] = set()
+    for candidate in (
+        send_operator_steering.USER_LANE_REGISTRY_DEFAULT,
+        send_operator_steering.LANE_REGISTRY_DEFAULT,
+    ):
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        records.extend(_load_lane_records_file(candidate))
+    return records
 
 
 def _target_key(record: dict[str, Any]) -> str:
@@ -193,6 +222,15 @@ def _target_key(record: dict[str, Any]) -> str:
     if branch:
         return f"branch:{branch}"
     return f"lane:{record.get('lane_id') or record.get('owner_session') or 'unknown'}"
+
+
+def _record_pr_number(record: dict[str, Any]) -> int | None:
+    if record.get("pr_number") is None:
+        return None
+    try:
+        return int(record.get("pr_number"))
+    except (TypeError, ValueError):
+        return None
 
 
 def _lane_age_minutes(record: dict[str, Any], now: dt.datetime) -> float | None:
@@ -294,7 +332,7 @@ def _recent_target_keys(
     recent_hours: float,
 ) -> set[str]:
     entries = [entry for entry in ledger.get("entries", []) if isinstance(entry, dict)]
-    recent_entries = entries[-max(0, recent_cycles) :]
+    recent_entries = entries[-recent_cycles:] if recent_cycles > 0 else []
     cutoff = now - dt.timedelta(hours=recent_hours)
     keys: set[str] = {
         str(entry.get("target_key")) for entry in recent_entries if entry.get("target_key")
@@ -309,7 +347,7 @@ def _recent_target_keys(
     return keys
 
 
-def _receipt_keys(receipt_dir: Path) -> tuple[set[str], set[str]]:
+def _resolved_receipt_keys(receipt_dir: Path) -> tuple[set[str], set[str]]:
     filenames: set[str] = set()
     shas: set[str] = set()
     if not receipt_dir.is_dir():
@@ -317,6 +355,8 @@ def _receipt_keys(receipt_dir: Path) -> tuple[set[str], set[str]]:
     for path in receipt_dir.glob("*.json"):
         payload = _load_json_file(path, {})
         if not isinstance(payload, dict):
+            continue
+        if str(payload.get("outcome") or "").strip().lower() not in RESOLVED_STEERING_OUTCOMES:
             continue
         if payload.get("message_filename"):
             filenames.add(str(payload["message_filename"]))
@@ -331,7 +371,7 @@ def unread_messages(owner_session: str, *, steering_inbox_root: Path) -> list[di
     )
     if not inbox.is_dir():
         return []
-    receipt_filenames, receipt_shas = _receipt_keys(inbox / "_read_receipts")
+    resolved_filenames, resolved_shas = _resolved_receipt_keys(inbox / "_read_receipts")
     unread: list[dict[str, Any]] = []
     for path in sorted(p for p in inbox.glob("*.json") if p.is_file()):
         payload = _load_json_file(path, {})
@@ -339,7 +379,7 @@ def unread_messages(owner_session: str, *, steering_inbox_root: Path) -> list[di
             unread.append({"path": str(path), "reason": "unreadable"})
             continue
         sha = str(payload.get("message_sha256") or "")
-        if path.name not in receipt_filenames and (not sha or sha not in receipt_shas):
+        if path.name not in resolved_filenames and (not sha or sha not in resolved_shas):
             unread.append(
                 {
                     "path": str(path),
@@ -405,8 +445,22 @@ def choose_candidate(
         if excluded:
             skips.append({"target_key": target_key, "reason": excluded})
             continue
+        pr_number = _record_pr_number(record)
+        if pr_number is not None and pr_number not in open_prs:
+            skips.append({"target_key": target_key, "reason": "PR is not open"})
+            continue
         owner_session = str(record.get("owner_session") or "").strip()
-        unread = unread_messages(owner_session, steering_inbox_root=steering_inbox_root)
+        try:
+            unread = unread_messages(owner_session, steering_inbox_root=steering_inbox_root)
+        except ValueError as exc:
+            skips.append(
+                {
+                    "target_key": target_key,
+                    "owner_session": owner_session,
+                    "reason": f"invalid owner_session: {exc}",
+                }
+            )
+            continue
         if unread:
             skips.append(
                 {
@@ -502,24 +556,6 @@ def collect_live_state(
         cwd=repo_root,
         command_runner=command_runner,
     )
-    sessions_payload = _run_json(
-        ["python3", "scripts/list_active_agent_sessions.py", "--json"],
-        cwd=repo_root,
-        command_runner=command_runner,
-        timeout=45,
-    )
-    snapshot_payload = _run_json(
-        ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"],
-        cwd=repo_root,
-        command_runner=command_runner,
-        timeout=45,
-    )
-    sentinel_payload = _run_json(
-        ["python3", "scripts/fleet_sentinel.py", "--json"],
-        cwd=repo_root,
-        command_runner=command_runner,
-        timeout=45,
-    )
     return {
         "fetch": fetch_result,
         "status": status.stdout,
@@ -527,11 +563,6 @@ def collect_live_state(
         "origin_main": rev_lines[1] if len(rev_lines) >= 2 else None,
         "open_prs": pr_payload if isinstance(pr_payload, list) else [],
         "open_pr_count": len(pr_payload) if isinstance(pr_payload, list) else None,
-        "sessions_summary": sessions_payload if isinstance(sessions_payload, dict) else None,
-        "operator_snapshot_summary": snapshot_payload
-        if isinstance(snapshot_payload, dict)
-        else None,
-        "fleet_sentinel_summary": sentinel_payload if isinstance(sentinel_payload, dict) else None,
     }
 
 
@@ -600,6 +631,9 @@ def run_cycle(
             "skip_reason": "candidate drifted before send",
         }
         ledger = _append_ledger_entry(ledger, entry, sent=False)
+        if ledger["consecutive_no_send"] >= 3:
+            result["stop"] = True
+            result["stop_reason"] = "three consecutive no-send cycles"
         if not config.dry_run:
             write_ledger(config.ledger_path, ledger)
         result.update(

--- a/scripts/steering_conductor.py
+++ b/scripts/steering_conductor.py
@@ -456,6 +456,36 @@ def _score_candidate(
     )
 
 
+def _active_owner_conflicts(
+    records: list[dict[str, Any]],
+    *,
+    open_prs: dict[int, dict[str, Any]],
+    now: dt.datetime,
+    max_lane_age_minutes: float,
+    steering_inbox_root: Path,
+) -> dict[str, list[str]]:
+    owners_by_target: dict[str, set[str]] = {}
+    for record in records:
+        if _is_excluded_record(record, now, max_lane_age_minutes):
+            continue
+        pr_number = _record_pr_number(record)
+        if pr_number is not None and pr_number not in open_prs:
+            continue
+        owner_session = str(record.get("owner_session") or "").strip()
+        try:
+            send_operator_steering.validate_to_session(
+                owner_session, steering_inbox_root=steering_inbox_root
+            )
+        except ValueError:
+            continue
+        owners_by_target.setdefault(_target_key(record), set()).add(owner_session)
+    return {
+        target_key: sorted(owners)
+        for target_key, owners in owners_by_target.items()
+        if len(owners) > 1
+    }
+
+
 def choose_candidate(
     records: list[dict[str, Any]],
     *,
@@ -469,6 +499,13 @@ def choose_candidate(
 ) -> tuple[Candidate | None, list[dict[str, Any]]]:
     skips: list[dict[str, Any]] = []
     candidates: list[Candidate] = []
+    owner_conflicts = _active_owner_conflicts(
+        records,
+        open_prs=open_prs,
+        now=now,
+        max_lane_age_minutes=max_lane_age_minutes,
+        steering_inbox_root=steering_inbox_root,
+    )
     for record in records:
         target_key = _target_key(record)
         excluded = _is_excluded_record(record, now, max_lane_age_minutes)
@@ -480,6 +517,16 @@ def choose_candidate(
             skips.append({"target_key": target_key, "reason": "PR is not open"})
             continue
         owner_session = str(record.get("owner_session") or "").strip()
+        if target_key in owner_conflicts:
+            skips.append(
+                {
+                    "target_key": target_key,
+                    "owner_session": owner_session,
+                    "reason": "multiple active owners",
+                    "owner_sessions": owner_conflicts[target_key],
+                }
+            )
+            continue
         try:
             unread = unread_messages(owner_session, steering_inbox_root=steering_inbox_root)
         except ValueError as exc:

--- a/scripts/steering_conductor.py
+++ b/scripts/steering_conductor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fcntl
 import hashlib
 import json
 import subprocess
@@ -27,7 +28,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import send_operator_steering
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_LEDGER_PATH = Path("/tmp/aragora_steering_conductor_ledger.json")
+DEFAULT_LEDGER_PATH = Path.home() / ".aragora" / "steering_conductor_ledger.json"
 DEFAULT_RECENT_TARGET_CYCLES = 3
 DEFAULT_RECENT_TARGET_HOURS = 2.0
 DEFAULT_MAX_LANE_AGE_MINUTES = 120.0
@@ -181,8 +182,23 @@ def load_ledger(path: Path) -> dict[str, Any]:
 
 
 def write_ledger(path: Path, ledger: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     path.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _acquire_cycle_lock(path: Path) -> Any:
+    lock_path = path.with_name(f"{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    handle = lock_path.open("a+", encoding="utf-8")
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    return handle
+
+
+def _release_cycle_lock(handle: Any) -> None:
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
 
 
 def _load_lane_records_file(path: Path) -> list[dict[str, Any]]:
@@ -322,6 +338,20 @@ def _message_body(
 
 def _body_hash(body: str) -> str:
     return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _ledger_has_sent_body(
+    ledger: dict[str, Any],
+    *,
+    target_key: str,
+    body_hash: str,
+) -> bool:
+    for entry in reversed([e for e in ledger.get("entries", []) if isinstance(e, dict)]):
+        if entry.get("target_key") != target_key:
+            continue
+        if entry.get("sent") is True and entry.get("body_sha256") == body_hash:
+            return True
+    return False
 
 
 def _recent_target_keys(
@@ -501,6 +531,26 @@ def _find_current_record(
     return None
 
 
+def _current_record_blocker(
+    record: dict[str, Any],
+    candidate: Candidate,
+    *,
+    open_prs: dict[int, dict[str, Any]],
+    now: dt.datetime,
+    max_lane_age_minutes: float,
+) -> str | None:
+    current_target_key = _target_key(record)
+    if current_target_key != candidate.target_key:
+        return f"candidate target changed to {current_target_key}"
+    excluded = _is_excluded_record(record, now, max_lane_age_minutes)
+    if excluded:
+        return excluded
+    pr_number = _record_pr_number(record)
+    if pr_number is not None and pr_number not in open_prs:
+        return "PR is not open"
+    return None
+
+
 def _append_ledger_entry(
     ledger: dict[str, Any],
     entry: dict[str, Any],
@@ -541,7 +591,7 @@ def collect_live_state(
         command_runner=command_runner,
     )
     rev_lines = (rev.stdout or "").splitlines()
-    pr_payload = _run_json(
+    pr_proc = _run(
         [
             "gh",
             "pr",
@@ -556,13 +606,25 @@ def collect_live_state(
         cwd=repo_root,
         command_runner=command_runner,
     )
+    pr_payload: Any = None
+    pr_error: str | None = None
+    if pr_proc.returncode == 0:
+        try:
+            pr_payload = json.loads(pr_proc.stdout or "null")
+        except json.JSONDecodeError as exc:
+            pr_error = f"invalid gh pr list JSON: {exc}"
+    else:
+        pr_error = (pr_proc.stderr or pr_proc.stdout or "gh pr list failed").strip()
+    if not isinstance(pr_payload, list):
+        pr_payload = None
     return {
         "fetch": fetch_result,
         "status": status.stdout,
         "head": rev_lines[0] if len(rev_lines) >= 1 else None,
         "origin_main": rev_lines[1] if len(rev_lines) >= 2 else None,
-        "open_prs": pr_payload if isinstance(pr_payload, list) else [],
-        "open_pr_count": len(pr_payload) if isinstance(pr_payload, list) else None,
+        "open_prs": pr_payload,
+        "open_pr_count": len(pr_payload) if pr_payload is not None else None,
+        "open_pr_error": pr_error,
     }
 
 
@@ -574,9 +636,54 @@ def run_cycle(
 ) -> dict[str, Any]:
     now = now or _utc_now()
     live_state = collect_live_state(config, command_runner=command_runner)
+    lock_handle = None
+    if not config.dry_run:
+        lock_handle = _acquire_cycle_lock(config.ledger_path)
+    try:
+        return _run_cycle_locked(config, live_state=live_state, now=now)
+    finally:
+        if lock_handle is not None:
+            _release_cycle_lock(lock_handle)
+
+
+def _run_cycle_locked(
+    config: CycleConfig,
+    *,
+    live_state: dict[str, Any],
+    now: dt.datetime,
+) -> dict[str, Any]:
     ledger = load_ledger(config.ledger_path)
     records = load_lane_records(config.lane_registry_path)
-    open_prs = _open_pr_lookup(live_state.get("open_prs"))
+    open_prs_payload = live_state.get("open_prs")
+    open_prs = _open_pr_lookup(open_prs_payload)
+
+    result: dict[str, Any] = {
+        "ok": True,
+        "sent": False,
+        "dry_run": config.dry_run,
+        "timestamp": _iso(now),
+        "origin_main": live_state.get("origin_main"),
+        "open_pr_count": live_state.get("open_pr_count"),
+        "candidate_skips": [],
+        "selected": None,
+        "message_path": None,
+        "stop": False,
+        "stop_reason": None,
+    }
+
+    if open_prs_payload is None:
+        result.update(
+            {
+                "ok": False,
+                "no_send_reason": "open PR list unavailable",
+                "open_pr_error": live_state.get("open_pr_error"),
+                "ledger_consecutive_no_send": ledger["consecutive_no_send"],
+                "ledger_updated": False,
+                "next_prompt": _next_prompt(config.repo_root),
+            }
+        )
+        return result
+
     candidate, skips = choose_candidate(
         records,
         open_prs=open_prs,
@@ -587,20 +694,7 @@ def run_cycle(
         max_lane_age_minutes=config.max_lane_age_minutes,
         steering_inbox_root=config.steering_inbox_root,
     )
-
-    result: dict[str, Any] = {
-        "ok": True,
-        "sent": False,
-        "dry_run": config.dry_run,
-        "timestamp": _iso(now),
-        "origin_main": live_state.get("origin_main"),
-        "open_pr_count": live_state.get("open_pr_count"),
-        "candidate_skips": skips[:25],
-        "selected": None,
-        "message_path": None,
-        "stop": False,
-        "stop_reason": None,
-    }
+    result["candidate_skips"] = skips[:25]
 
     if candidate is None:
         entry = {
@@ -622,13 +716,24 @@ def run_cycle(
 
     latest_records = load_lane_records(config.lane_registry_path)
     current_record = _find_current_record(latest_records, candidate)
-    if current_record is None or current_record != candidate.record:
+    current_blocker = (
+        "candidate disappeared before send"
+        if current_record is None
+        else _current_record_blocker(
+            current_record,
+            candidate,
+            open_prs=open_prs,
+            now=now,
+            max_lane_age_minutes=config.max_lane_age_minutes,
+        )
+    )
+    if current_blocker is not None:
         entry = {
             "timestamp": _iso(now),
             "sent": False,
             "target_key": candidate.target_key,
             "owner_session": candidate.owner_session,
-            "skip_reason": "candidate drifted before send",
+            "skip_reason": current_blocker,
         }
         ledger = _append_ledger_entry(ledger, entry, sent=False)
         if ledger["consecutive_no_send"] >= 3:
@@ -639,13 +744,20 @@ def run_cycle(
         result.update(
             {
                 "selected": {"target_key": candidate.target_key, "reason": candidate.reason},
-                "no_send_reason": "candidate drifted before send",
+                "no_send_reason": current_blocker,
                 "ledger_consecutive_no_send": ledger["consecutive_no_send"],
                 "ledger_updated": not config.dry_run,
                 "next_prompt": _next_prompt(config.repo_root),
             }
         )
         return result
+    candidate = Candidate(
+        record=current_record,
+        target_key=candidate.target_key,
+        owner_session=candidate.owner_session,
+        score=candidate.score,
+        reason=candidate.reason,
+    )
 
     open_pr: dict[str, Any] | None = None
     try:
@@ -660,6 +772,31 @@ def run_cycle(
         open_pr = open_prs.get(pr_number)
     body = _message_body(candidate.record, repo_root=config.repo_root, open_pr=open_pr)
     body_hash = _body_hash(body)
+    if _ledger_has_sent_body(ledger, target_key=candidate.target_key, body_hash=body_hash):
+        entry = {
+            "timestamp": _iso(now),
+            "sent": False,
+            "target_key": candidate.target_key,
+            "owner_session": candidate.owner_session,
+            "skip_reason": "duplicate steering body already sent",
+            "body_sha256": body_hash,
+        }
+        ledger = _append_ledger_entry(ledger, entry, sent=False)
+        if ledger["consecutive_no_send"] >= 3:
+            result["stop"] = True
+            result["stop_reason"] = "three consecutive no-send cycles"
+        if not config.dry_run:
+            write_ledger(config.ledger_path, ledger)
+        result.update(
+            {
+                "selected": {"target_key": candidate.target_key, "reason": candidate.reason},
+                "no_send_reason": "duplicate steering body already sent",
+                "ledger_consecutive_no_send": ledger["consecutive_no_send"],
+                "ledger_updated": not config.dry_run,
+                "next_prompt": _next_prompt(config.repo_root),
+            }
+        )
+        return result
     route = send_operator_steering.direct_route_payload(
         candidate.owner_session, steering_inbox_root=config.steering_inbox_root
     )
@@ -730,7 +867,7 @@ def _next_prompt(repo_root: Path = REPO_ROOT) -> str:
         "Operating contract: re-read docs/AGENT_OPERATING_CONTRACT.md §Conductor, "
         "docs/REVIEW_AUTHORITY_PRINCIPLES.md, and AGENTS.md this cycle. Send at most "
         "one local operator-steering message via scripts/steering_conductor.py, "
-        "respecting /tmp/aragora_steering_conductor_ledger.json rotation and all "
+        "respecting steering-conductor ledger rotation and all "
         "hard exclusions. Do not mutate GitHub, PR branches, evidence, settlements, "
         "workflows, branch protection, or repo-tracked files."
     )

--- a/tests/scripts/test_steering_conductor.py
+++ b/tests/scripts/test_steering_conductor.py
@@ -58,6 +58,27 @@ def _write_lanes(path: Path, lanes: list[dict[str, Any]]) -> None:
     path.write_text(json.dumps(lanes), encoding="utf-8")
 
 
+def _write_receipt(
+    inbox: Path,
+    *,
+    message_filename: str,
+    message_sha256: str,
+    outcome: str,
+) -> None:
+    receipt_dir = inbox / "_read_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / f"{outcome}.json").write_text(
+        json.dumps(
+            {
+                "message_filename": message_filename,
+                "message_sha256": message_sha256,
+                "outcome": outcome,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
 def _runner(open_prs: list[dict[str, Any]] | None = None) -> Any:
     def fake_runner(
         command: list[str],
@@ -146,6 +167,109 @@ def test_unread_pending_message_blocks_duplicate_send(tmp_path: Path) -> None:
     assert result["candidate_skips"][0]["reason"] == "unread pending steering"
 
 
+def test_read_receipt_does_not_clear_pending_message(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+    inbox = tmp_path / "operator-steering" / "owner-a"
+    inbox.mkdir(parents=True)
+    message = sc.send_operator_steering.build_message(
+        to_session="owner-a",
+        body="already pending",
+    )
+    message_path = inbox / "pending.json"
+    message_path.write_text(json.dumps(message), encoding="utf-8")
+    _write_receipt(
+        inbox,
+        message_filename=message_path.name,
+        message_sha256=message["message_sha256"],
+        outcome="read",
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "no eligible live owner target"
+    assert result["candidate_skips"][0]["reason"] == "unread pending steering"
+
+
+def test_resolved_receipt_clears_pending_message(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+    inbox = tmp_path / "operator-steering" / "owner-a"
+    inbox.mkdir(parents=True)
+    message = sc.send_operator_steering.build_message(
+        to_session="owner-a",
+        body="already handled",
+    )
+    message_path = inbox / "pending.json"
+    message_path.write_text(json.dumps(message), encoding="utf-8")
+    _write_receipt(
+        inbox,
+        message_filename=message_path.name,
+        message_sha256=message["message_sha256"],
+        outcome="completed",
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9001"
+
+
+def test_invalid_owner_session_skips_record_without_aborting(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(
+        lanes_path,
+        [
+            _lane("bad", "owner/bad", pr_number=9001),
+            _lane("good", "owner-good", pr_number=9002),
+        ],
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner(
+            [
+                {"number": 9001, "headRefOid": "abc123"},
+                {"number": 9002, "headRefOid": "def456"},
+            ]
+        ),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9002"
+    reasons = {skip["target_key"]: skip["reason"] for skip in result["candidate_skips"]}
+    assert reasons["pr:9001"].startswith("invalid owner_session:")
+
+
+def test_closed_pr_lane_is_excluded(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a", pr_number=9001)])
+
+    result = sc.run_cycle(_config(tmp_path, lanes_path), command_runner=_runner([]), now=NOW)
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "no eligible live owner target"
+    assert result["candidate_skips"][0]["reason"] == "PR is not open"
+
+
 def test_recent_target_rotation_prefers_different_lane(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -186,6 +310,42 @@ def test_recent_target_rotation_prefers_different_lane(tmp_path: Path) -> None:
     assert result["selected"]["target_key"] == "pr:9002"
     assert len(list((tmp_path / "operator-steering" / "owner-a").glob("*.json"))) == 0
     assert len(list((tmp_path / "operator-steering" / "owner-b").glob("*.json"))) == 1
+
+
+def test_recent_target_cycles_zero_uses_no_cycle_suppression() -> None:
+    ledger = {
+        "entries": [
+            {
+                "timestamp": "2026-07-07T16:30:00Z",
+                "target_key": "pr:9001",
+            }
+        ]
+    }
+
+    assert (
+        sc._recent_target_keys(
+            ledger,
+            now=NOW,
+            recent_cycles=0,
+            recent_hours=0.0,
+        )
+        == set()
+    )
+
+
+def test_load_lane_records_merges_default_user_and_repo_registries(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    user_lanes = tmp_path / "user" / "lanes.json"
+    repo_lanes = tmp_path / "repo" / "lanes.json"
+    _write_lanes(user_lanes, [_lane("user-lane", "owner-user", pr_number=9001)])
+    _write_lanes(repo_lanes, [_lane("repo-lane", "owner-repo", pr_number=9002)])
+    monkeypatch.setattr(sc.send_operator_steering, "USER_LANE_REGISTRY_DEFAULT", user_lanes)
+    monkeypatch.setattr(sc.send_operator_steering, "LANE_REGISTRY_DEFAULT", repo_lanes)
+
+    records = sc.load_lane_records(repo_lanes)
+
+    assert [record["lane_id"] for record in records] == ["user-lane", "repo-lane"]
 
 
 def test_stale_terminal_and_unpushed_lanes_are_excluded(tmp_path: Path) -> None:
@@ -233,6 +393,39 @@ def test_third_no_send_cycle_sets_stop(tmp_path: Path) -> None:
     assert result["stop_reason"] == "three consecutive no-send cycles"
     updated = json.loads((tmp_path / "ledger.json").read_text(encoding="utf-8"))
     assert updated["consecutive_no_send"] == 3
+
+
+def test_third_drift_no_send_cycle_sets_stop(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    ledger = {
+        "schema_version": sc.SCHEMA_VERSION,
+        "consecutive_no_send": 2,
+        "entries": [],
+    }
+    (tmp_path / "ledger.json").write_text(json.dumps(ledger), encoding="utf-8")
+    calls = 0
+
+    def fake_load_lane_records(_path: Path) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [_lane("lane-a", "owner-a", pr_number=9001)]
+        return []
+
+    monkeypatch.setattr(sc, "load_lane_records", fake_load_lane_records)
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["stop"] is True
+    assert result["stop_reason"] == "three consecutive no-send cycles"
+    assert result["ledger_consecutive_no_send"] == 3
 
 
 def test_dry_run_does_not_write_message_or_ledger(tmp_path: Path) -> None:

--- a/tests/scripts/test_steering_conductor.py
+++ b/tests/scripts/test_steering_conductor.py
@@ -428,6 +428,171 @@ def test_third_drift_no_send_cycle_sets_stop(tmp_path: Path, monkeypatch: Any) -
     assert result["ledger_consecutive_no_send"] == 3
 
 
+def test_heartbeat_only_drift_still_sends(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    calls = 0
+
+    def fake_load_lane_records(_path: Path) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [_lane("lane-a", "owner-a", pr_number=9001)]
+        return [
+            _lane(
+                "lane-a",
+                "owner-a",
+                pr_number=9001,
+                updated_at="2026-07-07T16:56:00Z",
+            )
+        ]
+
+    monkeypatch.setattr(sc, "load_lane_records", fake_load_lane_records)
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9001"
+    assert len(list((tmp_path / "operator-steering" / "owner-a").glob("*.json"))) == 1
+
+
+def test_target_drift_blocks_send(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    calls = 0
+
+    def fake_load_lane_records(_path: Path) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [_lane("lane-a", "owner-a", pr_number=9001)]
+        return [_lane("lane-a", "owner-a", pr_number=9002)]
+
+    monkeypatch.setattr(sc, "load_lane_records", fake_load_lane_records)
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner(
+            [
+                {"number": 9001, "headRefOid": "abc123"},
+                {"number": 9002, "headRefOid": "def456"},
+            ]
+        ),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "candidate target changed to pr:9002"
+    assert result["ledger_consecutive_no_send"] == 1
+
+
+def test_pr_list_failure_short_circuits_without_counting_no_send(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a", pr_number=9001)])
+
+    def failing_pr_runner(
+        command: list[str],
+        *,
+        cwd: str,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(command, 1, "", "auth failed")
+        return _runner([])(
+            command,
+            cwd=cwd,
+            capture_output=capture_output,
+            text=text,
+            timeout=timeout,
+            check=check,
+        )
+
+    result = sc.run_cycle(_config(tmp_path, lanes_path), command_runner=failing_pr_runner, now=NOW)
+
+    assert result["ok"] is False
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "open PR list unavailable"
+    assert result["open_pr_error"] == "auth failed"
+    assert result["ledger_consecutive_no_send"] == 0
+    assert result["ledger_updated"] is False
+    assert not (tmp_path / "ledger.json").exists()
+
+
+def test_duplicate_sent_body_is_not_resent(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    lane = _lane("lane-a", "owner-a", pr_number=9001)
+    _write_lanes(lanes_path, [lane])
+    body_hash = sc._body_hash(
+        sc._message_body(lane, repo_root=tmp_path / "repo", open_pr={"headRefOid": "abc123"})
+    )
+    ledger = {
+        "schema_version": sc.SCHEMA_VERSION,
+        "consecutive_no_send": 0,
+        "entries": [
+            {
+                "timestamp": "2026-07-07T16:30:00Z",
+                "sent": True,
+                "target_key": "pr:9001",
+                "body_sha256": body_hash,
+            }
+        ],
+    }
+    (tmp_path / "ledger.json").write_text(json.dumps(ledger), encoding="utf-8")
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "duplicate steering body already sent"
+    assert len(list((tmp_path / "operator-steering" / "owner-a").glob("*.json"))) == 0
+    updated = json.loads((tmp_path / "ledger.json").read_text(encoding="utf-8"))
+    assert updated["consecutive_no_send"] == 1
+    assert updated["entries"][-1]["body_sha256"] == body_hash
+
+
+def test_non_dry_run_acquires_and_releases_ledger_lock(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+    lock_events: list[str] = []
+
+    def fake_acquire(_path: Path) -> object:
+        lock_events.append("acquire")
+        return object()
+
+    def fake_release(_handle: object) -> None:
+        lock_events.append("release")
+
+    monkeypatch.setattr(sc, "_acquire_cycle_lock", fake_acquire)
+    monkeypatch.setattr(sc, "_release_cycle_lock", fake_release)
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert lock_events == ["acquire", "release"]
+
+
 def test_dry_run_does_not_write_message_or_ledger(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/scripts/test_steering_conductor.py
+++ b/tests/scripts/test_steering_conductor.py
@@ -257,6 +257,64 @@ def test_invalid_owner_session_skips_record_without_aborting(tmp_path: Path) -> 
     assert reasons["pr:9001"].startswith("invalid owner_session:")
 
 
+def test_duplicate_active_owners_block_target(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(
+        lanes_path,
+        [
+            _lane("lane-a", "owner-a", pr_number=9001),
+            _lane("lane-b", "owner-b", pr_number=9001),
+        ],
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "no eligible live owner target"
+    assert len(list((tmp_path / "operator-steering").glob("*/*.json"))) == 0
+    duplicate_skips = [
+        skip for skip in result["candidate_skips"] if skip["reason"] == "multiple active owners"
+    ]
+    assert len(duplicate_skips) == 2
+    assert duplicate_skips[0]["owner_sessions"] == ["owner-a", "owner-b"]
+
+
+def test_duplicate_active_owners_do_not_block_clean_target(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(
+        lanes_path,
+        [
+            _lane("lane-a", "owner-a", pr_number=9001),
+            _lane("lane-b", "owner-b", pr_number=9001),
+            _lane("lane-c", "owner-c", pr_number=9002),
+        ],
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner(
+            [
+                {"number": 9001, "headRefOid": "abc123"},
+                {"number": 9002, "headRefOid": "def456"},
+            ]
+        ),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9002"
+    assert len(list((tmp_path / "operator-steering" / "owner-c").glob("*.json"))) == 1
+    assert any(skip["reason"] == "multiple active owners" for skip in result["candidate_skips"])
+
+
 def test_closed_pr_lane_is_excluded(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/scripts/test_steering_conductor.py
+++ b/tests/scripts/test_steering_conductor.py
@@ -398,12 +398,19 @@ def test_load_lane_records_merges_default_user_and_repo_registries(
     repo_lanes = tmp_path / "repo" / "lanes.json"
     _write_lanes(user_lanes, [_lane("user-lane", "owner-user", pr_number=9001)])
     _write_lanes(repo_lanes, [_lane("repo-lane", "owner-repo", pr_number=9002)])
-    monkeypatch.setattr(sc.send_operator_steering, "USER_LANE_REGISTRY_DEFAULT", user_lanes)
-    monkeypatch.setattr(sc.send_operator_steering, "LANE_REGISTRY_DEFAULT", repo_lanes)
+    monkeypatch.setattr(sc, "USER_LANE_REGISTRY_DEFAULT", user_lanes)
+    monkeypatch.setattr(sc, "LANE_REGISTRY_DEFAULT", repo_lanes)
 
     records = sc.load_lane_records(repo_lanes)
 
     assert [record["lane_id"] for record in records] == ["user-lane", "repo-lane"]
+
+
+def test_default_paths_use_canonical_owner_lookup_state_root() -> None:
+    assert sc.LANE_REGISTRY_DEFAULT == sc.owner_lookup.LANE_REGISTRY_DEFAULT
+    assert sc.STEERING_INBOX_ROOT_DEFAULT == sc.owner_lookup.STEERING_INBOX_ROOT_DEFAULT
+    assert sc.CycleConfig().lane_registry_path == sc.owner_lookup.LANE_REGISTRY_DEFAULT
+    assert sc.CycleConfig().steering_inbox_root == sc.owner_lookup.STEERING_INBOX_ROOT_DEFAULT
 
 
 def test_stale_terminal_and_unpushed_lanes_are_excluded(tmp_path: Path) -> None:
@@ -622,6 +629,38 @@ def test_duplicate_sent_body_is_not_resent(tmp_path: Path) -> None:
     updated = json.loads((tmp_path / "ledger.json").read_text(encoding="utf-8"))
     assert updated["consecutive_no_send"] == 1
     assert updated["entries"][-1]["body_sha256"] == body_hash
+
+
+def test_duplicate_active_owner_appearing_before_send_blocks_target(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    calls = 0
+
+    def fake_load_lane_records(_path: Path) -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return [_lane("lane-a", "owner-a", pr_number=9001)]
+        return [
+            _lane("lane-a", "owner-a", pr_number=9001),
+            _lane("lane-b", "owner-b", pr_number=9001),
+        ]
+
+    monkeypatch.setattr(sc, "load_lane_records", fake_load_lane_records)
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "multiple active owners"
+    assert result["owner_sessions"] == ["owner-a", "owner-b"]
+    assert len(list((tmp_path / "operator-steering").glob("*/*.json"))) == 0
 
 
 def test_non_dry_run_acquires_and_releases_ledger_lock(tmp_path: Path, monkeypatch: Any) -> None:

--- a/tests/scripts/test_steering_conductor.py
+++ b/tests/scripts/test_steering_conductor.py
@@ -1,0 +1,253 @@
+"""Tests for ``scripts/steering_conductor.py``."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "steering_conductor.py"
+    spec = importlib.util.spec_from_file_location("steering_conductor_under_test", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sc = _load_module()
+
+
+NOW = dt.datetime(2026, 7, 7, 17, 0, 0, tzinfo=dt.UTC)
+
+
+def _lane(
+    lane_id: str,
+    owner_session: str,
+    *,
+    pr_number: int | None = 9001,
+    branch: str = "codex/live-branch",
+    status: str = "active",
+    updated_at: str = "2026-07-07T16:55:00Z",
+    next_action: str = "re-ground and avoid duplicate evidence lanes",
+    possible_unpushed_work: bool | None = None,
+) -> dict[str, Any]:
+    return {
+        "lane_id": lane_id,
+        "owner_session": owner_session,
+        "status": status,
+        "pr_number": pr_number,
+        "branch": branch,
+        "updated_at": updated_at,
+        "last_heartbeat_at": updated_at,
+        "next_action": next_action,
+        "possible_unpushed_work": possible_unpushed_work,
+    }
+
+
+def _write_lanes(path: Path, lanes: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(lanes), encoding="utf-8")
+
+
+def _runner(open_prs: list[dict[str, Any]] | None = None) -> Any:
+    def fake_runner(
+        command: list[str],
+        *,
+        cwd: str,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        del cwd, capture_output, text, timeout, check
+        if command[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(command, 0, "## main...origin/main\n", "")
+        if command[:2] == ["git", "rev-parse"]:
+            return subprocess.CompletedProcess(command, 0, "head-sha\norigin-main-sha\n", "")
+        if command[:3] == ["gh", "pr", "list"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps(open_prs or []), "")
+        if command == ["python3", "scripts/list_active_agent_sessions.py", "--json"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"open_prs": []}), "")
+        if command == ["python3", "scripts/agent_bridge.py", "operator-snapshot", "--json"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"lanes": []}), "")
+        if command == ["python3", "scripts/fleet_sentinel.py", "--json"]:
+            return subprocess.CompletedProcess(command, 0, json.dumps({"ok": True}), "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    return fake_runner
+
+
+def _config(tmp_path: Path, lanes_path: Path, *, dry_run: bool = False) -> Any:
+    return sc.CycleConfig(
+        repo_root=tmp_path / "repo",
+        ledger_path=tmp_path / "ledger.json",
+        lane_registry_path=lanes_path,
+        steering_inbox_root=tmp_path / "operator-steering",
+        dry_run=dry_run,
+        skip_fetch=True,
+    )
+
+
+def test_cycle_sends_one_message_and_records_ledger(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9001"
+    messages = list((tmp_path / "operator-steering" / "owner-a").glob("*.json"))
+    assert len(messages) == 1
+    payload = json.loads(messages[0].read_text(encoding="utf-8"))
+    assert payload["from"] == "steering-conductor"
+    assert "Target: PR #9001 at live observed head abc123" in payload["body"]
+    ledger = json.loads((tmp_path / "ledger.json").read_text(encoding="utf-8"))
+    assert ledger["consecutive_no_send"] == 0
+    assert ledger["entries"][-1]["target_key"] == "pr:9001"
+
+
+def test_unread_pending_message_blocks_duplicate_send(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+    inbox = tmp_path / "operator-steering" / "owner-a"
+    inbox.mkdir(parents=True)
+    message = sc.send_operator_steering.build_message(
+        to_session="owner-a",
+        body="already pending",
+    )
+    (inbox / "pending.json").write_text(json.dumps(message), encoding="utf-8")
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["no_send_reason"] == "no eligible live owner target"
+    assert len(list(inbox.glob("*.json"))) == 1
+    assert result["candidate_skips"][0]["reason"] == "unread pending steering"
+
+
+def test_recent_target_rotation_prefers_different_lane(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(
+        lanes_path,
+        [
+            _lane("lane-a", "owner-a", pr_number=9001),
+            _lane("lane-b", "owner-b", pr_number=9002),
+        ],
+    )
+    ledger = {
+        "schema_version": sc.SCHEMA_VERSION,
+        "consecutive_no_send": 0,
+        "entries": [
+            {
+                "timestamp": "2026-07-07T16:30:00Z",
+                "sent": True,
+                "target_key": "pr:9001",
+                "owner_session": "owner-a",
+            }
+        ],
+    }
+    (tmp_path / "ledger.json").write_text(json.dumps(ledger), encoding="utf-8")
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner(
+            [
+                {"number": 9001, "headRefOid": "abc123"},
+                {"number": 9002, "headRefOid": "def456"},
+            ]
+        ),
+        now=NOW,
+    )
+
+    assert result["sent"] is True
+    assert result["selected"]["target_key"] == "pr:9002"
+    assert len(list((tmp_path / "operator-steering" / "owner-a").glob("*.json"))) == 0
+    assert len(list((tmp_path / "operator-steering" / "owner-b").glob("*.json"))) == 1
+
+
+def test_stale_terminal_and_unpushed_lanes_are_excluded(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(
+        lanes_path,
+        [
+            _lane("old", "owner-old", pr_number=9001, updated_at="2026-07-07T12:00:00Z"),
+            _lane("done", "owner-done", pr_number=9002, status="completed"),
+            _lane("unpushed", "owner-unpushed", pr_number=9003, possible_unpushed_work=True),
+        ],
+    )
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    reasons = {skip["target_key"]: skip["reason"] for skip in result["candidate_skips"]}
+    assert reasons["pr:9001"].startswith("stale lane age")
+    assert reasons["pr:9002"] == "terminal status completed"
+    assert reasons["pr:9003"] == "possible_unpushed_work"
+
+
+def test_third_no_send_cycle_sets_stop(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [])
+    ledger = {
+        "schema_version": sc.SCHEMA_VERSION,
+        "consecutive_no_send": 2,
+        "entries": [],
+    }
+    (tmp_path / "ledger.json").write_text(json.dumps(ledger), encoding="utf-8")
+
+    result = sc.run_cycle(_config(tmp_path, lanes_path), command_runner=_runner(), now=NOW)
+
+    assert result["sent"] is False
+    assert result["stop"] is True
+    assert result["stop_reason"] == "three consecutive no-send cycles"
+    updated = json.loads((tmp_path / "ledger.json").read_text(encoding="utf-8"))
+    assert updated["consecutive_no_send"] == 3
+
+
+def test_dry_run_does_not_write_message_or_ledger(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    lanes_path = tmp_path / "lanes.json"
+    _write_lanes(lanes_path, [_lane("lane-a", "owner-a")])
+
+    result = sc.run_cycle(
+        _config(tmp_path, lanes_path, dry_run=True),
+        command_runner=_runner([{"number": 9001, "headRefOid": "abc123"}]),
+        now=NOW,
+    )
+
+    assert result["sent"] is False
+    assert result["selected"]["target_key"] == "pr:9001"
+    assert not (tmp_path / "operator-steering").exists()
+    assert not (tmp_path / "ledger.json").exists()


### PR DESCRIPTION
## Summary
- add scripts/steering_conductor.py for one bounded local operator-steering message per cycle
- maintain /tmp/aragora_steering_conductor_ledger.json for rotation/no-send breaker state
- skip stale/terminal/possible-unpushed lanes, duplicate unread mailbox messages, and recent targets
- add focused tests for send, duplicate skip, rotation, exclusions, no-send stop, and dry-run behavior

## Validation
- python3 -m pytest tests/scripts/test_steering_conductor.py -q
- python3 -m ruff check scripts/steering_conductor.py tests/scripts/test_steering_conductor.py
- git diff --check origin/main HEAD
- python3 scripts/check_portability.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python3 scripts/steering_conductor.py --dry-run --skip-fetch --json
