### PR TITLE
fix(scripts): accept conductor cycle context in Fable packets

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -48,6 +48,10 @@ MAX_CONTEXT_FILE_BYTES = 64 * 1024
 MAX_PACKET_BYTES = 400 * 1024
 MAX_PACKET_SECTION_BYTES = 96 * 1024
 SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
+SAFE_CONTEXT_SUBDIRS = (
+    SAFE_CONTEXT_SUBDIR,
+    Path(".aragora") / "conductor_cycles",
+)
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
 MAX_ACTIVE_PROCESS_LINES = 40
@@ -337,15 +341,16 @@ def _packet_with_footer(parts: list[str]) -> str:
 
 def _read_context_file(path: Path, root: Path) -> tuple[str | None, str | None]:
     """Read a repo-local safe context file with a hard byte cap."""
-    safe_root = (root / SAFE_CONTEXT_SUBDIR).resolve(strict=False)
+    safe_roots = tuple((root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS)
     candidate = path if path.is_absolute() else root / path
     try:
         resolved = candidate.resolve(strict=True)
     except OSError as exc:
         return None, f"context file unreadable: {path}: {exc}"
 
-    if not _is_relative_to(resolved, safe_root):
-        return None, f"context file must be under {SAFE_CONTEXT_SUBDIR}: {path}"
+    if not any(_is_relative_to(resolved, safe_root) for safe_root in safe_roots):
+        allowed_roots = " or ".join(str(subdir) for subdir in SAFE_CONTEXT_SUBDIRS)
+        return None, f"context file must be under {allowed_roots}: {path}"
     try:
         if not resolved.is_file():
             return None, f"context file is not a regular file: {path}"
@@ -483,10 +488,16 @@ def build_packet(
         ]
     for path in extra_files:
         body, note = _read_context_file(path, root)
+        if body is None:
+            if note:
+                parts += [
+                    "",
+                    f"### Operator context {path} (unavailable)",
+                    f"OPERATOR CONTEXT MISSING: {note}",
+                ]
+            continue
         if note:
             parts += ["", f"### Operator context {path} ({note})"]
-        if body is None:
-            continue
         parts += [
             "",
             f"### Operator context: {path.name}",

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -102,6 +102,43 @@ def test_build_packet_truncates_large_context_file(tmp_path: Path) -> None:
     assert "a" * (fable_goal_cycle.MAX_CONTEXT_FILE_BYTES + 1) not in packet
 
 
+def test_build_packet_accepts_conductor_cycles_context_file(tmp_path: Path) -> None:
+    context_dir = tmp_path / ".aragora" / "conductor_cycles"
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle_report.md"
+    context_file.write_text("cycle 157: transport_blocked", encoding="utf-8")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=tmp_path,
+    )
+
+    assert "cycle 157: transport_blocked" in packet
+    assert "OPERATOR CONTEXT MISSING" not in packet
+
+
+def test_build_packet_truncates_large_conductor_cycles_context_file(tmp_path: Path) -> None:
+    context_dir = tmp_path / ".aragora" / "conductor_cycles"
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle_report.md"
+    context_file.write_bytes(b"a" * (fable_goal_cycle.MAX_CONTEXT_FILE_BYTES + 50))
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=tmp_path,
+    )
+
+    assert "context file truncated" in packet
+    assert "a" * fable_goal_cycle.MAX_CONTEXT_FILE_BYTES in packet
+    assert "a" * (fable_goal_cycle.MAX_CONTEXT_FILE_BYTES + 1) not in packet
+
+
 def test_build_packet_respects_aggregate_prompt_budget() -> None:
     oversized_body = "x" * (fable_goal_cycle.MAX_PACKET_SECTION_BYTES * 8)
 
@@ -156,7 +193,11 @@ def test_build_packet_refuses_sensitive_context_path(tmp_path: Path) -> None:
         root=tmp_path,
     )
 
-    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "OPERATOR CONTEXT MISSING" in packet
+    assert (
+        "context file must be under .aragora/goal-cycle-context or .aragora/conductor_cycles"
+        in packet
+    )
     assert "TOKEN=secret" not in packet
 
 
@@ -181,7 +222,11 @@ def test_build_packet_refuses_symlink_to_sensitive_context_path(tmp_path: Path) 
         root=tmp_path,
     )
 
-    assert "context file must be under .aragora/goal-cycle-context" in packet
+    assert "OPERATOR CONTEXT MISSING" in packet
+    assert (
+        "context file must be under .aragora/goal-cycle-context or .aragora/conductor_cycles"
+        in packet
+    )
     assert "TOKEN=secret" not in packet
 
 


### PR DESCRIPTION
## Summary
- allow `scripts/fable_goal_cycle.py --context-file` to include safe `.aragora/conductor_cycles/*` reports as operator context
- keep existing `.aragora/goal-cycle-context/*` support and byte caps
- make rejected explicit context paths show a loud `OPERATOR CONTEXT MISSING` packet banner instead of a heading-only note

## Why
Cycle 158 found that the Fable goal-cycle helper silently dropped the previous conductor cycle report because the report lived under `.aragora/conductor_cycles/`, while the helper only accepted `.aragora/goal-cycle-context/`. That made Fable plan without the actual latest cycle evidence.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/armand/.pyenv/versions/3.11.11/bin/python -m pytest -q tests/scripts/test_fable_goal_cycle.py` -> 18 passed
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python -m ruff format --check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- dry-run smoke: `scripts/fable_goal_cycle.py --context-file .aragora/conductor_cycles/test-cycle-context.md --skip-digest --dry-run --json`, packet contained the sentinel conductor-cycle context

## Boundaries
Draft only. No merge, settlement, evidence posting, branch-protection mutation, workflow mutation, or outbox/archive action.