### PR TITLE
Guard required contexts against path-filtered main pushes

### DIFF
--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -128,6 +128,46 @@ def _inline_yaml_value_mentions(value: str, expected: str) -> bool:
     )
 
 
+def _flow_mapping_value(value: str, key: str) -> str | None:
+    stripped = value.strip()
+    if not (stripped.startswith("{") and stripped.endswith("}")):
+        return None
+
+    match = re.search(
+        rf"(?<![A-Za-z0-9_-]){re.escape(key)}\s*:\s*(?P<value>\[[^\]]*\]|[^,}}]+)",
+        stripped[1:-1],
+    )
+    if match is None:
+        return None
+    return match.group("value").strip()
+
+
+def _flow_push_targets_main(value: str) -> bool:
+    branches = _flow_mapping_value(value, "branches")
+    if branches is not None:
+        return _inline_yaml_value_mentions(branches, "main")
+
+    branches_ignore = _flow_mapping_value(value, "branches-ignore")
+    if branches_ignore is not None and _inline_yaml_value_mentions(
+        branches_ignore,
+        "main",
+    ):
+        return False
+
+    return True
+
+
+def _flow_push_has_path_filter(value: str) -> bool:
+    return (
+        _flow_mapping_value(value, "paths") is not None
+        or _flow_mapping_value(
+            value,
+            "paths-ignore",
+        )
+        is not None
+    )
+
+
 def _block_value_for_key(lines: list[str], key: str) -> list[str] | None:
     for index, line in enumerate(lines):
         parsed = _parse_yaml_mapping_line(line)
@@ -182,6 +222,14 @@ def _main_push_trigger(workflow_text: str) -> _MainPushTrigger:
             on_parsed = _parse_yaml_mapping_line(on_line)
             if on_parsed is None or on_parsed.key != "push":
                 continue
+
+            if on_parsed.value:
+                if not _flow_push_targets_main(on_parsed.value):
+                    return _MainPushTrigger(targets_main=False, path_filtered=False)
+                return _MainPushTrigger(
+                    targets_main=True,
+                    path_filtered=_flow_push_has_path_filter(on_parsed.value),
+                )
 
             push_block = _nested_yaml_block(on_block, on_index, on_parsed.indent)
             if not _push_block_targets_main(push_block):

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -102,8 +102,26 @@ def _parse_yaml_mapping_line(line: str) -> _YamlMappingLine | None:
     return _YamlMappingLine(
         indent=len(match.group("indent")),
         key=match.group("key").strip("\"'"),
-        value=match.group("value").strip(),
+        value=_strip_yaml_comment(match.group("value")).strip(),
     )
+
+
+def _strip_yaml_comment(value: str) -> str:
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif (
+            char == "#"
+            and not in_single
+            and not in_double
+            and (index == 0 or value[index - 1].isspace())
+        ):
+            return value[:index].rstrip()
+    return value.rstrip()
 
 
 def _nested_yaml_block(lines: list[str], index: int, parent_indent: int) -> list[str]:
@@ -179,7 +197,9 @@ def _block_value_for_key(lines: list[str], key: str) -> list[str] | None:
             child_parsed = _parse_yaml_mapping_line(child)
             if child_parsed is not None and child_parsed.indent <= parsed.indent:
                 break
-            values.append(child.strip())
+            child_value = _strip_yaml_comment(child.strip())
+            if child_value:
+                values.append(child_value)
         return values
     return None
 

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -124,6 +124,44 @@ def _strip_yaml_comment(value: str) -> str:
     return value.rstrip()
 
 
