### PR TITLE
docs(m6): canonical consistency sweep across quickstart/verifier/action docs

### DIFF
--- a/docs-site/docs/enterprise/why-aragora.md
+++ b/docs-site/docs/enterprise/why-aragora.md
@@ -165,6 +165,16 @@ No well-funded competitor builds adversarial decision vetting. They build cooper
 
 ---
 
+## The oversight ring is the product
+
+The industry's own flagship agent-factory experiments report the same constraint: the bottleneck is not agent throughput but review throughput -- the human ability to conceptualize what the system is doing (publicly stated of Anthropic's internal experience running Claude-built software, July 2026). Scaling agents without scaling oversight just moves the queue.
+
+Aragora is built for that exact checkpoint. Decision receipts, adversarial multi-model quorums, operator decision tokens, and digest reports are instruments for human oversight -- they compress what the machine did into something a person can actually judge. Orchestras before factories: an orchestra keeps a human conductor.
+
+Autonomy then ratchets up per tier as trust accumulates (the executor arming path) -- never by removing the conductor.
+
+---
+
 ## Get Started
 
 ```bash

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -7,6 +7,22 @@ description: Quickstart
 
 Get from zero to a working adversarial debate in under a minute.
 
+**Fastest path:** already have `aragora` installed (`pip install aragora`)? Skip
+the numbered steps below and run the guided command directly -- no API keys
+required. This is the same offline chain the [Independent Verifier
+Guide](../specs/independent-verifier-guide) and
+[GitHub Action Setup](../guides/github-action-setup) both build on:
+
+```bash
+aragora quickstart --demo --no-browser --output r.json
+aragora receipt export r.json --format odr -o r.odr.json
+pip install -U 'aragora-verify>=0.1.1' && aragora-verify r.odr.json
+```
+
+This runs a demo debate, exports the receipt to the portable ODR format, and
+verifies it offline with the standalone verifier -- exit `0` end to end. Run
+`aragora quickstart --help` for the live-provider and spec-first variants.
+
 ---
 
 ## 1. Install

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -28,8 +28,12 @@ verifies it offline with the standalone verifier -- exit `0` end to end. Run
 ## 1. Install
 
 ```bash
