### PR TITLE
fix(scripts): accept goal-cycle output dir as context

### DIFF
--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -47,13 +47,15 @@ DIGEST_TIMEOUT_SECONDS = 120
 MAX_CONTEXT_FILE_BYTES = 64 * 1024
 MAX_PACKET_BYTES = 400 * 1024
 MAX_PACKET_SECTION_BYTES = 96 * 1024
+DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 SAFE_CONTEXT_SUBDIR = Path(".aragora") / "goal-cycle-context"
+# Every directory this script writes cycle context to must be accepted here.
 SAFE_CONTEXT_SUBDIRS = (
     SAFE_CONTEXT_SUBDIR,
+    Path(DEFAULT_OUTPUT_DIR),
     Path(".aragora") / "conductor_cycles",
     Path(".aragora") / "operator-context",
 )
-DEFAULT_OUTPUT_DIR = ".aragora/goal_cycles"
 DEFAULT_MODEL = "claude-fable-5"
 MAX_ACTIVE_PROCESS_LINES = 40
 ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -57,6 +57,9 @@ SAFE_CONTEXT_SUBDIRS = (
     Path(".aragora") / "conductor_cycles",
     Path(".aragora") / "operator-context",
 )
+EXTRA_CONTEXT_ROOT_NAME_RE = re.compile(
+    r"(^|[-_.])(aragora|conductor|cycle|cycles|goal|goals|operator-context)([-_.]|$)"
+)
 DEFAULT_MODEL = "claude-fable-5"
 MAX_ACTIVE_PROCESS_LINES = 40
 ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(
@@ -351,17 +354,38 @@ def _packet_with_footer(parts: list[str]) -> str:
     return "\n".join(kept) + "\n" + footer
 
 
-def _context_safe_roots(root: Path, extra_roots: Iterable[Path] = ()) -> tuple[Path, ...]:
-    safe_roots = [(root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS]
+def _is_dedicated_extra_context_root(root: Path, path: Path) -> bool:
+    root_resolved = root.resolve(strict=False)
+    resolved = path.resolve(strict=False)
+    if resolved == root_resolved or resolved in root_resolved.parents:
+        return False
+    if resolved == resolved.parent or resolved == Path.home().resolve(strict=False):
+        return False
+    return bool(EXTRA_CONTEXT_ROOT_NAME_RE.search(resolved.name.lower()))
+
+
+def _accepted_extra_context_roots(root: Path, extra_roots: Iterable[Path]) -> tuple[Path, ...]:
+    accepted: list[Path] = []
     for extra_root in extra_roots:
         candidate = extra_root if extra_root.is_absolute() else root / extra_root
-        safe_roots.append(candidate.resolve(strict=False))
+        resolved = candidate.resolve(strict=False)
+        if _is_dedicated_extra_context_root(root, resolved):
+            accepted.append(resolved)
+    return tuple(dict.fromkeys(accepted))
+
+
+def _context_safe_roots(root: Path, extra_roots: Iterable[Path] = ()) -> tuple[Path, ...]:
+    safe_roots = [(root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS]
+    safe_roots.extend(_accepted_extra_context_roots(root, extra_roots))
     return tuple(dict.fromkeys(safe_roots))
 
 
-def _context_safe_root_labels(extra_roots: Iterable[Path] = ()) -> tuple[str, ...]:
+def _context_safe_root_labels(
+    root: Path,
+    extra_roots: Iterable[Path] = (),
+) -> tuple[str, ...]:
     labels = [str(subdir) for subdir in SAFE_CONTEXT_SUBDIRS]
-    labels.extend(str(root) for root in extra_roots)
+    labels.extend(str(root) for root in _accepted_extra_context_roots(root, extra_roots))
     return tuple(dict.fromkeys(labels))
 
 
@@ -379,7 +403,7 @@ def _read_context_file(
         return None, f"context file unreadable: {path}: {exc}"
 
     if not any(_is_relative_to(resolved, safe_root) for safe_root in safe_roots):
-        allowed_roots = " or ".join(_context_safe_root_labels(extra_safe_roots))
+        allowed_roots = " or ".join(_context_safe_root_labels(root, extra_safe_roots))
         return None, f"context file must be under {allowed_roots}: {path}"
     try:
         if not resolved.is_file():

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -31,6 +31,7 @@ Examples::
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
 import datetime as _dt
 import json
 import os
@@ -264,14 +265,17 @@ def _active_process_label(command: str) -> str | None:
             return f"{executable} {basename}"
 
     lowered = [word.lower() for word in words]
-    for pattern in ACTIVE_PROCESS_COMMAND_PATTERNS:
-        if len(lowered) >= len(pattern) and tuple(lowered[: len(pattern)]) == pattern:
-            return " ".join(pattern)
+    for command_pattern in ACTIVE_PROCESS_COMMAND_PATTERNS:
+        if (
+            len(lowered) >= len(command_pattern)
+            and tuple(lowered[: len(command_pattern)]) == command_pattern
+        ):
+            return " ".join(command_pattern)
 
     command_lower = " ".join(lowered)
-    for pattern in ACTIVE_PROCESS_TOKEN_PATTERNS:
-        if pattern in command_lower:
-            return pattern
+    for token_pattern in ACTIVE_PROCESS_TOKEN_PATTERNS:
+        if token_pattern in command_lower:
+            return token_pattern
 
     return None
 
@@ -347,9 +351,27 @@ def _packet_with_footer(parts: list[str]) -> str:
     return "\n".join(kept) + "\n" + footer
 
 
-def _read_context_file(path: Path, root: Path) -> tuple[str | None, str | None]:
+def _context_safe_roots(root: Path, extra_roots: Iterable[Path] = ()) -> tuple[Path, ...]:
+    safe_roots = [(root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS]
+    for extra_root in extra_roots:
+        candidate = extra_root if extra_root.is_absolute() else root / extra_root
+        safe_roots.append(candidate.resolve(strict=False))
+    return tuple(dict.fromkeys(safe_roots))
+
+
+def _context_safe_root_labels(extra_roots: Iterable[Path] = ()) -> tuple[str, ...]:
+    labels = [str(subdir) for subdir in SAFE_CONTEXT_SUBDIRS]
+    labels.extend(str(root) for root in extra_roots)
+    return tuple(dict.fromkeys(labels))
+
+
+def _read_context_file(
+    path: Path,
+    root: Path,
+    extra_safe_roots: Iterable[Path] = (),
+) -> tuple[str | None, str | None]:
     """Read a repo-local safe context file with a hard byte cap."""
-    safe_roots = tuple((root / subdir).resolve(strict=False) for subdir in SAFE_CONTEXT_SUBDIRS)
+    safe_roots = _context_safe_roots(root, extra_safe_roots)
     candidate = path if path.is_absolute() else root / path
     try:
         resolved = candidate.resolve(strict=True)
@@ -357,7 +379,7 @@ def _read_context_file(path: Path, root: Path) -> tuple[str | None, str | None]:
         return None, f"context file unreadable: {path}: {exc}"
 
     if not any(_is_relative_to(resolved, safe_root) for safe_root in safe_roots):
-        allowed_roots = " or ".join(str(subdir) for subdir in SAFE_CONTEXT_SUBDIRS)
+        allowed_roots = " or ".join(_context_safe_root_labels(extra_safe_roots))
         return None, f"context file must be under {allowed_roots}: {path}"
     try:
         if not resolved.is_file():
@@ -466,6 +488,7 @@ def build_packet(
     extra_files: list[Path],
     since_hours: float,
     root: Path | None = None,
+    context_safe_roots: Iterable[Path] = (),
 ) -> str:
     root = Path.cwd() if root is None else root
     now = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -495,7 +518,7 @@ def build_packet(
             _markdown_code_block(_bounded_code_block(gap_body)),
         ]
     for path in extra_files:
-        body, note = _read_context_file(path, root)
+        body, note = _read_context_file(path, root, context_safe_roots)
         if body is None:
             if note:
                 parts += [
@@ -611,6 +634,7 @@ def main(argv: list[str] | None = None) -> int:
         [Path(p) for p in args.context_file],
         args.since_hours,
         root=root,
+        context_safe_roots=[cycle_root],
     )
     packet_path = cycle_dir / "packet.md"
     packet_path.write_text(packet, encoding="utf-8")

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -167,6 +167,31 @@ def test_build_packet_accepts_runtime_output_dir_context_file(tmp_path: Path) ->
     assert str(output_root) in packet
 
 
+def test_build_packet_rejects_broad_runtime_output_dir_context_file(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    broad_output_root = tmp_path
+    context_file = tmp_path / "secret.md"
+    context_file.write_text("TOKEN=secret", encoding="utf-8")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=repo_root,
+        context_safe_roots=[broad_output_root],
+    )
+
+    assert "OPERATOR CONTEXT MISSING" in packet
+    assert (
+        "context file must be under .aragora/goal-cycle-context or "
+        ".aragora/goal_cycles or .aragora/conductor_cycles or "
+        ".aragora/operator-context"
+    ) in packet
+    assert "TOKEN=secret" not in packet
+
+
 def test_build_packet_accepts_operator_context_file(tmp_path: Path) -> None:
     context_dir = tmp_path / ".aragora" / "operator-context"
     context_dir.mkdir(parents=True)

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -141,6 +141,32 @@ def test_build_packet_accepts_default_output_dir_context_file(tmp_path: Path) ->
     assert "OPERATOR CONTEXT MISSING" not in packet
 
 
+def test_build_packet_accepts_runtime_output_dir_context_file(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    output_root = tmp_path / "custom-goal-cycles"
+    context_dir = output_root / "20260709T040000Z"
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle-summary.md"
+    context_file.write_text("cycle 206: runtime output dir context", encoding="utf-8")
+    outside_file = tmp_path / "outside.md"
+    outside_file.write_text("TOKEN=secret", encoding="utf-8")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file, outside_file],
+        since_hours=24,
+        root=repo_root,
+        context_safe_roots=[output_root],
+    )
+
+    assert "cycle 206: runtime output dir context" in packet
+    assert "TOKEN=secret" not in packet
+    assert "context file must be under" in packet
+    assert str(output_root) in packet
+
+
 def test_build_packet_accepts_operator_context_file(tmp_path: Path) -> None:
     context_dir = tmp_path / ".aragora" / "operator-context"
     context_dir.mkdir(parents=True)

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -120,6 +120,27 @@ def test_build_packet_accepts_conductor_cycles_context_file(tmp_path: Path) -> N
     assert "OPERATOR CONTEXT MISSING" not in packet
 
 
+def test_build_packet_accepts_default_output_dir_context_file(tmp_path: Path) -> None:
+    default_output_subdir = Path(fable_goal_cycle.DEFAULT_OUTPUT_DIR)
+    assert default_output_subdir in fable_goal_cycle.SAFE_CONTEXT_SUBDIRS
+
+    context_dir = tmp_path / default_output_subdir / "20260708T190000Z"
+    context_dir.mkdir(parents=True)
+    context_file = context_dir / "cycle-summary.md"
+    context_file.write_text("cycle 90: goal-cycle output context", encoding="utf-8")
+
+    packet = fable_goal_cycle.build_packet(
+        {"sections": {}, "gaps": []},
+        "standing mission",
+        [context_file],
+        since_hours=24,
+        root=tmp_path,
+    )
+
+    assert "cycle 90: goal-cycle output context" in packet
+    assert "OPERATOR CONTEXT MISSING" not in packet
+
+
 def test_build_packet_accepts_operator_context_file(tmp_path: Path) -> None:
     context_dir = tmp_path / ".aragora" / "operator-context"
     context_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- Accept the goal-cycle helper's own `.aragora/goal_cycles` output directory as a safe `--context-file` root by deriving it from `DEFAULT_OUTPUT_DIR`.
- Add an invariant comment on `SAFE_CONTEXT_SUBDIRS` so future output-context writers stay allowlisted.
- Add a regression test proving a cycle summary written under `DEFAULT_OUTPUT_DIR` is accepted as operator context.

## Cycle 90 fallback
Primary #8961 settlement/evidence was not legal because `identify_lane_owner.py --pr 8961 --json` reported `owner_blocking_state=stale_owner` with `advisory_withheld=possible_unpushed_work`. No evidence, settlement, merge, or PR mutation was performed on #8961.

## Validation
- `python3 -m pytest tests/scripts/test_fable_goal_cycle.py -q` -> 20 passed
- `python3 -m ruff check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py` -> passed
- `python3 -m ruff format --check scripts/fable_goal_cycle.py tests/scripts/test_fable_goal_cycle.py` -> passed
- `git diff --check` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- push hooks passed, including ruff, ruff format, mypy, gitleaks, and portability guard

No workflow, branch-protection, CI-rerun, settlement, merge, or force-push action was used.
