### PR TITLE
feat(nomic): work-mix classification + throughput ledger library (Phase 1, advisory)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,533 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,532 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,533 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions | 5,452 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,526 test functions across 5,452 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions | 5,452 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -442,7 +442,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,526 test functions across 5,452 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,532 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/aragora/nomic/throughput.py
+++ b/aragora/nomic/throughput.py
@@ -71,7 +71,13 @@ class LedgerRecord:
         raw = json.loads(line)
         if not isinstance(raw, Mapping):
             raise TypeError("ledger record must be a JSON object")
-        return cls(kind=raw["kind"], timestamp=raw["timestamp"], data=raw.get("data", {}))
+        data = raw.get("data", {})
+        # A non-dict data payload (e.g. "data": []) would pass records()'s
+        # timestamp validation and crash consumers downstream; reject it here
+        # so the corrupt-line skip in records() handles it (#9047 openai [P2]).
+        if not isinstance(data, dict):
+            raise TypeError("ledger record data must be a JSON object")
+        return cls(kind=raw["kind"], timestamp=raw["timestamp"], data=data)
 
     @property
     def when(self) -> datetime:

--- a/aragora/nomic/throughput.py
+++ b/aragora/nomic/throughput.py
@@ -1,0 +1,331 @@
+"""
+Append-only throughput ledger for the self-improvement loop.
+
+One JSONL file (``.aragora/throughput/ledger.jsonl``) records what the loop
+actually retires — merges (classified by :mod:`aragora.nomic.work_mix`),
+external artifacts, parks, reverts, and daily SENSE snapshots — so the
+work-mix budget, the kill switches, and the weekly founder digest all read
+from a single source of truth.
+
+Also owns the substrate-freeze marker (``substrate_freeze.marker``): written
+when the mix budget is breached, honored by goal selection while it exists.
+Advisory in Phase 1 — this module computes and records; nothing here mutates
+GitHub or gate behavior.
+
+Plan: docs/plans/2026-07-08-vision-audit-and-work-mix-governor.md (section 4.4).
+Part of epic #9039 (issue #9040).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.nomic.work_mix import (
+    ClassifiedWork,
+    MixBudget,
+    MixReport,
+    WorkClass,
+    compute_mix,
+    evaluate_budget,
+)
+
+THROUGHPUT_DIR = Path(".aragora") / "throughput"
+LEDGER_FILENAME = "ledger.jsonl"
+FREEZE_FILENAME = "substrate_freeze.marker"
+
+_RECORD_KINDS = frozenset({"merge", "snapshot", "artifact", "park", "revert", "note"})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class LedgerRecord:
+    """One append-only ledger entry."""
+
+    kind: str
+    timestamp: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.kind not in _RECORD_KINDS:
+            raise ValueError(f"unknown ledger record kind: {self.kind!r}")
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"kind": self.kind, "timestamp": self.timestamp, "data": self.data},
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, line: str) -> LedgerRecord:
+        raw = json.loads(line)
+        return cls(kind=raw["kind"], timestamp=raw["timestamp"], data=raw.get("data", {}))
+
+    @property
+    def when(self) -> datetime:
+        return datetime.fromisoformat(self.timestamp)
+
+
+class ThroughputLedger:
+    """Append-only JSONL ledger rooted at a repo checkout."""
+
+    def __init__(self, root: Path | str = ".") -> None:
+        self.root = Path(root)
+        self.path = self.root / THROUGHPUT_DIR / LEDGER_FILENAME
+
+    def append(self, record: LedgerRecord) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(record.to_json() + "\n")
+
+    def records(self, since: datetime | None = None) -> list[LedgerRecord]:
+        if not self.path.exists():
+            return []
+        result: list[LedgerRecord] = []
+        with self.path.open(encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                record = LedgerRecord.from_json(line)
+                if since is None or record.when >= since:
+                    result.append(record)
+        return result
+
+    # -- convenience writers -------------------------------------------------
+
+    def record_merge(
+        self,
+        classified: ClassifiedWork,
+        *,
+        title: str = "",
+        when: datetime | None = None,
+    ) -> LedgerRecord:
+        record = LedgerRecord(
+            kind="merge",
+            timestamp=(when or _utcnow()).isoformat(),
+            data={
+                "identifier": classified.identifier,
+                "work_class": classified.work_class.value,
+                "exempt": classified.exempt,
+                "rationale": classified.rationale,
+                "cross_check_disagreement": classified.cross_check_disagreement,
+                "title": title,
+                "file_counts": {
+                    cls.value: count for cls, count in classified.file_counts.items() if count
+                },
+            },
+        )
+        self.append(record)
+        return record
+
+    def record_artifact(
+        self, name: str, *, url: str = "", when: datetime | None = None
+    ) -> LedgerRecord:
+        record = LedgerRecord(
+            kind="artifact",
+            timestamp=(when or _utcnow()).isoformat(),
+            data={"name": name, "url": url},
+        )
+        self.append(record)
+        return record
+
+    def record_snapshot(
+        self, metrics: dict[str, Any], *, when: datetime | None = None
+    ) -> LedgerRecord:
+        record = LedgerRecord(
+            kind="snapshot", timestamp=(when or _utcnow()).isoformat(), data=metrics
+        )
+        self.append(record)
+        return record
+
+
+@dataclass
+class ThroughputMetrics:
+    """Rolling loop-health metrics computed from ledger records."""
+
+    window_days: int
+    merges_total: int
+    merges_by_class: dict[WorkClass, int]
+    product_share: float
+    substrate_share: float
+    self_repair_ratio: float
+    external_artifacts: int
+    parks: int
+    reverts: int
+    cross_check_disagreements: int
+
+
+def _merge_to_classified(record: LedgerRecord) -> ClassifiedWork:
+    data = record.data
+    counts = {cls: 0 for cls in WorkClass}
+    for value, count in data.get("file_counts", {}).items():
+        counts[WorkClass(value)] = count
+    return ClassifiedWork(
+        identifier=str(data.get("identifier", "")),
+        work_class=WorkClass(data["work_class"]),
+        file_counts=counts,
+        rationale=str(data.get("rationale", "")),
+        exempt=bool(data.get("exempt", False)),
+        cross_check_disagreement=data.get("cross_check_disagreement"),
+    )
+
+
+def compute_metrics(
+    records: list[LedgerRecord],
+    *,
+    now: datetime | None = None,
+    window_days: int = 7,
+) -> ThroughputMetrics:
+    """Compute rolling metrics over the trailing window."""
+    now = now or _utcnow()
+    cutoff = now - timedelta(days=window_days)
+    windowed = [r for r in records if r.when >= cutoff]
+
+    merges = [r for r in windowed if r.kind == "merge"]
+    classified = [_merge_to_classified(r) for r in merges]
+    mix = compute_mix(classified, window_days=window_days)
+
+    # Self-repair: fixes whose target is the loop itself (substrate-class
+    # merges with a fix-shaped title). High ratios trigger the
+    # remove-the-fragile-abstraction review, not more patches.
+    self_repair = sum(
+        1
+        for record, work in zip(merges, classified)
+        if work.work_class is WorkClass.SUBSTRATE
+        and str(record.data.get("title", "")).lower().startswith(("fix", "repair"))
+    )
+
+    return ThroughputMetrics(
+        window_days=window_days,
+        merges_total=len(merges),
+        merges_by_class=dict(mix.counts),
+        product_share=mix.product_share,
+        substrate_share=mix.substrate_share,
+        self_repair_ratio=self_repair / len(merges) if merges else 0.0,
+        external_artifacts=sum(1 for r in windowed if r.kind == "artifact"),
+        parks=sum(1 for r in windowed if r.kind == "park"),
+        reverts=sum(1 for r in windowed if r.kind == "revert"),
+        cross_check_disagreements=sum(1 for work in classified if work.cross_check_disagreement),
+    )
+
+
+def mix_from_records(
+    records: list[LedgerRecord],
+    *,
+    now: datetime | None = None,
+    window_days: int = 7,
+) -> MixReport:
+    """The windowed work-mix report used for budget evaluation."""
+    now = now or _utcnow()
+    cutoff = now - timedelta(days=window_days)
+    classified = [
+        _merge_to_classified(r) for r in records if r.kind == "merge" and r.when >= cutoff
+    ]
+    return compute_mix(classified, window_days=window_days)
+
+
+# -- substrate-freeze marker -------------------------------------------------
+
+
+def freeze_marker_path(root: Path | str = ".") -> Path:
+    return Path(root) / THROUGHPUT_DIR / FREEZE_FILENAME
+
+
+def write_freeze_marker(root: Path | str = ".", *, reason: str) -> Path:
+    path = freeze_marker_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"timestamp": _utcnow().isoformat(), "reason": reason}, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def clear_freeze_marker(root: Path | str = ".") -> bool:
+    path = freeze_marker_path(root)
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def freeze_active(root: Path | str = ".") -> dict[str, Any] | None:
+    """Return the marker payload if the freeze is active, else None."""
+    path = freeze_marker_path(root)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    return payload if isinstance(payload, dict) else {}
+
+
+# -- digest ------------------------------------------------------------------
+
+
+def render_digest(
+    metrics: ThroughputMetrics,
+    *,
+    previous: ThroughputMetrics | None = None,
+    budget: MixBudget | None = None,
+    freeze: dict[str, Any] | None = None,
+    samples: list[dict[str, Any]] | None = None,
+) -> str:
+    """Render the weekly founder digest as markdown."""
+    budget = budget or MixBudget()
+    mix = MixReport(
+        counts=metrics.merges_by_class,
+        total=metrics.merges_total,
+        window_days=metrics.window_days,
+    )
+    verdict = evaluate_budget(mix, budget)
+
+    def delta(current: float, prev: float | None) -> str:
+        if prev is None:
+            return ""
+        change = current - prev
+        return f" ({'+' if change >= 0 else ''}{change:.0%} WoW)"
+
+    lines = [
+        "# Weekly throughput digest",
+        "",
+        f"Window: trailing {metrics.window_days} days",
+        "",
+        "| Metric | Value |",
+        "|---|---|",
+        f"| Merges | {metrics.merges_total} |",
+        "| Product share | "
+        f"{metrics.product_share:.0%}"
+        f"{delta(metrics.product_share, previous.product_share if previous else None)} |",
+        "| Substrate share | "
+        f"{metrics.substrate_share:.0%} (budget ≤ {budget.substrate_max:.0%}) |",
+        f"| Self-repair ratio | {metrics.self_repair_ratio:.0%} |",
+        f"| External artifacts | {metrics.external_artifacts} |",
+        f"| Parks / reverts | {metrics.parks} / {metrics.reverts} |",
+        f"| Classifier disagreements | {metrics.cross_check_disagreements} |",
+        "",
+        f"**Budget verdict:** {'OK' if verdict.ok else '; '.join(verdict.reasons)}",
+        "",
+        "**Substrate freeze:** "
+        + (
+            f"ACTIVE since {freeze.get('timestamp', '?')} — {freeze.get('reason', '')}"
+            if freeze
+            else "inactive"
+        ),
+    ]
+    if samples:
+        lines += ["", "## Spot-audit sample", ""]
+        for sample in samples:
+            lines.append(
+                f"- {sample.get('identifier', '?')}: {sample.get('work_class', '?')}"
+                f" — {sample.get('title', '')}"
+            )
+    return "\n".join(lines) + "\n"

--- a/aragora/nomic/throughput.py
+++ b/aragora/nomic/throughput.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -181,8 +182,13 @@ class ThroughputMetrics:
 
 def _merge_to_classified(record: LedgerRecord) -> ClassifiedWork:
     data = record.data
+    file_counts = data.get("file_counts", {})
+    if not isinstance(file_counts, Mapping):
+        raise ValueError("merge record file_counts must be a mapping")
     counts = {cls: 0 for cls in WorkClass}
-    for value, count in data.get("file_counts", {}).items():
+    for value, count in file_counts.items():
+        if not isinstance(count, int):
+            raise ValueError(f"merge record file count must be int: {value!r}")
         counts[WorkClass(value)] = count
     return ClassifiedWork(
         identifier=str(data.get("identifier", "")),
@@ -192,6 +198,25 @@ def _merge_to_classified(record: LedgerRecord) -> ClassifiedWork:
         exempt=bool(data.get("exempt", False)),
         cross_check_disagreement=data.get("cross_check_disagreement"),
     )
+
+
+def _valid_classified_merges(
+    records: list[LedgerRecord],
+) -> list[tuple[LedgerRecord, ClassifiedWork]]:
+    classified: list[tuple[LedgerRecord, ClassifiedWork]] = []
+    skipped = 0
+    for record in records:
+        try:
+            classified.append((record, _merge_to_classified(record)))
+        except (KeyError, TypeError, ValueError):
+            skipped += 1
+            logger.warning(
+                "skipping semantically invalid merge ledger record %s",
+                record.data.get("identifier", "<unknown>"),
+            )
+    if skipped:
+        logger.warning("skipped %d semantically invalid merge ledger record(s)", skipped)
+    return classified
 
 
 def compute_metrics(
@@ -211,26 +236,28 @@ def compute_metrics(
     windowed = [r for r in records if cutoff <= r.when < now]
 
     merges = [r for r in windowed if r.kind == "merge"]
-    classified = [_merge_to_classified(r) for r in merges]
+    classified_merges = _valid_classified_merges(merges)
+    classified = [work for _, work in classified_merges]
     mix = compute_mix(classified, window_days=window_days)
+    valid_merges_total = len(classified_merges)
 
     # Self-repair: fixes whose target is the loop itself (substrate-class
     # merges with a fix-shaped title). High ratios trigger the
     # remove-the-fragile-abstraction review, not more patches.
     self_repair = sum(
         1
-        for record, work in zip(merges, classified)
+        for record, work in classified_merges
         if work.work_class is WorkClass.SUBSTRATE
         and str(record.data.get("title", "")).lower().startswith(("fix", "repair"))
     )
 
     return ThroughputMetrics(
         window_days=window_days,
-        merges_total=len(merges),
+        merges_total=valid_merges_total,
         merges_by_class=dict(mix.counts),
         product_share=mix.product_share,
         substrate_share=mix.substrate_share,
-        self_repair_ratio=self_repair / len(merges) if merges else 0.0,
+        self_repair_ratio=self_repair / valid_merges_total if valid_merges_total else 0.0,
         external_artifacts=sum(1 for r in windowed if r.kind == "artifact"),
         parks=sum(1 for r in windowed if r.kind == "park"),
         reverts=sum(1 for r in windowed if r.kind == "revert"),
@@ -248,9 +275,8 @@ def mix_from_records(
     """The windowed work-mix report used for budget evaluation."""
     now = now or _utcnow()
     cutoff = now - timedelta(days=window_days)
-    classified = [
-        _merge_to_classified(r) for r in records if r.kind == "merge" and cutoff <= r.when < now
-    ]
+    merges = [r for r in records if r.kind == "merge" and cutoff <= r.when < now]
+    classified = [work for _, work in _valid_classified_merges(merges)]
     return compute_mix(classified, window_days=window_days)
 
 
@@ -306,7 +332,7 @@ def render_digest(
     budget = budget or MixBudget()
     mix = MixReport(
         counts=metrics.merges_by_class,
-        total=metrics.merges_total,
+        total=sum(metrics.merges_by_class.values()),
         window_days=metrics.window_days,
     )
     verdict = evaluate_budget(mix, budget)

--- a/aragora/nomic/throughput.py
+++ b/aragora/nomic/throughput.py
@@ -19,10 +19,13 @@ Part of epic #9039 (issue #9040).
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 from aragora.nomic.work_mix import (
     ClassifiedWork,
@@ -85,17 +88,28 @@ class ThroughputLedger:
             handle.write(record.to_json() + "\n")
 
     def records(self, since: datetime | None = None) -> list[LedgerRecord]:
+        """Read records, skipping corrupt lines (e.g. a write truncated by a
+        killed process) so one bad line never bricks the ledger."""
         if not self.path.exists():
             return []
         result: list[LedgerRecord] = []
+        skipped = 0
         with self.path.open(encoding="utf-8") as handle:
-            for line in handle:
+            for line_number, line in enumerate(handle, start=1):
                 line = line.strip()
                 if not line:
                     continue
-                record = LedgerRecord.from_json(line)
+                try:
+                    record = LedgerRecord.from_json(line)
+                    record.when  # noqa: B018 - validate timestamp eagerly
+                except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+                    skipped += 1
+                    logger.warning("skipping corrupt ledger line %d in %s", line_number, self.path)
+                    continue
                 if since is None or record.when >= since:
                     result.append(record)
+        if skipped:
+            logger.warning("ledger %s had %d corrupt line(s)", self.path, skipped)
         return result
 
     # -- convenience writers -------------------------------------------------
@@ -160,6 +174,9 @@ class ThroughputMetrics:
     parks: int
     reverts: int
     cross_check_disagreements: int
+    # Exempt merges (security/main-red/revert) are excluded from the mix but
+    # remain visible here and in the digest — exemption is a gaming surface.
+    exempt_merges: int = 0
 
 
 def _merge_to_classified(record: LedgerRecord) -> ClassifiedWork:
@@ -183,10 +200,15 @@ def compute_metrics(
     now: datetime | None = None,
     window_days: int = 7,
 ) -> ThroughputMetrics:
-    """Compute rolling metrics over the trailing window."""
+    """Compute rolling metrics over the window ``[now - window_days, now)``.
+
+    The window is bounded on BOTH ends so a caller computing a *previous*
+    period (``now=real_now - 7d``) does not silently absorb current-period
+    records — week-over-week deltas depend on this.
+    """
     now = now or _utcnow()
     cutoff = now - timedelta(days=window_days)
-    windowed = [r for r in records if r.when >= cutoff]
+    windowed = [r for r in records if cutoff <= r.when < now]
 
     merges = [r for r in windowed if r.kind == "merge"]
     classified = [_merge_to_classified(r) for r in merges]
@@ -213,6 +235,7 @@ def compute_metrics(
         parks=sum(1 for r in windowed if r.kind == "park"),
         reverts=sum(1 for r in windowed if r.kind == "revert"),
         cross_check_disagreements=sum(1 for work in classified if work.cross_check_disagreement),
+        exempt_merges=sum(1 for work in classified if work.exempt),
     )
 
 
@@ -226,7 +249,7 @@ def mix_from_records(
     now = now or _utcnow()
     cutoff = now - timedelta(days=window_days)
     classified = [
-        _merge_to_classified(r) for r in records if r.kind == "merge" and r.when >= cutoff
+        _merge_to_classified(r) for r in records if r.kind == "merge" and cutoff <= r.when < now
     ]
     return compute_mix(classified, window_days=window_days)
 
@@ -311,6 +334,7 @@ def render_digest(
         f"| External artifacts | {metrics.external_artifacts} |",
         f"| Parks / reverts | {metrics.parks} / {metrics.reverts} |",
         f"| Classifier disagreements | {metrics.cross_check_disagreements} |",
+        f"| Exempt merges (excluded from mix) | {metrics.exempt_merges} |",
         "",
         f"**Budget verdict:** {'OK' if verdict.ok else '; '.join(verdict.reasons)}",
         "",
@@ -324,8 +348,9 @@ def render_digest(
     if samples:
         lines += ["", "## Spot-audit sample", ""]
         for sample in samples:
+            exempt_tag = " [EXEMPT — not counted in mix]" if sample.get("exempt") else ""
             lines.append(
                 f"- {sample.get('identifier', '?')}: {sample.get('work_class', '?')}"
-                f" — {sample.get('title', '')}"
+                f"{exempt_tag} — {sample.get('title', '')}"
             )
     return "\n".join(lines) + "\n"

--- a/aragora/nomic/throughput.py
+++ b/aragora/nomic/throughput.py
@@ -69,11 +69,16 @@ class LedgerRecord:
     @classmethod
     def from_json(cls, line: str) -> LedgerRecord:
         raw = json.loads(line)
+        if not isinstance(raw, Mapping):
+            raise TypeError("ledger record must be a JSON object")
         return cls(kind=raw["kind"], timestamp=raw["timestamp"], data=raw.get("data", {}))
 
     @property
     def when(self) -> datetime:
-        return datetime.fromisoformat(self.timestamp)
+        parsed = datetime.fromisoformat(self.timestamp)
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            raise ValueError("ledger timestamp must include timezone information")
+        return parsed
 
 
 class ThroughputLedger:
@@ -233,7 +238,7 @@ def compute_metrics(
     """
     now = now or _utcnow()
     cutoff = now - timedelta(days=window_days)
