### PR TITLE
feat(scripts): parked-PR head recheck (conductor)

### DIFF
--- a/scripts/parked_pr_recheck.py
+++ b/scripts/parked_pr_recheck.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Report whether parked PRs have moved to a new head SHA."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+DEFAULT_LEDGER = Path(".aragora/parked_prs.json")
+DEFAULT_REPO = "synaptent/aragora"
+DEFAULT_TIMEOUT_SECONDS = 20
+
+
+@dataclass(frozen=True)
+class ParkedPr:
+    pr: int
+    head_sha: str
+    parked_at: str
+    blocker_class: str
+    source: str
+
+
+@dataclass(frozen=True)
+class RecheckResult:
+    pr: int
+    parked_head: str
+    live_head: str | None
+    changed: bool | None
+    recommendation: str
+    blocker_class: str
+    source: str
+    error: str | None = None
+
+
+RunGh = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def load_ledger(path: Path) -> list[ParkedPr]:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"ledger not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"ledger is not valid JSON: {path}: {exc}") from exc
+
+    records = raw.get("records") if isinstance(raw, dict) else raw
+    if not isinstance(records, list):
+        raise ValueError("ledger must be a list or an object with a records list")
+
+    parked: list[ParkedPr] = []
+    for index, record in enumerate(records, 1):
+        if not isinstance(record, dict):
+            raise ValueError(f"ledger record {index} must be an object")
+        try:
+            pr = int(record["pr"])
+            head_sha = str(record["head_sha"])
+            parked_at = str(record["parked_at"])
+            blocker_class = str(record["blocker_class"])
+            source = str(record["source"])
+        except KeyError as exc:
+            raise ValueError(f"ledger record {index} missing field: {exc.args[0]}") from exc
+        if pr <= 0:
+            raise ValueError(f"ledger record {index} has invalid pr: {pr}")
+        if not head_sha:
+            raise ValueError(f"ledger record {index} has empty head_sha")
+        parked.append(
+            ParkedPr(
+                pr=pr,
+                head_sha=head_sha,
+                parked_at=parked_at,
+                blocker_class=blocker_class,
+                source=source,
+            )
+        )
+    return parked
+
+
+def fetch_live_head(
+    pr: int,
+    *,
+    repo: str,
+    gh_bin: str,
+    timeout: int,
+    run: RunGh = subprocess.run,
+) -> str:
+    proc = run(
+        [
+            gh_bin,
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "headRefOid",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        stderr = proc.stderr.strip() or proc.stdout.strip() or f"gh exited {proc.returncode}"
+        raise RuntimeError(stderr)
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh returned invalid JSON for PR #{pr}: {exc}") from exc
+    head = payload.get("headRefOid")
+    if not isinstance(head, str) or not head:
+        raise RuntimeError(f"gh response for PR #{pr} did not include headRefOid")
+    return head
+
+
+def recheck_records(
+    records: list[ParkedPr],
+    *,
+    repo: str = DEFAULT_REPO,
+    gh_bin: str = "gh",
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    run: RunGh = subprocess.run,
+) -> tuple[list[RecheckResult], bool]:
+    results: list[RecheckResult] = []
+    ok = True
+    for record in records:
+        try:
+            live_head = fetch_live_head(
+                record.pr,
+                repo=repo,
+                gh_bin=gh_bin,
+                timeout=timeout,
+                run=run,
+            )
+        except (RuntimeError, subprocess.TimeoutExpired) as exc:
+            ok = False
+            results.append(
+                RecheckResult(
+                    pr=record.pr,
+                    parked_head=record.head_sha,
+                    live_head=None,
+                    changed=None,
+                    recommendation="lookup failed; preserve parked state",
+                    blocker_class=record.blocker_class,
+                    source=record.source,
+                    error=str(exc),
+                )
+            )
+            continue
+
+        changed = live_head != record.head_sha
+        recommendation = "requeue candidate (head changed)" if changed else "skip parked head"
+        results.append(
+            RecheckResult(
+                pr=record.pr,
+                parked_head=record.head_sha,
+                live_head=live_head,
+                changed=changed,
+                recommendation=recommendation,
+                blocker_class=record.blocker_class,
+                source=record.source,
+            )
+        )
+    return results, ok
+
+
+def _short_sha(value: str | None) -> str:
+    if not value:
+        return "-"
+    return value[:12]
+
+
+def render_table(results: list[RecheckResult]) -> str:
+    headers = ("pr", "parked_head", "live_head", "changed", "recommendation")
+    rows = [
+        (
+            f"#{result.pr}",
+            _short_sha(result.parked_head),
+            _short_sha(result.live_head),
+            "unknown" if result.changed is None else str(result.changed).lower(),
+            result.recommendation,
+        )
+        for result in results
+    ]
+    widths = [
+        max(len(str(item)) for item in column) for column in zip(headers, *rows, strict=False)
+    ]
+    lines = [
+        " | ".join(str(item).ljust(width) for item, width in zip(headers, widths, strict=False)),
+        "-+-".join("-" * width for width in widths),
+    ]
+    for row in rows:
+        lines.append(
+            " | ".join(str(item).ljust(width) for item, width in zip(row, widths, strict=False))
+        )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Recheck parked PRs and flag heads that changed since parking."
+    )
+    parser.add_argument("--ledger", type=Path, default=DEFAULT_LEDGER)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--gh-bin", default="gh")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        records = load_ledger(args.ledger)
+    except ValueError as exc:
+        print(f"parked_pr_recheck: {exc}", file=sys.stderr)
+        return 2
+
+    results, ok = recheck_records(
+        records,
+        repo=args.repo,
+        gh_bin=args.gh_bin,
+        timeout=args.timeout,
+    )
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "ok": ok,
+                    "ledger": str(args.ledger),
+                    "repo": args.repo,
+                    "results": [asdict(result) for result in results],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(render_table(results))
+        errors = [result for result in results if result.error]
+        if errors:
+            print("\nlookup errors:", file=sys.stderr)
+            for result in errors:
+                print(f"- PR #{result.pr}: {result.error}", file=sys.stderr)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_parked_pr_recheck.py
+++ b/tests/scripts/test_parked_pr_recheck.py
@@ -1,0 +1,132 @@
+"""Unit tests for scripts/parked_pr_recheck.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def test_recheck_records_marks_changed_heads() -> None:
+    import parked_pr_recheck as mod
+
+    records = [
+        mod.ParkedPr(
+            pr=8908,
+            head_sha="old8908",
+            parked_at="2026-07-08",
+            blocker_class="current_head_p2",
+            source="test",
+        ),
+        mod.ParkedPr(
+            pr=8945,
+            head_sha="same8945",
+            parked_at="2026-07-08",
+            blocker_class="tier4",
+            source="test",
+        ),
+    ]
+
+    def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        pr = int(cmd[3])
+        head = {8908: "new8908", 8945: "same8945"}[pr]
+        return subprocess.CompletedProcess(cmd, 0, json.dumps({"headRefOid": head}), "")
+
+    results, ok = mod.recheck_records(records, repo="synaptent/aragora", run=fake_run)
+
+    assert ok is True
+    assert results[0].changed is True
+    assert results[0].recommendation == "requeue candidate (head changed)"
+    assert results[1].changed is False
+    assert results[1].recommendation == "skip parked head"
+
+
+def test_render_table_includes_requeue_candidate() -> None:
+    import parked_pr_recheck as mod
+
+    table = mod.render_table(
+        [
+            mod.RecheckResult(
+                pr=8908,
+                parked_head="old8908abcdef",
+                live_head="new8908abcdef",
+                changed=True,
+                recommendation="requeue candidate (head changed)",
+                blocker_class="current_head_p2",
+                source="test",
+            )
+        ]
+    )
+
+    assert "#8908" in table
+    assert "requeue candidate (head changed)" in table
+
+
+def test_load_ledger_accepts_records_object(tmp_path: Path) -> None:
+    import parked_pr_recheck as mod
+
+    ledger = tmp_path / "parked.json"
+    ledger.write_text(
+        json.dumps(
+            {
+                "records": [
+                    {
+                        "pr": 8908,
+                        "head_sha": "abc",
+                        "parked_at": "2026-07-08",
+                        "blocker_class": "current_head_p2",
+                        "source": "test",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    records = mod.load_ledger(ledger)
+
+    assert records == [
+        mod.ParkedPr(
+            pr=8908,
+            head_sha="abc",
+            parked_at="2026-07-08",
+            blocker_class="current_head_p2",
+            source="test",
+        )
+    ]
+
+
+def test_recheck_records_preserves_state_on_lookup_failure() -> None:
+    import parked_pr_recheck as mod
+
+    records = [
+        mod.ParkedPr(
+            pr=8908,
+            head_sha="old8908",
+            parked_at="2026-07-08",
+            blocker_class="current_head_p2",
+            source="test",
+        )
+    ]
+
+    def fake_run(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, "", "not found")
+
+    results, ok = mod.recheck_records(records, repo="synaptent/aragora", run=fake_run)
+
+    assert ok is False
+    assert results[0].changed is None
+    assert results[0].recommendation == "lookup failed; preserve parked state"
+    assert results[0].error == "not found"


### PR DESCRIPTION
## Summary

- Add `scripts/parked_pr_recheck.py`, a read-only helper that reads an ignored local `.aragora/parked_prs.json` ledger and reports whether parked PR heads changed.
- Add mocked-`gh` unit coverage for changed heads, unchanged heads, ledger loading, and lookup failures.
- Implements the small checker follow-up described by `docs/plans/2026-07-07-repeat-blocker-park-policy.md` without changing settlement authority, workflows, branch protection, or parked PR branches.

## Live parked-head recheck

```
pr    | parked_head  | live_head    | changed | recommendation  
------+--------------+--------------+---------+-----------------
#8908 | 7848d6ad0255 | 7848d6ad0255 | false   | skip parked head
#8931 | 8adc0f8e6a48 | 8adc0f8e6a48 | false   | skip parked head
#8945 | 7b30e8ffbec3 | 7b30e8ffbec3 | false   | skip parked head
#8948 | be56200ae6a1 | be56200ae6a1 | false   | skip parked head
#8961 | 13bf57d45b77 | 13bf57d45b77 | false   | skip parked head
#8965 | babad5424058 | babad5424058 | false   | skip parked head
#8970 | 905b3dcfb3bb | 905b3dcfb3bb | false   | skip parked head
#8995 | 241d57db0048 | 241d57db0048 | false   | skip parked head
#9001 | 87818cf7139e | 87818cf7139e | false   | skip parked head
```

No parked head changed, so none were requeued or touched in this cycle. #9002, #9003, #8992, Dependabot PRs, and all parked PR branches were left untouched.

## Validation

- `python3 -m py_compile scripts/parked_pr_recheck.py tests/scripts/test_parked_pr_recheck.py`
- `python3 -m pytest -q tests/scripts/test_parked_pr_recheck.py` -> 4 passed, 8 existing deprecation warnings
- `python3 -m ruff check scripts/parked_pr_recheck.py tests/scripts/test_parked_pr_recheck.py`
- `python3 -m mypy scripts/parked_pr_recheck.py --ignore-missing-imports`
- `python3 scripts/parked_pr_recheck.py`
- `python3 scripts/parked_pr_recheck.py --json`
- `make ci-required` reached repo-wide `mypy aragora/ --ignore-missing-imports` and failed on the inherited baseline: 2646 errors in 648 files. Repo-wide ruff passed before that failure.
- Push hooks passed, including changed-file mypy.

Forbidden actions not used: no `--admin`, no force-push, no workflow edits, no branch-protection edits, no PR settlement/merge.