-pip install aragora-debate
+pip install aragora aragora-debate
 ```
+
+The full `aragora` distribution provides the `aragora` CLI used by the
+fastest-path ODR commands above. The smaller `aragora-debate` package provides
+the Python module used by the demo and code examples below.
 
 ## 2. Zero-Key Demo
 

--- a/docs-site/docs/guides/github-action-setup.md
+++ b/docs-site/docs/guides/github-action-setup.md
@@ -255,6 +255,14 @@ illustrative -- it is not literally a file a live run produced -- but it comes f
 the identical emitter this action's `Emit decision receipt` step calls, so its shape
 is what `receipt-path` will point to.
 
+`aragora-verify`'s full exit-code contract is
+`0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked` -- see the
+[Independent Verifier Guide](../specs/independent-verifier-guide#exit-code-contract)
+for what each of the other three codes means. This is always the standalone
+`aragora-verify`, never the in-tree `aragora verify` / `aragora receipt verify`
+commands, which check a different object (the native `DecisionReceipt`, not the
+portable ODR).
+
 ## How It Works
 
 1. The action fetches the PR diff using `gh pr diff`

--- a/docs-site/docs/specs/independent-verifier-guide.md
+++ b/docs-site/docs/specs/independent-verifier-guide.md
@@ -117,6 +117,8 @@ aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl] [--json
 
 ## Exit-code contract
 
+In short: `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`. In full:
+
 | Exit | Meaning |
 |---|---|
 | `0` | **Verified.** No check failed, and any present signatures were checked against `--pubkey` and passed. |

--- a/docs-site/docs/specs/receipt-lineage-reconciliation.md
+++ b/docs-site/docs/specs/receipt-lineage-reconciliation.md
@@ -12,12 +12,18 @@ touched by this document: `aragora/gauntlet/odr_schema.json` is unmodified.
 
 ## Purpose
 
-"Decision receipt" currently names at least three independent code lineages in this
-repo, each with its own module path, its own hashing/signing mechanism, and its own
-level of maturity. This document maps the three lineages, states which one is
-canonical for which audience, and documents how each lineage's decision-state
-(`verdict`) field relates to the others. It introduces no new receipt implementation,
-changes no schema, and does not edit `RECEIPT_CONTRACT.md`.
+Per the front-door positioning in [`README.md`](https://github.com/synaptent/aragora/blob/main/README.md) (quoted verbatim; not
+edited by this document):
+
+> **Aragora is an auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out.**
+
+The "receipt out" half of that sentence is not one artifact. "Decision receipt"
+currently names at least three independent code lineages in this repo, each with its
+own module path, its own hashing/signing mechanism, and its own level of maturity.
+This document maps the three lineages, states which one is canonical for which
+audience, and documents how each lineage's decision-state (`verdict`) field relates to
+the others. It introduces no new receipt implementation, changes no schema, and does
+not edit `RECEIPT_CONTRACT.md`.
 
 ## Canonical decision
 

--- a/docs/GITHUB_ACTION_SETUP.md
+++ b/docs/GITHUB_ACTION_SETUP.md
@@ -250,6 +250,14 @@ illustrative -- it is not literally a file a live run produced -- but it comes f
 the identical emitter this action's `Emit decision receipt` step calls, so its shape
 is what `receipt-path` will point to.
 
+`aragora-verify`'s full exit-code contract is
+`0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked` -- see the
+[Independent Verifier Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md#exit-code-contract)
+for what each of the other three codes means. This is always the standalone
+`aragora-verify`, never the in-tree `aragora verify` / `aragora receipt verify`
+commands, which check a different object (the native `DecisionReceipt`, not the
+portable ODR).
+
 ## How It Works
 
 1. The action fetches the PR diff using `gh pr diff`

--- a/docs/deployment/GITHUB_ACTIONS.md
+++ b/docs/deployment/GITHUB_ACTIONS.md
@@ -2,6 +2,14 @@
 
 Integrate Aragora's AI code review and security auditing into your CI/CD pipeline with GitHub Actions.
 
+> **Different mechanism than the packaged Action.** The workflow template below
+> (`aragora-review-template.yml`) runs the raw `aragora review` CLI on a job with
+> `runs-on: aragora` -- a custom runner label your infrastructure must provide --
+> and does not emit a Decision Receipt. Most external adopters instead want the
+> **[GitHub Action Setup Guide](../GITHUB_ACTION_SETUP.md)**, the canonical doc
+> for the packaged `uses: synaptent/aragora@<sha>` Action: it runs on stock
+> `ubuntu-latest`, needs no custom runner, and supports `emit-receipt`.
+
 ## Quick Start
 
 ### 1. Add API Keys

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,22 @@
 
 Get from zero to a working adversarial debate in under a minute.
 
+**Fastest path:** already have `aragora` installed (`pip install aragora`)? Skip
+the numbered steps below and run the guided command directly -- no API keys
+required. This is the same offline chain the [Independent Verifier
+Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md) and
+[GitHub Action Setup](GITHUB_ACTION_SETUP.md) both build on:
+
+```bash
+aragora quickstart --demo --no-browser --output r.json
+aragora receipt export r.json --format odr -o r.odr.json
+pip install -U 'aragora-verify>=0.1.1' && aragora-verify r.odr.json
+```
+
+This runs a demo debate, exports the receipt to the portable ODR format, and
+verifies it offline with the standalone verifier -- exit `0` end to end. Run
+`aragora quickstart --help` for the live-provider and spec-first variants.
+
 ---
 
 ## 1. Install

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,8 +23,12 @@ verifies it offline with the standalone verifier -- exit `0` end to end. Run
 ## 1. Install
 
 ```bash
