### PR TITLE
feat(scripts): harness weakness miner (#8973)

### DIFF
--- a/docs/runbooks/HARNESS_WEAKNESS_MINER.md
+++ b/docs/runbooks/HARNESS_WEAKNESS_MINER.md
@@ -1,0 +1,39 @@
+# Harness Weakness Miner
+
+`scripts/harness_weakness_miner.py` is advisory self-harness tooling for issue
+#8973. It reads gate receipts, exported PR/issue comments, and conductor ledger
+records, then produces a ranked weakness report for the harness-edit proposer.
+It does not mutate receipts, GitHub comments, branches, evidence, settlement
+state, or merge gates.
+
+Default usage keeps the report local under `.aragora/`:
+
+```bash
+python3 scripts/harness_weakness_miner.py \
+  --output .aragora/harness-weakness-reports/latest.md \
+  --json
+```
+
+The production path uses the bounded Claude consult helper to classify examples
+by causal mechanism and harness surface. The classifier output feeds two passes:
+
+- `taxonomy_seeded`: groups examples against
+  `docs/artifacts/2026-07-reviewer-failure-taxonomy.md`.
+- `emergent_bottom_up`: groups model-written evidence summaries by explicit
+  emergent cluster keys or, when those are absent, a local density-style
+  similarity pass over the summaries.
+
+Tests and offline repros should avoid live model calls by supplying fixture
+classifications:
+
+```bash
+python3 scripts/harness_weakness_miner.py \
+  --input-json tests/fixtures/harness-weakness/examples.json \
+  --classification-json tests/fixtures/harness-weakness/classifications.json \
+  --output /tmp/harness-weakness-report.md \
+  --json
+```
+
+Committed scheduling, required-check wiring, branch-protection changes, and
+automatic harness edits are intentionally out of scope. A report is reviewable
+input only; follow-up changes need their own bounded PRs and normal gates.

--- a/docs/runbooks/HARNESS_WEAKNESS_MINER.md
+++ b/docs/runbooks/HARNESS_WEAKNESS_MINER.md
@@ -23,6 +23,10 @@ by causal mechanism and harness surface. The classifier output feeds two passes:
   emergent cluster keys or, when those are absent, a local density-style
   similarity pass over the summaries.
 
+The `--since-days` window applies to every input source. Examples with missing,
+malformed, stale, or future timestamps are excluded so untrusted metadata cannot
+inflate recent weakness counts.
+
 Tests and offline repros should avoid live model calls by supplying fixture
 classifications:
 

--- a/scripts/harness_weakness_miner.py
+++ b/scripts/harness_weakness_miner.py
@@ -8,19 +8,25 @@ import json
 import re
 import subprocess
 import sys
+import tempfile
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Iterable, Sequence
+from urllib.parse import quote
 
 
+UTC = timezone.utc
 SEVERITY_WEIGHTS = {"P0": 13, "P1": 8, "P2": 5, "P3": 2, "INFO": 1}
 SECRET_PATTERNS = [
     re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-    re.compile(r"(?i)\b([A-Z0-9_]*(?:API_KEY|TOKEN|SECRET))\s*[:=]\s*\S+"),
+    re.compile(
+        r"""(?ix)(?P<quote>["']?)\b[A-Z0-9_]*(?:API_KEY|TOKEN|SECRET)\b"""
+        r"""(?P=quote)\s*[:=]\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,}]+)"""
+    ),
 ]
 SEVERITY_RE = re.compile(r"\[(P[0-3])\]|\b(P[0-3])\b")
 TAXONOMY_HEADING_RE = re.compile(r"^#{2,4}\s+(\d+)\.\s+(.+?)\s*$")
@@ -149,6 +155,16 @@ def _target_label(value: Any) -> str:
     return str(value)
 
 
+def _target_value(mapping: dict[str, Any]) -> Any:
+    if mapping.get("target") not in (None, ""):
+        return mapping["target"]
+    if mapping.get("pr") is not None:
+        return {"pr": mapping["pr"]}
+    if mapping.get("issue") is not None:
+        return {"issue": mapping["issue"]}
+    return None
+
+
 def _within_window(created_at: str, *, since_days: int, now: datetime) -> bool:
     try:
         parsed = parse_timestamp(created_at)
@@ -201,7 +217,7 @@ def _load_input_examples(path: Path) -> list[WeaknessExample]:
             WeaknessExample(
                 id=str(item.get("id") or f"input:{index}"),
                 source=str(item.get("source") or "input"),
-                target=_target_label(item.get("target") or item.get("pr") or item.get("issue")),
+                target=_target_label(_target_value(item)),
                 created_at=str(item.get("created_at") or item.get("timestamp") or ""),
                 severity=_severity_from_text(text, str(item.get("severity") or "")),
                 text=text,
@@ -232,7 +248,7 @@ def _load_ledger_examples(path: Path, *, since_days: int, now: datetime) -> list
             WeaknessExample(
                 id=f"ledger:{path.name}:{line_no}",
                 source="ledger",
-                target=_target_label(record.get("target") or record.get("pr")),
+                target=_target_label(_target_value(record)),
                 created_at=created_at,
                 severity=_severity_from_text(text, str(record.get("severity") or "")),
                 text=text,
@@ -265,7 +281,7 @@ def _load_comment_examples(path: Path, *, since_days: int, now: datetime) -> lis
             WeaknessExample(
                 id=str(item.get("id") or f"comment:{item.get('pr') or 'unknown'}:{index}"),
                 source="github_comment",
-                target=_target_label(item.get("target") or item.get("pr") or item.get("issue")),
+                target=_target_label(_target_value(item)),
                 created_at=created_at,
                 severity=_severity_from_text(text, str(item.get("severity") or "")),
                 text=text,
@@ -371,13 +387,16 @@ def _consult_classifier(
         "taxonomy": taxonomy,
         "examples": compact_examples,
     }
-    proc = subprocess.run(
-        [sys.executable, str(consult), "--json", json.dumps(prompt, sort_keys=True)],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    with tempfile.TemporaryDirectory(prefix="aragora-harness-weakness-") as temp_dir:
+        prompt_path = Path(temp_dir) / "classifier-prompt.json"
+        prompt_path.write_text(json.dumps(prompt, sort_keys=True), encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(consult), "--json", "--prompt-file", str(prompt_path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
     if proc.returncode != 0:
         raise RuntimeError(f"LLM classifier failed: {proc.stderr.strip() or proc.stdout.strip()}")
     envelope = json.loads(proc.stdout)
@@ -535,20 +554,19 @@ def _emergent_clusters(
     min_cluster_size: int,
     similarity_threshold: float,
 ) -> list[WeaknessCluster]:
-    explicit_groups: dict[str, list[ClassifiedExample]] = defaultdict(list)
+    groups: dict[str, list[ClassifiedExample]] = defaultdict(list)
     unlabelled: list[ClassifiedExample] = []
     for item in classified:
         if item.emergent_cluster:
-            explicit_groups[item.emergent_cluster].append(item)
+            groups[_normalize_key(item.emergent_cluster)].append(item)
         else:
             unlabelled.append(item)
-    groups = list(explicit_groups.items())
     for component in _density_components(unlabelled, threshold=similarity_threshold):
         if not component:
             continue
-        groups.append((_normalize_key(component[0].causal_mechanism), component))
+        groups[_normalize_key(component[0].causal_mechanism)].extend(component)
     clusters: list[WeaknessCluster] = []
-    for label, examples in groups:
+    for label, examples in groups.items():
         if len({item.id for item in examples}) < min_cluster_size:
             continue
         mechanism = _summarize_mechanisms(examples)
@@ -670,15 +688,32 @@ def render_markdown(result: MiningResult) -> str:
             ]
         )
         for item in cluster.examples:
-            evidence = item.evidence_summary.replace("\n", " ").strip()
+            evidence = _markdown_cell(item.evidence_summary)
             if len(evidence) > 180:
                 evidence = f"{evidence[:177]}..."
-            target = item.target
+            target = _markdown_cell(item.target)
             if item.url:
-                target = f"[{target}]({item.url})"
-            lines.append(f"| {target} | `{item.severity}` | `{item.example.source}` | {evidence} |")
+                safe_url = quote(item.url, safe=":/?#@!$&'*+,;=%-._~")
+                target = f"[{target}]({safe_url})"
+            severity = _markdown_cell(item.severity)
+            source = _markdown_cell(item.example.source)
+            lines.append(f"| {target} | `{severity}` | `{source}` | {evidence} |")
         lines.append("")
     return "\n".join(lines)
+
+
+def _markdown_cell(value: Any) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .replace("|", "\\|")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("`", "\\`")
+        .strip()
+    )
 
 
 def _default_ledger_paths(root: Path) -> list[Path]:

--- a/scripts/harness_weakness_miner.py
+++ b/scripts/harness_weakness_miner.py
@@ -166,11 +166,13 @@ def _target_value(mapping: dict[str, Any]) -> Any:
 
 
 def _within_window(created_at: str, *, since_days: int, now: datetime) -> bool:
+    if not created_at.strip():
+        return False
     try:
         parsed = parse_timestamp(created_at)
     except ValueError:
-        return True
-    return parsed >= now - timedelta(days=since_days)
+        return False
+    return now - timedelta(days=since_days) <= parsed <= now
 
 
 def _ledger_text(record: dict[str, Any]) -> str:
@@ -202,7 +204,12 @@ def _comment_is_relevant(body: str) -> bool:
     return any(marker.upper() in upper_body for marker in markers)
 
 
-def _load_input_examples(path: Path) -> list[WeaknessExample]:
+def _load_input_examples(
+    path: Path,
+    *,
+    since_days: int,
+    now: datetime,
+) -> list[WeaknessExample]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, list):
         raise ValueError(f"{path} must contain a JSON list of examples")
@@ -213,12 +220,15 @@ def _load_input_examples(path: Path) -> list[WeaknessExample]:
         text = _redact(str(item.get("text") or item.get("body") or ""))
         if not text.strip():
             continue
+        created_at = str(item.get("created_at") or item.get("timestamp") or "")
+        if not _within_window(created_at, since_days=since_days, now=now):
+            continue
         examples.append(
             WeaknessExample(
                 id=str(item.get("id") or f"input:{index}"),
                 source=str(item.get("source") or "input"),
                 target=_target_label(_target_value(item)),
-                created_at=str(item.get("created_at") or item.get("timestamp") or ""),
+                created_at=created_at,
                 severity=_severity_from_text(text, str(item.get("severity") or "")),
                 text=text,
                 url=str(item["url"]) if item.get("url") else None,
@@ -239,7 +249,7 @@ def _load_ledger_examples(path: Path, *, since_days: int, now: datetime) -> list
         if not isinstance(record, dict):
             continue
         created_at = str(record.get("timestamp") or record.get("generated_at") or "")
-        if created_at and not _within_window(created_at, since_days=since_days, now=now):
+        if not _within_window(created_at, since_days=since_days, now=now):
             continue
         text = _redact(_ledger_text(record))
         if not text:
@@ -274,7 +284,7 @@ def _load_comment_examples(path: Path, *, since_days: int, now: datetime) -> lis
         if not _comment_is_relevant(body):
             continue
         created_at = str(item.get("created_at") or item.get("createdAt") or "")
-        if created_at and not _within_window(created_at, since_days=since_days, now=now):
+        if not _within_window(created_at, since_days=since_days, now=now):
             continue
         text = _redact(body)
         examples.append(
@@ -302,7 +312,7 @@ def collect_examples(
     now = now or datetime.now(UTC)
     examples: list[WeaknessExample] = []
     if input_json is not None:
-        examples.extend(_load_input_examples(input_json))
+        examples.extend(_load_input_examples(input_json, since_days=since_days, now=now))
     for path in ledger_paths:
         if path.exists():
             examples.extend(_load_ledger_examples(path, since_days=since_days, now=now))

--- a/scripts/harness_weakness_miner.py
+++ b/scripts/harness_weakness_miner.py
@@ -1,0 +1,766 @@
+#!/usr/bin/env python3
+"""Mine recurring harness weaknesses from gate receipts and conductor traces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+SEVERITY_WEIGHTS = {"P0": 13, "P1": 8, "P2": 5, "P3": 2, "INFO": 1}
+SECRET_PATTERNS = [
+    re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"(?i)\b([A-Z0-9_]*(?:API_KEY|TOKEN|SECRET))\s*[:=]\s*\S+"),
+]
+SEVERITY_RE = re.compile(r"\[(P[0-3])\]|\b(P[0-3])\b")
+TAXONOMY_HEADING_RE = re.compile(r"^#{2,4}\s+(\d+)\.\s+(.+?)\s*$")
+TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]{1,}")
+
+
+@dataclass(frozen=True)
+class WeaknessExample:
+    id: str
+    source: str
+    target: str
+    created_at: str
+    severity: str
+    text: str
+    url: str | None = None
+
+
+@dataclass(frozen=True)
+class ClassifiedExample:
+    example: WeaknessExample
+    taxonomy_id: str
+    finding_class: str
+    causal_mechanism: str
+    harness_surface: str
+    emergent_cluster: str
+    evidence_summary: str
+
+    @property
+    def id(self) -> str:
+        return self.example.id
+
+    @property
+    def severity(self) -> str:
+        return self.example.severity
+
+    @property
+    def target(self) -> str:
+        return self.example.target
+
+    @property
+    def url(self) -> str | None:
+        return self.example.url
+
+
+@dataclass(frozen=True)
+class WeaknessCluster:
+    pass_name: str
+    cluster_key: str
+    title: str
+    finding_class: str
+    causal_mechanism: str
+    harness_surfaces: list[str]
+    rank_score: int
+    examples: list[ClassifiedExample]
+
+    @property
+    def example_count(self) -> int:
+        return len(self.examples)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["example_count"] = self.example_count
+        return payload
+
+
+@dataclass(frozen=True)
+class MiningResult:
+    ok: bool
+    generated_at: str
+    input_count: int
+    classified_count: int
+    clusters: list[WeaknessCluster]
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "generated_at": self.generated_at,
+            "input_count": self.input_count,
+            "classified_count": self.classified_count,
+            "cluster_count": len(self.clusters),
+            "clusters": [cluster.to_dict() for cluster in self.clusters],
+            "warnings": self.warnings,
+        }
+
+
+def parse_timestamp(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _redact(text: str) -> str:
+    redacted = text
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED_SECRET]", redacted)
+    return redacted
+
+
+def _severity_from_text(text: str, explicit: str | None = None) -> str:
+    if explicit:
+        normalized = explicit.strip().upper()
+        if normalized in SEVERITY_WEIGHTS:
+            return normalized
+    match = SEVERITY_RE.search(text)
+    if not match:
+        return "INFO"
+    return next(group for group in match.groups() if group)
+
+
+def _target_label(value: Any) -> str:
+    if isinstance(value, dict):
+        if value.get("pr") is not None:
+            return f"PR #{value['pr']}"
+        if value.get("issue") is not None:
+            return f"issue #{value['issue']}"
+        if value.get("branch"):
+            return f"branch {value['branch']}"
+        return json.dumps(value, sort_keys=True)
+    if value is None:
+        return "unknown"
+    return str(value)
+
+
+def _within_window(created_at: str, *, since_days: int, now: datetime) -> bool:
+    try:
+        parsed = parse_timestamp(created_at)
+    except ValueError:
+        return True
+    return parsed >= now - timedelta(days=since_days)
+
+
+def _ledger_text(record: dict[str, Any]) -> str:
+    pieces: list[str] = []
+    for key in ("blocker_class", "result", "progress_kind", "action"):
+        value = record.get(key)
+        if value:
+            pieces.append(f"{key}: {value}")
+    blockers = record.get("blockers")
+    if isinstance(blockers, list):
+        pieces.extend(str(item) for item in blockers)
+    elif blockers:
+        pieces.append(str(blockers))
+    return "\n".join(pieces).strip()
+
+
+def _comment_is_relevant(body: str) -> bool:
+    markers = (
+        "CHANGES-REQUESTED",
+        "[P0]",
+        "[P1]",
+        "[P2]",
+        "[P3]",
+        "blocker",
+        "dissent",
+        "park record",
+    )
+    upper_body = body.upper()
+    return any(marker.upper() in upper_body for marker in markers)
+
+
+def _load_input_examples(path: Path) -> list[WeaknessExample]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"{path} must contain a JSON list of examples")
+    examples: list[WeaknessExample] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"{path} example {index} is not an object")
+        text = _redact(str(item.get("text") or item.get("body") or ""))
+        if not text.strip():
+            continue
+        examples.append(
+            WeaknessExample(
+                id=str(item.get("id") or f"input:{index}"),
+                source=str(item.get("source") or "input"),
+                target=_target_label(item.get("target") or item.get("pr") or item.get("issue")),
+                created_at=str(item.get("created_at") or item.get("timestamp") or ""),
+                severity=_severity_from_text(text, str(item.get("severity") or "")),
+                text=text,
+                url=str(item["url"]) if item.get("url") else None,
+            )
+        )
+    return examples
+
+
+def _load_ledger_examples(path: Path, *, since_days: int, now: datetime) -> list[WeaknessExample]:
+    examples: list[WeaknessExample] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        created_at = str(record.get("timestamp") or record.get("generated_at") or "")
+        if created_at and not _within_window(created_at, since_days=since_days, now=now):
+            continue
+        text = _redact(_ledger_text(record))
+        if not text:
+            continue
+        examples.append(
+            WeaknessExample(
+                id=f"ledger:{path.name}:{line_no}",
+                source="ledger",
+                target=_target_label(record.get("target") or record.get("pr")),
+                created_at=created_at,
+                severity=_severity_from_text(text, str(record.get("severity") or "")),
+                text=text,
+                url=None,
+            )
+        )
+    return examples
+
+
+def _load_comment_examples(path: Path, *, since_days: int, now: datetime) -> list[WeaknessExample]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        comments = payload.get("comments") or payload.get("items") or []
+    else:
+        comments = payload
+    if not isinstance(comments, list):
+        raise ValueError(f"{path} must contain a list or an object with comments/items")
+    examples: list[WeaknessExample] = []
+    for index, item in enumerate(comments, start=1):
+        if not isinstance(item, dict):
+            continue
+        body = str(item.get("body") or item.get("text") or "")
+        if not _comment_is_relevant(body):
+            continue
+        created_at = str(item.get("created_at") or item.get("createdAt") or "")
+        if created_at and not _within_window(created_at, since_days=since_days, now=now):
+            continue
+        text = _redact(body)
+        examples.append(
+            WeaknessExample(
+                id=str(item.get("id") or f"comment:{item.get('pr') or 'unknown'}:{index}"),
+                source="github_comment",
+                target=_target_label(item.get("target") or item.get("pr") or item.get("issue")),
+                created_at=created_at,
+                severity=_severity_from_text(text, str(item.get("severity") or "")),
+                text=text,
+                url=str(item["url"]) if item.get("url") else None,
+            )
+        )
+    return examples
+
+
+def collect_examples(
+    *,
+    input_json: Path | None = None,
+    ledger_paths: Sequence[Path] = (),
+    comment_json_paths: Sequence[Path] = (),
+    since_days: int = 30,
+    now: datetime | None = None,
+) -> list[WeaknessExample]:
+    now = now or datetime.now(UTC)
+    examples: list[WeaknessExample] = []
+    if input_json is not None:
+        examples.extend(_load_input_examples(input_json))
+    for path in ledger_paths:
+        if path.exists():
+            examples.extend(_load_ledger_examples(path, since_days=since_days, now=now))
+    for path in comment_json_paths:
+        if path.exists():
+            examples.extend(_load_comment_examples(path, since_days=since_days, now=now))
+    return examples
+
+
+def load_taxonomy(path: Path) -> dict[str, str]:
+    taxonomy: dict[str, str] = {}
+    if not path.exists():
+        return taxonomy
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = TAXONOMY_HEADING_RE.match(line)
+        if match:
+            taxonomy[match.group(1)] = match.group(2).strip()
+    return taxonomy
+
+
+def _normalize_key(value: str) -> str:
+    tokens = TOKEN_RE.findall(value.lower().replace("_", "-"))
+    return "-".join(tokens) or "unknown"
+
+
+def _load_classification_fixture(path: Path) -> dict[str, dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return {
+            str(item["id"]): item for item in payload if isinstance(item, dict) and item.get("id")
+        }
+    if isinstance(payload, dict):
+        return {str(key): value for key, value in payload.items() if isinstance(value, dict)}
+    raise ValueError(f"{path} must contain a JSON object or list")
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return json.loads(stripped)
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("classifier output did not contain a JSON object")
+    return json.loads(stripped[start : end + 1])
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _consult_classifier(
+    examples: Sequence[WeaknessExample],
+    taxonomy: dict[str, str],
+    *,
+    timeout: int,
+) -> dict[str, dict[str, Any]]:
+    consult = _repo_root() / "scripts" / "consult_claude.py"
+    if not consult.exists():
+        consult = Path.home() / ".codex" / "skills" / "consult-fable" / "consult_claude.py"
+    if not consult.exists():
+        raise RuntimeError("no consult_claude.py helper found for LLM classification")
+    compact_examples = [
+        {
+            "id": example.id,
+            "source": example.source,
+            "target": example.target,
+            "severity": example.severity,
+            "text": example.text[:1200],
+        }
+        for example in examples
+    ]
+    prompt = {
+        "task": "Classify recurring Aragora harness weakness examples for issue #8973.",
+        "requirements": [
+            "Use taxonomy_id/finding_class when the seed taxonomy applies.",
+            "Name the causal mechanism, not only the surface symptom.",
+            "Name the implicated harness surface.",
+            "Assign an emergent_cluster key suitable for bottom-up grouping.",
+            "Return only a JSON object keyed by example id.",
+        ],
+        "taxonomy": taxonomy,
+        "examples": compact_examples,
+    }
+    proc = subprocess.run(
+        [sys.executable, str(consult), "--json", json.dumps(prompt, sort_keys=True)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"LLM classifier failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    envelope = json.loads(proc.stdout)
+    response_text = str(envelope.get("response") or envelope.get("text") or envelope)
+    payload = _extract_json_object(response_text)
+    return {str(key): value for key, value in payload.items() if isinstance(value, dict)}
+
+
+def _classified_examples(
+    examples: Sequence[WeaknessExample],
+    taxonomy: dict[str, str],
+    *,
+    classification_json: Path | None,
+    classifier: str,
+    classifier_timeout: int,
+) -> tuple[list[ClassifiedExample], list[str]]:
+    warnings: list[str] = []
+    if classification_json is not None:
+        classifications = _load_classification_fixture(classification_json)
+    elif classifier == "llm":
+        classifications = _consult_classifier(examples, taxonomy, timeout=classifier_timeout)
+    else:
+        raise RuntimeError(
+            "classification requires --classification-json or --classifier llm; "
+            "issue #8973 intentionally avoids regex-only clustering"
+        )
+    classified: list[ClassifiedExample] = []
+    for example in examples:
+        item = classifications.get(example.id)
+        if not item:
+            warnings.append(f"missing classification for {example.id}")
+            continue
+        taxonomy_id = str(item.get("taxonomy_id") or "unclassified")
+        finding_class = str(
+            item.get("finding_class") or taxonomy.get(taxonomy_id) or "Unclassified"
+        )
+        causal_mechanism = str(item.get("causal_mechanism") or item.get("mechanism") or "").strip()
+        harness_surface = str(item.get("harness_surface") or item.get("surface") or "").strip()
+        emergent_cluster = str(item.get("emergent_cluster") or "").strip()
+        evidence_summary = str(item.get("evidence_summary") or example.text[:500]).strip()
+        if not causal_mechanism or not harness_surface:
+            warnings.append(f"incomplete classification for {example.id}")
+            continue
+        classified.append(
+            ClassifiedExample(
+                example=example,
+                taxonomy_id=taxonomy_id,
+                finding_class=finding_class,
+                causal_mechanism=causal_mechanism,
+                harness_surface=harness_surface,
+                emergent_cluster=emergent_cluster,
+                evidence_summary=evidence_summary,
+            )
+        )
+    return classified, warnings
+
+
+def _rank_score(examples: Iterable[ClassifiedExample]) -> int:
+    score = 0
+    for item in examples:
+        score += SEVERITY_WEIGHTS.get(item.severity, 1)
+    return score
+
+
+def _cluster_from_group(
+    *,
+    pass_name: str,
+    cluster_key: str,
+    examples: list[ClassifiedExample],
+    title: str,
+    finding_class: str,
+    causal_mechanism: str,
+) -> WeaknessCluster:
+    return WeaknessCluster(
+        pass_name=pass_name,
+        cluster_key=cluster_key,
+        title=title,
+        finding_class=finding_class,
+        causal_mechanism=causal_mechanism,
+        harness_surfaces=sorted({item.harness_surface for item in examples}),
+        rank_score=_rank_score(examples),
+        examples=sorted(examples, key=lambda item: (item.target, item.id)),
+    )
+
+
+def _taxonomy_seeded_clusters(
+    classified: Sequence[ClassifiedExample],
+    *,
+    min_cluster_size: int,
+) -> list[WeaknessCluster]:
+    groups: dict[tuple[str, str], list[ClassifiedExample]] = defaultdict(list)
+    for item in classified:
+        groups[(item.taxonomy_id, _normalize_key(item.causal_mechanism))].append(item)
+    clusters: list[WeaknessCluster] = []
+    for (taxonomy_id, mechanism_key), examples in groups.items():
+        if len({item.id for item in examples}) < min_cluster_size:
+            continue
+        first = examples[0]
+        clusters.append(
+            _cluster_from_group(
+                pass_name="taxonomy_seeded",
+                cluster_key=f"taxonomy:{taxonomy_id}:{mechanism_key}",
+                examples=examples,
+                title=f"{first.finding_class}: {first.causal_mechanism}",
+                finding_class=first.finding_class,
+                causal_mechanism=first.causal_mechanism,
+            )
+        )
+    return sorted(clusters, key=lambda cluster: (-cluster.rank_score, cluster.cluster_key))
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        token
+        for token in TOKEN_RE.findall(text.lower())
+        if token not in {"a", "an", "the", "and", "for", "is", "to"}
+    }
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    if not left or not right:
+        return 0.0
+    return len(left & right) / len(left | right)
+
+
+def _density_components(
+    classified: Sequence[ClassifiedExample],
+    *,
+    threshold: float,
+) -> list[list[ClassifiedExample]]:
+    remaining = set(range(len(classified)))
+    token_sets = [
+        _tokens(f"{item.evidence_summary} {item.causal_mechanism} {item.harness_surface}")
+        for item in classified
+    ]
+    components: list[list[ClassifiedExample]] = []
+    while remaining:
+        seed = remaining.pop()
+        stack = [seed]
+        component_indexes = {seed}
+        while stack:
+            current = stack.pop()
+            for candidate in list(remaining):
+                if _jaccard(token_sets[current], token_sets[candidate]) >= threshold:
+                    remaining.remove(candidate)
+                    component_indexes.add(candidate)
+                    stack.append(candidate)
+        components.append([classified[index] for index in sorted(component_indexes)])
+    return components
+
+
+def _emergent_clusters(
+    classified: Sequence[ClassifiedExample],
+    *,
+    min_cluster_size: int,
+    similarity_threshold: float,
+) -> list[WeaknessCluster]:
+    explicit_groups: dict[str, list[ClassifiedExample]] = defaultdict(list)
+    unlabelled: list[ClassifiedExample] = []
+    for item in classified:
+        if item.emergent_cluster:
+            explicit_groups[item.emergent_cluster].append(item)
+        else:
+            unlabelled.append(item)
+    groups = list(explicit_groups.items())
+    for component in _density_components(unlabelled, threshold=similarity_threshold):
+        if not component:
+            continue
+        groups.append((_normalize_key(component[0].causal_mechanism), component))
+    clusters: list[WeaknessCluster] = []
+    for label, examples in groups:
+        if len({item.id for item in examples}) < min_cluster_size:
+            continue
+        mechanism = _summarize_mechanisms(examples)
+        finding_class = _summarize_finding_classes(examples)
+        clusters.append(
+            _cluster_from_group(
+                pass_name="emergent_bottom_up",
+                cluster_key=f"emergent:{label}",
+                examples=examples,
+                title=f"{finding_class}: {mechanism}",
+                finding_class=finding_class,
+                causal_mechanism=mechanism,
+            )
+        )
+    return sorted(clusters, key=lambda cluster: (-cluster.rank_score, cluster.cluster_key))
+
+
+def _summarize_mechanisms(examples: Sequence[ClassifiedExample]) -> str:
+    counts: dict[str, int] = defaultdict(int)
+    for item in examples:
+        counts[item.causal_mechanism] += 1
+    return sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))[0][0]
+
+
+def _summarize_finding_classes(examples: Sequence[ClassifiedExample]) -> str:
+    counts: dict[str, int] = defaultdict(int)
+    for item in examples:
+        counts[item.finding_class] += 1
+    return sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))[0][0]
+
+
+def build_clusters(
+    classified: Sequence[ClassifiedExample],
+    *,
+    min_cluster_size: int,
+    similarity_threshold: float,
+) -> list[WeaknessCluster]:
+    return [
+        *_taxonomy_seeded_clusters(classified, min_cluster_size=min_cluster_size),
+        *_emergent_clusters(
+            classified,
+            min_cluster_size=min_cluster_size,
+            similarity_threshold=similarity_threshold,
+        ),
+    ]
+
+
+def run_miner(
+    *,
+    input_json: Path | None = None,
+    taxonomy_path: Path,
+    classification_json: Path | None = None,
+    ledger_paths: Sequence[Path] = (),
+    comment_json_paths: Sequence[Path] = (),
+    since_days: int = 30,
+    min_cluster_size: int = 2,
+    similarity_threshold: float = 0.42,
+    classifier: str = "llm",
+    classifier_timeout: int = 600,
+) -> MiningResult:
+    taxonomy = load_taxonomy(taxonomy_path)
+    examples = collect_examples(
+        input_json=input_json,
+        ledger_paths=ledger_paths,
+        comment_json_paths=comment_json_paths,
+        since_days=since_days,
+    )
+    classified, warnings = _classified_examples(
+        examples,
+        taxonomy,
+        classification_json=classification_json,
+        classifier=classifier,
+        classifier_timeout=classifier_timeout,
+    )
+    clusters = build_clusters(
+        classified,
+        min_cluster_size=min_cluster_size,
+        similarity_threshold=similarity_threshold,
+    )
+    return MiningResult(
+        ok=bool(clusters),
+        generated_at=datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        input_count=len(examples),
+        classified_count=len(classified),
+        clusters=clusters,
+        warnings=warnings,
+    )
+
+
+def render_markdown(result: MiningResult) -> str:
+    lines = [
+        "# Harness Weakness Report",
+        "",
+        f"Generated: `{result.generated_at}`",
+        f"Examples classified: `{result.classified_count}/{result.input_count}`",
+        f"Clusters: `{len(result.clusters)}`",
+        "",
+        "This report is advisory input for the harness-edit loop. It does not trigger edits, evidence, settlement, or merges.",
+        "",
+    ]
+    if result.warnings:
+        lines.extend(["## Warnings", ""])
+        for warning in result.warnings:
+            lines.append(f"- {warning}")
+        lines.append("")
+    for index, cluster in enumerate(result.clusters, start=1):
+        lines.extend(
+            [
+                f"## {index}. {cluster.title}",
+                "",
+                f"- Pass: `{cluster.pass_name}`",
+                f"- Key: `{cluster.cluster_key}`",
+                f"- Rank score: `{cluster.rank_score}`",
+                f"- Distinct examples: `{cluster.example_count}`",
+                f"- Harness surfaces: {', '.join(cluster.harness_surfaces)}",
+                "",
+                "| Target | Severity | Source | Evidence |",
+                "| --- | --- | --- | --- |",
+            ]
+        )
+        for item in cluster.examples:
+            evidence = item.evidence_summary.replace("\n", " ").strip()
+            if len(evidence) > 180:
+                evidence = f"{evidence[:177]}..."
+            target = item.target
+            if item.url:
+                target = f"[{target}]({item.url})"
+            lines.append(f"| {target} | `{item.severity}` | `{item.example.source}` | {evidence} |")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _default_ledger_paths(root: Path) -> list[Path]:
+    paths = [root / ".aragora" / "conductor_cycles" / "long_run_ledger.jsonl"]
+    return [path for path in paths if path.exists()]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-json", type=Path, help="Normalized fixture/input examples JSON")
+    parser.add_argument(
+        "--ledger",
+        action="append",
+        type=Path,
+        default=[],
+        help="Conductor ledger JSONL input. Defaults to .aragora/conductor_cycles/long_run_ledger.jsonl when present.",
+    )
+    parser.add_argument(
+        "--comments-json",
+        action="append",
+        type=Path,
+        default=[],
+        help="Exported PR/issue comments JSON fixture. Network fetching is intentionally out of scope.",
+    )
+    parser.add_argument(
+        "--taxonomy",
+        type=Path,
+        default=Path("docs/artifacts/2026-07-reviewer-failure-taxonomy.md"),
+    )
+    parser.add_argument(
+        "--classification-json",
+        type=Path,
+        help="Offline classification fixture keyed by example id",
+    )
+    parser.add_argument("--classifier", choices=["llm"], default="llm")
+    parser.add_argument("--classifier-timeout", type=int, default=600)
+    parser.add_argument("--since-days", type=int, default=30)
+    parser.add_argument("--min-cluster-size", type=int, default=2)
+    parser.add_argument("--similarity-threshold", type=float, default=0.42)
+    parser.add_argument("--output", type=Path, help="Write Markdown report to this path")
+    parser.add_argument("--json", action="store_true", help="Print JSON summary")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    root = _repo_root()
+    taxonomy = args.taxonomy
+    if not taxonomy.is_absolute():
+        taxonomy = root / taxonomy
+    ledger_paths = list(args.ledger)
+    if not ledger_paths and args.input_json is None:
+        ledger_paths = _default_ledger_paths(root)
+    try:
+        result = run_miner(
+            input_json=args.input_json,
+            taxonomy_path=taxonomy,
+            classification_json=args.classification_json,
+            ledger_paths=ledger_paths,
+            comment_json_paths=args.comments_json,
+            since_days=args.since_days,
+            min_cluster_size=args.min_cluster_size,
+            similarity_threshold=args.similarity_threshold,
+            classifier=args.classifier,
+            classifier_timeout=args.classifier_timeout,
+        )
+    except Exception as exc:
+        if args.json:
+            print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(render_markdown(result), encoding="utf-8")
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    else:
+        print(render_markdown(result))
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_harness_weakness_miner.py
+++ b/tests/scripts/test_harness_weakness_miner.py
@@ -1,0 +1,260 @@
+"""Tests for ``scripts/harness_weakness_miner.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_module() -> Any:
+    here = Path(__file__).resolve()
+    script_path = here.parents[2] / "scripts" / "harness_weakness_miner.py"
+    spec = importlib.util.spec_from_file_location(
+        "harness_weakness_miner_under_test",
+        script_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+miner = _load_module()
+
+
+def _write_json(path: Path, payload: Any) -> Path:
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+def _taxonomy(tmp_path: Path) -> Path:
+    path = tmp_path / "taxonomy.md"
+    path.write_text(
+        "\n".join(
+            [
+                "# Taxonomy",
+                "### 1. Diff-blind grounding",
+                "A reviewer reasons over only the changed files.",
+                "### 2. Stale-external-world grounding",
+                "A reviewer relies on stale external state.",
+            ],
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_two_pass_clustering_uses_seeded_and_emergent_identities(tmp_path: Path) -> None:
+    examples_path = _write_json(
+        tmp_path / "examples.json",
+        [
+            {
+                "id": "pr1-openai",
+                "source": "gate",
+                "target": "PR #1",
+                "created_at": "2026-07-01T00:00:00Z",
+                "severity": "P2",
+                "text": "OpenAI said the docs artifact was missing because it was outside the diff.",
+            },
+            {
+                "id": "pr2-claude",
+                "source": "gate",
+                "target": "PR #2",
+                "created_at": "2026-07-02T00:00:00Z",
+                "severity": "P1",
+                "text": "Claude called a README link dead because the artifact was not changed.",
+            },
+            {
+                "id": "pr3-openai",
+                "source": "ledger",
+                "target": "PR #3",
+                "created_at": "2026-07-03T00:00:00Z",
+                "severity": "P2",
+                "text": "OpenAI saw PyPI 0.1.0 although 0.1.1 was already published.",
+            },
+            {
+                "id": "pr4-claude",
+                "source": "ledger",
+                "target": "PR #4",
+                "created_at": "2026-07-04T00:00:00Z",
+                "severity": "P2",
+                "text": "Claude read the release date using a stale local clock.",
+            },
+        ],
+    )
+    classifications_path = _write_json(
+        tmp_path / "classifications.json",
+        {
+            "pr1-openai": {
+                "taxonomy_id": "1",
+                "finding_class": "Diff-blind grounding",
+                "causal_mechanism": "Reviewer prompt lacked head-tree context",
+                "harness_surface": "reviewer grounding prompt",
+                "emergent_cluster": "review_context_not_tree_complete",
+                "evidence_summary": "Reviewer reasoned from changed files instead of head tree.",
+            },
+            "pr2-claude": {
+                "taxonomy_id": "1",
+                "finding_class": "Diff-blind grounding",
+                "causal_mechanism": "Reviewer prompt lacked head-tree context",
+                "harness_surface": "reviewer grounding prompt",
+                "emergent_cluster": "review_context_not_tree_complete",
+                "evidence_summary": "Reviewer treated unchanged artifact as absent.",
+            },
+            "pr3-openai": {
+                "taxonomy_id": "2",
+                "finding_class": "Stale-external-world grounding",
+                "causal_mechanism": "External fetch freshness is not timestamped",
+                "harness_surface": "external evidence fetch template",
+                "emergent_cluster": "freshness_proof_missing",
+                "evidence_summary": "Reviewer trusted stale PyPI state.",
+            },
+            "pr4-claude": {
+                "taxonomy_id": "2",
+                "finding_class": "Stale-external-world grounding",
+                "causal_mechanism": "External fetch freshness is not timestamped",
+                "harness_surface": "external evidence fetch template",
+                "emergent_cluster": "freshness_proof_missing",
+                "evidence_summary": "Reviewer lacked timestamped freshness proof.",
+            },
+        },
+    )
+
+    result = miner.run_miner(
+        input_json=examples_path,
+        taxonomy_path=_taxonomy(tmp_path),
+        classification_json=classifications_path,
+        min_cluster_size=2,
+    )
+
+    assert result.ok is True
+    assert [cluster.pass_name for cluster in result.clusters] == [
+        "taxonomy_seeded",
+        "taxonomy_seeded",
+        "emergent_bottom_up",
+        "emergent_bottom_up",
+    ]
+    assert {cluster.cluster_key for cluster in result.clusters} == {
+        "taxonomy:1:reviewer-prompt-lacked-head-tree-context",
+        "taxonomy:2:external-fetch-freshness-is-not-timestamped",
+        "emergent:freshness_proof_missing",
+        "emergent:review_context_not_tree_complete",
+    }
+    first = result.clusters[0]
+    assert first.example_count == 2
+    assert first.rank_score > 0
+    assert first.harness_surfaces == ["reviewer grounding prompt"]
+    assert first.examples[0].id in {"pr1-openai", "pr2-claude"}
+
+
+def test_reads_ledger_and_comment_fixtures_with_redaction(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "long_run_ledger.jsonl"
+    ledger_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-07-01T00:00:00Z",
+                "target": {"pr": 10},
+                "blockers": ["OpenAI P2: API key leaked sk-test-1234567890abcdef"],
+                "progress_kind": "parked_pr",
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    comments_path = _write_json(
+        tmp_path / "comments.json",
+        [
+            {
+                "pr": 11,
+                "author": "openai",
+                "created_at": "2026-07-02T00:00:00Z",
+                "body": "CHANGES-REQUESTED [P1] The reviewer missed the base tree.",
+                "url": "https://example.invalid/comment",
+            }
+        ],
+    )
+
+    examples = miner.collect_examples(
+        ledger_paths=[ledger_path],
+        comment_json_paths=[comments_path],
+        since_days=30,
+        now=miner.parse_timestamp("2026-07-08T00:00:00Z"),
+    )
+
+    assert [example.source for example in examples] == ["ledger", "github_comment"]
+    assert examples[0].target == "PR #10"
+    assert "sk-test-" not in examples[0].text
+    assert "[REDACTED_SECRET]" in examples[0].text
+    assert examples[1].url == "https://example.invalid/comment"
+
+
+def test_cli_writes_markdown_and_json_reports(tmp_path: Path, capsys: Any) -> None:
+    examples_path = _write_json(
+        tmp_path / "examples.json",
+        [
+            {
+                "id": "a",
+                "source": "gate",
+                "target": "PR #1",
+                "created_at": "2026-07-01T00:00:00Z",
+                "severity": "P2",
+                "text": "A",
+            },
+            {
+                "id": "b",
+                "source": "gate",
+                "target": "PR #2",
+                "created_at": "2026-07-01T00:00:00Z",
+                "severity": "P2",
+                "text": "B",
+            },
+        ],
+    )
+    classifications_path = _write_json(
+        tmp_path / "classifications.json",
+        {
+            "a": {
+                "taxonomy_id": "1",
+                "finding_class": "Diff-blind grounding",
+                "causal_mechanism": "Prompt lacks tree context",
+                "harness_surface": "reviewer grounding prompt",
+                "emergent_cluster": "tree_context",
+            },
+            "b": {
+                "taxonomy_id": "1",
+                "finding_class": "Diff-blind grounding",
+                "causal_mechanism": "Prompt lacks tree context",
+                "harness_surface": "reviewer grounding prompt",
+                "emergent_cluster": "tree_context",
+            },
+        },
+    )
+    output_path = tmp_path / "report.md"
+
+    status = miner.main(
+        [
+            "--input-json",
+            str(examples_path),
+            "--taxonomy",
+            str(_taxonomy(tmp_path)),
+            "--classification-json",
+            str(classifications_path),
+            "--output",
+            str(output_path),
+            "--json",
+        ],
+    )
+
+    assert status == 0
+    stdout = json.loads(capsys.readouterr().out)
+    assert stdout["ok"] is True
+    assert stdout["cluster_count"] == 2
+    report = output_path.read_text(encoding="utf-8")
+    assert "# Harness Weakness Report" in report
+    assert "taxonomy_seeded" in report
+    assert "emergent_bottom_up" in report

--- a/tests/scripts/test_harness_weakness_miner.py
+++ b/tests/scripts/test_harness_weakness_miner.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 
@@ -103,7 +104,7 @@ def test_two_pass_clustering_uses_seeded_and_emergent_identities(tmp_path: Path)
                 "finding_class": "Diff-blind grounding",
                 "causal_mechanism": "Reviewer prompt lacked head-tree context",
                 "harness_surface": "reviewer grounding prompt",
-                "emergent_cluster": "review_context_not_tree_complete",
+                "emergent_cluster": "review context not tree complete",
                 "evidence_summary": "Reviewer treated unchanged artifact as absent.",
             },
             "pr3-openai": {
@@ -142,8 +143,8 @@ def test_two_pass_clustering_uses_seeded_and_emergent_identities(tmp_path: Path)
     assert {cluster.cluster_key for cluster in result.clusters} == {
         "taxonomy:1:reviewer-prompt-lacked-head-tree-context",
         "taxonomy:2:external-fetch-freshness-is-not-timestamped",
-        "emergent:freshness_proof_missing",
-        "emergent:review_context_not_tree_complete",
+        "emergent:freshness-proof-missing",
+        "emergent:review-context-not-tree-complete",
     }
     first = result.clusters[0]
     assert first.example_count == 2
@@ -173,7 +174,10 @@ def test_reads_ledger_and_comment_fixtures_with_redaction(tmp_path: Path) -> Non
                 "pr": 11,
                 "author": "openai",
                 "created_at": "2026-07-02T00:00:00Z",
-                "body": "CHANGES-REQUESTED [P1] The reviewer missed the base tree.",
+                "body": (
+                    "CHANGES-REQUESTED [P1] The reviewer missed the base tree. "
+                    'Payload included "api_key": "json-secret-value".'
+                ),
                 "url": "https://example.invalid/comment",
             }
         ],
@@ -190,7 +194,107 @@ def test_reads_ledger_and_comment_fixtures_with_redaction(tmp_path: Path) -> Non
     assert examples[0].target == "PR #10"
     assert "sk-test-" not in examples[0].text
     assert "[REDACTED_SECRET]" in examples[0].text
+    assert examples[1].target == "PR #11"
+    assert "json-secret-value" not in examples[1].text
+    assert "[REDACTED_SECRET]" in examples[1].text
     assert examples[1].url == "https://example.invalid/comment"
+
+
+def test_classifier_uses_prompt_file_instead_of_argv(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    consult = scripts_dir / "consult_claude.py"
+    consult.write_text("# test stub\n", encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    def fake_run(command: list[str], **kwargs: Any) -> SimpleNamespace:
+        assert "--prompt-file" in command
+        prompt_path = Path(command[command.index("--prompt-file") + 1])
+        captured["command"] = command
+        captured["prompt"] = json.loads(prompt_path.read_text(encoding="utf-8"))
+        response = {
+            "example-1": {
+                "taxonomy_id": "1",
+                "finding_class": "Diff-blind grounding",
+                "causal_mechanism": "Prompt lacked tree context",
+                "harness_surface": "reviewer grounding prompt",
+                "emergent_cluster": "tree context",
+            }
+        }
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"response": json.dumps(response)}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(miner, "_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(miner.subprocess, "run", fake_run)
+    classifications = miner._consult_classifier(
+        [
+            miner.WeaknessExample(
+                id="example-1",
+                source="gate",
+                target="PR #1",
+                created_at="2026-07-01T00:00:00Z",
+                severity="P2",
+                text="A" * 10_000,
+            )
+        ],
+        {"1": "Diff-blind grounding"},
+        timeout=10,
+    )
+
+    assert classifications["example-1"]["taxonomy_id"] == "1"
+    assert len(captured["command"]) == 5
+    assert captured["prompt"]["examples"][0]["text"] == "A" * 1200
+
+
+def test_render_markdown_escapes_untrusted_table_content() -> None:
+    example = miner.WeaknessExample(
+        id="example-1",
+        source="gate|spoof",
+        target="PR #1 | forged",
+        created_at="2026-07-01T00:00:00Z",
+        severity="P2",
+        text="finding",
+        url="https://example.invalid/a)b",
+    )
+    classified = miner.ClassifiedExample(
+        example=example,
+        taxonomy_id="1",
+        finding_class="Diff-blind grounding",
+        causal_mechanism="Prompt lacked tree context",
+        harness_surface="reviewer grounding prompt",
+        emergent_cluster="tree-context",
+        evidence_summary="Evidence | with [misleading](https://evil.invalid)",
+    )
+    cluster = miner.WeaknessCluster(
+        pass_name="emergent_bottom_up",
+        cluster_key="emergent:tree-context",
+        title="Diff-blind grounding",
+        finding_class="Diff-blind grounding",
+        causal_mechanism="Prompt lacked tree context",
+        harness_surfaces=["reviewer grounding prompt"],
+        rank_score=5,
+        examples=[classified],
+    )
+    report = miner.render_markdown(
+        miner.MiningResult(
+            ok=True,
+            generated_at="2026-07-01T00:00:00Z",
+            input_count=1,
+            classified_count=1,
+            clusters=[cluster],
+        )
+    )
+
+    assert r"PR #1 \| forged" in report
+    assert "a%29b" in report
+    assert r"gate\|spoof" in report
+    assert r"Evidence \| with \[misleading\]" in report
 
 
 def test_cli_writes_markdown_and_json_reports(tmp_path: Path, capsys: Any) -> None:

--- a/tests/scripts/test_harness_weakness_miner.py
+++ b/tests/scripts/test_harness_weakness_miner.py
@@ -200,6 +200,59 @@ def test_reads_ledger_and_comment_fixtures_with_redaction(tmp_path: Path) -> Non
     assert examples[1].url == "https://example.invalid/comment"
 
 
+def test_since_days_filters_every_source_and_rejects_untrusted_timestamps(
+    tmp_path: Path,
+) -> None:
+    input_path = _write_json(
+        tmp_path / "examples.json",
+        [
+            {"id": "input-recent", "created_at": "2026-07-01T00:00:00Z", "text": "recent"},
+            {"id": "input-stale", "created_at": "2026-05-01T00:00:00Z", "text": "stale"},
+            {"id": "input-future", "created_at": "2026-07-09T00:00:00Z", "text": "future"},
+            {"id": "input-invalid", "created_at": "not-a-date", "text": "invalid"},
+            {"id": "input-missing", "text": "missing"},
+        ],
+    )
+    ledger_path = tmp_path / "ledger.jsonl"
+    ledger_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "timestamp": "2026-07-02T00:00:00Z",
+                        "blocker_class": "recent-ledger",
+                    }
+                ),
+                json.dumps({"timestamp": "invalid", "blocker_class": "invalid-ledger"}),
+                json.dumps({"blocker_class": "missing-ledger"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    comments_path = _write_json(
+        tmp_path / "comments.json",
+        [
+            {"id": "comment-recent", "created_at": "2026-07-03T00:00:00Z", "body": "[P2] recent"},
+            {"id": "comment-missing", "body": "[P2] missing"},
+        ],
+    )
+
+    examples = miner.collect_examples(
+        input_json=input_path,
+        ledger_paths=[ledger_path],
+        comment_json_paths=[comments_path],
+        since_days=30,
+        now=miner.parse_timestamp("2026-07-08T00:00:00Z"),
+    )
+
+    assert [example.id for example in examples] == [
+        "input-recent",
+        "ledger:ledger.jsonl:1",
+        "comment-recent",
+    ]
+
+
 def test_classifier_uses_prompt_file_instead_of_argv(
     tmp_path: Path,
     monkeypatch: Any,


### PR DESCRIPTION
## Summary

Implements the #8973 stage-1 harness weakness miner as advisory tooling.

- Adds `scripts/harness_weakness_miner.py` to collect normalized examples from conductor ledgers, exported PR/issue comments, or fixture JSON.
- Uses a bounded LLM classification seam by default so grouping is by causal mechanism and harness surface, not regex symptom matching.
- Supports offline `--classification-json` fixtures for tests and reproducible dogfood without live API calls.
- Produces two cluster passes: `taxonomy_seeded` against `docs/artifacts/2026-07-reviewer-failure-taxonomy.md` and `emergent_bottom_up` from model-written emergent cluster keys or local density-style similarity over evidence summaries.
- Adds `docs/runbooks/HARNESS_WEAKNESS_MINER.md` with usage and advisory boundary.

## Validation

- `python3 -m pytest tests/scripts/test_harness_weakness_miner.py -q` -> `3 passed, 8 warnings`
- `python3 -m ruff check scripts/harness_weakness_miner.py tests/scripts/test_harness_weakness_miner.py` -> pass
- `python3 -m ruff format --check scripts/harness_weakness_miner.py tests/scripts/test_harness_weakness_miner.py` -> pass
- `python3 -m mypy scripts/harness_weakness_miner.py` -> pass
- `python3 scripts/harness_weakness_miner.py --help` -> pass
- `git diff --check` -> pass
- commit/push hooks -> pass, including ruff, ruff format, mypy, gitleaks, and portability guard

## Scope Notes

This is report-only/advisory self-harness tooling. It does not wire a workflow, required check, scheduler, branch protection, evidence gate, settlement path, or automatic harness edit. Scheduling and any harness-edit proposer remain separate operator-gated follow-ups.

Closes #8973 when accepted.
