### PR TITLE
docs(runbooks): classify unstable merge-state blockers

### DIFF
--- a/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
+++ b/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
@@ -73,13 +73,15 @@ target PR head before clearing the PR source.
 
 ```bash
 git fetch origin main:refs/remotes/origin/main
-main_tmp="$(mktemp -d /tmp/aragora-portability-main.XXXXXX)"
+main_parent="$(mktemp -d /tmp/aragora-portability-main.XXXXXX)"
+main_tmp="$main_parent/worktree"
 git worktree add --detach "$main_tmp" origin/main
 (cd "$main_tmp" && python3 scripts/check_portability.py)
 
 head_sha="$(gh pr view <pr> --repo synaptent/aragora --json headRefOid --jq .headRefOid)"
 git fetch origin "pull/<pr>/head:refs/remotes/pr/<pr>/head"
-pr_tmp="$(mktemp -d /tmp/aragora-portability-pr.XXXXXX)"
+pr_parent="$(mktemp -d /tmp/aragora-portability-pr.XXXXXX)"
+pr_tmp="$pr_parent/worktree"
 git worktree add --detach "$pr_tmp" "$head_sha"
 test "$(git -C "$pr_tmp" rev-parse HEAD)" = "$head_sha"
 (cd "$pr_tmp" && python3 scripts/check_portability.py)

--- a/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
+++ b/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
@@ -68,16 +68,24 @@ gh run view <run-id> --repo synaptent/aragora --log \
 ```
 
 Use local reproduction to distinguish a workflow cancellation from a real guard
-failure:
+failure. Check `origin/main` for a possible main regression, then check the
+target PR head before clearing the PR source.
 
 ```bash
 git fetch origin main
-tmp="$(mktemp -d /tmp/aragora-portability-repro.XXXXXX)"
-git worktree add --detach "$tmp" origin/main
-git -C "$tmp" status --short --branch
-(cd "$tmp" && python3 scripts/check_portability.py)
+main_tmp="$(mktemp -d /tmp/aragora-portability-main.XXXXXX)"
+git worktree add --detach "$main_tmp" origin/main
+(cd "$main_tmp" && python3 scripts/check_portability.py)
+
+head_sha="$(gh pr view <pr> --repo synaptent/aragora --json headRefOid --jq .headRefOid)"
+git fetch origin "pull/<pr>/head:refs/remotes/pr/<pr>/head"
+pr_tmp="$(mktemp -d /tmp/aragora-portability-pr.XXXXXX)"
+git worktree add --detach "$pr_tmp" "$head_sha"
+test "$(git -C "$pr_tmp" rev-parse HEAD)" = "$head_sha"
+(cd "$pr_tmp" && python3 scripts/check_portability.py)
 ```
 
-If local `origin/main` passes and the failed workflow never reached the guard
-command, classify the target PR as parked on CI/merge-state noise rather than
-source correctness.
+If local `origin/main` and the exact PR head both pass, or the exact PR head
+already has a prior green portability run and the failed workflow never reached
+the guard command, classify the target PR as parked on CI/merge-state noise
+rather than source correctness.

