### PR TITLE
docs(runbooks): settlement queue partition ledger 2026-07-08

### DIFF
--- a/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
+++ b/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
@@ -1,0 +1,116 @@
+# Settlement Queue Partition Ledger - 2026-07-08
+
+Generated: 2026-07-08T15:05Z
+
+Base: `origin/main` at `2caed5d61fa0f80b632a86ab7971a9bb884b0b8f`
+
+Purpose: provide a live, reproducible partition of the open non-draft settlement queue after the #9001 merge so conductor cycles can drain one safe item without re-scanning the same blocked lanes.
+
+## Main Context
+
+Branch protection currently requires:
+
+- `lint`
+- `typecheck`
+- `sdk-parity`
+- `Generate & Validate`
+- `TypeScript SDK Type Check`
+- `aragora-merge-quorum`
+
+Exact-head check-runs observed for `2caed5d61fa0f80b632a86ab7971a9bb884b0b8f`:
+
+- `lint`: success
+- `typecheck`: success
+- `sdk-parity`: success
+- `Generate & Validate`: success
+- `TypeScript SDK Type Check`: success
+- `aragora-merge-quorum`: skipped for main
+
+The shared root checkout was not used for edits. It was on `codex/required-context-main-push-policy-20260707` with pre-existing modified files, so this ledger was generated from an isolated worktree.
+
+## Inputs
+
+Raw helper outputs for this run were written outside the repo:
+
+- `/tmp/aragora_queue_ledger_20260708T145542Z/non_draft_prs_final.json`
+- `/tmp/aragora_queue_ledger_20260708T145542Z/steward-<pr>.json`
+- `/tmp/aragora_queue_ledger_20260708T145542Z/owner-<pr>.json`
+- `/tmp/aragora_queue_ledger_20260708T145542Z/packet-<pr>.json` for targeted quorum-blocked PRs
+
+Regeneration sketch:
+
+```bash
+git fetch origin --prune
+gh pr list --repo synaptent/aragora --state open --draft=false --limit 200 \
+  --json number,title,headRefName,headRefOid,updatedAt,mergeStateStatus,isDraft,author
+for pr in $(gh pr list --repo synaptent/aragora --state open --draft=false --limit 200 --json number --jq '.[].number'); do
+  timeout 180 python3 scripts/settle_one_pr.py --pr "$pr" --json > "/tmp/steward-$pr.json"
+  timeout 45 python3 scripts/read_operator_steering.py --pr "$pr" --json --no-receipt > "/tmp/owner-$pr.json" || true
+done
+```
+
+## Rubric
+
+Each open non-draft PR is placed in exactly one live bucket, using this precedence:
+
+1. Active-owned lane if owner/steering metadata resolves a current lane for the PR.
+2. Parked at current head if repo-visible comments record repeat blocker or current-head dry-run dissent for the exact live head.
+3. Tier 3/4 or human-risk if helpers require human-risk settlement or classify the PR at Tier 3+.
+4. Policy-excluded Dependabot when it is a dependency bot PR not otherwise already caught by a stronger bucket.
+5. Dirty/conflicting if merge metadata or policy exclusions report dirty/conflicting state.
+6. Autonomous evidence candidate if it is Tier 0-2, non-human-risk, unowned, non-draft, and blocked only by merge-quorum/model evidence.
+7. Transport-limited if helper data is unavailable.
+
+Unresolved `CHANGES-REQUESTED`, `Verdict: CHANGES-REQUESTED`, `[P0]`, `[P1]`, or concrete `[P2]` evidence is a hard stop for evidence or settlement even when a helper also reports countable support.
+
+## Partition
+
+Counts:
+
+| Bucket | Count |
+| --- | ---: |
+| Autonomous evidence candidate | 1 |
+| Parked at current head | 2 |
+| Active-owned lane | 7 |
+| Tier 3/4 or human-risk | 7 |
+| Policy-excluded Dependabot | 4 |
+
+| Bucket | PR | Head | Branch | Reason |
+| --- | ---: | --- | --- | --- |
+| Autonomous evidence candidate | #9012 | `c9fa521f4044` | `factory/pum-m6-docs-scrutiny-fixes` | Tier 2; non-quorum checks green, merge-quorum failing due missing model/dogfood evidence; unresolved dissent is false. |
+| Parked at current head | #9009 | `0ffdbbaae531` | `codex/goal-conductor-context-materialize-20260708` | Repo-visible current-head park record after OpenAI and Grok `CHANGES-REQUESTED` dry-run. |
+| Active-owned lane | #8995 | `2a8cb9d8987b` | `codex/charter-checker-fixture-precision-20260707` | Owner `codex-conductor-pr8995-evidence-20260708T0336Z`; no receipt written. |
+| Active-owned lane | #8992 | `ac2e6a35f183` | `codex/settlement-preflight-classifier-20260707` | Owner `session-armand@Mac` via lane `codex/pr8992-settlement-preflight-20260707`; no receipt written. |
+| Parked at current head | #8970 | `256cbba5d2a5` | `factory/pum-m5-packaging-deps-pr` | Repo-visible repeat-blocker park record at exact head; operator-review-required gate present. |
+| Active-owned lane | #8961 | `6c90e8b45fb1` | `codex/founder-decision-queue-complete-pending` | Owner `codex-conductor-pr8961-evidence-20260708T0658Z`; no receipt written. |
+| Active-owned lane | #8948 | `e619f2a82aab` | `codex/prompt-handoff-outbox-20260706T1541Z` | Owner `codex-conductor-pr8948-prompt-retry-repair-20260708T144303Z`; no receipt written. |
+| Tier 3/4 or human-risk | #8945 | `7b30e8ffbec3` | `codex/verify-post-publish-aragora-verify-20260706T1518Z` | `requires_human_risk_settlement=true`. |
+| Tier 3/4 or human-risk | #8931 | `8adc0f8e6a48` | `codex/settle-policy-park-dependabot-20260706` | `requires_human_risk_settlement=true`. |
+| Policy-excluded Dependabot | #8924 | `416fb013bd4a` | `dependabot/pip/uvicorn-gte-0.50.0-and-lt-1.0` | Dependabot PR excluded from autonomous settlement in this lane. |
+| Policy-excluded Dependabot | #8923 | `48ec93213932` | `dependabot/pip/fastapi-gte-0.139.0-and-lt-1.0` | Dependabot PR excluded from autonomous settlement in this lane. |
+| Policy-excluded Dependabot | #8922 | `3311a665b1b2` | `dependabot/pip/playwright-gte-1.61.0-and-lt-2.0` | Dependabot PR excluded from autonomous settlement in this lane. |
+| Policy-excluded Dependabot | #8921 | `d826520ae9a5` | `dependabot/pip/hatchling-gte-1.30.1-and-lt-2.0` | Dependabot PR excluded from autonomous settlement in this lane. |
+| Tier 3/4 or human-risk | #8920 | `6f4ae553e18d` | `dependabot/npm_and_yarn/aragora/live/supabase/supabase-js-2.110.0` | `requires_human_risk_settlement=true`. |
+| Tier 3/4 or human-risk | #8917 | `0d578344432f` | `dependabot/npm_and_yarn/sdk/typescript/sdk-deps-f002f4927b` | `requires_human_risk_settlement=true`. |
+| Active-owned lane | #8879 | `89d17eb9a550` | `codex/pr8811-adjudication-stall-salvage-20260705` | Owner `codex-pr8879-tier4-evidence-20260705T174839Z`; no receipt written. |
+| Active-owned lane | #8823 | `eed70b0a4005` | `codex/epistemic-question-batteries-8815` | Owner `codex-pr8823-cycle8-evidence-20260706T050108Z`; no receipt written. |
+| Tier 3/4 or human-risk | #8809 | `a7006b16317d` | `claude/odr-signing-key-endpoint-8804` | `requires_human_risk_settlement=true`. |
+| Tier 3/4 or human-risk | #8756 | `af4e82ebf149` | `worktree-m0a-operator-dissent-post-path` | `requires_human_risk_settlement=true`. |
+| Tier 3/4 or human-risk | #8519 | `1826013d4833` | `vision-incubator/agt-04-github-event-resolver` | `requires_human_risk_settlement=true`. |
+| Active-owned lane | #8406 | `ac8d65f17850` | `codex/settle-tier4-rest-fallback-20260614` | Owner `engineering-autopilot-2-Q558-pr8406-test-fast-rerun-20260615T052547Z`; no receipt written. |
+
+## External Change During Sweep
+
+PR #8908 was open when the initial non-draft list was captured, then closed externally at `2026-07-08T15:02:23Z` while this ledger was running. It is intentionally omitted from the live open partition above. Its preserved branch/head was `codex/steering-message-ack-flow-20260706` at `7848d6ad02551a03bb283b0e60e466a9bb2fd4bb`.
+
+## Safe Next Action
+
+The only unowned Tier 0-2 non-human-risk item found in the live non-draft queue is #9012. It is not merge-ready; it needs current-head evidence collection first.
+
+Paste-ready next prompt:
+
+```text
+Start from live truth in the Aragora repo root. Goal: collect only the minimum current-head evidence for non-draft PR #9012 at exact head c9fa521f4044b6984e904a04f54ecc7e006a4e95, without marking ready, merging, using --admin, rerunning workflows, touching outbox/receipts, labels, branch protection, unrelated PRs/worktrees, queue settlement state, deploy/workflow/security/auth/RBAC/public-API surfaces, product-proof, or human-risk settlement state.
+
+Check mailbox/owner state read-only/no receipt if possible for #9012 and branch factory/pum-m6-docs-scrutiny-fixes; fetch; verify exact head/open/non-draft/unowned/mergeable, required checks are green except aragora-merge-quorum, Tier 2, requires_human_risk_settlement=false, unresolved_dissent=false, and the only blocker is missing focused dogfood/model quorum. Run focused current-head dogfood for the M6 docs scrutiny fixes, then exactly the minimum no-publish model reviews required by policy from counted healthy families. If reviews are non-blocking and countable, post no more than the minimum evidence comments required by policy, rerun review-queue merge-packet --pr 9012 --json and settle_one_pr.py --json --pr 9012, and report readiness without marking ready or merging.
+```