+def _flow_curly_balance(value: str) -> int:
+    balance = 0
+    in_single = False
+    in_double = False
+    for char in value:
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if char == "{":
+                balance += 1
+            elif char == "}":
+                balance -= 1
+    return balance
+
+
+def _complete_flow_mapping_value(
+    value: str,
+    lines: list[str],
+    index: int,
+) -> str:
+    if not value.strip().startswith("{"):
+        return value
+
+    parts = [value]
+    balance = _flow_curly_balance(value)
+    for child in lines[index + 1 :]:
+        if balance <= 0:
+            break
+        child_value = _strip_yaml_comment(child.strip())
+        if not child_value:
+            continue
+        parts.append(child_value)
+        balance += _flow_curly_balance(child_value)
+    return " ".join(parts)
+
+
 def _nested_yaml_block(lines: list[str], index: int, parent_indent: int) -> list[str]:
     block: list[str] = []
     for line in lines[index + 1 :]:
@@ -290,9 +328,10 @@ def _main_push_trigger(workflow_text: str) -> _MainPushTrigger:
             continue
 
         if parsed.value:
-            inline_push = _flow_mapping_value(parsed.value, "push")
+            on_value = _complete_flow_mapping_value(parsed.value, lines, index)
+            inline_push = _flow_mapping_value(on_value, "push")
             if inline_push is None:
-                if _inline_yaml_value_mentions(parsed.value, "push"):
+                if _inline_yaml_value_mentions(on_value, "push"):
                     return _MainPushTrigger(targets_main=True, path_filtered=False)
             else:
                 if not _flow_push_targets_main(inline_push):
@@ -309,11 +348,16 @@ def _main_push_trigger(workflow_text: str) -> _MainPushTrigger:
                 continue
 
             if on_parsed.value:
-                if not _flow_push_targets_main(on_parsed.value):
+                push_value = _complete_flow_mapping_value(
+                    on_parsed.value,
+                    on_block,
+                    on_index,
+                )
+                if not _flow_push_targets_main(push_value):
                     return _MainPushTrigger(targets_main=False, path_filtered=False)
                 return _MainPushTrigger(
                     targets_main=True,
-                    path_filtered=_flow_push_has_path_filter(on_parsed.value),
+                    path_filtered=_flow_push_has_path_filter(push_value),
                 )
 
             push_block = _nested_yaml_block(on_block, on_index, on_parsed.indent)

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -15,6 +15,19 @@ class Violation:
     message: str
 
 