--- a/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
+++ b/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
@@ -72,7 +72,7 @@ failure. Check `origin/main` for a possible main regression, then check the
 target PR head before clearing the PR source.
 
 ```bash
-git fetch origin main
+git fetch origin main:refs/remotes/origin/main
 main_tmp="$(mktemp -d /tmp/aragora-portability-main.XXXXXX)"
 git worktree add --detach "$main_tmp" origin/main
 (cd "$main_tmp" && python3 scripts/check_portability.py)

--- a/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
+++ b/docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md
@@ -1,0 +1,83 @@
+# Merge-State `UNSTABLE` Settlement Triage
+
+Use this runbook when a PR has green branch-protection checks but GitHub reports
+`mergeStateStatus=UNSTABLE`, especially during high-churn automation queues.
+
+## Immediate Rule
+
+Do not collect more model-review evidence or retry settlement until the
+`UNSTABLE` source is classified. Model quorum cannot repair a GitHub merge-state
+summary that is being held open by cancelled or stale check runs.
+
+## Classification
+
+1. Read required checks from branch protection:
+
+   ```bash
+   gh api repos/synaptent/aragora/branches/main/protection/required_status_checks \
+     --jq '{strict,contexts,checks}'
+   gh pr checks <pr> --repo synaptent/aragora --required
+   ```
+
+2. Read the full check list and live merge state:
+
+   ```bash
+   gh pr checks <pr> --repo synaptent/aragora
+   gh pr view <pr> --repo synaptent/aragora \
+     --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup
+   ```
+
+3. Classify the blocker:
+
+   | Signal | Meaning | Action |
+   | --- | --- | --- |
+   | Required check is red | hard gate | Repair the PR or main before settlement. |
+   | Required checks pass and only advisory checks are pending | queue churn | Recheck once, then proceed under the merge contract if policy allows. |
+   | Latest advisory check is `cancelled` before its command ran | merge-state poison | Park target settlement and file or link a CI issue. |
+   | Advisory check ran and failed in files touched by the PR | in-scope failure | Repair or explicitly park the PR. |
+   | Advisory check ran and failed outside PR scope | possible main regression | Verify on `origin/main`, then open or link a main-health issue. |
+
+## Portability Cancellation Pattern
+
+Issue #9031 tracks the July 8, 2026 instance where `Portability Lint /
+portability` cancelled during `actions/checkout` before
+`scripts/check_portability.py` ran. The local guard passed on detached
+`origin/main`, and main's own portability run was green, but GitHub still
+reported `mergeStateStatus=UNSTABLE` for #9027.
+
+This pattern is not evidence that the PR introduced private paths or portability
+violations. It is a CI/workflow-concurrency settlement hazard because the
+newest check run for the `portability` name can be a cancelled advisory run.
+
+When this pattern appears:
+
+1. Link the affected PR to #9031 or a successor issue.
+2. Leave a PR handoff comment with the check name, run URL, and exact
+   classification.
+3. Stop settlement and evidence-collection loops for that PR until merge state
+   becomes `CLEAN` or the CI issue is repaired.
+4. Work the CI/runbook/tooling issue as a separate bounded unit.
+
+## Evidence Commands
+
+Use targeted logs to avoid large CI output:
+
+```bash
+gh run view <run-id> --repo synaptent/aragora --log \
+  | rg -n "operation was canceled|Portability guard|check_portability|fetch --no-tags|##\\[error\\]"
+```
+
+Use local reproduction to distinguish a workflow cancellation from a real guard
+failure:
+
+```bash
+git fetch origin main
+tmp="$(mktemp -d /tmp/aragora-portability-repro.XXXXXX)"
+git worktree add --detach "$tmp" origin/main
+git -C "$tmp" status --short --branch
+(cd "$tmp" && python3 scripts/check_portability.py)
+```
+
+If local `origin/main` passes and the failed workflow never reached the guard
+command, classify the target PR as parked on CI/merge-state noise rather than
+source correctness.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,7 @@ Operational runbooks for responding to Aragora alerts and incidents.
 | Redis Failover | [redis-failover.md](./redis-failover.md) | Redis HA and recovery procedures |
 | Multi-Region | [RUNBOOK_MULTI_REGION_SETUP.md](./RUNBOOK_MULTI_REGION_SETUP.md) | Multi-region deployment and failover |
 | Fleet Coordination | [RUNBOOK_FLEET_COORDINATION.md](./RUNBOOK_FLEET_COORDINATION.md) | Multi-agent worktree ownership and merge queue policy |
+| Merge-State `UNSTABLE` Settlement | [MERGE_STATE_UNSTABLE_SETTLEMENT.md](./MERGE_STATE_UNSTABLE_SETTLEMENT.md) | Classifying GitHub merge-state blockers from required checks, advisory checks, and cancelled CI runs |
 | Proof-First tmux Operator | [RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md](./RUNBOOK_PROOF_FIRST_TMUX_OPERATOR.md) | Conductor-led tmux coordination for benchmark/docs/monitor lanes without replacing the unattended proof-first shift |
 | Outbox Disposition | [outbox-disposition-rubric.md](./outbox-disposition-rubric.md) | Read-only rubric for classifying automation outbox-depth blockers before any publisher or reconcile mutation |
 


### PR DESCRIPTION
## Summary

- adds a runbook for classifying `mergeStateStatus=UNSTABLE` when required checks are green
- documents the July 8 portability cancellation pattern from #9027/#9028
- links the runbook from `docs/runbooks/README.md`

Fixes #9031.

## Validation

- `git diff --check`
- `rg -n "TBD|TODO|fill in later" docs/runbooks/MERGE_STATE_UNSTABLE_SETTLEMENT.md docs/runbooks/README.md` (no matches)
- `python3 scripts/check_portability.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes

No workflow, schema, API, or product-code changes. This only preserves the settlement triage rule so agents stop looping model-evidence collection when GitHub merge-state is poisoned by cancelled advisory checks.
