### PR TITLE
test(cli): isolate provider preflight from offline mode

### DIFF
--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -350,6 +350,7 @@ class TestCommandHandlers:
         """Should fail before debate when any selected provider cannot be configured."""
         from aragora.cli.main import cmd_ask
 
+        monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
         monkeypatch.setenv("GROK_API_KEY", "test-grok-key")
         monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- Fixes the current-main/full-shard provider-readiness test drift exposed by #9011.
- Makes the selected-provider-missing test explicitly clear ARAGORA_OFFLINE so it always exercises the intended provider-preflight path.
- Avoids touching #9011 park-record helper files or the broader autouse fixture surface.

## Validation
- ARAGORA_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/test_cli_main.py::TestCommandHandlers::test_cmd_ask_exits_when_selected_agent_provider_is_missing -q -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/test_cli_main.py::TestCommandHandlers -q -p no:cacheprovider
- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/cli/test_cli_main.py::TestCommandHandlers::test_cmd_ask_exits_when_selected_agent_provider_is_missing tests/cli/test_cli_main.py::TestCommandHandlers::test_cmd_ask_exits_when_all_agents_return_failure_placeholders -q -p no:cacheprovider
- python3 -m ruff check tests/cli/test_cli_main.py
- python3 -m ruff format --check tests/cli/test_cli_main.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- Full tests/cli/test_cli_main.py still has an unrelated local TestMain parser/sys.argv failure on current main; this PR intentionally does not widen scope to that issue.
- After this lands, resume #9011 at head 5bd7531ad46eaa75b3d5cc98374f2e2454d8d0a4 and re-check non-quorum checks before evidence/preapproval.