### PR TITLE
docs(conductor): wrong-hill disclosure clause + per-object lock scoping

### DIFF
--- a/.agents/skills/fable-goal-cycle/SKILL.md
+++ b/.agents/skills/fable-goal-cycle/SKILL.md
@@ -41,6 +41,13 @@ standard — something that takes frontier judgment to WRITE but only ordinary
 intelligence to APPLY (charters, rubrics, playbooks, skills, checkers). Test:
 could a cheaper model redo this artifact tomorrow? If yes, rank it lower.
 
+Wrong-hill disclosure: before ranking goals, if the standing mission metric
+itself is the wrong hill — mis-specified, superseded by events, or clearly
+worse than an adjacent goal — the consult is expected to say so FIRST in a
+dedicated 'WRONG HILL' section with one-paragraph evidence, and propose the
+better goal. Misalignment disclosure is invited and costs nothing; grinding a
+bad metric costs cycles.
+
 Useful flags: `--dry-run` (build the packet only — inspect it before spending
 a consult), `--context-file <path>` (repeatable; include a redacted cycle
 report or steering note only after placing it under

--- a/docs/AGENT_OPERATING_CONTRACT.md
+++ b/docs/AGENT_OPERATING_CONTRACT.md
@@ -245,7 +245,24 @@ a worker implementation lane.
 Dependabot/Tier-3 merge the operator authorized at an exact head) is reported as "merged
 under explicit operator override", never as "the helper said it was safe".
 
+#### Per-object locks (single-conductor rule scope)
+
+The single-conductor rule prevents two lanes mutating the **same object**; it is not a
+global mutex on running processes. Locks are scoped by object type:
+
+- **Branch work** — a `scripts/check_work_lease.py` claim on the branch.
+- **PR settlement** — a conductor ownership declaration on the PR/issue.
+- **Harvest items** (issue #8993 protocol) — a claim comment on the issue: claim first,
+  then execute; on a race, the later claim timestamp yields.
+
+A sighted goal-cycle/consult process elsewhere is **not** a collision absent a conflicting
+claim or lease on the same object; standing down on process sightings alone is the
+false-collision failure mode (observed 2026-07-08 as a three-cycle false breaker).
+
 #### Thin recursive-prompt template (carry this shape forward, not the rules)
+
+Goal preambles handed to lanes should include the wrong-hill disclosure clause, so lanes
+surface mis-specified metrics before cycling instead of grinding them.
 
 ```text
 Start from live repo truth in <repo>. Do not trust prior transcript state.

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -120,6 +120,11 @@ next cycles. Prefer goals whose output is a durable standard — something that
 takes frontier judgment to WRITE but only ordinary intelligence to APPLY
 (charters, rubrics, playbooks, skills, checkers). Test: could a cheaper model
 redo this artifact tomorrow? If yes, rank it lower.
+Before ranking goals: if the standing mission metric itself is the wrong
+hill — mis-specified, superseded by events, or clearly worse than an adjacent
+goal — say so FIRST in a dedicated 'WRONG HILL' section with one-paragraph
+evidence, and propose the better goal. Misalignment disclosure is invited and
+costs nothing; grinding a bad metric costs cycles.
 
 ## NEXT PLAN
 Bounded steps for ONE cycle only (not a roadmap). Each step must be completable


### PR DESCRIPTION
Operator-approved 2026-07-08.

## Motivation

Two coupled coordination fixes:

1. **False-breaker incident (2026-07-08):** a conductor stood down for three consecutive cycles after merely *sighting* another goal-cycle/consult process, with no conflicting claim or lease on any shared object. The single-conductor rule was being read as a global mutex on running processes. This PR scopes it explicitly to per-object locks (branch lease, PR settlement ownership declaration, harvest-item claim comment per issue #8993 protocol) and names process-sighting stand-downs as the false-collision failure mode.

2. **Misalignment-disclosure channel:** the fable-goal-cycle consult had a durability filter for ranking goals but no invited channel to say the standing mission metric itself is the wrong hill. This PR adds a verbatim WRONG-HILL CLAUSE to the consult's response-format instructions (scripts/fable_goal_cycle.py), mirrors it in .agents/skills/fable-goal-cycle/SKILL.md, and adds one sentence of conductor goal-design guidance so goal preambles carry the clause.

## Changes

- `scripts/fable_goal_cycle.py` — wrong-hill clause adjacent to the NEXT GOALS durability filter in RESPONSE_FORMAT_INSTRUCTIONS (ast.parse-validated).
- `.agents/skills/fable-goal-cycle/SKILL.md` — "Wrong-hill disclosure" paragraph beside the durability-filter paragraph.
- `docs/AGENT_OPERATING_CONTRACT.md` §Conductor — new "Per-object locks (single-conductor rule scope)" subsection + goal-preamble sentence ahead of the thin recursive-prompt template.

Note: touches §Conductor, so per the contract this is merge-authority governance — Tier 4, requires human risk settlement (draft accordingly).

Validation: ast.parse OK; `scripts/check_docs_consistency.py` all checks PASS; `git diff --check` clean.

Refs #8978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)