### PR TITLE
fix(ci): report lint/typecheck required checks on docs-only main commits (follow-up to #8952)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,16 +3,6 @@ name: Lint
 on:
   push:
     branches: [main]
-    paths:
-      - 'aragora/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - 'AGENTS.md'
-      - 'pyproject.toml'
-      - '.github/workflows/**'
-      - 'deploy/**'
-      - 'security/policies/**'
-      - 'aragora-operator/**'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]


### PR DESCRIPTION
Removes the `on.push.paths` filter from lint.yml so the required `lint` and `typecheck` aggregate contexts report on every main push, including docs-only commits (evidence: both contexts missing on docs-only main SHA 92af0c8d while sdk-parity/OpenAPI/TS contexts succeeded — the #8952 class, third and fourth affected contexts).

Mechanism identical to #8952: the `changes` classifier still skips heavy Python jobs on docs-only pushes; the `lint`/`typecheck` aggregate jobs use `if: always()` and report success when their run jobs are skipped, so cost is minimal.

Hazard scan (from the diagnosing goal thread, re-verified): no job in lint.yml pushes, deploys, auto-commits, or mutates GitHub state on push events; docs-sync regenerates locally and diff-checks only.

Rollback: single-commit revert.

Operator-authorized: authorize-lint-typecheck-main-required-context on #8845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)