### PR TITLE
docs(m6): canonicalize docker compose + verifier exit-code contract

### DIFF
--- a/docs-site/docs/contributing/documentation-index.md
+++ b/docs-site/docs/contributing/documentation-index.md
@@ -19,7 +19,7 @@ then wire it into CI.
 
 1. [Quickstart](../getting-started/quickstart) — a working debate in under a minute
 2. [Receipt Lineage Reconciliation](../specs/receipt-lineage-reconciliation) — what a receipt is: the native record vs. the portable ODR
-3. [Independent Verifier Guide](../specs/independent-verifier-guide) — verify a receipt with `aragora-verify`, no Aragora install required
+3. [Independent Verifier Guide](../specs/independent-verifier-guide) — verify a receipt with `aragora-verify` (exit codes: `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`), no Aragora install required
 4. [GitHub Action Setup](../guides/github-action-setup) — add multi-model CI review + receipts to your pull requests
 
 ## Getting Started

--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -20,8 +20,10 @@ pip install -U 'aragora-verify>=0.1.1' && aragora-verify r.odr.json
 ```
 
 This runs a demo debate, exports the receipt to the portable ODR format, and
-verifies it offline with the standalone verifier -- exit `0` end to end. Run
-`aragora quickstart --help` for the live-provider and spec-first variants.
+verifies it offline with the standalone verifier -- exit `0` end to end.
+`aragora-verify`'s full exit-code contract is `0 verified / 1 failed / 2 usage /
+3 signatures-present-unchecked`. Run `aragora quickstart --help` for the
+live-provider and spec-first variants.
 
 ---
 
@@ -157,6 +159,13 @@ aragora receipt verify aragora-demo-receipt.json
 PyPI `aragora` 2.9.0 supports the explicit offline demo receipt round trip
 shown above. Use the source checkout path when you need to audit this exact
 branch or unreleased local changes.
+
+`aragora receipt verify` above checks the **native** demo receipt (exit 0/1);
+it is a different verb from the standalone `aragora-verify` used on the
+portable `.odr.json` artifact in the fastest path at the top of this page. For
+the contributor dev/test install, use the declared form
+`pip install -e ".[test]"` -- see `docs/reference/INSTALL_MATRIX.md` for the
+full per-audience breakdown.
 
 ## Next Steps
 

--- a/docs-site/docs/specs/receipt-lineage-reconciliation.md
+++ b/docs-site/docs/specs/receipt-lineage-reconciliation.md
@@ -90,7 +90,9 @@ must be kept in lockstep:
    aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`. To
    exercise this exact checkout instead of the published package, run
    `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from `aragora-verify/`, or
-   `pip install ./aragora-verify` for a local `aragora-verify` console script.
+   `pip install ./aragora-verify` for a local `aragora-verify` console script. Its
+   exit-code contract is `0 verified / 1 failed / 2 usage / 3
+   signatures-present-unchecked`.
 
 Both engines are hand-rolled, dependency-light mirrors of the same normative artifact
 — `aragora/gauntlet/odr_schema.json`, also bundled inside the `aragora-verify` package

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,7 +14,7 @@ then wire it into CI.
 
 1. [Quickstart](quickstart.md) — a working debate in under a minute
 2. [Receipt Lineage Reconciliation](specs/RECEIPT_LINEAGE_RECONCILIATION.md) — what a receipt is: the native record vs. the portable ODR
-3. [Independent Verifier Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md) — verify a receipt with `aragora-verify`, no Aragora install required
+3. [Independent Verifier Guide](specs/INDEPENDENT_VERIFIER_GUIDE.md) — verify a receipt with `aragora-verify` (exit codes: `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`), no Aragora install required
 4. [GitHub Action Setup](GITHUB_ACTION_SETUP.md) — add multi-model CI review + receipts to your pull requests
 
 ## Getting Started

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ wire it into CI — comes first below; everything else follows.
 |------|----------|
 | **Run your first debate in under a minute** | [Quickstart](./quickstart.md) |
 | Understand the receipt model (native record vs. the portable ODR) | [Receipt Lineage Reconciliation](./specs/RECEIPT_LINEAGE_RECONCILIATION.md) |
-| Verify a receipt independently, no Aragora install required | [Independent Verifier Guide](./specs/INDEPENDENT_VERIFIER_GUIDE.md) |
+| Verify a receipt independently, no Aragora install required (`aragora-verify` exit codes: `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked`) | [Independent Verifier Guide](./specs/INDEPENDENT_VERIFIER_GUIDE.md) |
 | Add multi-model CI review + receipts to your pull requests | [GitHub Action Setup](./GITHUB_ACTION_SETUP.md) |
 | Review or audit the project quickly | [Cold Reviewer Guide](./COLD_REVIEWER_GUIDE.md) |
 | Understand the supported API contract | [Supported API Surface](./api/SUPPORTED_SURFACE.md) |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,8 +15,10 @@ pip install -U 'aragora-verify>=0.1.1' && aragora-verify r.odr.json
 ```
 
 This runs a demo debate, exports the receipt to the portable ODR format, and