--- a/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
+++ b/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
@@ -121,9 +121,11 @@ New-arrival intake rule:
 3. If `operator-review-required` is present, treat the PR as a handoff target, not autonomous settlement-ready.
 4. Re-run targeted `merge-packet` before any evidence or settlement prompt; do not rely on the ledger snapshot.
 
+Post-amendment live check: #9013 merged externally at `2026-07-08T15:13:42Z` with merge commit `32e692ed2162cea7abf36ea83c1843d30d684007`. Its source branch was deleted. #9012 remained open at `c9fa521f4044b6984e904a04f54ecc7e006a4e95` with `operator-review-required` still present.
+
 ## Safe Next Action
 
-No autonomous merge target was found. #9013 is under an active external lane, and #9012 is blocked by the operator-review-required gate before it can be treated as settlement-ready.
+No autonomous merge target was found. #9013 merged externally during the intake update, and #9012 is blocked by the operator-review-required gate before it can be treated as settlement-ready.
 
 Paste-ready next prompt:
 

--- a/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
+++ b/docs/runbooks/2026-07-08-settlement-queue-partition-ledger.md
@@ -103,14 +103,32 @@ Counts:
 
 PR #8908 was open when the initial non-draft list was captured, then closed externally at `2026-07-08T15:02:23Z` while this ledger was running. It is intentionally omitted from the live open partition above. Its preserved branch/head was `codex/steering-message-ack-flow-20260706` at `7848d6ad02551a03bb283b0e60e466a9bb2fd4bb`.
 