+@dataclass(frozen=True)
+class _YamlMappingLine:
+    indent: int
+    key: str
+    value: str
+
+
+@dataclass(frozen=True)
+class _MainPushTrigger:
+    targets_main: bool
+    path_filtered: bool
+
+
 WORKFLOW_PATH = Path(".github/workflows/required-check-priority.yml")
 
 REQUIRED_KEEP_WORKFLOW_PATHS = {
@@ -77,6 +90,110 @@ def _extract_js_set_items(workflow_text: str, set_name: str) -> list[str] | None
     return re.findall(r"""["']([^"']+)["']""", body)
 
 
+def _parse_yaml_mapping_line(line: str) -> _YamlMappingLine | None:
+    if not line.strip() or line.lstrip().startswith("#"):
+        return None
+    match = re.match(
+        r"^(?P<indent>\s*)(?P<key>['\"]?[A-Za-z0-9_-]+['\"]?)\s*:\s*(?P<value>.*)$",
+        line,
+    )
+    if not match:
+        return None
+    return _YamlMappingLine(
+        indent=len(match.group("indent")),
+        key=match.group("key").strip("\"'"),
+        value=match.group("value").strip(),
+    )
+
+
+def _nested_yaml_block(lines: list[str], index: int, parent_indent: int) -> list[str]:
+    block: list[str] = []
+    for line in lines[index + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            block.append(line)
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent <= parent_indent:
+            break
+        block.append(line)
+    return block
+
+
+def _inline_yaml_value_mentions(value: str, expected: str) -> bool:
+    return bool(
+        re.search(
+            rf"(?<![A-Za-z0-9_./-]){re.escape(expected)}(?![A-Za-z0-9_./-])",
+            value,
+        )
+    )
+
+
+def _block_value_for_key(lines: list[str], key: str) -> list[str] | None:
+    for index, line in enumerate(lines):
+        parsed = _parse_yaml_mapping_line(line)
+        if parsed is None or parsed.key != key:
+            continue
+
+        values = [parsed.value]
+        for child in lines[index + 1 :]:
+            child_parsed = _parse_yaml_mapping_line(child)
+            if child_parsed is not None and child_parsed.indent <= parsed.indent:
+                break
+            values.append(child.strip())
+        return values
+    return None
+
+
+def _push_block_targets_main(push_block: list[str]) -> bool:
+    branch_values = _block_value_for_key(push_block, "branches")
+    if branch_values is not None:
+        return _inline_yaml_value_mentions("\n".join(branch_values), "main")
+
+    ignored_branch_values = _block_value_for_key(push_block, "branches-ignore")
+    if ignored_branch_values is not None and _inline_yaml_value_mentions(
+        "\n".join(ignored_branch_values),
+        "main",
+    ):
+        return False
+
+    return True
+
+
+def _push_block_has_path_filter(push_block: list[str]) -> bool:
+    for line in push_block:
+        parsed = _parse_yaml_mapping_line(line)
+        if parsed is not None and parsed.key in {"paths", "paths-ignore"}:
+            return True
+    return False
+
+
+def _main_push_trigger(workflow_text: str) -> _MainPushTrigger:
+    lines = workflow_text.splitlines()
+    for index, line in enumerate(lines):
+        parsed = _parse_yaml_mapping_line(line)
+        if parsed is None or parsed.key != "on" or parsed.indent != 0:
+            continue
+
+        if parsed.value and _inline_yaml_value_mentions(parsed.value, "push"):
+            return _MainPushTrigger(targets_main=True, path_filtered=False)
+
+        on_block = _nested_yaml_block(lines, index, parsed.indent)
+        for on_index, on_line in enumerate(on_block):
+            on_parsed = _parse_yaml_mapping_line(on_line)
+            if on_parsed is None or on_parsed.key != "push":
+                continue
+
+            push_block = _nested_yaml_block(on_block, on_index, on_parsed.indent)
+            if not _push_block_targets_main(push_block):
+                return _MainPushTrigger(targets_main=False, path_filtered=False)
+            return _MainPushTrigger(
+                targets_main=True,
+                path_filtered=_push_block_has_path_filter(push_block),
+            )
+
+    return _MainPushTrigger(targets_main=False, path_filtered=False)
+
+
 def find_required_check_priority_violations(
     workflow_text: str,
     *,
@@ -114,6 +231,7 @@ def find_required_check_priority_violations(
         violations.append(f"missing required keep workflow name: {name}")
 
     if repo_root is not None:
+        mapped_workflows: dict[str, str] = {}
         for rel in sorted(path_set):
             wf_path = (repo_root / rel).resolve()
             if not wf_path.exists():
@@ -123,9 +241,19 @@ def find_required_check_priority_violations(
             if not wf_path.exists():
                 continue
             text = wf_path.read_text(encoding="utf-8")
+            mapped_workflows[rel] = text
             if context not in text:
                 violations.append(
                     f"required context marker `{context}` not found in mapped workflow: {rel}"
+                )
+        for context, rel in sorted(REQUIRED_CONTEXT_TO_WORKFLOW_PATH.items()):
+            text = mapped_workflows.get(rel)
+            if text is None:
+                continue
+            main_push = _main_push_trigger(text)
+            if main_push.targets_main and main_push.path_filtered:
+                violations.append(
+                    f"required context `{context}` maps to path-filtered main push workflow: {rel}"
                 )
 
     return violations

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -151,13 +151,68 @@ def _flow_mapping_value(value: str, key: str) -> str | None:
     if not (stripped.startswith("{") and stripped.endswith("}")):
         return None
 
-    match = re.search(
-        rf"(?<![A-Za-z0-9_-]){re.escape(key)}\s*:\s*(?P<value>\[[^\]]*\]|[^,}}]+)",
-        stripped[1:-1],
-    )
-    if match is None:
-        return None
-    return match.group("value").strip()
+    for item in _split_flow_items(stripped[1:-1]):
+        colon_index = _top_level_colon_index(item)
+        if colon_index is None:
+            continue
+        item_key = item[:colon_index].strip().strip("\"'")
+        if item_key == key:
+            return item[colon_index + 1 :].strip()
+    return None
+
+
+def _split_flow_items(value: str) -> list[str]:
+    items: list[str] = []
+    start = 0
+    depth_curly = 0
+    depth_square = 0
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if char == "{":
+                depth_curly += 1
+            elif char == "}":
+                depth_curly = max(depth_curly - 1, 0)
+            elif char == "[":
+                depth_square += 1
+            elif char == "]":
+                depth_square = max(depth_square - 1, 0)
+            elif char == "," and depth_curly == 0 and depth_square == 0:
+                items.append(value[start:index].strip())
+                start = index + 1
+    trailing = value[start:].strip()
+    if trailing:
+        items.append(trailing)
+    return items
+
+
+def _top_level_colon_index(value: str) -> int | None:
+    depth_curly = 0
+    depth_square = 0
+    in_single = False
+    in_double = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            if char == "{":
+                depth_curly += 1
+            elif char == "}":
+                depth_curly = max(depth_curly - 1, 0)
+            elif char == "[":
+                depth_square += 1
+            elif char == "]":
+                depth_square = max(depth_square - 1, 0)
+            elif char == ":" and depth_curly == 0 and depth_square == 0:
+                return index
+    return None
 
 
 def _flow_push_targets_main(value: str) -> bool:
@@ -234,8 +289,18 @@ def _main_push_trigger(workflow_text: str) -> _MainPushTrigger:
         if parsed is None or parsed.key != "on" or parsed.indent != 0:
             continue
 
-        if parsed.value and _inline_yaml_value_mentions(parsed.value, "push"):
-            return _MainPushTrigger(targets_main=True, path_filtered=False)
+        if parsed.value:
+            inline_push = _flow_mapping_value(parsed.value, "push")
+            if inline_push is None:
+                if _inline_yaml_value_mentions(parsed.value, "push"):
+                    return _MainPushTrigger(targets_main=True, path_filtered=False)
+            else:
+                if not _flow_push_targets_main(inline_push):
+                    return _MainPushTrigger(targets_main=False, path_filtered=False)
+                return _MainPushTrigger(
+                    targets_main=True,
+                    path_filtered=_flow_push_has_path_filter(inline_push),
+                )
 
         on_block = _nested_yaml_block(lines, index, parsed.indent)
         for on_index, on_line in enumerate(on_block):

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from scripts.check_required_check_priority_policy import (
+    REQUIRED_CONTEXT_TO_WORKFLOW_PATH,
     check_repo,
     find_required_check_priority_violations,
 )
@@ -64,6 +65,41 @@ jobs:
               'OpenAPI Spec',
             ]);
 """
+
+
+def _write_policy_repo(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    workflow_dir = repo_root / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+
+    workflow_paths = {
+        line.split("'")[1]
+        for line in _valid_workflow_text().splitlines()
+        if ".github/workflows/" in line
+    }
+    for rel in workflow_paths:
+        (repo_root / rel).parent.mkdir(parents=True, exist_ok=True)
+        (repo_root / rel).write_text(
+            f"name: {Path(rel).stem}\njobs:\n  placeholder:\n    runs-on: ubuntu-latest\n",
+            encoding="utf-8",
+        )
+
+    for context, rel in REQUIRED_CONTEXT_TO_WORKFLOW_PATH.items():
+        (repo_root / rel).write_text(
+            f"""
+name: {Path(rel).stem}
+on:
+  push:
+    branches: [main]
+jobs:
+  required-context:
+    name: {context}
+    runs-on: ubuntu-latest
+""",
+            encoding="utf-8",
+        )
+
+    return repo_root
 
 
 def test_policy_accepts_required_keep_entries() -> None:
@@ -263,6 +299,55 @@ jobs:
         "required context marker `typecheck` not found in mapped workflow: .github/workflows/lint.yml"
         == v
         for v in violations
+    )
+
+
+def test_policy_allows_unfiltered_main_push_required_workflows(tmp_path: Path) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert violations == []
+
+
+def test_policy_rejects_path_filtered_main_push_required_workflow(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+    (repo_root / ".github/workflows/lint.yml").write_text(
+        """
+name: Lint
+on:
+  push:
+    branches: [main]
+    paths:
+      - "aragora/**"
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+""",
+        encoding="utf-8",
+    )
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert (
+        "required context `lint` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+    assert (
+        "required context `typecheck` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
     )
 
 

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -420,6 +420,44 @@ jobs:
     )
 
 
+def test_policy_rejects_multiline_flow_style_path_filtered_main_push_required_workflow(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+    (repo_root / ".github/workflows/lint.yml").write_text(
+        """
+name: Lint
+on:
+  push: {
+    branches: [main],
+    paths: ["aragora/**"],
+  }
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+""",
+        encoding="utf-8",
+    )
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert (
+        "required context `lint` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+    assert (
+        "required context `typecheck` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+
+
 def test_policy_ignores_comments_when_matching_main_push_branches(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -386,6 +386,40 @@ jobs:
     )
 
 
+def test_policy_rejects_top_level_flow_style_path_filtered_main_push_required_workflow(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+    (repo_root / ".github/workflows/lint.yml").write_text(
+        """
+name: Lint
+on: {push: {branches: [main], paths: ["aragora/**"]}}
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+""",
+        encoding="utf-8",
+    )
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert (
+        "required context `lint` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+    assert (
+        "required context `typecheck` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+
+
 def test_policy_ignores_comments_when_matching_main_push_branches(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -386,6 +386,39 @@ jobs:
     )
 
 
+def test_policy_ignores_comments_when_matching_main_push_branches(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+    (repo_root / ".github/workflows/lint.yml").write_text(
+        """
+name: Lint
+on:
+  push:
+    branches:
+      # main is intentionally handled by another workflow.
+      - release
+    paths:
+      - "aragora/**"
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+""",
+        encoding="utf-8",
+    )
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert violations == []
+
+
 def test_repo_required_check_priority_policy_passes_for_current_tree() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     violations = check_repo(repo_root)

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -351,6 +351,41 @@ jobs:
     )
 
 
+def test_policy_rejects_flow_style_path_filtered_main_push_required_workflow(
+    tmp_path: Path,
+) -> None:
+    repo_root = _write_policy_repo(tmp_path)
+    (repo_root / ".github/workflows/lint.yml").write_text(
+        """
+name: Lint
+on:
+  push: {branches: [main], paths: ["aragora/**"]}
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+""",
+        encoding="utf-8",
+    )
+
+    violations = find_required_check_priority_violations(
+        _valid_workflow_text(),
+        repo_root=repo_root,
+    )
+
+    assert (
+        "required context `lint` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+    assert (
+        "required context `typecheck` maps to path-filtered main push workflow: .github/workflows/lint.yml"
+        in violations
+    )
+
+
 def test_repo_required_check_priority_policy_passes_for_current_tree() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     violations = check_repo(repo_root)


### PR DESCRIPTION
## Summary
- add required-context policy inspection for mapped workflow `push: main` path filters
- fail when a branch-protection required context maps to a workflow whose main push trigger can be skipped by `paths` or `paths-ignore`
- add regression coverage for unfiltered and path-filtered required workflow triggers

## Validation
- `python3 -m pytest tests/scripts/test_check_required_check_priority_policy.py -q`
- `python3 scripts/check_required_check_priority_policy.py`
- `python3 -m ruff check scripts/check_required_check_priority_policy.py tests/scripts/test_check_required_check_priority_policy.py`
- `git diff --check`