### PR TITLE
fix(quorum): honor argv reviewer timeout overrides

### DIFF
--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1339,7 +1339,7 @@ def _resolve_grok_build_bin() -> str:
 
 
 def _run_argv_cli_reviewer(
-    family: str, argv: list[str], harness: str, timeout: float = _REVIEWER_TIMEOUT
+    family: str, argv: list[str], harness: str, timeout: float | None = None
 ) -> ReviewerResult:
     """Run a headless single-prompt CLI reviewer (prompt passed as an argv value).
 
@@ -1348,13 +1348,18 @@ def _run_argv_cli_reviewer(
     the review body. Same exact-head composition + evidence-lint as every other
     reviewer decides whether the result can count.
     """
+    effective_timeout = (
+        _timeout_seconds(_REVIEWER_TIMEOUT_ENV, _REVIEWER_TIMEOUT) if timeout is None else timeout
+    )
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=effective_timeout, check=False
+        )
     except FileNotFoundError:
         return ReviewerResult(family, "", False, f"{family} CLI not found: {argv[0]}")
     except subprocess.TimeoutExpired:
         return ReviewerResult(
-            family, "", False, f"{family} CLI timed out after {_format_seconds(timeout)}s"
+            family, "", False, f"{family} CLI timed out after {_format_seconds(effective_timeout)}s"
         )
     except (OSError, subprocess.SubprocessError) as exc:
         return ReviewerResult(family, "", False, f"{type(exc).__name__}: {str(exc)[:200]}")

--- a/tests/cli/commands/test_review_queue.py
+++ b/tests/cli/commands/test_review_queue.py
@@ -6386,6 +6386,7 @@ class TestCommandDispatch:
                 "90",
                 "--overall-timeout",
                 "150",
+                "--apply",
                 "--json",
             ]
         )
@@ -6396,7 +6397,7 @@ class TestCommandDispatch:
         assert ns_collect.author == "an0mium"
         assert ns_collect.reviewer_timeout == 90.0
         assert ns_collect.overall_timeout == 150.0
-        assert ns_collect.apply is False
+        assert ns_collect.apply is True
         assert ns_collect.json_output is True
         # run invocation parses
         ns_run = root.parse_args(["review-queue", "run", "--limit", "3", "--ready-only"])

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -338,6 +338,52 @@ def test_run_claude_cli_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> Non
     )
 
 
+def test_run_argv_cli_reviewer_uses_env_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run(
+        argv: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        check: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        seen.update(
+            {
+                "argv": argv,
+                "capture_output": capture_output,
+                "text": text,
+                "timeout": timeout,
+                "check": check,
+            }
+        )
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout)
+
+    monkeypatch.setenv(qe._REVIEWER_TIMEOUT_ENV, "2.5")
+    monkeypatch.setattr(qe.subprocess, "run", fake_run)
+
+    result = qe._run_argv_cli_reviewer(
+        "grok",
+        ["grok", "--sandbox", "read-only", "-p", "review prompt"],
+        "Grok Build CLI harness",
+    )
+
+    assert seen == {
+        "argv": ["grok", "--sandbox", "read-only", "-p", "review prompt"],
+        "capture_output": True,
+        "text": True,
+        "timeout": 2.5,
+        "check": False,
+    }
+    assert result == ReviewerResult(
+        "grok",
+        "",
+        False,
+        "grok CLI timed out after 2.5s",
+    )
+
+
 def test_run_claude_cli_uses_file_backed_mcp_config(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary

Adopts #8993 S44 onto current `origin/main` as a clean draft PR.

This fixes argv-based CLI reviewers, such as Grok/Grok Build, so they resolve `ARAGORA_REVIEWER_TIMEOUT` at call time instead of binding the module import-time default. It also keeps the current review-queue parser timeout coverage while preserving the S44 `--apply` parser assertion.

## Source

- #8993 item: S44
- Source worktree: `/Users/armand/.codex/worktrees/fix-review-queue-collect-evidence-8343/aragora`
- Source branch/head: `codex/fix-review-queue-collect-evidence-8343` @ `15ecfdabffd840630a2bd9797301a4b9bfffec22`
- Source helper state: preserved, `branch_ahead_of_origin_main`, no cleanup attempted
- Adoption branch lease: `1c8e6178-c52`

## Validation

- `python3 -m pytest tests/swarm/test_quorum_evidence.py::test_run_argv_cli_reviewer_uses_env_timeout tests/cli/commands/test_review_queue.py::TestCommandDispatch::test_parser_registers_build_packet_run_and_act -q`
- Commit/push hooks passed, including ruff, ruff format, gitleaks, portability guard, and mypy for changed Aragora files.

## Safety

Draft only. No evidence collection, settlement, mark-ready, merge, CI rerun, workflow/branch-protection edit, `--admin`, force-push, raw deletion, branch deletion, or source-worktree cleanup was performed.
