### PR TITLE
feat(swarm): wire PR-keyed round budget into A1 reconciler (Tier 4, #9042)

### DIFF
--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -117,13 +117,20 @@ class QuorumRun:
 
 @dataclass(frozen=True)
 class RerunDecision:
-    """Whether A1 should re-run the gate for a PR."""
+    """Whether A1 should re-run the gate for a PR.
+
+    ``needs_adjudication`` is set when the per-PR round budget is exhausted:
+    the correct next step is a net-value adjudication decision (merge-as-is /
+    one bounded round / close / restructure), not another rerun. Callers use
+    this structured flag instead of sniffing the reason string.
+    """
 
     pr_number: int
     should_rerun: bool
     reason: str
     run_id: int | None = None
     next_prompt: str = ""
+    needs_adjudication: bool = False
 
 
 @dataclass(frozen=True)
@@ -235,10 +242,15 @@ def plan_rerun(
         return decide(False, "quorum run already postdates the newest countable evidence")
 
     if pr_round_budget and pr_rounds_consumed >= pr_round_budget:
-        return decide(
-            False,
-            f"PR round budget exhausted ({pr_rounds_consumed}/{pr_round_budget} repair "
-            "rounds across head drift); net-value adjudication required, not another rerun",
+        return RerunDecision(
+            pr_number=pr_number,
+            should_rerun=False,
+            reason=(
+                f"PR round budget exhausted ({pr_rounds_consumed}/{pr_round_budget} repair "
+                "rounds across head drift); net-value adjudication required, not another rerun"
+            ),
+            run_id=run.run_id if run else None,
+            needs_adjudication=True,
         )
     if reruns_this_head >= max_reruns_per_head:
         return decide(False, f"max reruns reached for this head ({max_reruns_per_head})")

--- a/scripts/reconcile_merge_quorum.py
+++ b/scripts/reconcile_merge_quorum.py
@@ -45,6 +45,10 @@ from aragora.swarm.merge_quorum_io import (  # noqa: E402
     list_open_prs,
     run,
 )
+from aragora.swarm.convergence_ledger import (  # noqa: E402
+    DEFAULT_LEDGER_PATH,
+    ConvergenceLedger,
+)
 from aragora.swarm.merge_quorum_reconcile import (  # noqa: E402
     QuorumRun,
     RerunDecision,
@@ -54,6 +58,23 @@ from aragora.swarm.merge_quorum_reconcile import (  # noqa: E402
 )
 
 DEFAULT_STATE_FILE = Path.home() / ".aragora" / "merge_quorum_reconcile_state.json"
+
+# Per-PR repair-round budget that survives head drift (issue #9042, Tier-4
+# preapproved). 0 = DISABLED (default): behavior is byte-identical to the
+# pre-#9042 reconciler. Enable via --pr-round-budget or ARAGORA_PR_ROUND_BUDGET.
+_PR_ROUND_BUDGET_ENV = "ARAGORA_PR_ROUND_BUDGET"
+
+
+def _default_pr_round_budget() -> int:
+    raw = os.getenv(_PR_ROUND_BUDGET_ENV, "0").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        print(
+            f"warning: ignoring non-integer {_PR_ROUND_BUDGET_ENV}={raw!r}",
+            file=sys.stderr,
+        )
+        return 0
 
 
 _MAX_STATE_ENTRIES = 500
@@ -116,6 +137,8 @@ def evaluate_pr(
     state: dict[str, Any],
     cooldown_seconds: int,
     max_reruns: int,
+    pr_rounds_consumed: int = 0,
+    pr_round_budget: int = 0,
 ) -> tuple[RerunDecision, QuorumRun | None]:
     ctx = fetch_pr_context(repo, pr)
     head_sha = ctx["head_sha"]
@@ -133,6 +156,8 @@ def evaluate_pr(
         cooldown_seconds=cooldown_seconds,
         max_reruns_per_head=max_reruns,
         has_real_required_failure=ctx["has_real_required_failure"],
+        pr_rounds_consumed=pr_rounds_consumed,
+        pr_round_budget=pr_round_budget,
     )
     if decision.should_rerun and quorum_run is not None:
         ci_packet = fetch_quorum_run_packet_classification(
@@ -168,6 +193,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit", type=int, default=200, help="Max open PRs to walk")
     parser.add_argument("--cooldown-minutes", type=int, default=10)
     parser.add_argument("--max-reruns", type=int, default=3, help="Max reruns per head SHA")
+    parser.add_argument(
+        "--pr-round-budget",
+        type=int,
+        default=_default_pr_round_budget(),
+        help=(
+            "Per-PR repair-round budget that survives head drift (issue #9042). "
+            "0 = disabled (default; behavior unchanged). When exhausted, the PR is "
+            "flagged needs_adjudication instead of re-run — route it to net-value "
+            f"adjudication. Env default: {_PR_ROUND_BUDGET_ENV}."
+        ),
+    )
+    parser.add_argument(
+        "--convergence-ledger",
+        type=Path,
+        default=DEFAULT_LEDGER_PATH,
+        help="Path to the per-PR convergence ledger (used only when budget > 0)",
+    )
     parser.add_argument("--state-file", type=Path, default=DEFAULT_STATE_FILE)
     parser.add_argument("--apply", action="store_true", help="Execute reruns (default: dry-run)")
     parser.add_argument("--json", action="store_true", help="Emit the plan as JSON")
@@ -180,8 +222,15 @@ def main(argv: list[str] | None = None) -> int:
     state = _load_state(args.state_file)
     prs = [args.pr] if args.pr else list_open_prs(args.repo, limit=args.limit, author=args.author)
 
+    # PR-keyed round budget (issue #9042): the ledger counts *distinct heads*
+    # per PR, so a repair commit consumes budget instead of resetting it. Only
+    # touched when the budget is enabled — budget 0 never opens the ledger.
+    budget = max(0, args.pr_round_budget)
+    ledger = ConvergenceLedger(args.convergence_ledger) if budget else None
+
     plan: list[dict[str, Any]] = []
     for pr in prs:
+        rounds_consumed = ledger.rounds(pr) if ledger else 0
         try:
             decision, quorum_run = evaluate_pr(
                 args.repo,
@@ -190,6 +239,8 @@ def main(argv: list[str] | None = None) -> int:
                 state=state,
                 cooldown_seconds=args.cooldown_minutes * 60,
                 max_reruns=args.max_reruns,
+                pr_rounds_consumed=rounds_consumed,
+                pr_round_budget=budget,
             )
         except RuntimeError as exc:
             plan.append({"pr": pr, "error": str(exc)})
@@ -203,6 +254,19 @@ def main(argv: list[str] | None = None) -> int:
         }
         if decision.next_prompt:
             record["next_prompt"] = decision.next_prompt
+        if ledger:
+            record["pr_rounds_consumed"] = rounds_consumed
+            record["pr_round_budget"] = budget
+        if decision.needs_adjudication:
+            # Budget exhausted: the PR needs a net-value DECISION (merge-as-is /
+            # one bounded round / close / restructure), not another rerun. The
+            # adjudication itself runs in the evidence path (quorum_evidence +
+            # ARAGORA_ENABLE_REVIEW_ADJUDICATOR, #8748/#8749) or by the operator;
+            # its outcome is recorded via ConvergenceLedger.record_adjudication.
+            record["needs_adjudication"] = True
+            existing = ledger.get(pr) if ledger else None
+            if existing and existing.adjudication:
+                record["adjudication"] = existing.adjudication
         if decision.should_rerun and args.apply and quorum_run is not None:
             if execute_rerun(args.repo, quorum_run.run_id):
                 record["applied"] = True
@@ -211,6 +275,10 @@ def main(argv: list[str] | None = None) -> int:
                 )
                 head_state["count"] = int(head_state.get("count", 0)) + 1
                 head_state["last_rerun_at"] = now.isoformat()
+                if ledger:
+                    # A new head = one repair round; re-running the same head
+                    # appends history without consuming budget.
+                    ledger.record_round(pr, quorum_run.head_sha)
         plan.append(record)
 
     if args.apply:
@@ -223,7 +291,12 @@ def main(argv: list[str] | None = None) -> int:
             if "error" in record:
                 print(f"PR #{record['pr']}: ERROR {record['error']}")
                 continue
-            flag = "RERUN" if record["should_rerun"] else "skip"
+            if record.get("needs_adjudication"):
+                flag = "ADJUDICATE"
+            elif record["should_rerun"]:
+                flag = "RERUN"
+            else:
+                flag = "skip"
             applied = " (applied)" if record["applied"] else ""
             print(f"PR #{record['pr']}: {flag}{applied} — {record['reason']}")
     return 0

--- a/tests/scripts/test_reconcile_merge_quorum_budget.py
+++ b/tests/scripts/test_reconcile_merge_quorum_budget.py
@@ -1,0 +1,189 @@
+"""PR-keyed round budget wiring in the A1 reconciler (issue #9042, Tier 4).
+
+Proves the acceptance criteria on a synthetic stuck cycle:
+- budget is keyed by PR and survives head drift (repair commits consume it,
+  never reset it);
+- exhaustion flags ``needs_adjudication`` and stops re-running;
+- budget 0 (the default) is byte-identical to the pre-#9042 reconciler and
+  never touches the convergence ledger.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.convergence_ledger import ConvergenceLedger
+from aragora.swarm.merge_quorum_reconcile import EvidenceComment, QuorumRun
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "reconcile_merge_quorum.py"
+
+NOW = datetime(2026, 7, 8, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture()
+def mod():
+    spec = importlib.util.spec_from_file_location("reconcile_merge_quorum_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Fleet:
+    """Fake GitHub surface for one churning PR."""
+
+    def __init__(self) -> None:
+        self.head = "h1"
+        self.rerun_calls: list[int] = []
+
+    def install(self, mod, monkeypatch) -> None:
+        monkeypatch.setattr(
+            mod,
+            "fetch_pr_context",
+            lambda repo, pr: {
+                "head_sha": self.head,
+                "head_committed_at": (NOW - timedelta(hours=2)).isoformat(),
+                "has_real_required_failure": False,
+            },
+        )
+        monkeypatch.setattr(
+            mod,
+            "fetch_latest_quorum_run",
+            lambda repo, head_sha: QuorumRun(
+                run_id=1000,
+                created_at=(NOW - timedelta(hours=1)).isoformat(),
+                conclusion="FAILURE",
+                head_sha=head_sha,
+            ),
+        )
+        monkeypatch.setattr(
+            mod,
+            "fetch_evidence_comments",
+            lambda repo, pr, head_sha, committed_at: [
+                EvidenceComment(
+                    created_at=(NOW - timedelta(minutes=5)).isoformat(),
+                    would_count=True,
+                    reviewer_id="claude",
+                )
+            ],
+        )
+        # Divergence guard needs live packet fetches; identity keeps this a
+        # pure plan_rerun wiring test.
+        monkeypatch.setattr(
+            mod,
+            "guard_rerun_classification_divergence",
+            lambda decision, **kwargs: decision,
+        )
+        monkeypatch.setattr(
+            mod, "execute_rerun", lambda repo, run_id: self.rerun_calls.append(run_id) or True
+        )
+
+
+def _run(mod, tmp_path, *extra: str) -> list[dict]:
+    out = tmp_path / "plan.json"
+    argv = [
+        "--repo",
+        "synaptent/aragora",
+        "--pr",
+        "77",
+        "--apply",
+        "--cooldown-minutes",
+        "0",
+        "--max-reruns",
+        "99",
+        "--state-file",
+        str(tmp_path / "state.json"),
+        "--convergence-ledger",
+        str(tmp_path / "ledger.json"),
+        "--json",
+        *extra,
+    ]
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        assert mod.main(argv) == 0
+    out.write_text(buf.getvalue())
+    return json.loads(buf.getvalue())["plan"]
+
+
+class TestSyntheticStuckCycle:
+    def test_budget_survives_head_drift_and_routes_to_adjudication(
+        self, mod, monkeypatch, tmp_path
+    ):
+        fleet = _Fleet()
+        fleet.install(mod, monkeypatch)
+        budget = ["--pr-round-budget", "3"]
+
+        # Three repair rounds: each cycle the "repairer" pushes a new head.
+        for round_number, head in enumerate(["h1", "h2", "h3"], start=1):
+            fleet.head = head
+            (record,) = _run(mod, tmp_path, *budget)
+            assert record["applied"] is True, record
+            assert record["pr_rounds_consumed"] == round_number - 1
+            assert "needs_adjudication" not in record
+
+        ledger = ConvergenceLedger(tmp_path / "ledger.json")
+        assert ledger.rounds(77) == 3  # distinct heads counted, never reset
+
+        # Fourth repair commit: budget exhausted -> adjudication, no rerun.
+        fleet.head = "h4"
+        rerun_count_before = len(fleet.rerun_calls)
+        (record,) = _run(mod, tmp_path, *budget)
+        assert record["needs_adjudication"] is True
+        assert record["should_rerun"] is False
+        assert record["applied"] is False
+        assert len(fleet.rerun_calls) == rerun_count_before
+        assert "net-value adjudication" in record["reason"]
+
+    def test_same_head_rerun_does_not_consume_budget(self, mod, monkeypatch, tmp_path):
+        fleet = _Fleet()
+        fleet.install(mod, monkeypatch)
+        budget = ["--pr-round-budget", "3", "--max-reruns", "99"]
+        fleet.head = "h1"
+        _run(mod, tmp_path, *budget)
+        _run(mod, tmp_path, *budget)  # same head again
+        assert ConvergenceLedger(tmp_path / "ledger.json").rounds(77) == 1
+
+    def test_recorded_adjudication_surfaces_in_plan(self, mod, monkeypatch, tmp_path):
+        fleet = _Fleet()
+        fleet.install(mod, monkeypatch)
+        ledger = ConvergenceLedger(tmp_path / "ledger.json")
+        for head in ["h1", "h2", "h3"]:
+            ledger.record_round(77, head)
+        ledger.record_adjudication(77, verdict="close", rationale="net-negative churn")
+        (record,) = _run(mod, tmp_path, "--pr-round-budget", "3")
+        assert record["needs_adjudication"] is True
+        assert record["adjudication"]["verdict"] == "close"
+
+
+class TestBudgetDisabledByDefault:
+    def test_default_off_is_behavior_identical_and_ledger_untouched(
+        self, mod, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("ARAGORA_PR_ROUND_BUDGET", raising=False)
+        fleet = _Fleet()
+        fleet.install(mod, monkeypatch)
+        for head in ["h1", "h2", "h3", "h4", "h5", "h6", "h7", "h8"]:
+            fleet.head = head
+            (record,) = _run(mod, tmp_path)
+            assert record["applied"] is True
+            assert "needs_adjudication" not in record
+            assert "pr_rounds_consumed" not in record
+        assert not (tmp_path / "ledger.json").exists()
+
+    def test_env_default_feeds_parser(self, mod, monkeypatch):
+        monkeypatch.setenv("ARAGORA_PR_ROUND_BUDGET", "6")
+        assert mod._default_pr_round_budget() == 6
+        monkeypatch.setenv("ARAGORA_PR_ROUND_BUDGET", "garbage")
+        assert mod._default_pr_round_budget() == 0
+        monkeypatch.setenv("ARAGORA_PR_ROUND_BUDGET", "-3")
+        assert mod._default_pr_round_budget() == 0

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -154,6 +154,11 @@ class TestPlanRerun:
         assert decision.should_rerun is False
         assert "round budget exhausted" in decision.reason
         assert "net-value adjudication" in decision.reason
+        assert decision.needs_adjudication is True
+
+    def test_needs_adjudication_false_on_all_other_paths(self) -> None:
+        assert self._call(pr_rounds_consumed=2, pr_round_budget=6).needs_adjudication is False
+        assert self._call(reruns_this_head=5).needs_adjudication is False
 
     def test_pr_budget_bites_even_when_per_head_cap_is_fresh(self) -> None:
         # THE fix: a repair push creates a new head, so the per-head cap resets


### PR DESCRIPTION
## Summary

**TIER 4 — merge-authority change. Founder preapproval recorded on #9042 ([approval comment](https://github.com/synaptent/aragora/issues/9042#issuecomment-4920249395)). This PR settles ONLY via human exact-head Tier-4 sign-off (`settle_tier4_pr.py`), never via the gate it modifies.**

Closes #9042. Part of epic #9039. Plan: `docs/plans/2026-07-08-vision-audit-and-work-mix-governor.md` §1.2/§4.1.

### The problem (measured)

The per-head rerun cap resets on every repair commit, so a churning PR never hits any budget — the mechanical root of the nitpick treadmill (2026-06-26 forensics: 4 PRs, 78 commits, 0 merges; one PR made 16 near-duplicate commits in <2h).

### The fix is wiring, not new machinery

`ConvergenceLedger` (per-PR round budget across head drift, file-locked, #8623-era) and `plan_rerun`'s `pr_round_budget` check **both already existed with zero callers**. This PR connects them:

- `RerunDecision` gains a structured `needs_adjudication` flag (set on the budget-exhausted branch)
- `scripts/reconcile_merge_quorum.py`: `--pr-round-budget` (**default 0 = OFF**, env `ARAGORA_PR_ROUND_BUDGET`) + `--convergence-ledger`; each APPLIED rerun records a round keyed by **PR** — a new head is one repair round, same-head reruns consume nothing, and nothing ever resets it
- On exhaustion the plan emits `ADJUDICATE` / `needs_adjudication` and surfaces any recorded net-value adjudication (merge-as-is / one bounded round / close / restructure) instead of re-running
- Adjudication itself remains in the evidence path (`quorum_evidence` + `ARAGORA_ENABLE_REVIEW_ADJUDICATOR`, #8748/#8749), where the *single evidence-backed [P2] is never suppressed* guarantee is already enforced and tested

### Safety

- **Default OFF, zero behavior change**: budget 0 never opens the ledger — proven by `test_default_off_is_behavior_identical_and_ledger_untouched`
- **Synthetic stuck cycle proven** (per #9042 acceptance): 3 repair rounds across heads h1–h3 consume the budget; the h4 repair commit routes to adjudication with **no rerun executed**
- Same-head reruns don't consume budget; recorded adjudications surface in the plan
- 276 related tests pass (full `test_quorum_evidence`, `test_merge_quorum_reconcile`, `test_convergence_ledger`, new wiring suite)

### Rollout

After human settlement of this PR: enable on the launchd reconciler with `ARAGORA_PR_ROUND_BUDGET=6` (the `DEFAULT_ROUND_BUDGET` the convergence plan chose) and watch the ledger `summarize()` output for a week before considering it default-on (separate Tier-4 decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)