### PR TITLE
docs(reference): restore live-verified aragora-verify 0.1.1 PyPI facts (m5-install)

### DIFF
--- a/docs/reference/INSTALL_MATRIX.md
+++ b/docs/reference/INSTALL_MATRIX.md
@@ -23,13 +23,15 @@ re-verified 2026-07-07):
 | Root platform | `aragora` | `pyproject.toml` | **2.9.0** | Published; latest on PyPI = 2.9.0 |
 | Debate engine | `aragora-debate` | `aragora-debate/pyproject.toml` | **0.2.3** | Published; latest on PyPI = 0.2.3 |
 | Python SDK | `aragora-sdk` | `sdk/python/pyproject.toml` | **2.9.0** | Published; latest on PyPI = **2.8.0** (2026-02-25) — the repo's in-tree version has moved to 2.9.0 but that build has not been released to PyPI yet, so `pip install aragora-sdk` today gives you 2.8.0, not 2.9.0 |
-| Verifier | `aragora-verify` | `aragora-verify/pyproject.toml` | **0.1.1** | Published; latest on PyPI = **0.1.0** (first released 2026-06-29T23:32Z, GitHub release [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0)); the repo's in-tree version has moved to 0.1.1 but that build has not been released to PyPI yet, so `pip install aragora-verify` today gives you 0.1.0 |
+| Verifier | `aragora-verify` | `aragora-verify/pyproject.toml` | **0.1.1** | Published; latest on PyPI = **0.1.1** (0.1.0 released 2026-06-29T23:32Z, GitHub release [`aragora-verify-v0.1.0`](https://github.com/synaptent/aragora/releases/tag/aragora-verify-v0.1.0); 0.1.1 released 2026-07-04T03:28Z) |
+
+<!-- FACT (live-verified 2026-07-07T17:42Z): aragora-verify 0.1.1 IS on PyPI (info.version=0.1.1). Before "correcting" this to unreleased, re-run: curl -s https://pypi.org/pypi/aragora-verify/json | jq .info.version -->
 
 `aragora-verify` is **live and installable from PyPI today**, not merely
 staged or forthcoming — `pip install aragora-verify` installs the real
-published package. Today that package is 0.1.0; use the from-checkout options
-below when you need this branch's in-tree 0.1.1 verifier behavior.
-Self-verify anytime with the `curl` command above.
+published package, currently 0.1.1 — matching this branch's in-tree version,
+no lag between the two as of this check. Self-verify anytime with the `curl`
+command above.
 
 ## Install path per audience
 
@@ -47,19 +49,25 @@ Python standard library plus `cryptography` (see the
 [Independent Verifier Guide](../specs/INDEPENDENT_VERIFIER_GUIDE.md) for the
 full exit-code contract and disambiguation from the in-tree `aragora verify`).
 
-**PyPI install:** installs the current published package. As of the live check
-above, PyPI resolves this to 0.1.0:
+**PyPI install (floor-pinned, recommended):** 0.1.1 adds the `key_id`-equality
+check that closes a signer-label-tampering gap present in 0.1.0 (a relabeled
+`key_id` on an otherwise-valid signature silently passes verification on
+0.1.0 but correctly fails it on 0.1.1). Pin the floor so an install always
+gets that protection:
+
+<!-- FACT (live-verified 2026-07-07T17:42Z): aragora-verify 0.1.1 IS on PyPI (info.version=0.1.1). Before "correcting" this to unreleased, re-run: curl -s https://pypi.org/pypi/aragora-verify/json | jq .info.version -->
+
+```bash
+pip install "aragora-verify>=0.1.1"
+```
+
+**Unpinned (also correct today):** PyPI's latest already resolves to 0.1.1,
+so the plain form installs the same secure version — the floor pin is what
+protects you if that ever stops being true:
 
 ```bash
 pip install aragora-verify
 ```
-
-Security note: the in-tree 0.1.1 verifier adds the `key_id`-equality check
-that closes a signer-label-tampering gap present in 0.1.0 (a relabeled
-`key_id` on an otherwise-valid signature silently passes on 0.1.0 but fails on
-0.1.1). Do not use `pip install "aragora-verify>=0.1.1"` until 0.1.1 is
-published to PyPI; it will fail today. Use a from-checkout option below when
-that security behavior is required before publication.
 
 From-checkout options — no PyPI install at all, useful for auditing this
 exact commit or working offline:


### PR DESCRIPTION
## What

Restores truthful, live-verified PyPI facts for `aragora-verify` in
`docs/reference/INSTALL_MATRIX.md` after a post-session foreign commit
(`337d943a`, author `armand@synaptent.com`, 2026-07-07T12:01-05:00,
`docs(reference): correct aragora-verify PyPI version`) landed on PR #8967's
branch **after** the worker session and **before** merge, and got squashed
into `92af0c8df5` on `main`. That commit rewrote the correct wording to a
stale/false claim:

- Verifier row: "latest on PyPI = 0.1.0 ... 0.1.1 has not been released"
- Floor-pin section: "Do not use `pip install \"aragora-verify>=0.1.1\"` until
  0.1.1 is published; it will fail today."

Both statements are **factually false** per a fresh live check (below). This
regressed `VAL-INSTALL-001` and `VAL-INSTALL-003` in the mission's
user-testing validation (round 1, 2026-07-07T17:30Z).

## Live verification (mandatory first step, run fresh for this PR)

```console
$ curl -s https://pypi.org/pypi/aragora-verify/json | jq '.info.version, (.releases|keys)'
"0.1.1"
[
  "0.1.0",
  "0.1.1"
]

$ curl -s https://pypi.org/pypi/aragora-verify/json | jq '.releases["0.1.0"][0] | {upload_time, yanked}'
{
  "upload_time": "2026-06-29T23:32:42",
  "yanked": false
}

$ curl -s https://pypi.org/pypi/aragora-verify/json | jq '.releases["0.1.1"][0] | {upload_time, yanked}'
{
  "upload_time": "2026-07-04T03:28:00",
  "yanked": false
}
```

Throwaway-venv install resolution proof (fresh venv, 2026-07-07):

```console
$ python3 -m venv /tmp/av-verify-check && /tmp/av-verify-check/bin/pip install "aragora-verify>=0.1.1"
Collecting aragora-verify>=0.1.1
  Using cached aragora_verify-0.1.1-py3-none-any.whl.metadata (6.2 kB)
Collecting cryptography>=41.0 (from aragora-verify>=0.1.1)
  Using cached cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl.metadata (4.3 kB)
Collecting cffi>=2.0.0 (from cryptography>=41.0->aragora-verify>=0.1.1)
  Using cached cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl.metadata (2.5 kB)
Collecting pycparser (from cffi>=2.0.0->cryptography>=41.0->aragora-verify>=0.1.1)
  Using cached pycparser-3.0-py3-none-any.whl.metadata (8.2 kB)
Using cached aragora_verify-0.1.1-py3-none-any.whl (20 kB)
Using cached cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl (4.0 MB)
Using cached cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl (184 kB)
Using cached pycparser-3.0-py3-none-any.whl (48 kB)
Installing collected packages: pycparser, cffi, cryptography, aragora-verify
Successfully installed aragora-verify-0.1.1 cffi-2.1.0 cryptography-49.0.0 pycparser-3.0

$ /tmp/av-verify-check/bin/pip show aragora-verify | grep -E "^(Name|Version):"
Name: aragora-verify
Version: 0.1.1

$ /tmp/av-verify-check/bin/aragora-verify --help | head -5
usage: aragora-verify [-h] [--pubkey KEY] [--chain JSONL] [--json] [--version]
                      receipt

Offline verifier for Open Decision Receipts (ODR v0.1): schema conformance,
JCS canonical digest, Ed25519 signature, hash-chain link, and quorum
```

**Conclusion: PyPI `info.version` = `0.1.1`, both 0.1.0 and 0.1.1 are live and
un-yanked, and `pip install "aragora-verify>=0.1.1"` resolves and installs
cleanly from a fresh venv.** The merged wording was false; this PR restores
the truth.

## Changes

`docs/reference/INSTALL_MATRIX.md`:

1. Verifier row in "Distributions at a glance" now reads "latest on PyPI =
   **0.1.1** (0.1.0 released 2026-06-29T23:32Z, ... 0.1.1 released
   2026-07-04T03:28Z)" instead of claiming 0.1.0 is latest / 0.1.1
   unreleased.
2. Floor-pinned `pip install "aragora-verify>=0.1.1"` restored as the
   **primary/recommended** verifier install snippet, with the `key_id`-
   equality security rationale (matches the established convention in
   `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` and
   `docs/compliance/fixtures/README.md`). Unpinned `pip install
   aragora-verify` kept as a secondary snippet.
3. Added a dated inoculation HTML comment adjacent to **both** the verifier
   table row and the floor-pin snippet:
   `<!-- FACT (live-verified 2026-07-07T17:42Z): aragora-verify 0.1.1 IS on
   PyPI (info.version=0.1.1). Before "correcting" this to unreleased, re-run:
   curl -s https://pypi.org/pypi/aragora-verify/json | jq .info.version -->`
   to preempt another stale-knowledge reversal.

No other rows/sections touched (the `aragora-sdk` PyPI-lag row is unrelated
and left as-is — out of scope for this fix).

## Verification

- `python3 scripts/check_docs_consistency.py` (== `make docs-check`): PASS (all checks, no findings).
- `python3 scripts/validate_doc_links.py docs/reference/INSTALL_MATRIX.md`: all links valid.
- `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js`: 0 metric drift; no
  docs-site mirror exists for this path (same as `docs/specs/**`), so no mirror diff to commit.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: `preflight: ok` (docs-only diff detected).

## Merge

Docs-only change (single `.md` file) → auto-merge eligible per the mission's
merge policy. Enabling `gh pr merge --auto --squash`.

Refs: `VAL-INSTALL-001`, `VAL-INSTALL-003`, milestone `m5-install`, feature
`m5-install-matrix-pypi-regression-fix`.