+## New-Arrival Intake Update
+
+Checked: 2026-07-08T15:13Z
+
+After this ledger was published, #9013 entered the non-draft queue and #9012 received additional governance context. Follow-up classification:
+
+| PR | Head | Tier | Diff Scope | Lane Owner / Competing Work | Verdict |
+| --- | --- | --- | --- | --- | --- |
+| #9013 | `36a97bcda23e` | Tier 2 per `merge-packet` | `.agents/skills/fable-goal-cycle/SKILL.md`, `docs/AGENT_OPERATING_CONTRACT.md`, `scripts/fable_goal_cycle.py` | A separate `collect_quorum_evidence.py` / settlement shell was already running against #9013; repo-visible Claude/OpenAI evidence and a scarmani settlement comment already existed. | Do not start another lane. `merge-packet` reported counted Claude/OpenAI evidence, 19/19 checks green, `unresolved_dissent=false`, but `mergeStateStatus=UNSTABLE`; this is not a merge target for this ledger cycle. |
+| #9012 | `c9fa521f4044` | Tier 2 | M6 docs and two docs-check scripts | No owner lane matched, but the PR has `operator-review-required`. | Not autonomous-settlement-ready. `merge-packet` reported `operator_review_required=true`, no counted model families, and `admin_squash_gate_blockers=["operator-review-required label present"]`. |
+
+New-arrival intake rule:
+
+1. Record PR number, exact head SHA, tier, diff scope, lane owner or competing process, and verdict.
+2. If any competing evidence or settlement process already targets the PR, stop instead of opening a second lane.
+3. If `operator-review-required` is present, treat the PR as a handoff target, not autonomous settlement-ready.
+4. Re-run targeted `merge-packet` before any evidence or settlement prompt; do not rely on the ledger snapshot.
+
 ## Safe Next Action
 
