### PR TITLE
fix(conductor): surface active goal-cycle processes

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -48,6 +49,18 @@ MAX_PACKET_SECTION_BYTES = 96 * 1024
 SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
+MAX_ACTIVE_PROCESS_LINES = 40
+ACTIVE_PROCESS_PATTERNS = (
+    "fable_goal_cycle",
+    "consult_claude",
+    "collect_quorum_evidence",
+    "collect-evidence",
+    "claude --print",
+    "claude-fable",
+    "settle_one_pr",
+    "settle_tier4_pr",
+    "gh pr merge",
+)
 NEXT_PROMPT_HEADING = "## NEXT PROMPT"
 NEXT_PROMPT_HEADING_RE = re.compile(
     rf"^{re.escape(NEXT_PROMPT_HEADING)}\s*$", re.IGNORECASE | re.MULTILINE
@@ -178,6 +191,44 @@ def _markdown_code_block(body: str, language: str = "text") -> str:
     return f"{opener}\n{body}\n{fence}"
 
 
+def _active_conductor_processes() -> tuple[bool, str]:
+    """Return a compact process snapshot for collision-prone conductor work."""
+
+    errors: list[str] = []
+    current_pid = str(os.getpid())
+    ps_commands = (
+        ["ps", "-axo", "pid,ppid,etime,command"],
+        ["ps", "-eo", "pid,ppid,etime,command"],
+    )
+    for command in ps_commands:
+        ok, out = _run(command, CONTEXT_STEP_TIMEOUT_SECONDS)
+        if not ok:
+            errors.append(out)
+            continue
+
+        matches: list[str] = []
+        for line in out.splitlines()[1:]:
+            fields = line.split(None, 3)
+            if len(fields) < 4:
+                continue
+            pid, _ppid, _elapsed, process_command = fields
+            if pid == current_pid:
+                continue
+            command_lower = process_command.lower()
+            if any(pattern in command_lower for pattern in ACTIVE_PROCESS_PATTERNS):
+                matches.append(line.strip())
+
+        if not matches:
+            return True, "none observed"
+        body = "\n".join(matches[:MAX_ACTIVE_PROCESS_LINES])
+        omitted = len(matches) - MAX_ACTIVE_PROCESS_LINES
+        if omitted > 0:
+            body += f"\n[truncated {omitted} additional active process(es)]"
+        return True, body
+
+    return False, "; ".join(error for error in errors if error) or "ps unavailable"
+
+
 def _is_relative_to(path: Path, parent: Path) -> bool:
     try:
         path.relative_to(parent)
@@ -257,6 +308,11 @@ def gather_context(root: Path, since_hours: float, max_prs: int, skip_digest: bo
     section("branch status", ["git", "status", "--short", "--branch"])
     section("recent commits (main)", ["git", "log", "--oneline", "-10", "origin/main"])
     section("worktrees", ["git", "worktree", "list"])
+    ok, active_processes = _active_conductor_processes()
+    if ok:
+        sections["active conductor/evidence processes"] = active_processes
+    else:
+        gaps.append(f"active conductor/evidence processes: {active_processes}")
     if shutil.which("gh"):
         section(
             f"open non-draft PRs (up to {max_prs})",

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -35,6 +35,7 @@ import datetime as _dt
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -50,16 +51,48 @@ SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
 MAX_ACTIVE_PROCESS_LINES = 40
-ACTIVE_PROCESS_PATTERNS = (
-    "fable_goal_cycle",
-    "consult_claude",
-    "collect_quorum_evidence",
-    "collect-evidence",
-    "claude --print",
+ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(
+    {
+        "agent_bridge.py",
+        "auto_evidence_cycle.py",
+        "boss_drain_pass.py",
+        "build_next_prompt.py",
+        "collect_quorum_evidence.py",
+        "consult_claude.py",
+        "fable_goal_cycle.py",
+        "reconcile_automation_outbox.py",
+        "settle_one_pr.py",
+        "settle_pr.py",
+        "settle_tier4_pr.py",
+    }
+)
+ACTIVE_PROCESS_COMMAND_PATTERNS = (
+    ("aragora", "review-queue", "collect-evidence"),
+    ("aragora", "review-queue", "merge-packet"),
+    ("gh", "pr", "merge"),
+    ("droid", "exec"),
+)
+ACTIVE_PROCESS_TOKEN_PATTERNS = (
     "claude-fable",
-    "settle_one_pr",
-    "settle_tier4_pr",
-    "gh pr merge",
+    "overnight-conductor",
+    "overnight_conductor",
+)
+ACTIVE_PROCESS_IGNORED_EXECUTABLES = frozenset(
+    {
+        "awk",
+        "cat",
+        "code",
+        "emacs",
+        "grep",
+        "head",
+        "less",
+        "nvim",
+        "rg",
+        "sed",
+        "tail",
+        "vi",
+        "vim",
+    }
 )
 NEXT_PROMPT_HEADING = "## NEXT PROMPT"
 NEXT_PROMPT_HEADING_RE = re.compile(
@@ -191,6 +224,46 @@ def _markdown_code_block(body: str, language: str = "text") -> str:
     return f"{opener}\n{body}\n{fence}"
 
 
+def _shell_words(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _active_process_label(command: str) -> str | None:
+    """Return a sanitized collision label for command, or None when irrelevant.
+
+    The packet is sent to an external reviewer, so never include raw argv. CLI
+    arguments can carry credentials, private paths, or unrelated task content.
+    """
+
+    words = _shell_words(command)
+    if not words:
+        return None
+
+    executable = Path(words[0]).name
+    if executable in ACTIVE_PROCESS_IGNORED_EXECUTABLES:
+        return None
+
+    basenames = [Path(word).name for word in words]
+    for index, basename in enumerate(basenames[1:], start=1):
+        if basename in ACTIVE_PROCESS_SCRIPT_NAMES:
+            return f"{executable} {basename}"
+
+    lowered = [word.lower() for word in words]
+    for pattern in ACTIVE_PROCESS_COMMAND_PATTERNS:
+        if len(lowered) >= len(pattern) and tuple(lowered[: len(pattern)]) == pattern:
+            return " ".join(pattern)
+
+    command_lower = " ".join(lowered)
+    for pattern in ACTIVE_PROCESS_TOKEN_PATTERNS:
+        if pattern in command_lower:
+            return pattern
+
+    return None
+
+
 def _active_conductor_processes() -> tuple[bool, str]:
     """Return a compact process snapshot for collision-prone conductor work."""
 
@@ -214,9 +287,9 @@ def _active_conductor_processes() -> tuple[bool, str]:
             pid, _ppid, _elapsed, process_command = fields
             if pid == current_pid:
                 continue
-            command_lower = process_command.lower()
-            if any(pattern in command_lower for pattern in ACTIVE_PROCESS_PATTERNS):
-                matches.append(line.strip())
+            label = _active_process_label(process_command)
+            if label:
+                matches.append(f"pid={pid} elapsed={_elapsed} command={label}")
 
         if not matches:
             return True, "none observed"

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -218,7 +218,7 @@ def test_active_conductor_processes_reports_colliding_work_and_filters_self(monk
             """\
   PID  PPID ELAPSED COMMAND
    42     1   00:05 python3 scripts/fable_goal_cycle.py --goal self
-  100     1   10:00 python3 scripts/collect_quorum_evidence.py --pr 8982
+  100     1   10:00 python3 scripts/collect_quorum_evidence.py --token secret --pr 8982
   101     1   03:00 python3 scripts/consult_claude.py --model claude-fable-5
   102     1   02:00 python3 scripts/unrelated.py
 """,
@@ -229,10 +229,65 @@ def test_active_conductor_processes_reports_colliding_work_and_filters_self(monk
     ok, body = fable_goal_cycle._active_conductor_processes()
 
     assert ok is True
-    assert "collect_quorum_evidence.py --pr 8982" in body
-    assert "consult_claude.py --model claude-fable-5" in body
+    assert "pid=100 elapsed=10:00 command=python3 collect_quorum_evidence.py" in body
+    assert "pid=101 elapsed=03:00 command=python3 consult_claude.py" in body
+    assert "--token secret" not in body
+    assert "--model claude-fable-5" not in body
     assert "fable_goal_cycle.py --goal self" not in body
     assert "unrelated.py" not in body
+
+
+def test_active_process_label_covers_collision_prone_scripts_without_raw_args() -> None:
+    assert (
+        fable_goal_cycle._active_process_label(
+            "python3 scripts/auto_evidence_cycle.py --apply --prepared-json /tmp/secret.json"
+        )
+        == "python3 auto_evidence_cycle.py"
+    )
+    assert (
+        fable_goal_cycle._active_process_label("python3 scripts/boss_drain_pass.py --goal drain")
+        == "python3 boss_drain_pass.py"
+    )
+    assert (
+        fable_goal_cycle._active_process_label(
+            "python3 scripts/agent_bridge.py launch --token secret"
+        )
+        == "python3 agent_bridge.py"
+    )
+    assert (
+        fable_goal_cycle._active_process_label("aragora review-queue collect-evidence --pr 1")
+        == "aragora review-queue collect-evidence"
+    )
+    assert fable_goal_cycle._active_process_label("rg fable_goal_cycle.py") is None
+    assert fable_goal_cycle._active_process_label("vim scripts/fable_goal_cycle.py") is None
+
+
+def test_active_conductor_processes_falls_back_to_portable_ps(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(command, timeout, cwd=None):
+        calls.append(command)
+        if command == ["ps", "-axo", "pid,ppid,etime,command"]:
+            return False, "unsupported ps"
+        assert command == ["ps", "-eo", "pid,ppid,etime,command"]
+        return (
+            True,
+            """\
+  PID  PPID ELAPSED COMMAND
+  200     1   01:00 python3 scripts/settle_pr.py --pr 8988
+""",
+        )
+
+    monkeypatch.setattr(fable_goal_cycle, "_run", fake_run)
+
+    ok, body = fable_goal_cycle._active_conductor_processes()
+
+    assert ok is True
+    assert calls == [
+        ["ps", "-axo", "pid,ppid,etime,command"],
+        ["ps", "-eo", "pid,ppid,etime,command"],
+    ]
+    assert "pid=200 elapsed=01:00 command=python3 settle_pr.py" in body
 
 
 def test_run_consult_sets_overall_timeout_and_bounded_outer_timeout(

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -208,6 +208,33 @@ def test_build_packet_fences_context_gaps() -> None:
     assert "```text\n- transport error echoed ## injected heading\n```" in packet
 
 
+def test_active_conductor_processes_reports_colliding_work_and_filters_self(monkeypatch) -> None:
+    monkeypatch.setattr(fable_goal_cycle.os, "getpid", lambda: 42)
+
+    def fake_run(command, timeout, cwd=None):
+        assert command == ["ps", "-axo", "pid,ppid,etime,command"]
+        return (
+            True,
+            """\
+  PID  PPID ELAPSED COMMAND
+   42     1   00:05 python3 scripts/fable_goal_cycle.py --goal self
+  100     1   10:00 python3 scripts/collect_quorum_evidence.py --pr 8982
+  101     1   03:00 python3 scripts/consult_claude.py --model claude-fable-5
+  102     1   02:00 python3 scripts/unrelated.py
+""",
+        )
+
+    monkeypatch.setattr(fable_goal_cycle, "_run", fake_run)
+
+    ok, body = fable_goal_cycle._active_conductor_processes()
+
+    assert ok is True
+    assert "collect_quorum_evidence.py --pr 8982" in body
+    assert "consult_claude.py --model claude-fable-5" in body
+    assert "fable_goal_cycle.py --goal self" not in body
+    assert "unrelated.py" not in body
+
+
 def test_run_consult_sets_overall_timeout_and_bounded_outer_timeout(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- add active Fable/evidence/settlement process context to fable goal-cycle packets
- filter the helper's own process while preserving other collision-prone conductor work
- cover the process snapshot with a focused regression test

## Validation
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest tests/scripts/test_fable_goal_cycle.py --tb=short -q
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py
- /Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD