### PR TITLE
fix(steward): skip draft PRs during broad settlement selection

### DIFF
--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -410,7 +410,8 @@ def policy_exclusion_reasons(
     title_branch_text = _title_branch_text(entry, metadata)
     if _is_dependabot_pr(entry, metadata):
         reasons.append("Dependabot PR")
-    if bool(metadata.get("isDraft") or entry.get("isDraft")):
+    is_draft = metadata["isDraft"] if "isDraft" in metadata else entry.get("isDraft")
+    if bool(is_draft):
         reasons.append("draft PR")
 
     mergeable = str(metadata.get("mergeable") or entry.get("mergeable") or "").upper()
@@ -1353,6 +1354,7 @@ def load_pr_policy_metadata_rest(
         "number": _coerce_int(pull_payload.get("number")) or pr_number,
         "title": pull_payload.get("title"),
         "headRefName": head.get("ref") if isinstance(head, dict) else "",
+        "isDraft": bool(pull_payload.get("draft")),
         "author": {"login": user.get("login")} if isinstance(user, dict) else {},
         "mergeable": _rest_mergeable(pull_payload.get("mergeable")),
         "mergeStateStatus": _rest_merge_state(pull_payload.get("mergeable_state")),

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -62,7 +62,7 @@ OPEN_PR_LIGHT_FIELDS = (
     "number,title,url,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,"
     "reviewDecision,labels,author,additions,deletions,changedFiles"
 )
-PR_POLICY_FIELDS = "number,title,headRefName,author,mergeable,mergeStateStatus,files"
+PR_POLICY_FIELDS = "number,title,headRefName,isDraft,author,mergeable,mergeStateStatus,files"
 SURFACE_EXCLUDE_REASON = (
     "security/auth/RBAC/secrets/deploy/workflow/legal/compliance/destructive/"
     "migration/public-API surface"

--- a/scripts/settle_one_pr.py
+++ b/scripts/settle_one_pr.py
@@ -410,6 +410,8 @@ def policy_exclusion_reasons(
     title_branch_text = _title_branch_text(entry, metadata)
     if _is_dependabot_pr(entry, metadata):
         reasons.append("Dependabot PR")
+    if bool(metadata.get("isDraft") or entry.get("isDraft")):
+        reasons.append("draft PR")
 
     mergeable = str(metadata.get("mergeable") or entry.get("mergeable") or "").upper()
     merge_state = str(

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -43,6 +43,10 @@ OWNER_PREFIX = [settle_one_pr.PYTHON_EXECUTABLE, "scripts/identify_lane_owner.py
 STEERING_PREFIX = [settle_one_pr.PYTHON_EXECUTABLE, "scripts/read_operator_steering.py", "--pr"]
 
 
+def test_pr_policy_fields_include_live_draft_state() -> None:
+    assert "isDraft" in settle_one_pr.PR_POLICY_FIELDS.split(",")
+
+
 def _entry(
     pr_number: int,
     *,

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -344,6 +344,27 @@ def test_select_candidate_excludes_draft_and_continues() -> None:
     assert exclusions[0]["reasons"] == ["draft PR"]
 
 
+def test_live_not_draft_metadata_overrides_stale_packet_draft() -> None:
+    stale_draft = {
+        **_entry(
+            7449,
+            tier=0,
+            reasons=["docs/tests/status-only", "model quorum incomplete: 0/1"],
+        ),
+        "isDraft": True,
+    }
+
+    selected, blockers, exclusions = select_candidate(
+        _packet(stale_draft),
+        policy_metadata={7449: {"isDraft": False}},
+        return_exclusions=True,
+    )
+
+    assert blockers == []
+    assert selected is stale_draft
+    assert exclusions == []
+
+
 def test_select_candidate_excludes_active_owned_and_dependabot() -> None:
     active = _entry(7460, tier=0, reasons=["docs/tests/status-only"])
     dependabot = _entry(7300, tier=1, reasons=["docs/tests/status-only"])
@@ -1486,6 +1507,7 @@ def test_pr_policy_metadata_uses_rest_fallback_when_graphql_unavailable(monkeypa
                     "number": 7451,
                     "title": "docs: candidate",
                     "head": {"ref": "codex/docs-candidate"},
+                    "draft": False,
                     "user": {"login": "alice"},
                     "mergeable": True,
                     "mergeable_state": "clean",
@@ -1507,6 +1529,7 @@ def test_pr_policy_metadata_uses_rest_fallback_when_graphql_unavailable(monkeypa
         "number": 7451,
         "title": "docs: candidate",
         "headRefName": "codex/docs-candidate",
+        "isDraft": False,
         "author": {"login": "alice"},
         "mergeable": "MERGEABLE",
         "mergeStateStatus": "CLEAN",

--- a/tests/scripts/test_settle_one_pr.py
+++ b/tests/scripts/test_settle_one_pr.py
@@ -326,6 +326,24 @@ def test_select_candidate_excludes_adc_and_continues() -> None:
     assert exclusions[0]["reasons"] == ["ADC PR"]
 
 
+def test_select_candidate_excludes_draft_and_continues() -> None:
+    draft = _entry(7449, tier=0, reasons=["docs/tests/status-only", "model quorum incomplete: 0/1"])
+    next_entry = _entry(
+        7450, tier=0, reasons=["docs/tests/status-only", "model quorum incomplete: 0/1"]
+    )
+
+    selected, blockers, exclusions = select_candidate(
+        _packet(draft, next_entry),
+        policy_metadata={7449: {"isDraft": True}},
+        return_exclusions=True,
+    )
+
+    assert blockers == []
+    assert selected is next_entry
+    assert exclusions[0]["pr_number"] == 7449
+    assert exclusions[0]["reasons"] == ["draft PR"]
+
+
 def test_select_candidate_excludes_active_owned_and_dependabot() -> None:
     active = _entry(7460, tier=0, reasons=["docs/tests/status-only"])
     dependabot = _entry(7300, tier=1, reasons=["docs/tests/status-only"])


### PR DESCRIPTION
## Summary
- exclude draft PRs during broad settle_one_pr candidate selection when live metadata is available
- keep explicit PR inspection behavior intact so named drafts still surface their draft blocker
- add regression coverage that selection continues past a draft to the next eligible PR

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_settle_one_pr.py --tb=short -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/settle_one_pr.py tests/scripts/test_settle_one_pr.py
- git diff --check origin/main...HEAD
- bash scripts/automation_pr_preflight.sh origin/main HEAD
