### PR TITLE
fix(conductor): materialize out-of-root operator context

### DIFF
--- a/docs/guides/CONDUCTOR_WORKFLOW.md
+++ b/docs/guides/CONDUCTOR_WORKFLOW.md
@@ -115,12 +115,13 @@ merge PRs, bypass Tier gates, install launchd jobs, run `observe-outcomes
 
 ### Operator Context Contract
 
-`context_file` values in goal-conductor mission lanes must ultimately be
-presented to `scripts/fable_goal_cycle.py` from one of its safe context roots:
-`.aragora/goal-cycle-context/` or `.aragora/conductor_cycles/`. If a mission
-references operator context elsewhere, `scripts/goal_conductor.py` materializes
-a capped copy into `.aragora/goal-cycle-context/` with a provenance header before
-passing it to downstream panel or goal-cycle commands. Missing, directory, or
+`context_file` values in goal-conductor mission lanes must be presented to
+downstream panel or goal-cycle commands from one of the safe context roots also
+accepted by `scripts/fable_goal_cycle.py`: `.aragora/goal-cycle-context/` or
+`.aragora/conductor_cycles/`. If a mission references operator context elsewhere,
+`scripts/goal_conductor.py` materializes a capped copy into the run-scoped
+`.aragora/conductor_cycles/goal-conductor/.../context/` tree with a provenance
+header before passing it to downstream panel commands. Missing, directory, or
 unreadable sources block that lane with an actionable error instead of launching
 a panel that would silently lose the operator context.
 

--- a/docs/guides/CONDUCTOR_WORKFLOW.md
+++ b/docs/guides/CONDUCTOR_WORKFLOW.md
@@ -113,6 +113,17 @@ transcript and markdown handoff under `.aragora/goal-conductor/`; it does not
 merge PRs, bypass Tier gates, install launchd jobs, run `observe-outcomes
 --write`, close issues, or clean worktrees.
 
+### Operator Context Contract
+
+`context_file` values in goal-conductor mission lanes must ultimately be
+presented to `scripts/fable_goal_cycle.py` from one of its safe context roots:
+`.aragora/goal-cycle-context/` or `.aragora/conductor_cycles/`. If a mission
+references operator context elsewhere, `scripts/goal_conductor.py` materializes
+a capped copy into `.aragora/goal-cycle-context/` with a provenance header before
+passing it to downstream panel or goal-cycle commands. Missing, directory, or
+unreadable sources block that lane with an actionable error instead of launching
+a panel that would silently lose the operator context.
+
 ## 4. Decision Rule
 
 Only do one of these per conductor cycle:

--- a/scripts/goal_conductor.py
+++ b/scripts/goal_conductor.py
@@ -14,6 +14,7 @@ The conductor is intentionally conservative. It is read-only by default; pass
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -550,7 +551,7 @@ class GoalConductor:
             (self.repo_root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS
         )
 
-    def _materialized_context_file_for(self, lane: LaneSpec) -> str:
+    def _materialized_context_file_for(self, lane: LaneSpec, run_dir: Path) -> str:
         if not lane.context_file:
             return ""
         original = Path(lane.context_file)
@@ -579,13 +580,26 @@ class GoalConductor:
 
         truncated = len(data) > MAX_CONTEXT_FILE_BYTES
         body = data[:MAX_CONTEXT_FILE_BYTES].decode("utf-8", errors="replace")
-        context_dir = self.repo_root / SAFE_CONTEXT_SUBDIRS[0]
+        run_context_root = (
+            self.repo_root
+            / SAFE_CONTEXT_SUBDIRS[1]
+            / "goal-conductor"
+            / _slug(self.mission.name)
+            / run_dir.name
+            / "context"
+        )
+        context_dir = run_context_root
         context_dir.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
         materialized = context_dir / f"{stamp}-{_slug(lane.lane_id)}.md"
         truncate_note = f"; truncated to {MAX_CONTEXT_FILE_BYTES} bytes" if truncated else ""
+        digest = hashlib.sha256(data[:MAX_CONTEXT_FILE_BYTES]).hexdigest()
         materialized.write_text(
-            f"<!-- Source context materialized from: {resolved}{truncate_note} -->\n{body}",
+            "<!-- "
+            "Source context materialized by goal_conductor from outside safe roots; "
+            f"source_name={resolved.name}; sha256={digest}{truncate_note} "
+            "-->\n"
+            f"{body}",
             encoding="utf-8",
         )
         return materialized.relative_to(self.repo_root).as_posix()
@@ -655,7 +669,7 @@ class GoalConductor:
             str(output_dir),
         ]
         if lane.context_file:
-            command.extend(["--context-file", self._materialized_context_file_for(lane)])
+            command.extend(["--context-file", self._materialized_context_file_for(lane, run_dir)])
         return [command]
 
     def plan_lanes(self, snapshot: dict[str, Any], run_dir: Path) -> list[LaneDecision]:
@@ -674,6 +688,8 @@ class GoalConductor:
                     )
                 )
                 continue
+            reserve_implementation = False
+            reserve_review = False
             if lane.mutates:
                 if implementation_used >= self.mission.limits.max_implementation_lanes:
                     decisions.append(
@@ -684,7 +700,7 @@ class GoalConductor:
                         )
                     )
                     continue
-                implementation_used += 1
+                reserve_implementation = True
             elif lane.is_review:
                 if review_used >= self.mission.limits.max_review_lanes:
                     decisions.append(
@@ -695,7 +711,7 @@ class GoalConductor:
                         )
                     )
                     continue
-                review_used += 1
+                reserve_review = True
             try:
                 commands = (
                     self._panel_commands(lane, run_dir)
@@ -711,6 +727,10 @@ class GoalConductor:
                     )
                 )
                 continue
+            if reserve_implementation:
+                implementation_used += 1
+            if reserve_review:
+                review_used += 1
             decisions.append(
                 LaneDecision(
                     lane_id=lane.lane_id,

--- a/scripts/goal_conductor.py
+++ b/scripts/goal_conductor.py
@@ -30,6 +30,14 @@ DEFAULT_OUTPUT_DIR = Path(".aragora/goal-conductor")
 DEFAULT_QUEUE_CAP = 6
 DEFAULT_MAX_IMPLEMENTATION_LANES = 2
 DEFAULT_MAX_REVIEW_LANES = 1
+try:
+    from fable_goal_cycle import MAX_CONTEXT_FILE_BYTES, SAFE_CONTEXT_SUBDIRS
+except ImportError:  # pragma: no cover - fallback for partial script checkouts
+    MAX_CONTEXT_FILE_BYTES = 64 * 1024
+    SAFE_CONTEXT_SUBDIRS = (
+        Path(".aragora") / "goal-cycle-context",
+        Path(".aragora") / "conductor_cycles",
+    )
 ALLOWED_AGENTS = {"codex", "claude", "droid", "factory"}
 PANEL_MODE = "panel"
 IMPLEMENTATION_MODES = {"implementation", "implement", "write"}
@@ -44,6 +52,14 @@ def _utc_now() -> str:
 def _slug(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip()).strip("-")
     return slug[:80] or "goal"
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
 
 
 def _mute_stdout_after_broken_pipe() -> bool:
@@ -333,6 +349,10 @@ class LaneDecision:
     commands: list[list[str]] = field(default_factory=list)
 
 
+class ContextFileError(ValueError):
+    """Raised when a lane context file cannot be safely materialized."""
+
+
 @dataclass
 class ConductorResult:
     mission_name: str
@@ -525,6 +545,51 @@ class GoalConductor:
         path.write_text(lane.prompt + "\n", encoding="utf-8")
         return path
 
+    def _safe_context_roots(self) -> tuple[Path, ...]:
+        return tuple(
+            (self.repo_root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS
+        )
+
+    def _materialized_context_file_for(self, lane: LaneSpec) -> str:
+        if not lane.context_file:
+            return ""
+        original = Path(lane.context_file)
+        candidate = original if original.is_absolute() else self.repo_root / original
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as exc:
+            raise ContextFileError(
+                f"context file unreadable for lane {lane.lane_id}: {lane.context_file}: {exc}"
+            ) from exc
+        if not resolved.is_file():
+            raise ContextFileError(
+                f"context file is not a regular file for lane {lane.lane_id}: {lane.context_file}"
+            )
+
+        if any(_is_relative_to(resolved, safe_root) for safe_root in self._safe_context_roots()):
+            return lane.context_file
+
+        try:
+            with resolved.open("rb") as handle:
+                data = handle.read(MAX_CONTEXT_FILE_BYTES + 1)
+        except OSError as exc:
+            raise ContextFileError(
+                f"context file unreadable for lane {lane.lane_id}: {lane.context_file}: {exc}"
+            ) from exc
+
+        truncated = len(data) > MAX_CONTEXT_FILE_BYTES
+        body = data[:MAX_CONTEXT_FILE_BYTES].decode("utf-8", errors="replace")
+        context_dir = self.repo_root / SAFE_CONTEXT_SUBDIRS[0]
+        context_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        materialized = context_dir / f"{stamp}-{_slug(lane.lane_id)}.md"
+        truncate_note = f"; truncated to {MAX_CONTEXT_FILE_BYTES} bytes" if truncated else ""
+        materialized.write_text(
+            f"<!-- Source context materialized from: {resolved}{truncate_note} -->\n{body}",
+            encoding="utf-8",
+        )
+        return materialized.relative_to(self.repo_root).as_posix()
+
     def _known_sessions(self) -> set[str]:
         data, _ = self._run_json(["python3", "scripts/agent_bridge.py", "--json", "sessions"])
         if not isinstance(data, list):
@@ -590,7 +655,7 @@ class GoalConductor:
             str(output_dir),
         ]
         if lane.context_file:
-            command.extend(["--context-file", lane.context_file])
+            command.extend(["--context-file", self._materialized_context_file_for(lane)])
         return [command]
 
     def plan_lanes(self, snapshot: dict[str, Any], run_dir: Path) -> list[LaneDecision]:
@@ -631,11 +696,21 @@ class GoalConductor:
                     )
                     continue
                 review_used += 1
-            commands = (
-                self._panel_commands(lane, run_dir)
-                if lane.mode == PANEL_MODE
-                else self._agent_commands(lane, run_dir, sessions)
-            )
+            try:
+                commands = (
+                    self._panel_commands(lane, run_dir)
+                    if lane.mode == PANEL_MODE
+                    else self._agent_commands(lane, run_dir, sessions)
+                )
+            except ContextFileError as exc:
+                decisions.append(
+                    LaneDecision(
+                        lane_id=lane.lane_id,
+                        action="blocked",
+                        reason=str(exc),
+                    )
+                )
+                continue
             decisions.append(
                 LaneDecision(
                     lane_id=lane.lane_id,

--- a/tests/scripts/test_goal_conductor.py
+++ b/tests/scripts/test_goal_conductor.py
@@ -460,10 +460,14 @@ def test_panel_context_file_outside_safe_roots_is_materialized(tmp_path: Path) -
     command = result.decisions[0].commands[0]
     context_arg = command[command.index("--context-file") + 1]
     materialized = tmp_path / context_arg
-    assert context_arg.startswith(".aragora/goal-cycle-context/")
+    assert context_arg.startswith(".aragora/conductor_cycles/goal-conductor/")
     assert materialized.exists()
     body = materialized.read_text(encoding="utf-8")
-    assert body.startswith(f"<!-- Source context materialized from: {external_context}")
+    assert body.startswith(
+        "<!-- Source context materialized by goal_conductor from outside safe roots; "
+    )
+    assert f"source_name={external_context.name}" in body
+    assert str(external_context) not in body
     assert "operator says: include this" in body
 
 
@@ -528,6 +532,44 @@ def test_panel_context_file_unreadable_blocks_lane(tmp_path: Path) -> None:
     assert result.decisions[0].action == "blocked"
     assert "context file unreadable for lane panel" in result.decisions[0].reason
     assert runner.executed == []
+
+
+def test_bad_review_context_does_not_consume_review_slot(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    payload["limits"]["max_review_lanes"] = 1
+    payload["lanes"] = [
+        {
+            "id": "bad-panel",
+            "mode": "panel",
+            "goal": "Review with missing context.",
+            "prompt": "Review only.",
+            "context_file": str(tmp_path / "missing.md"),
+        },
+        {
+            "id": "good-panel",
+            "mode": "panel",
+            "goal": "Review with valid context.",
+            "prompt": "Review only.",
+        },
+    ]
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[])
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=False,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.decisions[0].action == "blocked"
+    assert "context file unreadable for lane bad-panel" in result.decisions[0].reason
+    assert result.decisions[1].action == "dry_run"
+    assert result.decisions[1].commands[0][:2] == ["python3", "scripts/multi_agent_dialog.py"]
 
 
 def test_execute_reuses_existing_agent_lane_and_sends_prompt(tmp_path: Path) -> None:

--- a/tests/scripts/test_goal_conductor.py
+++ b/tests/scripts/test_goal_conductor.py
@@ -430,6 +430,106 @@ def test_run_once_blocks_mutating_lane_at_queue_cap_but_allows_panel(tmp_path: P
     )
 
 
+def test_panel_context_file_outside_safe_roots_is_materialized(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    external_context = tmp_path.parent / f"{tmp_path.name}-operator-context.md"
+    external_context.write_text("operator says: include this", encoding="utf-8")
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    payload["lanes"] = [
+        {
+            "id": "panel",
+            "mode": "panel",
+            "goal": "Review with operator context.",
+            "prompt": "Review only.",
+            "context_file": str(external_context),
+        }
+    ]
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[])
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=False,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    command = result.decisions[0].commands[0]
+    context_arg = command[command.index("--context-file") + 1]
+    materialized = tmp_path / context_arg
+    assert context_arg.startswith(".aragora/goal-cycle-context/")
+    assert materialized.exists()
+    body = materialized.read_text(encoding="utf-8")
+    assert body.startswith(f"<!-- Source context materialized from: {external_context}")
+    assert "operator says: include this" in body
+
+
+def test_panel_context_file_under_safe_root_passes_through(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    context_path = tmp_path / ".aragora" / "goal-cycle-context" / "cycle.md"
+    context_path.parent.mkdir(parents=True)
+    context_path.write_text("safe context", encoding="utf-8")
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    payload["lanes"] = [
+        {
+            "id": "panel",
+            "mode": "panel",
+            "goal": "Review with safe context.",
+            "prompt": "Review only.",
+            "context_file": ".aragora/goal-cycle-context/cycle.md",
+        }
+    ]
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[])
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=False,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    command = result.decisions[0].commands[0]
+    assert command[command.index("--context-file") + 1] == ".aragora/goal-cycle-context/cycle.md"
+    assert list((tmp_path / ".aragora" / "goal-cycle-context").iterdir()) == [context_path]
+
+
+def test_panel_context_file_unreadable_blocks_lane(tmp_path: Path) -> None:
+    import goal_conductor as mod
+
+    payload = _mission_dict(tmp_path)
+    payload["limits"]["queue_cap"] = 5
+    payload["lanes"] = [
+        {
+            "id": "panel",
+            "mode": "panel",
+            "goal": "Review with missing context.",
+            "prompt": "Review only.",
+            "context_file": str(tmp_path / "missing.md"),
+        }
+    ]
+    mission = mod.Mission.from_dict(payload)
+    runner = FakeRunner(mod, open_prs=[])
+    conductor = mod.GoalConductor(
+        mission=mission,
+        repo_root=tmp_path,
+        execute=True,
+        runner=runner,
+    )
+
+    result = conductor.run_once()
+
+    assert result.decisions[0].action == "blocked"
+    assert "context file unreadable for lane panel" in result.decisions[0].reason
+    assert runner.executed == []
+
+
 def test_execute_reuses_existing_agent_lane_and_sends_prompt(tmp_path: Path) -> None:
     import goal_conductor as mod
 


### PR DESCRIPTION
## Summary
- Materialize goal-conductor lane context files that live outside the fable safe context roots into `.aragora/goal-cycle-context/` before invoking panel/goal-cycle commands.
- Preserve pass-through behavior for already-safe `.aragora/goal-cycle-context/` and `.aragora/conductor_cycles/` inputs.
- Block lanes with missing, directory, or unreadable context sources instead of launching a panel that would silently drop operator context.
- Document the operator context contract in `docs/guides/CONDUCTOR_WORKFLOW.md`.

Fable cycle artifact: `.aragora/goal_cycles/20260708T121131Z/next_prompt.md`

## Validation
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m pytest tests/scripts/test_fable_goal_cycle.py tests/scripts/test_goal_conductor.py -q`
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m ruff check scripts/goal_conductor.py tests/scripts/test_goal_conductor.py`
- `PATH=/Users/armand/.pyenv/versions/3.11.11/bin:$PATH python3 -m ruff format --check scripts/goal_conductor.py tests/scripts/test_goal_conductor.py`
- `git diff --check origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Boundaries
No workflow, branch-protection, evidence, settlement, or merge changes.