-verifies it offline with the standalone verifier -- exit `0` end to end. Run
-`aragora quickstart --help` for the live-provider and spec-first variants.
+verifies it offline with the standalone verifier -- exit `0` end to end.
+`aragora-verify`'s full exit-code contract is `0 verified / 1 failed / 2 usage /
+3 signatures-present-unchecked`. Run `aragora quickstart --help` for the
+live-provider and spec-first variants.
 
 ---
 
@@ -152,6 +154,13 @@ aragora receipt verify aragora-demo-receipt.json
 PyPI `aragora` 2.9.0 supports the explicit offline demo receipt round trip
 shown above. Use the source checkout path when you need to audit this exact
 branch or unreleased local changes.
+
+`aragora receipt verify` above checks the **native** demo receipt (exit 0/1);
+it is a different verb from the standalone `aragora-verify` used on the
+portable `.odr.json` artifact in the fastest path at the top of this page. For
+the contributor dev/test install, use the declared form
+`pip install -e ".[test]"` -- see `docs/reference/INSTALL_MATRIX.md` for the
+full per-audience breakdown.
 
 ## Next Steps
 

--- a/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
+++ b/docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md
@@ -85,7 +85,9 @@ must be kept in lockstep:
    aragora-verify` or `curl -s https://pypi.org/pypi/aragora-verify/json`. To
    exercise this exact checkout instead of the published package, run
    `PYTHONPATH=src python -m aragora_verify <r>.odr.json` from `aragora-verify/`, or
-   `pip install ./aragora-verify` for a local `aragora-verify` console script.
+   `pip install ./aragora-verify` for a local `aragora-verify` console script. Its
+   exit-code contract is `0 verified / 1 failed / 2 usage / 3
+   signatures-present-unchecked`.
 
 Both engines are hand-rolled, dependency-light mirrors of the same normative artifact
 — `aragora/gauntlet/odr_schema.json`, also bundled inside the `aragora-verify` package

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -2968,13 +2968,13 @@ The codebase is **feature-rich with improving exposure**:
 ### Docker Deployment
 ```bash
 # Quick start (requires .env file with API keys)
-docker-compose up -d
+docker compose up -d
 
 # With frontend
-docker-compose --profile with-frontend up -d
+docker compose --profile with-frontend up -d
 
 # View logs
-docker-compose logs -f aragora
+docker compose logs -f aragora
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Summary

Implements the FIX halves of the m6 user-testing adjudication for **VAL-DOCS-001** and **VAL-CROSS-002**, per `contract-work/m6-user-testing-failure-analysis.md` (the amended assertion text is already applied to `validation-contract.md`).

### (1) VAL-DOCS-001 fix

- `docs/status/STATUS.md`: replaced legacy `docker-compose` with canonical `docker compose` in the live `## Deployment` → `### Docker Deployment` block (3 command lines: `up -d`, `--profile with-frontend up -d`, `logs -f aragora`). The `docker-compose.yml` **filename literal** at the end of the file is untouched (it names a file, not a command).
- `docs/quickstart.md`: added **additive-only** disambiguation sentences (no existing command line changed) clarifying that `aragora receipt verify` in that doc checks the **native** demo receipt, distinct from the standalone `aragora-verify` ODR verb used in the fastest-path chain at the top of the page. Also noted the declared dev/test-install form (`pip install -e ".[test]"`, see `docs/reference/INSTALL_MATRIX.md`) as a distinct verb from the plain source-checkout audit install already in this doc.

### (2) VAL-CROSS-002 fix

Added the verbatim exit-code contract string `0 verified / 1 failed / 2 usage / 3 signatures-present-unchecked` to the 4 non-gated surfaces that were missing it:

- `docs/README.md` (verifier row of the "What Are You Trying To Do?" table)
- `docs/INDEX.md` (Public Utility Path item 3)
- `docs/quickstart.md` (fastest-path paragraph)
- `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md` ("Two verifiers" §, `aragora-verify` bullet)

Root `README.md` is **untouched** (operator-gated; the amended assertion explicitly exempts it since it contains no exit-code text and thus no conflicting claim).

