### PR TITLE
fix(scripts): accept operator-context dir in goal-cycle context allowlist

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -51,6 +51,7 @@ SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
 SAFE_CONTEXT_SUBDIRS = (
     SAFE_CONTEXT_SUBDIR,
     Path(".aragora") / "conductor_cycles",
+    Path(".aragora") / "operator-context",
 )
 DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -120,6 +120,24 @@ def test_build_packet_accepts_conductor_cycles_context_file(tmp_path: Path) -> N
     assert "OPERATOR CONTEXT MISSING" not in packet
 
 
+def test_build_packet_accepts_operator_context_file(tmp_path: Path) -> None:
+    context_dir = tmp_path / ".aragora" / "operator-context"
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle_report.md"
+    context_file.write_text("cycle 177: C13 RETIRE-PRESERVE", encoding="utf-8")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=tmp_path,
+    )
+
+    assert "cycle 177: C13 RETIRE-PRESERVE" in packet
+    assert "OPERATOR CONTEXT MISSING" not in packet
+
+
 def test_build_packet_truncates_large_conductor_cycles_context_file(tmp_path: Path) -> None:
     context_dir = tmp_path / ".aragora" / "conductor_cycles"
     context_dir.mkdir(parents=True)
@@ -184,6 +202,7 @@ def test_build_packet_aggregate_truncation_preserves_closed_fences() -> None:
 def test_build_packet_refuses_sensitive_context_path(tmp_path: Path) -> None:
     context_file = tmp_path / "cycle_report.md"
     context_file.write_text("TOKEN=secret", encoding="utf-8")
+    allowed_roots = " or ".join(str(subdir) for subdir in fable_goal_cycle.SAFE_CONTEXT_SUBDIRS)
 
     packet = fable_goal_cycle.build_packet(
         {"sections": {}, "gaps": []},
@@ -194,10 +213,9 @@ def test_build_packet_refuses_sensitive_context_path(tmp_path: Path) -> None:
     )
 
     assert "OPERATOR CONTEXT MISSING" in packet
-    assert (
-        "context file must be under .aragora/goal-cycle-context or .aragora/conductor_cycles"
-        in packet
-    )
+    assert f"context file must be under {allowed_roots}" in packet
+    for subdir in fable_goal_cycle.SAFE_CONTEXT_SUBDIRS:
+        assert str(subdir) in packet
     assert "TOKEN=secret" not in packet
 
 
@@ -213,6 +231,7 @@ def test_build_packet_refuses_symlink_to_sensitive_context_path(tmp_path: Path) 
         context_file.symlink_to(sensitive)
     except OSError:
         return
+    allowed_roots = " or ".join(str(subdir) for subdir in fable_goal_cycle.SAFE_CONTEXT_SUBDIRS)
 
     packet = fable_goal_cycle.build_packet(
         {"sections": {}, "gaps": []},
@@ -223,10 +242,9 @@ def test_build_packet_refuses_symlink_to_sensitive_context_path(tmp_path: Path) 
     )
 
     assert "OPERATOR CONTEXT MISSING" in packet
-    assert (
-        "context file must be under .aragora/goal-cycle-context or .aragora/conductor_cycles"
-        in packet
-    )
+    assert f"context file must be under {allowed_roots}" in packet
+    for subdir in fable_goal_cycle.SAFE_CONTEXT_SUBDIRS:
+        assert str(subdir) in packet
     assert "TOKEN=secret" not in packet
 
 


### PR DESCRIPTION
## Summary
- Add `.aragora/operator-context` to the safe `--context-file` allowlist for `scripts/fable_goal_cycle.py`.
- Add regression coverage proving operator-context reports are included and rejected context paths list every allowed root dynamically.

## Evidence
Cycle 177 wrote the operator report to `.aragora/operator-context/20260708T174200Z-cycle177-c13-retire-preserve.md`; the current allowlist only covered `.aragora/goal-cycle-context` and `.aragora/conductor_cycles`, so this producer path was not durably covered by #9008. This PR keeps the boundary narrow and adds the missing producer directory.

Epic: #8972

## #8858 probe
#8858 is still open and actionable only with a real no-context human. No real outsider was available in this cycle, so no simulated run was counted.

## Validation
- `python3 -m pytest tests/scripts/test_fable_goal_cycle.py -q` -> 19 passed
- `python3 -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py` -> passed
- `python3 -m ruff format --check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py` -> passed
- `python3 scripts/run_typecheck_gate.py --files scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py --json` -> skip, `no_aragora_python_targets`
- `git diff --check` -> passed

Draft intentionally: normal settlement/quorum gates should decide readiness and merge.