-The only unowned Tier 0-2 non-human-risk item found in the live non-draft queue is #9012. It is not merge-ready; it needs current-head evidence collection first.
+No autonomous merge target was found. #9013 is under an active external lane, and #9012 is blocked by the operator-review-required gate before it can be treated as settlement-ready.
 
 Paste-ready next prompt:
 
 ```text
-Start from live truth in the Aragora repo root. Goal: collect only the minimum current-head evidence for non-draft PR #9012 at exact head c9fa521f4044b6984e904a04f54ecc7e006a4e95, without marking ready, merging, using --admin, rerunning workflows, touching outbox/receipts, labels, branch protection, unrelated PRs/worktrees, queue settlement state, deploy/workflow/security/auth/RBAC/public-API surfaces, product-proof, or human-risk settlement state.
+Start from live truth in the Aragora repo root. Goal: reclassify non-draft PR #9012 at exact head c9fa521f4044b6984e904a04f54ecc7e006a4e95 and prepare the smallest operator-review handoff, without collecting evidence, marking ready, merging, using --admin, rerunning workflows, touching outbox/receipts, labels, branch protection, unrelated PRs/worktrees, queue settlement state, deploy/workflow/security/auth/RBAC/public-API surfaces, product-proof, or human-risk settlement state.
 
-Check mailbox/owner state read-only/no receipt if possible for #9012 and branch factory/pum-m6-docs-scrutiny-fixes; fetch; verify exact head/open/non-draft/unowned/mergeable, required checks are green except aragora-merge-quorum, Tier 2, requires_human_risk_settlement=false, unresolved_dissent=false, and the only blocker is missing focused dogfood/model quorum. Run focused current-head dogfood for the M6 docs scrutiny fixes, then exactly the minimum no-publish model reviews required by policy from counted healthy families. If reviews are non-blocking and countable, post no more than the minimum evidence comments required by policy, rerun review-queue merge-packet --pr 9012 --json and settle_one_pr.py --json --pr 9012, and report readiness without marking ready or merging.
+Check mailbox/owner state read-only/no receipt if possible for #9012 and branch factory/pum-m6-docs-scrutiny-fixes; fetch; verify exact head/open/non-draft/unowned/mergeable, required checks are green except aragora-merge-quorum, Tier 2, requires_human_risk_settlement=false, unresolved_dissent=false, and `operator-review-required` is still present. Run `settle_one_pr.py --json --pr 9012` and `review-queue merge-packet --pr 9012 --json`. Report the exact operator-review blocker, whether model/dogfood evidence is still missing, and the smallest explicit authorization prompt needed before evidence collection or settlement.
 ```


### PR DESCRIPTION
## Summary\n- add a live settlement queue partition ledger after origin/main 2caed5d61fa0f80b632a86ab7971a9bb884b0b8f\n- classify the open non-draft queue into evidence candidate, parked, active-owned, Tier 3/4/human-risk, and Dependabot policy-excluded buckets\n- record the safest next prompt for #9012 without collecting evidence, marking ready, or merging\n\n## Validation\n- git diff --check origin/main HEAD\n- bash scripts/automation_pr_preflight.sh origin/main HEAD\n