The other 3 enumerated surfaces (`docs/specs/INDEPENDENT_VERIFIER_GUIDE.md`, `docs/GITHUB_ACTION_SETUP.md`, `docs/reference/INSTALL_MATRIX.md`) already contained the string and were left unmodified.

### Docs-site mirrors

3 of the touched files have docs-site mirrors (`docs/INDEX.md`, `docs/quickstart.md`, `docs/specs/RECEIPT_LINEAGE_RECONCILIATION.md`). Ran `python scripts/doc_stats.py --write && node docs-site/scripts/sync-docs.js` and committed the regenerated mirror deltas. `docs/status/STATUS.md` and `docs/README.md` have **no** DOC_MAP mirror entry (verified against `docs-site/scripts/sync-docs.js`), so no mirror change was expected or produced for those two.

**Mirror-link fix (discovered during this work):** my first draft of the quickstart.md addition linked to `docs/reference/INSTALL_MATRIX.md` with normal markdown link syntax. `docs/reference/**` has no DOC_MAP glob rule (see `library/docs-site.md`), so that link would have survived `sync-docs.js` unrewritten as a raw, broken relative path in the regenerated `docs-site/docs/getting-started/quickstart.md` mirror. Fixed by referencing the path as inline code (no markdown link) instead — avoids the dead link with no `sync-docs.js` edit, keeping this PR docs-only.

**Idempotence:** ran the `doc_stats.py --write && sync-docs.js` pair a second time after the fix; `git diff --stat` was identical before and after the extra run (zero additional drift).

## Verification

| Check | Result |
|---|---|
| `make docs-check` (`check_docs_consistency.py`) | ✅ Check 1 (broken links) PASS · Check 2 (live→archive) PASS · Check 3 (metric drift) PASS · Check 4 (tier contradictions) PASS |
| `python scripts/validate_doc_links.py` | ✅ "All documentation links are valid!" |
| `pytest tests/cli/test_public_demo_onboarding_docs.py -v` | ✅ 2 passed (pinned quickstart/README command strings intact) |
| `bash scripts/automation_pr_preflight.sh origin/main HEAD` | ✅ "docs-only diff detected" / "preflight: ok" |
| Newline-normalized (`tr -s '[:space:]' ' '`) `grep -F` of the exit-code string in all 7 enumerated VAL-CROSS-002 surfaces | ✅ 7/7 present |
| `grep -n docker-compose docs/status/STATUS.md` | ✅ only the `docker-compose.yml` filename literal remains (line ~3001); all 3 live command lines now say `docker compose` |
| `grep` root `README.md` for the exit-code string | ✅ absent (no conflicting claim; satisfies the amended assertion's exemption) |

## Scope / gated files

Docs-only, `*.md` diff. No `.github/workflows/**`, no `docs/THESIS.md`/`CANONICAL_GOALS.md`/`RECEIPT_CONTRACT.md`, no `odr_schema.json`, no root `README.md`, and no `scripts/**` touched. Auto-merge eligible per the mission's Tier-0 docs-only policy.

## Path-freeze / coordination note

Live-checked `gh pr list` + per-file `gh pr view --json files` before starting and again immediately before push (origin/main advanced by one unrelated commit, #9038, which does not touch any file in this diff):

- **#9012** (`factory/pum-m6-docs-scrutiny-fixes`, parked `operator-review-required`) also touches `docs/status/STATUS.md` and `docs/README.md`, but at disjoint line ranges (a `v0.2.0` aragora-debate note near STATUS.md:389, and the top positioning paragraph near README.md:6-15) — no textual overlap with this PR's edits (STATUS.md:2971-2977 Deployment block; README.md:22 verifier table row).
- **#8999** (`codex/landing-postmerge-doc-fixes-20260708`, draft) also touches `docs/quickstart.md`, and its rewrite of the "PyPI `aragora` 2.9.0 supports..." paragraph **does** sit immediately adjacent to this PR's additive disambiguation sentences (inserted right after that same paragraph, before `## Next Steps`). Both PRs keep the `tests/cli/test_public_demo_onboarding_docs.py`-pinned lines byte-intact, so there is no doctrinal conflict, but if #8999 lands first, whoever merges this PR second will need a routine rebase (context lines shifted, not a content collision). This PR's *other* quickstart.md edit (the exit-code sentence in the fastest-path paragraph near the top of the file) has zero line overlap with #8999.

## Milestone

`m6-docs` — fixes the two amended assertions (VAL-DOCS-001, VAL-CROSS-002) from `contract-work/m6-user-testing-failure-analysis.md`, round 2 of m6 user-testing.
