### PR TITLE
fix(routing): handle empty LLM domain responses

### DIFF
--- a/aragora/routing/domain_matcher.py
+++ b/aragora/routing/domain_matcher.py
@@ -474,11 +474,15 @@ Return up to {top_n} domains, sorted by confidence. Be conservative with technic
             # Anthropic's SDK is optional in baseline environments; accept any
             # response block that exposes text content instead of importing SDK
             # classes purely for an isinstance check.
+            if not response.content:
+                logger.warning("Response does not contain content")
+                return None
+
             first_block = response.content[0]
             content_text = getattr(first_block, "text", None)
             if not isinstance(content_text, str):
                 logger.warning("Response does not contain text content")
-                return []
+                return None
             content: str = content_text.strip()
 
             # Extract JSON from response

--- a/tests/routing/test_domain_matcher_root.py
+++ b/tests/routing/test_domain_matcher_root.py
@@ -4,9 +4,8 @@ Tests for the domain_matcher module.
 Tests domain detection via keywords and caching behavior.
 """
 
-import sys
 import time
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,12 +26,6 @@ except ModuleNotFoundError:
         def __init__(self, *, type: str, text: str) -> None:
             self.type = type
             self.text = text
-
-    _anthropic_module = sys.modules.setdefault("anthropic", ModuleType("anthropic"))
-    _anthropic_types_module = ModuleType("anthropic.types")
-    _anthropic_types_module.TextBlock = TextBlock
-    _anthropic_module.types = _anthropic_types_module
-    sys.modules.setdefault("anthropic.types", _anthropic_types_module)
 
 
 def text_block(text: str) -> SimpleNamespace:
@@ -358,6 +351,21 @@ class TestDomainDetectorLLM:
         mock_response.content = [
             MagicMock(text='{"domains": [{"name": "invalid_domain", "confidence": 0.9}]}')
         ]
+        mock_client.messages.create.return_value = mock_response
+
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"}):
+            detector = DomainDetector(use_llm=True, client=mock_client, use_cache=False)
+            result = detector.detect("Fix SQL injection vulnerability authentication")
+
+        # Should fall back to keywords
+        domains = [d for d, _ in result]
+        assert "security" in domains
+
+    def test_llm_detection_empty_response_fallback(self):
+        """Test that empty LLM responses fall back to keywords."""
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = []
         mock_client.messages.create.return_value = mock_response
 
         with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test_key"}):


### PR DESCRIPTION
## Summary

- Fold the focused #8993 C09 routing subset from closed PR #8460 onto current `origin/main`.
- Treat empty Anthropic-style LLM response content as a fallback path instead of indexing `response.content[0]`.
- Remove the test-local fake `anthropic` module injection that breaks the global external-API autouse mock when the real package is absent.

## Validation

- `python3 -m pytest tests/routing/test_domain_matcher_root.py -q`
- `python3 -m ruff check aragora/routing/domain_matcher.py tests/routing/test_domain_matcher_root.py`
- `git diff --check`
- commit hooks during `git commit`
- push hooks during `git push` including mypy

## Harvest

- #8993 C09 claim: https://github.com/synaptent/aragora/issues/8993#issuecomment-4917778033
- Source closed PR: #8460 @ `f3a8295e722d363ffec18b1b493da20b830d41cc`
- This PR intentionally does not replay the stale dependency/generated-doc portions of #8460; those were already superseded by later dependency-security work per the #8460 close receipt.