-    windowed = [r for r in records if cutoff <= r.when < now]
+    windowed = _records_in_window(records, cutoff=cutoff, now=now)
 
     merges = [r for r in windowed if r.kind == "merge"]
     classified_merges = _valid_classified_merges(merges)
@@ -275,9 +280,31 @@ def mix_from_records(
     """The windowed work-mix report used for budget evaluation."""
     now = now or _utcnow()
     cutoff = now - timedelta(days=window_days)
-    merges = [r for r in records if r.kind == "merge" and cutoff <= r.when < now]
+    merges = [r for r in _records_in_window(records, cutoff=cutoff, now=now) if r.kind == "merge"]
     classified = [work for _, work in _valid_classified_merges(merges)]
     return compute_mix(classified, window_days=window_days)
+
+
+def _records_in_window(
+    records: list[LedgerRecord], *, cutoff: datetime, now: datetime
+) -> list[LedgerRecord]:
+    windowed: list[LedgerRecord] = []
+    skipped = 0
+    for record in records:
+        try:
+            when = record.when
+        except (TypeError, ValueError):
+            skipped += 1
+            logger.warning(
+                "skipping ledger record with invalid timestamp %r",
+                record.timestamp,
+            )
+            continue
+        if cutoff <= when < now:
+            windowed.append(record)
+    if skipped:
+        logger.warning("skipped %d ledger record(s) with invalid timestamp", skipped)
+    return windowed
 
 
 # -- substrate-freeze marker -------------------------------------------------

--- a/aragora/nomic/work_mix.py
+++ b/aragora/nomic/work_mix.py
@@ -60,6 +60,9 @@ _PREFIX_CLASSES: tuple[tuple[str, WorkClass], ...] = (
     ("docs/verticals/", WorkClass.PRODUCT_PROOF),
     ("benchmarks/", WorkClass.PRODUCT_PROOF),
     ("aragora-verify/", WorkClass.PRODUCT_PROOF),
+    # Published user-facing docs (Docusaurus site) are product output, not
+    # repo maintenance (#9047 openai [P2] round 7).
+    ("docs-site/", WorkClass.PRODUCT_PROOF),
     # -- maintenance: keeps the lights on, neither product nor loop
     ("tests/", WorkClass.MAINTENANCE),
     ("requirements", WorkClass.MAINTENANCE),

--- a/aragora/nomic/work_mix.py
+++ b/aragora/nomic/work_mix.py
@@ -1,0 +1,259 @@
+"""
+Work-mix classification and budget for the self-improvement loop.
+
+Classifies merged work into product-core / product-proof / substrate /
+maintenance from diff paths against a checked-in module map, computes the
+rolling merged-work mix, and evaluates it against the work-mix budget
+(product >= 50%, substrate <= 25% over a 7-day window). A budget breach
+recommends the substrate-freeze marker that goal selection honors.
+
+The deterministic path classifier here is the anti-gaming baseline: it is
+computed from diff content, not labels or commit messages. Phase 2 (issue
+#9045) layers an LLM classifier of record on top ("use real intelligence,
+not regex"); disagreements between the two are surfaced for the weekly
+spot-audit rather than silently resolved.
+
+Plan: docs/plans/2026-07-08-vision-audit-and-work-mix-governor.md (section 4).
+Part of epic #9039 (issue #9040). Advisory only: nothing in this module
+changes gate or selection behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class WorkClass(str, Enum):
+    """The four work classes the mix budget is computed over."""
+
+    PRODUCT_CORE = "product-core"
+    PRODUCT_PROOF = "product-proof"
+    SUBSTRATE = "substrate"
+    MAINTENANCE = "maintenance"
+
+
+# Longest-prefix wins. Order within this list does not matter; specificity does.
+# Substrate = the machine that builds the product (gates, conductors, quorum
+# tooling, loop meta-docs). Product-proof = externally consumable evidence
+# (artifacts, specs, compliance packs, the standalone verifier docs).
+_PREFIX_CLASSES: tuple[tuple[str, WorkClass], ...] = (
+    # -- substrate: loop/gate machinery and its meta-docs
+    ("scripts/", WorkClass.SUBSTRATE),
+    ("aragora/swarm/", WorkClass.SUBSTRATE),
+    ("aragora/nomic/", WorkClass.SUBSTRATE),
+    ("aragora/missions/", WorkClass.SUBSTRATE),
+    ("aragora/harnesses/", WorkClass.SUBSTRATE),
+    ("aragora/worktree/", WorkClass.SUBSTRATE),
+    (".github/", WorkClass.SUBSTRATE),
+    ("docs/runbooks/", WorkClass.SUBSTRATE),
+    ("docs/plans/", WorkClass.SUBSTRATE),
+    ("docs/prompts/", WorkClass.SUBSTRATE),
+    ("docs/strategy/", WorkClass.SUBSTRATE),
+    # -- product-proof: evidence an outsider can consume
+    ("docs/artifacts/", WorkClass.PRODUCT_PROOF),
+    ("docs/specs/", WorkClass.PRODUCT_PROOF),
+    ("docs/compliance/", WorkClass.PRODUCT_PROOF),
+    ("docs/api/", WorkClass.PRODUCT_PROOF),
+    ("docs/guides/", WorkClass.PRODUCT_PROOF),
+    ("docs/verticals/", WorkClass.PRODUCT_PROOF),
+    ("benchmarks/", WorkClass.PRODUCT_PROOF),
+    ("aragora-verify/", WorkClass.PRODUCT_PROOF),
+    # -- maintenance: keeps the lights on, neither product nor loop
+    ("tests/", WorkClass.MAINTENANCE),
+    ("requirements", WorkClass.MAINTENANCE),
+    ("pyproject.toml", WorkClass.MAINTENANCE),
+    ("uv.lock", WorkClass.MAINTENANCE),
+    (".pre-commit-config.yaml", WorkClass.MAINTENANCE),
+    ("docs/", WorkClass.MAINTENANCE),
+    # -- product-core: the runtime users touch (catch-all for aragora/)
+    ("aragora/", WorkClass.PRODUCT_CORE),
+    ("sdk/", WorkClass.PRODUCT_CORE),
+)
+
+# Markers that exempt a change from the budget entirely (always admissible):
+# main-red repair, security fixes, reverts. Checked against labels first
+# (mechanical policy signal), then conservative title prefixes.
+_EXEMPT_LABELS = frozenset({"security", "main-red", "incident"})
+_EXEMPT_TITLE_PREFIXES = ("revert", "fix(main-red)", "security:", "fix(security)")
+
+
+def classify_path(path: str) -> WorkClass:
+    """Classify a single repo-relative path by longest matching prefix."""
+    best: tuple[int, WorkClass] | None = None
+    for prefix, work_class in _PREFIX_CLASSES:
+        if path.startswith(prefix) and (best is None or len(prefix) > best[0]):
+            best = (len(prefix), work_class)
+    return best[1] if best else WorkClass.MAINTENANCE
+
+
+@dataclass
+class ClassifiedWork:
+    """Classification of one unit of merged work (typically a PR)."""
+
+    identifier: str
+    work_class: WorkClass
+    file_counts: dict[WorkClass, int]
+    rationale: str
+    exempt: bool = False
+    # Set when an injected LLM classifier disagreed with the path baseline;
+    # surfaced in the weekly spot-audit, never silently resolved.
+    cross_check_disagreement: str | None = None
+
+
+def classify_paths(
+    paths: Sequence[str],
+    *,
+    identifier: str = "",
+    title: str = "",
+    labels: Iterable[str] = (),
+    llm_classifier: Callable[[Sequence[str], str], WorkClass | None] | None = None,
+) -> ClassifiedWork:
+    """Classify a set of changed paths into a single dominant work class.
+
+    Ties and mixed changes resolve conservatively: if substrate paths are at
+    least half the change, the change is substrate — so padding a loop PR
+    with product files does not launder it.
+
+    ``llm_classifier`` (Phase 2) becomes the classifier of record when it
+    returns a class; the path baseline is kept as the cross-check and any
+    disagreement is recorded on the result.
+    """
+    counts: dict[WorkClass, int] = {cls: 0 for cls in WorkClass}
+    for path in paths:
+        counts[classify_path(path)] += 1
+    total = sum(counts.values())
+
+    label_set = {label.lower() for label in labels}
+    title_lower = title.lower()
+    exempt = bool(label_set & _EXEMPT_LABELS) or title_lower.startswith(_EXEMPT_TITLE_PREFIXES)
+
+    if total == 0:
+        baseline = WorkClass.MAINTENANCE
+        rationale = "no changed paths"
+    elif counts[WorkClass.SUBSTRATE] * 2 >= total:
+        baseline = WorkClass.SUBSTRATE
+        rationale = f"substrate paths are {counts[WorkClass.SUBSTRATE]}/{total} of the change"
+    else:
+        # Dominant class by file count; ties resolve toward substrate first
+        # (conservative), then core, proof, maintenance.
+        precedence = (
+            WorkClass.SUBSTRATE,
+            WorkClass.PRODUCT_CORE,
+            WorkClass.PRODUCT_PROOF,
+            WorkClass.MAINTENANCE,
+        )
+        baseline = max(precedence, key=lambda cls: (counts[cls], -precedence.index(cls)))
+        rationale = f"dominant class by path count ({counts[baseline]}/{total})"
+
+    work_class = baseline
+    disagreement = None
+    if llm_classifier is not None:
+        llm_class = llm_classifier(paths, title)
+        if llm_class is not None:
+            work_class = llm_class
+            if llm_class is not baseline:
+                disagreement = f"llm={llm_class.value} vs path-baseline={baseline.value}"
+
+    return ClassifiedWork(
+        identifier=identifier,
+        work_class=work_class,
+        file_counts=counts,
+        rationale=rationale,
+        exempt=exempt,
+        cross_check_disagreement=disagreement,
+    )
+
+
+@dataclass
+class MixBudget:
+    """The work-mix budget the rolling merged-PR mix must satisfy."""
+
+    product_min: float = 0.50
+    substrate_max: float = 0.25
+    window_days: int = 7
+
+
+@dataclass
+class MixReport:
+    """Shares of merged work by class over a window."""
+
+    counts: dict[WorkClass, int]
+    total: int
+    window_days: int
+
+    def share(self, work_class: WorkClass) -> float:
+        return self.counts[work_class] / self.total if self.total else 0.0
+
+    @property
+    def product_share(self) -> float:
+        return self.share(WorkClass.PRODUCT_CORE) + self.share(WorkClass.PRODUCT_PROOF)
+
+    @property
+    def substrate_share(self) -> float:
+        return self.share(WorkClass.SUBSTRATE)
+
+
+def compute_mix(
+    classified: Iterable[ClassifiedWork],
+    *,
+    window_days: int = 7,
+    exclude_exempt: bool = True,
+) -> MixReport:
+    """Compute the class mix over already-windowed classified work."""
+    counts: dict[WorkClass, int] = {cls: 0 for cls in WorkClass}
+    for work in classified:
+        if exclude_exempt and work.exempt:
+            continue
+        counts[work.work_class] += 1
+    return MixReport(counts=counts, total=sum(counts.values()), window_days=window_days)
+
+
+@dataclass
+class BudgetVerdict:
+    """Outcome of evaluating a mix against the budget."""
+
+    ok: bool
+    substrate_breach: bool
+    product_shortfall: bool
+    freeze_recommended: bool
+    reasons: list[str] = field(default_factory=list)
+
+
+def evaluate_budget(mix: MixReport, budget: MixBudget | None = None) -> BudgetVerdict:
+    """Evaluate a mix report against the budget.
+
+    A substrate breach recommends the freeze marker. A product shortfall is
+    reported but does not by itself recommend a freeze on a single window —
+    the two-consecutive-week kill switch lives in the ledger layer, which
+    sees history.
+    """
+    budget = budget or MixBudget()
+    reasons: list[str] = []
+    if mix.total == 0:
+        return BudgetVerdict(
+            ok=True,
+            substrate_breach=False,
+            product_shortfall=False,
+            freeze_recommended=False,
+            reasons=["no countable merges in window"],
+        )
+
+    substrate_breach = mix.substrate_share > budget.substrate_max
+    product_shortfall = mix.product_share < budget.product_min
+    if substrate_breach:
+        reasons.append(
+            f"substrate share {mix.substrate_share:.0%} exceeds budget {budget.substrate_max:.0%}"
+        )
+    if product_shortfall:
+        reasons.append(
+            f"product share {mix.product_share:.0%} below target {budget.product_min:.0%}"
+        )
+    return BudgetVerdict(
+        ok=not (substrate_breach or product_shortfall),
+        substrate_breach=substrate_breach,
+        product_shortfall=product_shortfall,
+        freeze_recommended=substrate_breach,
+        reasons=reasons,
+    )

--- a/aragora/nomic/work_mix.py
+++ b/aragora/nomic/work_mix.py
@@ -20,7 +20,7 @@ changes gate or selection behavior.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -73,10 +73,15 @@ _PREFIX_CLASSES: tuple[tuple[str, WorkClass], ...] = (
 )
 
 # Markers that exempt a change from the budget entirely (always admissible):
-# main-red repair, security fixes, reverts. Checked against labels first
-# (mechanical policy signal), then conservative title prefixes.
+# main-red repair, security fixes, reverts. Exemption is a gaming surface
+# (an exempt merge is excluded from the mix), so it is deliberately narrow:
+# security/incident exemption requires a LABEL (applied via repo tooling and
+# auditable), never free-text title. Title prefixes are honored only for
+# reverts and main-red repair, whose truthfulness is externally checkable
+# (the reverted commit / the red run). Exempt merges stay in the ledger and
+# are surfaced in the digest spot-audit.
 _EXEMPT_LABELS = frozenset({"security", "main-red", "incident"})
-_EXEMPT_TITLE_PREFIXES = ("revert", "fix(main-red)", "security:", "fix(security)")
+_EXEMPT_TITLE_PREFIXES = ("revert", "fix(main-red)")
 
 
 def classify_path(path: str) -> WorkClass:
@@ -108,35 +113,45 @@ def classify_paths(
     identifier: str = "",
     title: str = "",
     labels: Iterable[str] = (),
+    weights: Mapping[str, int] | None = None,
     llm_classifier: Callable[[Sequence[str], str], WorkClass | None] | None = None,
 ) -> ClassifiedWork:
     """Classify a set of changed paths into a single dominant work class.
 
-    Ties and mixed changes resolve conservatively: if substrate paths are at
-    least half the change, the change is substrate — so padding a loop PR
-    with product files does not launder it.
+    ``weights`` maps each path to its lines changed (additions + deletions).
+    When provided, dominance is decided by lines rather than file count, so
+    trivial one-line edits to product files cannot launder a substantive
+    substrate change below the half guard. Without weights, each path counts
+    as 1 (the file-count fallback).
+
+    Ties and mixed changes resolve conservatively: if substrate weight is at
+    least half the change, the change is substrate.
 
     ``llm_classifier`` (Phase 2) becomes the classifier of record when it
     returns a class; the path baseline is kept as the cross-check and any
     disagreement is recorded on the result.
     """
     counts: dict[WorkClass, int] = {cls: 0 for cls in WorkClass}
+    weighted: dict[WorkClass, int] = {cls: 0 for cls in WorkClass}
     for path in paths:
-        counts[classify_path(path)] += 1
-    total = sum(counts.values())
+        cls = classify_path(path)
+        counts[cls] += 1
+        # A zero-line file (e.g. rename) still counts as weight 1.
+        weighted[cls] += max(1, (weights or {}).get(path, 1))
+    total = sum(weighted.values())
+    unit = "lines" if weights else "paths"
 
     label_set = {label.lower() for label in labels}
-    title_lower = title.lower()
-    exempt = bool(label_set & _EXEMPT_LABELS) or title_lower.startswith(_EXEMPT_TITLE_PREFIXES)
+    exempt = bool(label_set & _EXEMPT_LABELS) or title.lower().startswith(_EXEMPT_TITLE_PREFIXES)
 
     if total == 0:
         baseline = WorkClass.MAINTENANCE
         rationale = "no changed paths"
-    elif counts[WorkClass.SUBSTRATE] * 2 >= total:
+    elif weighted[WorkClass.SUBSTRATE] * 2 >= total:
         baseline = WorkClass.SUBSTRATE
-        rationale = f"substrate paths are {counts[WorkClass.SUBSTRATE]}/{total} of the change"
+        rationale = f"substrate {unit} are {weighted[WorkClass.SUBSTRATE]}/{total} of the change"
     else:
-        # Dominant class by file count; ties resolve toward substrate first
+        # Dominant class by weight; ties resolve toward substrate first
         # (conservative), then core, proof, maintenance.
         precedence = (
             WorkClass.SUBSTRATE,
@@ -144,8 +159,8 @@ def classify_paths(
             WorkClass.PRODUCT_PROOF,
             WorkClass.MAINTENANCE,
         )
-        baseline = max(precedence, key=lambda cls: (counts[cls], -precedence.index(cls)))
-        rationale = f"dominant class by path count ({counts[baseline]}/{total})"
+        baseline = max(precedence, key=lambda cls: (weighted[cls], -precedence.index(cls)))
+        rationale = f"dominant class by {unit} ({weighted[baseline]}/{total})"
 
     work_class = baseline
     disagreement = None

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,7 +20,7 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,173 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,179 | `docs/METRICS.md` |
 | Automated tests | 223,526 test functions | `docs/METRICS.md` |
 | Test files | 5,452 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
-| Automated tests | 223,198 test functions | `docs/METRICS.md` |
-| Test files | 5,437 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,173 | `docs/METRICS.md` |
+| Automated tests | 223,526 test functions | `docs/METRICS.md` |
+| Test files | 5,452 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,8 +20,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,191 | `docs/METRICS.md` |
-| Automated tests | 223,532 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,194 | `docs/METRICS.md` |
+| Automated tests | 223,533 test functions | `docs/METRICS.md` |
 | Test files | 5,453 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,9 +20,9 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,179 | `docs/METRICS.md` |
-| Automated tests | 223,526 test functions | `docs/METRICS.md` |
-| Test files | 5,452 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,191 | `docs/METRICS.md` |
+| Automated tests | 223,532 test functions | `docs/METRICS.md` |
+| Test files | 5,453 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions | 5,452 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,526 test functions across 5,452 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,532 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions | 5,437 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions | 5,452 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,198 test functions across 5,437 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,526 test functions across 5,452 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -197,7 +197,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
 <!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
+**Codebase Scale:** 4,263 tracked Python files | 144 top-level modules | 223,533 test functions | 5,453 test files | 3,297 API operations across 2,870 paths | canonical counts in `docs/METRICS.md`
 <!-- metrics:end -->
 
 ## Architecture
@@ -447,7 +447,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 ## Feature Status
 
 <!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,532 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
+**Test Suite:** 223,533 test functions across 5,453 test files (canonical counts in `docs/METRICS.md`)
 <!-- metrics:end -->
 
 **Core (stable):**

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions across 5,452 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,533 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions across 5,452 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,263 Python files | 223,526 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,532 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,526 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,263 Python files | 223,532 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,533 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,263
-- **Tests**: 223,532 across 5,453 test files
+- **Tests**: 223,533 across 5,453 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,263
-- **Tests**: 223,526 across 5,452 test files
+- **Tests**: 223,532 across 5,453 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,262
-- **Tests**: 223,198 across 5,437 test files
+- **Python files (`aragora/`)**: 4,263
+- **Tests**: 223,526 across 5,452 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,532 tests across 5,453 test files
+- **Test coverage**: 223,533 tests across 5,453 test files
 - **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,198 tests across 5,437 test files
-- **Source files**: 4,262 Python files under `aragora/`
+- **Test coverage**: 223,526 tests across 5,452 test files
+- **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,526 tests across 5,452 test files
+- **Test coverage**: 223,532 tests across 5,453 test files
 - **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,8 +15,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,191 | `docs/METRICS.md` |
-| Automated tests | 223,532 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,194 | `docs/METRICS.md` |
+| Automated tests | 223,533 test functions | `docs/METRICS.md` |
 | Test files | 5,453 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,7 +15,7 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,173 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,179 | `docs/METRICS.md` |
 | Automated tests | 223,526 test functions | `docs/METRICS.md` |
 | Test files | 5,452 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,262 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,976,521 | `docs/METRICS.md` |
-| Automated tests | 223,198 test functions | `docs/METRICS.md` |
-| Test files | 5,437 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,173 | `docs/METRICS.md` |
+| Automated tests | 223,526 test functions | `docs/METRICS.md` |
+| Test files | 5,452 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,9 +15,9 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,263 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,978,179 | `docs/METRICS.md` |
-| Automated tests | 223,526 test functions | `docs/METRICS.md` |
-| Test files | 5,452 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,978,191 | `docs/METRICS.md` |
+| Automated tests | 223,532 test functions | `docs/METRICS.md` |
+| Test files | 5,453 | `docs/METRICS.md` |
 | API operations | 3,297 across 2,870 paths | `docs/METRICS.md` |
 | API paths | 2,870 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,533 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,262 tracked Python files | 144 top-level modules | 223,198 test functions across 5,437 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions across 5,452 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,526 test functions across 5,452 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,263 tracked Python files | 144 top-level modules | 223,532 test functions across 5,453 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4262` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1976521` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4263` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1978146` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5437` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223198` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `834` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5452` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `223523` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `836` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3297` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1041` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1051` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `90` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,7 +13,7 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4263` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1978173` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1978179` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5452` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
 | Test functions (class + module level) | `223526` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4263` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1978146` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1978173` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5452` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223523` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223526` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `836` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4263` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1978191` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1978194` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5453` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223532` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223533` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `836` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4263` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1978179` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1978191` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5452` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223526` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5453` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `223532` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `836` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2870` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1051` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1058` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `90` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,263
-- **Tests**: 223,526 across 5,452 test files
+- **Tests**: 223,532 across 5,453 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,262
-- **Tests**: 223,198 across 5,437 test files
+- **Python files (`aragora/`)**: 4,263
+- **Tests**: 223,526 across 5,452 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,263
-- **Tests**: 223,532 across 5,453 test files
+- **Tests**: 223,533 across 5,453 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,297 across 2,870 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,532 tests across 5,453 test files
+- **Test coverage**: 223,533 tests across 5,453 test files
 - **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,198 tests across 5,437 test files
-- **Source files**: 4,262 Python files under `aragora/`
+- **Test coverage**: 223,526 tests across 5,452 test files
+- **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,526 tests across 5,452 test files
+- **Test coverage**: 223,532 tests across 5,453 test files
 - **Source files**: 4,263 Python files under `aragora/`
 - **API surface**: 3,297 API operations across 2,870 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,262 Python files | 223,198 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,526 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,263 Python files | 223,526 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,532 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,263 Python files | 223,532 tests | 3,297 API operations across 2,870 paths
+**Total**: 230+ features | 4,263 Python files | 223,533 tests | 3,297 API operations across 2,870 paths
 <!-- metrics:end -->
 
 ---

--- a/tests/nomic/test_throughput.py
+++ b/tests/nomic/test_throughput.py
@@ -39,6 +39,13 @@ class TestLedgerRecord:
         with pytest.raises(ValueError, match="unknown ledger record kind"):
             LedgerRecord(kind="bogus", timestamp=NOW.isoformat())
 
+    def test_from_json_rejects_non_object_payloads(self):
+        with pytest.raises(TypeError, match="ledger record must be a JSON object"):
+            LedgerRecord.from_json("[]")
+
+        with pytest.raises(TypeError, match="ledger record must be a JSON object"):
+            LedgerRecord.from_json("1")
+
 
 class TestThroughputLedger:
     def test_append_and_read(self, tmp_path):
@@ -67,6 +74,9 @@ class TestThroughputLedger:
         with ledger.path.open("a", encoding="utf-8") as handle:
             handle.write('{"kind": "merge", "timesta\n')  # truncated write
             handle.write("not json at all\n")
+            handle.write("[]\n")
+            handle.write("1\n")
+            handle.write('{"kind": "artifact", "timestamp": "2026-07-08T00:00:00", "data": {}}\n')
             handle.write('{"kind": "bogus-kind", "timestamp": "2026-07-08T00:00:00+00:00"}\n')
         _merge(ledger, ["aragora/b.py"], pr="2")
         records = ledger.records()
@@ -108,6 +118,40 @@ class TestComputeMetrics:
         assert metrics.merges_total == 0
         assert metrics.product_share == 0.0
         assert metrics.self_repair_ratio == 0.0
+
+    def test_naive_timestamp_records_are_ignored(self, tmp_path, caplog):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/a.py"], pr="good")
+        ledger.append(
+            LedgerRecord(
+                kind="artifact",
+                timestamp="2026-07-08T11:00:00",
+                data={"name": "naive"},
+            )
+        )
+
+        with caplog.at_level("WARNING", logger="aragora.nomic.throughput"):
+            metrics = compute_metrics(ledger.records(), now=NOW)
+
+        assert metrics.merges_total == 1
+        assert metrics.external_artifacts == 0
+        assert "corrupt ledger line" in caplog.text
+
+    def test_compute_metrics_skips_direct_naive_timestamp_records(self, tmp_path, caplog):
+        ledger = ThroughputLedger(tmp_path)
+        good = _merge(ledger, ["aragora/a.py"], pr="good")
+        naive = LedgerRecord(
+            kind="artifact",
+            timestamp="2026-07-08T11:00:00",
+            data={"name": "naive"},
+        )
+
+        with caplog.at_level("WARNING", logger="aragora.nomic.throughput"):
+            metrics = compute_metrics([good, naive], now=NOW)
+
+        assert metrics.merges_total == 1
+        assert metrics.external_artifacts == 0
+        assert "invalid timestamp" in caplog.text
 
     def test_previous_window_excludes_current_records(self, tmp_path):
         # WoW regression: computing metrics with now=NOW-7d must NOT absorb

--- a/tests/nomic/test_throughput.py
+++ b/tests/nomic/test_throughput.py
@@ -1,0 +1,140 @@
+"""Tests for aragora.nomic.throughput (epic #9039, issue #9040)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from aragora.nomic.throughput import (
+    LedgerRecord,
+    ThroughputLedger,
+    clear_freeze_marker,
+    compute_metrics,
+    freeze_active,
+    freeze_marker_path,
+    mix_from_records,
+    render_digest,
+    write_freeze_marker,
+)
+from aragora.nomic.work_mix import WorkClass, classify_paths
+
+NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+
+
+def _merge(ledger: ThroughputLedger, paths, *, title="", labels=(), when=NOW, pr="1"):
+    work = classify_paths(paths, identifier=pr, title=title, labels=labels)
+    return ledger.record_merge(work, title=title, when=when)
+
+
+class TestLedgerRecord:
+    def test_round_trip(self):
+        record = LedgerRecord(kind="merge", timestamp=NOW.isoformat(), data={"a": 1})
+        assert LedgerRecord.from_json(record.to_json()) == record
+
+    def test_unknown_kind_rejected(self):
+        with pytest.raises(ValueError, match="unknown ledger record kind"):
+            LedgerRecord(kind="bogus", timestamp=NOW.isoformat())
+
+
+class TestThroughputLedger:
+    def test_append_and_read(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/debate/a.py"], title="feat: x", pr="42")
+        ledger.record_artifact("dogfood-report", url="https://example.com", when=NOW)
+        records = ledger.records()
+        assert [r.kind for r in records] == ["merge", "artifact"]
+        assert records[0].data["identifier"] == "42"
+        assert records[0].data["work_class"] == "product-core"
+
+    def test_since_filter(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/a.py"], when=NOW - timedelta(days=10))
+        _merge(ledger, ["aragora/b.py"], when=NOW)
+        recent = ledger.records(since=NOW - timedelta(days=7))
+        assert len(recent) == 1
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert ThroughputLedger(tmp_path).records() == []
+
+
+class TestComputeMetrics:
+    def _build(self, tmp_path) -> ThroughputLedger:
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/debate/a.py"], title="feat: consensus", pr="1")
+        _merge(ledger, ["docs/artifacts/a.md"], title="docs: artifact", pr="2")
+        _merge(ledger, ["scripts/gate.py"], title="fix: gate hang", pr="3")
+        _merge(ledger, ["scripts/old.py"], title="feat: old", pr="4", when=NOW - timedelta(days=30))
+        ledger.record_artifact("verifier-release", when=NOW)
+        ledger.append(LedgerRecord(kind="park", timestamp=NOW.isoformat(), data={"pr": "5"}))
+        return ledger
+
+    def test_window_and_shares(self, tmp_path):
+        metrics = compute_metrics(self._build(tmp_path).records(), now=NOW)
+        assert metrics.merges_total == 3  # 30-day-old merge excluded
+        assert metrics.product_share == pytest.approx(2 / 3)
+        assert metrics.substrate_share == pytest.approx(1 / 3)
+        assert metrics.external_artifacts == 1
+        assert metrics.parks == 1
+        assert metrics.reverts == 0
+
+    def test_self_repair_ratio(self, tmp_path):
+        metrics = compute_metrics(self._build(tmp_path).records(), now=NOW)
+        # one substrate merge with fix-shaped title out of three merges
+        assert metrics.self_repair_ratio == pytest.approx(1 / 3)
+
+    def test_mix_from_records_matches(self, tmp_path):
+        mix = mix_from_records(self._build(tmp_path).records(), now=NOW)
+        assert mix.total == 3
+        assert mix.counts[WorkClass.SUBSTRATE] == 1
+
+    def test_empty_records(self):
+        metrics = compute_metrics([], now=NOW)
+        assert metrics.merges_total == 0
+        assert metrics.product_share == 0.0
+        assert metrics.self_repair_ratio == 0.0
+
+
+class TestFreezeMarker:
+    def test_lifecycle(self, tmp_path):
+        assert freeze_active(tmp_path) is None
+        path = write_freeze_marker(tmp_path, reason="substrate 40% > 25%")
+        assert path == freeze_marker_path(tmp_path)
+        payload = freeze_active(tmp_path)
+        assert payload is not None
+        assert payload["reason"] == "substrate 40% > 25%"
+        assert clear_freeze_marker(tmp_path)
+        assert freeze_active(tmp_path) is None
+        assert not clear_freeze_marker(tmp_path)
+
+    def test_corrupt_marker_still_reports_active(self, tmp_path):
+        path = write_freeze_marker(tmp_path, reason="x")
+        path.write_text("not json", encoding="utf-8")
+        assert freeze_active(tmp_path) == {}
+
+
+class TestRenderDigest:
+    def test_digest_contains_key_sections(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/debate/a.py"], title="feat: x", pr="1")
+        _merge(ledger, ["scripts/gate.py"], title="fix: y", pr="2")
+        metrics = compute_metrics(ledger.records(), now=NOW)
+        digest = render_digest(
+            metrics,
+            freeze={"timestamp": NOW.isoformat(), "reason": "test"},
+            samples=[{"identifier": "1", "work_class": "product-core", "title": "feat: x"}],
+        )
+        assert "# Weekly throughput digest" in digest
+        assert "Product share | 50%" in digest
+        assert "ACTIVE" in digest
+        assert "Spot-audit sample" in digest
+        assert "- 1: product-core" in digest
+
+    def test_digest_inactive_freeze_and_wow_delta(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/debate/a.py"], pr="1")
+        current = compute_metrics(ledger.records(), now=NOW)
+        previous = compute_metrics([], now=NOW - timedelta(days=7))
+        digest = render_digest(current, previous=previous)
+        assert "inactive" in digest
+        assert "WoW" in digest

--- a/tests/nomic/test_throughput.py
+++ b/tests/nomic/test_throughput.py
@@ -131,6 +131,52 @@ class TestComputeMetrics:
         mix = mix_from_records(ledger.records(), now=NOW)
         assert mix.total == 1  # exempt merge excluded from budget math
 
+    def test_semantically_invalid_merge_records_are_skipped(self, tmp_path, caplog):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/a.py"], pr="good")
+        ledger.append(
+            LedgerRecord(
+                kind="merge",
+                timestamp=RECENT.isoformat(),
+                data={
+                    "identifier": "bad-class",
+                    "work_class": "not-a-work-class",
+                    "file_counts": {},
+                },
+            )
+        )
+        ledger.append(
+            LedgerRecord(
+                kind="merge",
+                timestamp=RECENT.isoformat(),
+                data={
+                    "identifier": "bad-file-counts",
+                    "work_class": "substrate",
+                    "file_counts": ["not", "a", "mapping"],
+                },
+            )
+        )
+        ledger.append(
+            LedgerRecord(
+                kind="merge",
+                timestamp=RECENT.isoformat(),
+                data={
+                    "identifier": "bad-count-value",
+                    "work_class": "substrate",
+                    "file_counts": {"substrate": "many"},
+                },
+            )
+        )
+
+        with caplog.at_level("WARNING", logger="aragora.nomic.throughput"):
+            metrics = compute_metrics(ledger.records(), now=NOW)
+            mix = mix_from_records(ledger.records(), now=NOW)
+
+        assert metrics.merges_total == 1
+        assert metrics.product_share == 1.0
+        assert mix.total == 1
+        assert "semantically invalid merge ledger record" in caplog.text
+
 
 class TestFreezeMarker:
     def test_lifecycle(self, tmp_path):
@@ -175,3 +221,24 @@ class TestRenderDigest:
         digest = render_digest(current, previous=previous)
         assert "inactive" in digest
         assert "WoW" in digest
+
+    def test_digest_budget_uses_countable_non_exempt_denominator(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/debate/a.py"], pr="product")
+        for index in range(3):
+            _merge(
+                ledger,
+                [f"scripts/security_fix_{index}.py"],
+                labels=["security"],
+                pr=f"exempt-{index}",
+            )
+
+        metrics = compute_metrics(ledger.records(), now=NOW)
+        digest = render_digest(metrics)
+
+        assert metrics.merges_total == 4
+        assert metrics.exempt_merges == 3
+        assert metrics.product_share == 1.0
+        assert "Product share | 100%" in digest
+        assert "Exempt merges (excluded from mix) | 3" in digest
+        assert "**Budget verdict:** OK" in digest

--- a/tests/nomic/test_throughput.py
+++ b/tests/nomic/test_throughput.py
@@ -78,6 +78,11 @@ class TestThroughputLedger:
             handle.write("1\n")
             handle.write('{"kind": "artifact", "timestamp": "2026-07-08T00:00:00", "data": {}}\n')
             handle.write('{"kind": "bogus-kind", "timestamp": "2026-07-08T00:00:00+00:00"}\n')
+            # non-dict data payload passes timestamp validation but must be
+            # rejected as corrupt, not crash consumers (#9047 openai [P2])
+            handle.write(
+                '{"kind": "merge", "timestamp": "2026-07-08T00:00:00+00:00", "data": []}\n'
+            )
         _merge(ledger, ["aragora/b.py"], pr="2")
         records = ledger.records()
         assert [r.data["identifier"] for r in records] == ["1", "2"]

--- a/tests/nomic/test_throughput.py
+++ b/tests/nomic/test_throughput.py
@@ -20,9 +20,12 @@ from aragora.nomic.throughput import (
 from aragora.nomic.work_mix import WorkClass, classify_paths
 
 NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+# Windows are half-open [now - window, now): a record stamped exactly `now`
+# is excluded, so test merges use a realistic slightly-earlier timestamp.
+RECENT = NOW - timedelta(hours=1)
 
 
-def _merge(ledger: ThroughputLedger, paths, *, title="", labels=(), when=NOW, pr="1"):
+def _merge(ledger: ThroughputLedger, paths, *, title="", labels=(), when=RECENT, pr="1"):
     work = classify_paths(paths, identifier=pr, title=title, labels=labels)
     return ledger.record_merge(work, title=title, when=when)
 
@@ -57,6 +60,18 @@ class TestThroughputLedger:
     def test_missing_file_returns_empty(self, tmp_path):
         assert ThroughputLedger(tmp_path).records() == []
 
+    def test_corrupt_line_skipped_not_fatal(self, tmp_path):
+        # A write truncated by a killed process must not brick the ledger.
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["aragora/a.py"], pr="1")
+        with ledger.path.open("a", encoding="utf-8") as handle:
+            handle.write('{"kind": "merge", "timesta\n')  # truncated write
+            handle.write("not json at all\n")
+            handle.write('{"kind": "bogus-kind", "timestamp": "2026-07-08T00:00:00+00:00"}\n')
+        _merge(ledger, ["aragora/b.py"], pr="2")
+        records = ledger.records()
+        assert [r.data["identifier"] for r in records] == ["1", "2"]
+
 
 class TestComputeMetrics:
     def _build(self, tmp_path) -> ThroughputLedger:
@@ -65,8 +80,8 @@ class TestComputeMetrics:
         _merge(ledger, ["docs/artifacts/a.md"], title="docs: artifact", pr="2")
         _merge(ledger, ["scripts/gate.py"], title="fix: gate hang", pr="3")
         _merge(ledger, ["scripts/old.py"], title="feat: old", pr="4", when=NOW - timedelta(days=30))
-        ledger.record_artifact("verifier-release", when=NOW)
-        ledger.append(LedgerRecord(kind="park", timestamp=NOW.isoformat(), data={"pr": "5"}))
+        ledger.record_artifact("verifier-release", when=RECENT)
+        ledger.append(LedgerRecord(kind="park", timestamp=RECENT.isoformat(), data={"pr": "5"}))
         return ledger
 
     def test_window_and_shares(self, tmp_path):
@@ -93,6 +108,28 @@ class TestComputeMetrics:
         assert metrics.merges_total == 0
         assert metrics.product_share == 0.0
         assert metrics.self_repair_ratio == 0.0
+
+    def test_previous_window_excludes_current_records(self, tmp_path):
+        # WoW regression: computing metrics with now=NOW-7d must NOT absorb
+        # records from the current week (window is bounded on both ends).
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["scripts/old.py"], pr="prev1", when=NOW - timedelta(days=10))
+        _merge(ledger, ["aragora/new.py"], pr="cur1", when=NOW - timedelta(days=1))
+        previous = compute_metrics(ledger.records(), now=NOW - timedelta(days=7))
+        assert previous.merges_total == 1
+        assert previous.substrate_share == 1.0  # prior week was 100% substrate
+        current = compute_metrics(ledger.records(), now=NOW)
+        assert current.merges_total == 1
+        assert current.product_share == 1.0
+
+    def test_exempt_counted_in_metrics_not_mix(self, tmp_path):
+        ledger = ThroughputLedger(tmp_path)
+        _merge(ledger, ["scripts/x.py"], title="Revert broken gate", pr="1")
+        _merge(ledger, ["aragora/a.py"], pr="2")
+        metrics = compute_metrics(ledger.records(), now=NOW)
+        assert metrics.exempt_merges == 1
+        mix = mix_from_records(ledger.records(), now=NOW)
+        assert mix.total == 1  # exempt merge excluded from budget math
 
 
 class TestFreezeMarker:

--- a/tests/nomic/test_work_mix.py
+++ b/tests/nomic/test_work_mix.py
@@ -84,6 +84,30 @@ class TestClassifyPaths:
         assert classify_paths(["tests/a.py"], title="fix(main-red): shard").exempt
         assert not classify_paths(["scripts/x.py"], title="feat: new gate").exempt
 
+    def test_security_title_alone_does_not_exempt(self):
+        # Free-text titles must not confer security exemption — that requires
+        # a label (gaming vector: prefix a substrate PR with "security:").
+        assert not classify_paths(["scripts/x.py"], title="security: harden gate").exempt
+        assert not classify_paths(["scripts/x.py"], title="fix(security): races").exempt
+        assert classify_paths(["scripts/x.py"], labels=["security"]).exempt
+
+    def test_line_weights_defeat_trivial_padding(self):
+        # 4 substantive substrate files vs 5 one-line product edits: by file
+        # count product would win (5 > 4, substrate 44% < 50%); by line
+        # weight the substrate work dominates and the PR stays substrate.
+        paths = [f"scripts/gate_{i}.py" for i in range(4)] + [
+            f"aragora/debate/pad_{i}.py" for i in range(5)
+        ]
+        weights = dict.fromkeys(paths[:4], 200) | dict.fromkeys(paths[4:], 1)
+        assert classify_paths(paths, weights=weights).work_class is WorkClass.SUBSTRATE
+        # Without weights, the padding attack still flips it — documents why
+        # the snapshot feeder must pass line weights.
+        assert classify_paths(paths).work_class is WorkClass.PRODUCT_CORE
+
+    def test_zero_weight_paths_count_as_one(self):
+        work = classify_paths(["aragora/debate/a.py"], weights={"aragora/debate/a.py": 0})
+        assert work.work_class is WorkClass.PRODUCT_CORE
+
     def test_empty_paths_maintenance(self):
         work = classify_paths([])
         assert work.work_class is WorkClass.MAINTENANCE

--- a/tests/nomic/test_work_mix.py
+++ b/tests/nomic/test_work_mix.py
@@ -27,6 +27,10 @@ class TestClassifyPath:
         assert classify_path("docs/plans/2026-07-08-plan.md") is WorkClass.SUBSTRATE
         assert classify_path("docs/runbooks/main-red.md") is WorkClass.SUBSTRATE
 
+    def test_docs_site_is_product_proof(self):
+        # published user-facing docs are product output (#9047 openai [P2])
+        assert classify_path("docs-site/docs/api/reference.md") is WorkClass.PRODUCT_PROOF
+
     def test_product_proof_artifacts(self):
         assert classify_path("docs/artifacts/dogfood.md") is WorkClass.PRODUCT_PROOF
         assert classify_path("docs/specs/OPEN_DECISION_RECEIPT.md") is WorkClass.PRODUCT_PROOF

--- a/tests/nomic/test_work_mix.py
+++ b/tests/nomic/test_work_mix.py
@@ -1,0 +1,166 @@
+"""Tests for aragora.nomic.work_mix (epic #9039, issue #9040)."""
+
+from __future__ import annotations
+
+from aragora.nomic.work_mix import (
+    BudgetVerdict,
+    MixBudget,
+    WorkClass,
+    classify_path,
+    classify_paths,
+    compute_mix,
+    evaluate_budget,
+)
+
+
+class TestClassifyPath:
+    def test_product_core_runtime(self):
+        assert classify_path("aragora/debate/orchestrator.py") is WorkClass.PRODUCT_CORE
+        assert classify_path("aragora/gauntlet/receipts.py") is WorkClass.PRODUCT_CORE
+        assert classify_path("sdk/python/client.py") is WorkClass.PRODUCT_CORE
+
+    def test_substrate_loop_machinery(self):
+        assert classify_path("scripts/merge_executor.py") is WorkClass.SUBSTRATE
+        assert classify_path("aragora/swarm/boss_loop.py") is WorkClass.SUBSTRATE
+        assert classify_path("aragora/nomic/meta_planner.py") is WorkClass.SUBSTRATE
+        assert classify_path(".github/workflows/ci.yml") is WorkClass.SUBSTRATE
+        assert classify_path("docs/plans/2026-07-08-plan.md") is WorkClass.SUBSTRATE
+        assert classify_path("docs/runbooks/main-red.md") is WorkClass.SUBSTRATE
+
+    def test_product_proof_artifacts(self):
+        assert classify_path("docs/artifacts/dogfood.md") is WorkClass.PRODUCT_PROOF
+        assert classify_path("docs/specs/OPEN_DECISION_RECEIPT.md") is WorkClass.PRODUCT_PROOF
+        assert classify_path("aragora-verify/verify.py") is WorkClass.PRODUCT_PROOF
+        assert classify_path("benchmarks/ten_domain.py") is WorkClass.PRODUCT_PROOF
+
+    def test_maintenance(self):
+        assert classify_path("tests/nomic/test_x.py") is WorkClass.MAINTENANCE
+        assert classify_path("pyproject.toml") is WorkClass.MAINTENANCE
+        assert classify_path("docs/README_misc.md") is WorkClass.MAINTENANCE
+        assert classify_path("totally/unknown/file.txt") is WorkClass.MAINTENANCE
+
+    def test_longest_prefix_wins(self):
+        # docs/ is maintenance but docs/specs/ is product-proof
+        assert classify_path("docs/specs/x.md") is WorkClass.PRODUCT_PROOF
+        # aragora/ is product-core but aragora/swarm/ is substrate
+        assert classify_path("aragora/swarm/x.py") is WorkClass.SUBSTRATE
+
+
+class TestClassifyPaths:
+    def test_pure_product_pr(self):
+        work = classify_paths(["aragora/debate/a.py", "aragora/server/b.py"], identifier="1")
+        assert work.work_class is WorkClass.PRODUCT_CORE
+        assert not work.exempt
+
+    def test_substrate_half_or_more_is_substrate(self):
+        # 2 of 4 paths substrate -> substrate wins (anti-laundering)
+        work = classify_paths(
+            [
+                "scripts/settle_pr.py",
+                "aragora/swarm/gate.py",
+                "aragora/debate/a.py",
+                "aragora/server/b.py",
+            ]
+        )
+        assert work.work_class is WorkClass.SUBSTRATE
+
+    def test_minority_substrate_does_not_dominate(self):
+        work = classify_paths(
+            [
+                "scripts/settle_pr.py",
+                "aragora/debate/a.py",
+                "aragora/server/b.py",
+                "aragora/gauntlet/c.py",
+            ]
+        )
+        assert work.work_class is WorkClass.PRODUCT_CORE
+
+    def test_exempt_by_label(self):
+        work = classify_paths(["aragora/auth/x.py"], labels=["Security"])
+        assert work.exempt
+
+    def test_exempt_by_title_prefix(self):
+        assert classify_paths(["scripts/x.py"], title="Revert broken gate").exempt
+        assert classify_paths(["tests/a.py"], title="fix(main-red): shard").exempt
+        assert not classify_paths(["scripts/x.py"], title="feat: new gate").exempt
+
+    def test_empty_paths_maintenance(self):
+        work = classify_paths([])
+        assert work.work_class is WorkClass.MAINTENANCE
+        assert work.rationale == "no changed paths"
+
+    def test_llm_classifier_of_record_records_disagreement(self):
+        work = classify_paths(
+            ["scripts/x.py"],
+            llm_classifier=lambda paths, title: WorkClass.PRODUCT_PROOF,
+        )
+        assert work.work_class is WorkClass.PRODUCT_PROOF
+        assert work.cross_check_disagreement is not None
+        assert "substrate" in work.cross_check_disagreement
+
+    def test_llm_classifier_none_falls_back_to_baseline(self):
+        work = classify_paths(["scripts/x.py"], llm_classifier=lambda paths, title: None)
+        assert work.work_class is WorkClass.SUBSTRATE
+        assert work.cross_check_disagreement is None
+
+
+class TestMixAndBudget:
+    @staticmethod
+    def _work(cls: WorkClass, exempt: bool = False):
+        return classify_paths(
+            {
+                WorkClass.PRODUCT_CORE: ["aragora/debate/a.py"],
+                WorkClass.PRODUCT_PROOF: ["docs/artifacts/a.md"],
+                WorkClass.SUBSTRATE: ["scripts/a.py"],
+                WorkClass.MAINTENANCE: ["tests/a.py"],
+            }[cls],
+            labels=["security"] if exempt else [],
+        )
+
+    def test_compute_mix_shares(self):
+        works = [self._work(WorkClass.PRODUCT_CORE)] * 3 + [self._work(WorkClass.SUBSTRATE)]
+        mix = compute_mix(works)
+        assert mix.total == 4
+        assert mix.product_share == 0.75
+        assert mix.substrate_share == 0.25
+
+    def test_exempt_excluded(self):
+        works = [self._work(WorkClass.PRODUCT_CORE), self._work(WorkClass.SUBSTRATE, exempt=True)]
+        mix = compute_mix(works)
+        assert mix.total == 1
+        assert mix.substrate_share == 0.0
+
+    def test_budget_ok(self):
+        works = [self._work(WorkClass.PRODUCT_CORE)] * 3 + [self._work(WorkClass.SUBSTRATE)]
+        verdict = evaluate_budget(compute_mix(works))
+        assert isinstance(verdict, BudgetVerdict)
+        assert verdict.ok
+        assert not verdict.freeze_recommended
+
+    def test_substrate_breach_recommends_freeze(self):
+        works = [self._work(WorkClass.SUBSTRATE)] * 2 + [self._work(WorkClass.PRODUCT_CORE)]
+        verdict = evaluate_budget(compute_mix(works))
+        assert verdict.substrate_breach
+        assert verdict.freeze_recommended
+        assert any("substrate share" in r for r in verdict.reasons)
+
+    def test_product_shortfall_alone_no_freeze(self):
+        works = [self._work(WorkClass.MAINTENANCE)] * 3 + [self._work(WorkClass.PRODUCT_CORE)]
+        verdict = evaluate_budget(compute_mix(works))
+        assert verdict.product_shortfall
+        assert not verdict.substrate_breach
+        assert not verdict.freeze_recommended
+        assert not verdict.ok
+
+    def test_empty_window_is_ok(self):
+        verdict = evaluate_budget(compute_mix([]))
+        assert verdict.ok
+        assert not verdict.freeze_recommended
+
+    def test_custom_budget(self):
+        works = [self._work(WorkClass.SUBSTRATE)] + [self._work(WorkClass.PRODUCT_CORE)] * 9
+        verdict = evaluate_budget(
+            compute_mix(works), MixBudget(product_min=0.95, substrate_max=0.05)
+        )
+        assert verdict.substrate_breach
+        assert verdict.product_shortfall


### PR DESCRIPTION
## Summary

Library layer of the **work-mix governor** — the mechanism that mechanically enforces the substrate-freeze / external-proof principle the repo's own stage gate (#9007) detects but cannot act on.

Closes #9040. Part of epic #9039. Plan: `docs/plans/2026-07-08-vision-audit-and-work-mix-governor.md` §4 (PR #9038).

- **`aragora/nomic/work_mix.py`** — WorkClass taxonomy (product-core / product-proof / substrate / maintenance); deterministic diff-path classifier over a checked-in longest-prefix module map (the anti-gaming baseline: computed from diff content, never labels or commit messages); mixed changes resolve conservatively (substrate ≥50% of paths wins, so loop PRs can't be laundered with product files); injectable LLM classifier-of-record hook (Phase 2, #9045) with disagreements recorded for the weekly spot-audit; MixBudget (product ≥50%, substrate ≤25%, 7-day rolling window) and budget verdicts (substrate breach → freeze recommended).
- **`aragora/nomic/throughput.py`** — append-only JSONL ledger at `.aragora/throughput/ledger.jsonl` (merge / snapshot / artifact / park / revert records); rolling metrics: product share, substrate share, self-repair ratio, external-artifact cadence, classifier disagreements; substrate-freeze marker lifecycle; weekly founder digest renderer.

## Scope and safety

- **Advisory only.** Pure stdlib library; no GitHub calls, no LLM calls, no gate or goal-selection behavior changes. The only writes are the ledger file and (when explicitly asked) the freeze marker.
- CLI wrappers are #9041; enforcement wiring into boss_loop/fable_goal_cycle is Phase 2 (#9045), flag-gated.
- Tier 1 (additive), 896 LOC including 33 unit tests, all passing locally.

## Test plan

`pytest tests/nomic/test_work_mix.py tests/nomic/test_throughput.py` — classification (longest-prefix, anti-laundering, exemptions for security/main-red/revert), mix math, budget verdicts, ledger round-trip, freeze-marker lifecycle (incl. corrupt marker), digest rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)