-pip install aragora-debate
+pip install aragora aragora-debate
 ```
+
+The full `aragora` distribution provides the `aragora` CLI used by the
+fastest-path ODR commands above. The smaller `aragora-debate` package provides
+the Python module used by the demo and code examples below.
 
 ## 2. Zero-Key Demo
 

--- a/docs/reference/INSTALL_MATRIX.md
+++ b/docs/reference/INSTALL_MATRIX.md
@@ -147,8 +147,8 @@ the code actually in this checkout, not whatever was last released.
 ## Verifier console-script exit codes
 
 The same `aragora-verify` console script installed above honors the full
-exit-code contract (`0` verified / `1` failed / `2` usage / `3` signatures
-present but unchecked — see the
+exit-code contract (`0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`
+— see the
 [Independent Verifier Guide](../specs/INDEPENDENT_VERIFIER_GUIDE.md#exit-code-contract)
 for all four). The two ends of that contract that this matrix's smoke test
 depends on:

--- a/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
+++ b/docs/specs/INDEPENDENT_VERIFIER_GUIDE.md
@@ -112,6 +112,8 @@ aragora-verify RECEIPT.odr.json [--pubkey KEY.pem] [--chain CHAIN.jsonl] [--json
 
 ## Exit-code contract
 
+In short: `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`. In full:
+
 | Exit | Meaning |
 |---|---|
 | `0` | **Verified.** No check failed, and any present signatures were checked against `--pubkey` and passed. |

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -7,12 +7,18 @@ touched by this document: `aragora/gauntlet/odr_schema.json` is unmodified.
 
 ## Purpose
 
-"Decision receipt" currently names at least three independent code lineages in this
-repo, each with its own module path, its own hashing/signing mechanism, and its own
-level of maturity. This document maps the three lineages, states which one is
-canonical for which audience, and documents how each lineage's decision-state
-(`verdict`) field relates to the others. It introduces no new receipt implementation,
-changes no schema, and does not edit `RECEIPT_CONTRACT.md`.
+Per the front-door positioning in [`README.md`](../../README.md) (quoted verbatim; not
+edited by this document):
+
+> **Aragora is an auditable execution control plane for AI-assisted decisions: multi-model review in, a verifiable Decision Receipt out.**
+
+The "receipt out" half of that sentence is not one artifact. "Decision receipt"
+currently names at least three independent code lineages in this repo, each with its
+own module path, its own hashing/signing mechanism, and its own level of maturity.
+This document maps the three lineages, states which one is canonical for which
+audience, and documents how each lineage's decision-state (`verdict`) field relates to
+the others. It introduces no new receipt implementation, changes no schema, and does
+not edit `RECEIPT_CONTRACT.md`.
 
 ## Canonical decision
 


### PR DESCRIPTION
## Summary

M6 cross-doc consistency sweep (m6-canonical-consistency-sweep). Docs-only, no schema/gated-file changes.

- **Positioning sentence (VAL-CROSS-006):** added the root `README.md` top-line sentence, verbatim, to `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` (previously absent there). Verified byte-consistent via both a collapsed-whitespace full-sentence comparison and substring checks on both sides of README's own mid-sentence line wrap.
- **Verifier exit-code contract (VAL-CROSS-002):** normalized the compact "0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked" phrasing so it is byte-identical everywhere it appears: `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` (added as an at-a-glance line above the existing detail table), `docs/reference/INSTALL_MATRIX.md` (was using unhyphenated "signatures present but unchecked" split across 4 separate code spans; now one span, hyphenated to match), and `docs/GITHUB_ACTION_SETUP.md`'s "Verify a receipt offline right now" section (previously did not state the full 0/1/2/3 contract at all). Each location explicitly ties the contract to the standalone `aragora-verify`, never the native `aragora verify` / `aragora receipt verify`.
- **Offline chain (VAL-CROSS-003):** confirmed the chain `aragora quickstart --demo --no-browser --output r.json` -> `aragora receipt export r.json --format odr -o r.odr.json` -> `aragora-verify r.odr.json` runs exit 0 end to end in the mission venv (quickstart exit 0, export exit 0, verify VERIFIED exit 0).
- **`docs/quickstart.md` "fastest path" callout:** the doc named "Quickstart" never mentioned the actual `aragora quickstart` CLI subcommand. Added a short callout with the verified offline chain above, consistent with the flags already documented in `docs/reference/CLI_REFERENCE.md` (`--demo`, `--no-browser`, `--output`).
- **`docs/deployment/GITHUB_ACTIONS.md` disambiguation callout:** this doc's `aragora-review-template.yml` uses a custom `runs-on: aragora` runner plus the raw `aragora review` CLI (verified: no receipt-emission flag exists on that CLI command) -- a different distribution mechanism than the packaged root Action. Added a short callout cross-linking `docs/GITHUB_ACTION_SETUP.md` as the canonical packaged-Action path, without removing the custom-runner pattern.
- **Landing decision (unchanged, verified intact):** `docs/README.md` (canonical landing) and `docs/INDEX.md` (flat reference) both still route quickstart -> receipt-lineage-reconciliation -> verifier-guide -> action-setup to the same 4 targets; no drift found, no edits needed.
- **ODR canonical name (VAL-CROSS-001):** verified "Open Decision Receipt (ODR v0.1)" / "ODR" is already consistent across the reconciliation/verifier/Action/install docs; no drift found.
- Ran the docs-sync procedure (`doc_stats.py --write` then the docs-site sync script) per the mission's docs-sync requirement; this also picked up one unrelated pre-existing mirror-drift file (the docs-site mirror of `docs/WHY_ARAGORA.md`, already-committed source content that had not yet been synced) -- included so the "Ensure docs are synced" check stays green.

## Verification

- `make docs-check` -> PASS (0 findings, all 4 non-skipped checks green).
- Targeted pytest on `tests/scripts/test_github_action_setup_doc.py` and `tests/cli/test_public_demo_onboarding_docs.py` -> 11 passed (confirms the two open, unrelated in-flight PRs touching `docs/GITHUB_ACTION_SETUP.md` / `docs/quickstart.md` / root `README.md` do not collide with this PR's non-overlapping sections).
- Targeted pytest on the docs-site sync/link/stats test files -> 51 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok (docs-only diff detected).
- Live CLI verification in the mission venv: ran the full offline chain (quickstart demo receipt export, ODR export, standalone verify) -- all three steps exited 0, final verify result VERIFIED.
- Grep-confirmed the positioning sentence and exit-code phrase land byte-identically in every target location (see PR diff).

## Milestone

m6-docs / m6-canonical-consistency-sweep. No files under the gated set (workflows directory, THESIS, CANONICAL_GOALS, RECEIPT_CONTRACT, the README top-line claim, or the ODR JSON schema) were touched.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
