### PR TITLE
docs(action): add issues: write to GitHub Action permission examples

### DIFF
--- a/docs-site/docs/guides/github-action-setup.md
+++ b/docs-site/docs/guides/github-action-setup.md
@@ -49,6 +49,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:
@@ -152,6 +153,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:

--- a/docs/GITHUB_ACTION_SETUP.md
+++ b/docs/GITHUB_ACTION_SETUP.md
@@ -44,6 +44,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:
@@ -147,6 +148,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   review:


### PR DESCRIPTION
## Summary
- follow-up to merged PR #8991
- adds `issues: write` to both GitHub Action setup permission examples
- matches the root action behavior: `post-comment: true` uses `gh pr comment`, which writes issue comments for PRs

## Validation
- `python3 scripts/check_docs_consistency.py`
- `npm --prefix docs-site ci`
- `npm --prefix docs-site run build` (passed with existing broken-link warnings)
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Cycle Context
- Source cycle report: `.aragora/conductor_cycles/20260708T025538Z-throughput-cycle-report.md`
- Preserved patch: `/tmp/aragora-pr8991-permission-followup-20260708T025351Z.patch`

No evidence, settlement, merge, branch-protection, workflow, or outbox/archive action was performed.