### PR TITLE
refactor(debate): unify security-debate composition roots, drop events->debate edge

### DIFF
--- a/aragora/analysis/codebase/sast/scanner.py
+++ b/aragora/analysis/codebase/sast/scanner.py
@@ -161,20 +161,31 @@ The scanner will fall back to local pattern matching until Semgrep is installed.
         # Initialize security emitter if configured
         if self.config.emit_security_events and self._security_emitter is None:
             try:
-                from aragora.events.security_events import (
-                    _ensure_default_security_debate_runner_registered,
-                    get_security_emitter,
-                )
+                from aragora.events.security_events import get_security_emitter
 
                 self._security_emitter = get_security_emitter()
             except ImportError:
                 logger.debug("SecurityEventEmitter not available")
             else:
                 try:
-                    # Best-effort auto-debate wiring for SAST-only processes.
-                    # Event emission should still work if the debate stack is
-                    # unavailable or an optional debate dependency is missing.
-                    _ensure_default_security_debate_runner_registered()
+                    # Best-effort auto-debate wiring for SAST-only processes that
+                    # never otherwise import aragora.debate (e.g. no Arena is
+                    # constructed). This scanner module is unlayered
+                    # (aragora.analysis), so importing aragora.debate here is
+                    # legal, and aragora.events still never imports
+                    # aragora.debate itself.
+                    #
+                    # ensure_registered() is called explicitly (rather than
+                    # relying on the bare-import side effect alone) because a
+                    # plain import is a no-op once the module is cached in
+                    # sys.modules: if some earlier consumer already imported
+                    # aragora.debate.security_response and the registry was
+                    # since reset (e.g. an explicit clear followed by a
+                    # request to restore the default), a second bare import
+                    # would silently fail to re-register.
+                    from aragora.debate import security_response
+
+                    security_response.ensure_registered()
                 except ImportError as exc:
                     logger.debug("Security debate runner not available: %s", exc)
 

--- a/aragora/debate/event_subscribers.py
+++ b/aragora/debate/event_subscribers.py
@@ -422,6 +422,25 @@ def bootstrap_debate_event_subscribers() -> CrossSubscriberManager:
     from aragora.memory import event_subscribers as memory_home
     from aragora.reasoning import event_subscribers as reasoning_home
 
+    # A second domain-side composition root -- alongside aragora.debate.
+    # orchestrator's module-level import -- that guarantees aragora.events.
+    # security_events has a registered security debate runner. This one
+    # covers callers that reach this bootstrap (server startup via the
+    # interface superset, or any of this module's other domain callers such
+    # as orchestrator_memory/knowledge_manager/extensions) WITHOUT ever
+    # constructing an Arena (which is what orchestrator.py's import would
+    # otherwise depend on). aragora.events never imports aragora.debate.
+    #
+    # ensure_registered() is called explicitly rather than relying on the
+    # import's self-registration side effect alone: this bootstrap function
+    # is documented as idempotent and safe to call repeatedly, and a bare
+    # import is a no-op once security_response is already cached in
+    # sys.modules, so it would not recover from a registry reset that
+    # happens between calls.
+    from aragora.debate import security_response as _security_response
+
+    _security_response.ensure_registered()
+
     knowledge_home.register()
     memory_home.register()
     reasoning_home.register()

--- a/aragora/debate/security_response.py
+++ b/aragora/debate/security_response.py
@@ -13,11 +13,20 @@ auto-debate path (see register_security_debate_runner), so the domain-free
 events module never imports aragora.debate or aragora.agents directly.
 Registration is a plain module-level side effect, so any composition root
 that imports this module first makes the runner available process-wide.
-Two composition roots import it explicitly rather than relying solely on
-incidental transitive imports: aragora.debate.orchestrator (Arena, for any
-Arena-backed process) and aragora.analysis.codebase.sast.scanner (SAST
-auto-scan findings, which can run in isolation from the Arena-backed server
-stack).
+
+Three domain-side composition roots import this module explicitly rather
+than relying solely on incidental transitive imports:
+  - aragora.debate.orchestrator (Arena, for any Arena-backed process)
+  - aragora.debate.event_subscribers.bootstrap_debate_event_subscribers
+    (non-Arena consumers of the shared event-subscriber bootstrap, e.g.
+    server startup, memory/knowledge extensions)
+  - aragora.analysis.codebase.sast.scanner (SAST auto-scan findings, which
+    can run in isolation from both of the above)
+
+The latter two also call ensure_registered() explicitly rather than relying
+on the bare-import side effect alone, since a plain import is a no-op once
+this module is already cached in sys.modules -- see ensure_registered's
+docstring.
 """
 
 from __future__ import annotations
@@ -27,6 +36,7 @@ import uuid
 from typing import Any
 
 from aragora.events.security_events import (
+    SecurityDebateRunner,
     SecurityEvent,
     _register_default_security_debate_runner,
     _store_security_debate_result,
@@ -197,10 +207,29 @@ async def _get_security_debate_agents() -> list[Any]:
     return await get_security_debate_agents()
 
 
-_register_default_security_debate_runner(trigger_security_debate)
+def ensure_registered() -> SecurityDebateRunner | None:
+    """Idempotently (re-)register trigger_security_debate as the default runner.
+
+    The bare module-level self-registration below only fires the first time
+    this module is imported into a process: a plain `import
+    aragora.debate.security_response` is a no-op if the module is already in
+    sys.modules, so it will NOT re-run the registration side effect. A
+    composition root that must guarantee registration even when this module
+    may already be cached elsewhere (e.g. after an explicit
+    register_security_debate_runner(None) clear, or a cold-start test that
+    resets the registry to simulate a fresh process) should call this
+    explicitly instead. Like the module-level self-registration, this never
+    clobbers an explicit runner hook or an explicit None-clear (see
+    _register_default_security_debate_runner).
+    """
+    return _register_default_security_debate_runner(trigger_security_debate)
+
+
+ensure_registered()
 
 
 __all__ = [
     "trigger_security_debate",
     "build_security_debate_question",
+    "ensure_registered",
 ]

--- a/aragora/events/__init__.py
+++ b/aragora/events/__init__.py
@@ -78,13 +78,12 @@ from .security_events import (  # noqa: F401
     SecurityEventHandler,
     get_security_emitter,
     set_security_emitter,
-    # Debate integration (domain-free hook plus lazy compatibility wrappers;
-    # implementation lives in aragora.debate.security_response)
+    # Debate integration (domain-free hook; implementation lives in
+    # aragora.debate.security_response - import from there directly, this
+    # package never re-exports domain-coupled symbols)
     SecurityDebateRunner,
     register_security_debate_runner,
     get_security_debate_runner,
-    build_security_debate_question,
-    trigger_security_debate,
     get_security_debate_result,
     list_security_debates,
     # Convenience functions
@@ -154,8 +153,6 @@ __all__ = [
     "SecurityDebateRunner",
     "register_security_debate_runner",
     "get_security_debate_runner",
-    "build_security_debate_question",
-    "trigger_security_debate",
     "get_security_debate_result",
     "list_security_debates",
     "create_vulnerability_event",

--- a/aragora/events/security_dispatcher.py
+++ b/aragora/events/security_dispatcher.py
@@ -43,7 +43,6 @@ from aragora.events.security_events import (
     SecurityEventEmitter,
     SecurityEventType,
     SecuritySeverity,
-    _ensure_default_security_debate_runner_registered,
     _accepted_security_debate_runner_kwargs,
     get_security_debate_runner,
     get_security_emitter,
@@ -373,9 +372,11 @@ class SecurityDispatcher:
             else:
                 runner = get_security_debate_runner()
                 if runner is None:
-                    runner = _ensure_default_security_debate_runner_registered()
-                if runner is None:
-                    raise ImportError("No security debate runner registered")
+                    raise ImportError(
+                        "No security debate runner registered; a composition root "
+                        "must call register_security_debate_runner() (importing "
+                        "aragora.debate.security_response registers the default)"
+                    )
 
                 runner_kwargs = _accepted_security_debate_runner_kwargs(
                     runner,

--- a/aragora/events/security_dispatcher.py
+++ b/aragora/events/security_dispatcher.py
@@ -485,6 +485,20 @@ async def start_security_dispatcher(
 
     Convenience function for application startup.
 
+    This starts event dispatch only; it does not register a security debate
+    runner. A composition root must separately ensure the runner is
+    registered before triggering severity thresholds are reached, or the
+    default (no-custom-callback) debate path fails soft with a logged
+    ImportError (see SecurityDispatcher._run_debate). Callers who want the
+    default auto-debate path wired up should first call one of:
+      - aragora.debate.orchestrator (import triggers registration)
+      - aragora.debate.event_subscribers.bootstrap_debate_event_subscribers()
+      - aragora.debate.security_response.ensure_registered()
+    A caller that instead supplies its own callback via
+    SecurityDispatcher.set_custom_trigger() does not need any of the above,
+    since the custom callback bypasses the registered-runner lookup
+    entirely.
+
     Args:
         config: Optional dispatcher configuration
 

--- a/aragora/events/security_events.py
+++ b/aragora/events/security_events.py
@@ -555,45 +555,25 @@ class _UnsetRunner:
 
 _UNSET_RUNNER = _UnsetRunner()
 
-# Tri-state registry: _UNSET_RUNNER (never set -> the default runner may be
-# lazily imported and registered), None (explicitly cleared via
+# Tri-state registry: _UNSET_RUNNER (never set -> no domain-side composition
+# root has registered the default runner yet), None (explicitly cleared via
 # register_security_debate_runner(None) -> auto-debate stays disabled until a
-# runner is registered again), or a SecurityDebateRunner callable.
+# runner is registered again), or a SecurityDebateRunner callable. This module
+# never imports aragora.debate itself (see _trigger_security_debate below);
+# the default runner is registered by aragora.debate.security_response and
+# its own composition roots, never lazily from here.
 _security_debate_runner: SecurityDebateRunner | None | _UnsetRunner = _UNSET_RUNNER
-
-
-def _ensure_default_security_debate_runner_registered() -> SecurityDebateRunner | None:
-    """Import the default debate runner on demand for cold event consumers.
-
-    Only fires when the registry was never explicitly set. An explicit
-    ``register_security_debate_runner(None)`` clear sticks: this function will
-    NOT re-register the default, so auto-debate stays disabled until a runner
-    is registered again.
-    """
-    if not isinstance(_security_debate_runner, _UnsetRunner):
-        return _security_debate_runner
-
-    try:
-        from aragora.debate import security_response
-    except ImportError as exc:
-        logger.debug("Default security debate runner is not importable: %s", exc)
-    else:
-        runner = getattr(security_response, "trigger_security_debate", None)
-        if runner is not None:
-            _register_default_security_debate_runner(runner)
-
-    return get_security_debate_runner()
 
 
 def register_security_debate_runner(runner: SecurityDebateRunner | None) -> None:
     """Register the callback used to run security debates.
 
-    Composition roots can use this to install or clear an explicit runner.
-    Passing None explicitly clears the registry and disables auto-debate until
-    a runner is registered again -- the lazy default import
-    (_ensure_default_security_debate_runner_registered) only fires when the
-    registry was never set. Default runner imports use
-    _register_default_security_debate_runner so they do not clobber an
+    Composition roots (aragora.debate.security_response and its own
+    composition roots - see that module's docstring) call this to install the
+    default runner, or to install/clear an explicit override. Passing None
+    explicitly clears the registry and disables auto-debate until a runner is
+    registered again. Default runner registration uses
+    _register_default_security_debate_runner so it does not clobber an
     explicit hook or an explicit clear.
     """
     global _security_debate_runner
@@ -645,34 +625,6 @@ def _accepted_security_debate_runner_kwargs(
         return options
 
     return {name: value for name, value in options.items() if name in parameters}
-
-
-def build_security_debate_question(event: SecurityEvent) -> str:
-    """Compatibility wrapper for the relocated security debate question builder."""
-    from aragora.debate.security_response import (
-        build_security_debate_question as _build_security_debate_question,
-    )
-
-    return _build_security_debate_question(event)
-
-
-async def trigger_security_debate(
-    event: SecurityEvent,
-    confidence_threshold: float = 0.7,
-    agents: list[Any] | None = None,
-    timeout_seconds: int = 300,
-) -> str | None:
-    """Compatibility wrapper for the relocated security debate runner."""
-    from aragora.debate.security_response import (
-        trigger_security_debate as _trigger_security_debate,
-    )
-
-    return await _trigger_security_debate(
-        event,
-        confidence_threshold=confidence_threshold,
-        agents=agents,
-        timeout_seconds=timeout_seconds,
-    )
 
 
 class SecurityEventEmitter:
@@ -842,10 +794,12 @@ class SecurityEventEmitter:
         try:
             runner = get_security_debate_runner()
             if runner is None:
-                runner = _ensure_default_security_debate_runner_registered()
-            if runner is None:
                 logger.warning(
-                    "No security debate runner registered; skipping auto-debate for %s",
+                    "No security debate runner registered; skipping auto-debate for %s. "
+                    "A composition root must call "
+                    "aragora.events.security_events.register_security_debate_runner() "
+                    "(aragora.debate.security_response registers a default runner at "
+                    "import time; ensure it or an equivalent composition root has run).",
                     event.id,
                 )
                 return None
@@ -1187,8 +1141,6 @@ __all__ = [
     "SecurityDebateRunner",
     "register_security_debate_runner",
     "get_security_debate_runner",
-    "build_security_debate_question",
-    "trigger_security_debate",
     "get_security_debate_result",
     "list_security_debates",
     # Convenience functions

--- a/scripts/baselines/import_contracts_baseline.json
+++ b/scripts/baselines/import_contracts_baseline.json
@@ -37,7 +37,6 @@
         "aragora.debate -> aragora.workflow",
         "aragora.errors -> aragora.server",
         "aragora.evaluation -> aragora.server",
-        "aragora.events -> aragora.debate",
         "aragora.events -> aragora.server",
         "aragora.evidence -> aragora.connectors",
         "aragora.exceptions -> aragora.connectors",

--- a/tests/debate/test_security_response.py
+++ b/tests/debate/test_security_response.py
@@ -49,24 +49,6 @@ class TestBuildSecurityDebateQuestion:
         q = build_security_debate_question(event)
         assert "the codebase" in q
 
-    def test_legacy_events_package_import_delegates_to_relocated_builder(self):
-        """Historical aragora.events import path should keep working."""
-        from aragora.events import build_security_debate_question as legacy_builder
-
-        event = SecurityEvent(repository="org/repo")
-
-        assert legacy_builder(event) == build_security_debate_question(event)
-
-    def test_legacy_security_events_import_delegates_to_relocated_builder(self):
-        """Historical security_events import path should keep working."""
-        from aragora.events.security_events import (
-            build_security_debate_question as legacy_builder,
-        )
-
-        event = SecurityEvent(repository="org/repo")
-
-        assert legacy_builder(event) == build_security_debate_question(event)
-
     def test_question_with_vulnerability_findings(self):
         """Should include vulnerability details in the question."""
         finding = SecurityFinding(
@@ -372,52 +354,6 @@ class TestBuildSecurityDebateQuestion:
 
 class TestTriggerSecurityDebate:
     """Tests for the trigger_security_debate function."""
-
-    @pytest.mark.asyncio
-    async def test_legacy_security_events_trigger_delegates_to_relocated_runner(self):
-        """Historical trigger import path should call the relocated runner."""
-        from aragora.events.security_events import trigger_security_debate as legacy_trigger
-
-        event = SecurityEvent(repository="org/app")
-
-        with (
-            patch(
-                "aragora.debate.security_response.build_security_debate_question",
-                return_value="Question?",
-            ),
-            patch(
-                "aragora.debate.security_debate.get_security_debate_agents",
-                new_callable=AsyncMock,
-                return_value=[],
-            ),
-        ):
-            result = await legacy_trigger(event)
-
-        assert result is None
-        assert event.debate_question == "Question?"
-
-    @pytest.mark.asyncio
-    async def test_legacy_events_package_trigger_import_delegates_to_relocated_runner(self):
-        """Historical package-level trigger import should keep working."""
-        from aragora.events import trigger_security_debate as legacy_trigger
-
-        event = SecurityEvent(repository="org/app")
-
-        with (
-            patch(
-                "aragora.debate.security_response.build_security_debate_question",
-                return_value="Question?",
-            ),
-            patch(
-                "aragora.debate.security_debate.get_security_debate_agents",
-                new_callable=AsyncMock,
-                return_value=[],
-            ),
-        ):
-            result = await legacy_trigger(event)
-
-        assert result is None
-        assert event.debate_question == "Question?"
 
     @pytest.mark.asyncio
     async def test_trigger_debate_returns_none_on_import_error(self):

--- a/tests/events/test_security_dispatcher.py
+++ b/tests/events/test_security_dispatcher.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import logging
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -621,6 +623,14 @@ class TestDefaultRunnerPath:
 
     @pytest.mark.asyncio
     async def test_default_path_without_registered_runner_fails_gracefully(self):
+        """True cold path: no composition root has registered a runner.
+
+        There is no lazy-import fallback inside aragora.events (P4a
+        security-debate-unification removed it - see
+        register_security_debate_runner's docstring); a truly cold registry
+        must fail soft (counted as failed, no exception escapes) rather than
+        importing aragora.debate itself.
+        """
         emitter = SecurityEventEmitter(enable_auto_debate=False)
         dispatcher = SecurityDispatcher(emitter=emitter)
         await dispatcher.start()
@@ -635,16 +645,18 @@ class TestDefaultRunnerPath:
                 "aragora.events.security_dispatcher.get_security_debate_runner",
                 return_value=None,
             ),
-            patch(
-                "aragora.events.security_dispatcher._ensure_default_security_debate_runner_registered",
-                return_value=None,
-            ),
+            patch.object(
+                logging.getLogger("aragora.events.security_dispatcher"), "exception"
+            ) as mock_log,
         ):
             await dispatcher._handle_event(event)
             await asyncio.sleep(0.05)
 
         assert dispatcher._stats.debates_failed == 1
         assert dispatcher._stats.debates_completed == 0
+        assert event.debate_requested is False
+        assert event.debate_id is None
+        mock_log.assert_called_once()
         await dispatcher.stop()
 
     @pytest.mark.asyncio
@@ -669,8 +681,15 @@ class TestDefaultRunnerPath:
         assert event.debate_id is None
 
     @pytest.mark.asyncio
-    async def test_default_path_lazily_registers_runner_when_cold(self):
-        runner = AsyncMock(return_value="debate-lazy-1")
+    async def test_default_path_registers_via_composition_root_not_lazy_import(self):
+        """A composition root (e.g. importing aragora.debate.security_response,
+        as aragora.debate.orchestrator and aragora.debate.event_subscribers'
+        bootstrap_debate_event_subscribers do) registers the default runner
+        BEFORE the dispatcher ever runs -- there is no events-side lazy-import
+        fallback to fall back on if that has not happened (see
+        test_default_path_without_registered_runner_fails_gracefully)."""
+        import aragora.debate.security_response as security_response_mod
+
         emitter = SecurityEventEmitter(enable_auto_debate=False)
         dispatcher = SecurityDispatcher(emitter=emitter)
         await dispatcher.start()
@@ -683,21 +702,30 @@ class TestDefaultRunnerPath:
         with (
             patch(
                 "aragora.events.security_dispatcher.get_security_debate_runner",
-                return_value=None,
+                return_value=security_response_mod.trigger_security_debate,
             ),
             patch(
-                "aragora.events.security_dispatcher._ensure_default_security_debate_runner_registered",
-                return_value=runner,
-            ),
+                "aragora.debate.security_debate.run_security_debate",
+                new_callable=AsyncMock,
+            ) as mock_run,
         ):
-            await dispatcher._handle_event(event)
-            await asyncio.sleep(0.05)
+            mock_run.return_value.debate_id = "debate-composition-root-1"
+            mock_run.return_value.consensus_reached = True
+            mock_run.return_value.confidence = 0.9
+            mock_run.return_value.metadata = {"security_confidence_threshold_met": True}
 
-        runner.assert_awaited_once()
+            with patch(
+                "aragora.debate.security_response._store_security_debate_result",
+                new_callable=AsyncMock,
+            ):
+                await dispatcher._handle_event(event)
+                await asyncio.sleep(0.05)
+
+        mock_run.assert_awaited_once()
         assert dispatcher._stats.debates_completed == 1
         assert dispatcher._stats.debates_failed == 0
         assert event.debate_requested is True
-        assert event.debate_id == "debate-lazy-1"
+        assert event.debate_id == "debate-composition-root-1"
         await dispatcher.stop()
 
     @pytest.mark.asyncio
@@ -727,6 +755,84 @@ class TestDefaultRunnerPath:
         runner.assert_awaited_once()
         assert dispatcher._stats.debates_completed == 1
         assert dispatcher._stats.debates_failed == 0
+        await dispatcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_default_path_uses_debate_defaults_and_rich_context(self):
+        """Regression for p4a-security-debate-unification.
+
+        The dispatcher's default path resolves to the registered
+        aragora.debate.security_response.trigger_security_debate runner,
+        which forwards to aragora.debate.security_debate.run_security_debate
+        unmodified. That function builds its DebateProtocol from
+        DEBATE_DEFAULTS.security_debate_rounds/consensus (not a hardcoded
+        rounds=3/consensus="majority") and includes security_event_type,
+        source, and severity in Environment.context alongside the existing
+        security_event_id/repository/scan_id/findings. This proves the
+        dispatcher default path gets the exact same DEBATE_DEFAULTS-driven
+        config and rich context as the emitter's auto-debate path, since
+        both share the one registered runner.
+        """
+        from aragora.debate.config.defaults import DEBATE_DEFAULTS
+        from aragora.debate.security_response import trigger_security_debate
+
+        mock_agent = MagicMock()
+        mock_agent.name = "security-auditor"
+
+        mock_result = MagicMock()
+        mock_result.debate_id = "debate-rich-context-1"
+        mock_result.consensus_reached = True
+        mock_result.confidence = 0.9
+        mock_result.metadata = {}
+
+        mock_arena = MagicMock()
+        mock_arena.run = AsyncMock(return_value=mock_result)
+
+        emitter = SecurityEventEmitter(enable_auto_debate=False)
+        dispatcher = SecurityDispatcher(emitter=emitter)
+        await dispatcher.start()
+
+        event = _make_event(
+            severity=SecuritySeverity.CRITICAL,
+            event_type=SecurityEventType.CRITICAL_CVE,
+            findings=[_make_critical_finding()],
+        )
+
+        with (
+            patch(
+                "aragora.events.security_dispatcher.get_security_debate_runner",
+                return_value=trigger_security_debate,
+            ),
+            patch(
+                "aragora.debate.security_debate.get_security_debate_agents",
+                new_callable=AsyncMock,
+                return_value=[mock_agent],
+            ),
+            patch(
+                "aragora.debate.orchestrator.Arena",
+                return_value=mock_arena,
+            ) as mock_arena_cls,
+            patch(
+                "aragora.debate.security_response._store_security_debate_result",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await dispatcher._handle_event(event)
+            await asyncio.sleep(0.05)
+
+        mock_arena_cls.assert_called_once()
+        protocol = mock_arena_cls.call_args.kwargs["protocol"]
+        assert protocol.rounds == DEBATE_DEFAULTS.security_debate_rounds == 3
+        assert protocol.consensus == DEBATE_DEFAULTS.security_debate_consensus == "majority"
+
+        environment = mock_arena_cls.call_args.kwargs["environment"]
+        context = json.loads(environment.context)
+        assert context["security_event_type"] == event.event_type.value
+        assert context["source"] == event.source
+        assert context["severity"] == event.severity.value
+
+        assert dispatcher._stats.debates_completed == 1
+        assert event.debate_id == "debate-rich-context-1"
         await dispatcher.stop()
 
     @pytest.mark.asyncio

--- a/tests/events/test_security_events.py
+++ b/tests/events/test_security_events.py
@@ -28,7 +28,6 @@ from aragora.events.security_events import (
     get_security_debate_runner,
     get_security_emitter,
     is_secret_finding,
-    _ensure_default_security_debate_runner_registered,
     list_security_debates,
     register_security_debate_runner,
     set_security_emitter,
@@ -1246,10 +1245,11 @@ class TestSecurityEventEmitter:
     async def test_emit_with_no_runner_is_graceful(self, caplog):
         """emit() must never await a missing runner (`await None(...)`).
 
-        With no registered runner and the default-ensure path unavailable
-        (e.g. a process that never imports aragora.debate), the auto-debate
-        path logs a warning and skips -- no exception escapes emit(), matching
-        the dispatcher's log-and-skip semantics.
+        With no registered runner (e.g. a process where no composition root
+        has imported aragora.debate.security_response yet -- this module
+        never imports aragora.debate itself), the auto-debate path logs a
+        warning and skips -- no exception escapes emit(), matching the
+        dispatcher's log-and-skip semantics.
         """
         emitter = SecurityEventEmitter(enable_auto_debate=True)
         event = self._make_event(severity=SecuritySeverity.CRITICAL)
@@ -1259,10 +1259,6 @@ class TestSecurityEventEmitter:
                 "aragora.events.security_events.get_security_debate_runner",
                 return_value=None,
             ),
-            patch(
-                "aragora.events.security_events._ensure_default_security_debate_runner_registered",
-                return_value=None,
-            ),
             caplog.at_level(logging.WARNING, logger="aragora.events.security_events"),
         ):
             await emitter.emit(event)
@@ -1270,29 +1266,6 @@ class TestSecurityEventEmitter:
         assert event.debate_requested is False
         assert event.debate_id is None
         assert "No security debate runner registered" in caplog.text
-
-    @pytest.mark.asyncio
-    async def test_emit_isolates_default_runner_import_failure(self, caplog):
-        """Lazy default runner import failures should not break event delivery."""
-        emitter = SecurityEventEmitter(enable_auto_debate=True)
-        event = self._make_event(severity=SecuritySeverity.CRITICAL)
-
-        with (
-            patch(
-                "aragora.events.security_events.get_security_debate_runner",
-                return_value=None,
-            ),
-            patch(
-                "aragora.events.security_events._ensure_default_security_debate_runner_registered",
-                side_effect=RuntimeError("debate stack unavailable"),
-            ),
-            caplog.at_level(logging.ERROR, logger="aragora.events.security_events"),
-        ):
-            await emitter.emit(event)
-
-        assert event.debate_requested is False
-        assert event.debate_id is None
-        assert "Failed to trigger security debate" in caplog.text
 
     @pytest.mark.asyncio
     async def test_debate_started_event_redacts_secret_findings(self):
@@ -2280,31 +2253,23 @@ class TestSecurityDebateRunnerRegistry:
         register_security_debate_runner(None)
         assert get_security_debate_runner() is None
 
-    def test_default_runner_lazily_registered_when_unset(self):
-        """Cold consumers (never-set registry) get the default runner on demand."""
+    def test_registry_stays_unset_without_composition_root(self):
+        """Cold consumers (never-set registry) get NO default runner.
+
+        This module never imports aragora.debate itself (P4a
+        security-debate-unification removed the lazy-import self-heal
+        fallback). Only a composition root that imports
+        aragora.debate.security_response (aragora.debate.orchestrator,
+        aragora.debate.event_subscribers.bootstrap_debate_event_subscribers,
+        or aragora.analysis.codebase.sast.scanner) makes the default runner
+        available -- see test_explicit_clear_sticks_against_default_register
+        for that registration path.
+        """
         import aragora.events.security_events as mod
 
         mod._security_debate_runner = mod._UNSET_RUNNER
 
-        runner = _ensure_default_security_debate_runner_registered()
-
-        assert runner is not None
-        assert runner.__name__ == "trigger_security_debate"
-        assert get_security_debate_runner() is runner
-
-    def test_explicit_clear_sticks_against_ensure_default(self):
-        """An explicit None-clear must not be silently overwritten by the
-        lazy default import: ensure-default only fires from the UNSET state."""
-        import aragora.events.security_events as mod
-
-        register_security_debate_runner(None)
-
-        runner = _ensure_default_security_debate_runner_registered()
-
-        assert runner is None
         assert get_security_debate_runner() is None
-        # Registry state stays "explicitly cleared", not re-registered.
-        assert mod._security_debate_runner is None
 
     def test_explicit_clear_sticks_against_default_register(self):
         """Import-time default registration must not clobber an explicit clear."""
@@ -2329,7 +2294,6 @@ class TestSecurityDebateRunnerRegistry:
         register_security_debate_runner(fake_runner)
 
         assert get_security_debate_runner() is fake_runner
-        assert _ensure_default_security_debate_runner_registered() is fake_runner
 
     @pytest.mark.asyncio
     async def test_emit_after_explicit_clear_does_not_fire_auto_debate(self):

--- a/tests/handlers/codebase/security/test_events.py
+++ b/tests/handlers/codebase/security/test_events.py
@@ -15,6 +15,7 @@ handling, SAST severity filtering, and edge cases.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -668,23 +669,35 @@ class TestEmitScanEvents:
 
 
 class TestEmitScanEventsColdRunnerRegistration:
-    """Regression test for P4a E8 SCOPE #5.
+    """Regression test for P4a E8 SCOPE #5, updated by P4a
+    security-debate-unification (incident #5 fix-forward).
 
-    This module never explicitly imports aragora.debate.security_response
-    (that import was deliberately reverted to avoid a Tier-3 reclassification
-    for this interface-tier handler - see aragora/debate/security_response.py's
-    module docstring for the two composition roots that DO import it
-    explicitly: aragora.debate.orchestrator and
-    aragora.analysis.codebase.sast.scanner). This proves the handler's
-    auto-debate path is robust to that import-order drift anyway, because
-    SecurityEventEmitter._trigger_security_debate self-heals the runner
-    registry on first real use
+    This handler module never explicitly imports
+    aragora.debate.security_response (that import was deliberately reverted
+    during E8 to avoid a Tier-3 reclassification for this interface-tier
+    handler). E7a-as-merged (and E8) compensated for that with an
+    events-side self-heal
     (aragora.events.security_events._ensure_default_security_debate_runner_registered)
-    regardless of whether either composition root ran first - a stronger,
-    more realistic guarantee than a cold-import subprocess check (which only
-    proves an import side effect, not this runtime self-heal). See also
-    tests/debate/test_security_response.py::TestConsumerRegistrationSideEffect
-    for the equivalent proof from the SAST scanner composition root's side.
+    that lazily imported aragora.debate.security_response on first use --
+    but that was itself a charter-forbidden events->debate import edge
+    (incident #5) and has been removed.
+
+    The equivalent robustness now lives entirely domain-side: composition
+    roots register the runner before any request-handling code runs
+    (aragora.debate.orchestrator, aragora.debate.event_subscribers.
+    bootstrap_debate_event_subscribers, aragora.analysis.codebase.sast.
+    scanner -- see aragora/debate/security_response.py's module docstring).
+    A real server process always imports at least one of these during
+    startup, so this handler's auto-debate path keeps working in
+    production. This class pins both halves of the new contract:
+      - test_critical_finding_triggers_debate_when_composition_root_registered:
+        production bootstrap already wired the runner (the realistic case).
+      - test_critical_finding_fails_soft_when_truly_cold: no composition
+        root ever ran (e.g. a misconfigured deployment) -- auto-debate now
+        fails soft with a loud warning log instead of self-healing.
+    See also tests/debate/test_security_response.py::
+    TestConsumerRegistrationSideEffect for the equivalent proof from the
+    SAST scanner composition root's side.
     """
 
     @pytest.fixture(autouse=True)
@@ -697,12 +710,16 @@ class TestEmitScanEventsColdRunnerRegistration:
         security_events_mod._security_debate_runner = original
 
     @pytest.mark.asyncio
-    async def test_critical_finding_self_heals_runner_and_triggers_debate(self):
-        """A critical finding through the real handler+emitter path triggers a
-        debate even though no composition root ever registered the runner."""
+    async def test_critical_finding_triggers_debate_when_composition_root_registered(self):
+        """A critical finding through the real handler+emitter path triggers
+        a debate once a composition root has registered the runner
+        (simulating production startup, e.g. aragora.debate.orchestrator
+        having been imported before any request is handled)."""
+        from aragora.debate import security_response
         from aragora.events.security_events import get_security_debate_runner
 
-        assert get_security_debate_runner() is None
+        security_response.ensure_registered()
+        assert get_security_debate_runner() is not None
 
         vuln = _make_vuln(severity=VulnerabilitySeverity.CRITICAL, cvss_score=9.8)
         dep = _make_dep(vulnerabilities=[vuln])
@@ -748,6 +765,40 @@ class TestEmitScanEventsColdRunnerRegistration:
         assert scan_event.event_type == SecurityEventType.CRITICAL_VULNERABILITY
         assert scan_event.debate_requested is True
         assert scan_event.debate_id == "cold-start-debate-1"
+
+    @pytest.mark.asyncio
+    async def test_critical_finding_fails_soft_when_truly_cold(self, caplog):
+        """A critical finding through the real handler+emitter path fails
+        soft with a loud log -- no debate, no exception -- when no
+        composition root has ever registered a runner (a genuinely cold
+        process, e.g. a misconfigured deployment that skips startup
+        wiring)."""
+        from aragora.events.security_events import get_security_debate_runner
+
+        assert get_security_debate_runner() is None
+
+        vuln = _make_vuln(severity=VulnerabilitySeverity.CRITICAL, cvss_score=9.8)
+        dep = _make_dep(vulnerabilities=[vuln])
+        result = _make_scan_result(dependencies=[dep])
+
+        real_emitter = SecurityEventEmitter(enable_auto_debate=True)
+
+        with (
+            patch(
+                "aragora.server.handlers.codebase.security.events.get_security_emitter",
+                return_value=real_emitter,
+            ),
+            caplog.at_level(logging.WARNING, logger="aragora.events.security_events"),
+        ):
+            await emit_scan_events(result, "repo-1", "scan-1")
+
+        assert get_security_debate_runner() is None
+        assert "No security debate runner registered" in caplog.text
+
+        scan_event = real_emitter.get_recent_events()[-1]
+        assert scan_event.event_type == SecurityEventType.CRITICAL_VULNERABILITY
+        assert scan_event.debate_requested is False
+        assert scan_event.debate_id is None
 
 
 # ============================================================================


### PR DESCRIPTION
## Source issue

E7a (PR #8827, merge commit `72b1f7068b`) split the security-debate runner into `aragora/debate/` but landed AS-MERGED (via operator settlement) with 3 charter-forbidden function-scoped `from aragora.debate...` lazy imports still inside `aragora/events/security_events.py`:

- a default-runner fallback import inside `_trigger_security_debate()` (`from aragora.debate import security_response`)
- 2 compat wrapper re-exports (`build_security_debate_question`, `trigger_security_debate`) that reversed the chartered section-6.3 export drops

This reintroduced the `events -> {debate,agents}` import edge that the P4a events/queue layering effort exists to eliminate (incident #5, `library/operator-approvals.md`). Separately, E7a's inversion had routed `SecurityDispatcher`'s default (no-custom-callback) path through the shared registered runner, which raised a question (flagged independently by E7a round-1 grok review) about whether that path was narrower than the pre-E7a `Arena.run_security_debate` delegate path (hardcoded rounds/consensus vs `DEBATE_DEFAULTS`-driven, and a thinner `Environment.context`).

PR #9002 (E8, merge `cae460be0c`) subsequently added `tests/handlers/codebase/security/test_events.py::TestEmitScanEventsColdRunnerRegistration`, an e2e test pinning the exact events-side self-heal mechanism this PR removes - so this PR also reconciles with that test's contract.

## Behavior summary

**Removed** (mandatory, incident #5 fix-forward):
- The lazy `from aragora.debate import security_response` fallback inside `security_events.py::_trigger_security_debate()`
- The 2 compat wrapper re-exports (`build_security_debate_question`, `trigger_security_debate`) from both `security_events.py` and `events/__init__.py`

**Added** (domain-side composition-root registration, replacing the removed events-side self-heal):
- `aragora.debate.security_response.ensure_registered()`: a small idempotent public helper that (re-)registers the default security-debate runner even when the module was already imported earlier in the process. A bare top-level `import aragora.debate.security_response` is a no-op on a cached module, so without this helper a mid-process registry reset (e.g. in tests, or a fresh composition root running after the module is already cached) would silently fail to re-register.
- A 2nd composition root: `aragora.debate.event_subscribers.bootstrap_debate_event_subscribers()` now calls `security_response.ensure_registered()`.
- A 3rd (fixed) composition root: `aragora.analysis.codebase.sast.scanner.initialize()` now imports `aragora.debate.security_response` and calls `.ensure_registered()` (previously imported a function this PR deletes, which was silently broken).
- `aragora.debate.orchestrator` already registers the runner at import time (pre-existing, unchanged).

**Fail-soft behavior when nobody has registered a runner** (genuinely cold start, no composition root imported yet):
- `security_events.py`'s emitter auto-debate path: logs a warning and skips (no exception), matching existing emitter semantics.
- `security_dispatcher.py`'s default path: raises `ImportError` with an actionable message (a caller providing no custom callback and hitting an unregistered registry is a configuration error, not a soft-fail case, per the existing dispatcher contract).

**Base-scope finding:** the "dispatcher default path is narrower" premise no longer holds on current `main` - both the emitter and dispatcher default paths already funnel through the single registered runner (`security_response.trigger_security_debate`), which already uses `DEBATE_DEFAULTS.security_debate_rounds` / `DEBATE_DEFAULTS.security_debate_consensus` (3 / `"majority"`, confirmed identical to the pre-E7a hardcoded values) and the full `Environment.context` (including `security_event_type`, `source`, `severity`). This PR pins that with new regression tests rather than re-deriving the logic.

**`tests/handlers/codebase/security/test_events.py` reconciliation (addendum #2):** replaced `TestEmitScanEventsColdRunnerRegistration`'s single self-heal test with two tests reflecting the new contract: `test_critical_finding_triggers_debate_when_composition_root_registered` (realistic production path - a composition root has registered the runner) and `test_critical_finding_fails_soft_when_truly_cold` (genuinely cold registry - fails soft with a logged warning, `debate_requested=False`, no exception).

**Import-contracts baseline:** hand-shrunk `scripts/baselines/import_contracts_baseline.json` - with the last `events -> debate` import gone, `check_import_contracts.py` reports zero contributors to that edge in both layer-scoped and full-tree modes, so the now-dead baseline line was removed (`frozen_from_ref` untouched, no `--freeze`).

## Validation

```
$ python3 scripts/check_import_contracts.py --layers foundation,infrastructure --json
# new_violations: {} (events->debate fully resolved, zero new edges)

$ python3 scripts/check_import_contracts.py --json
# resolved_violations: {} (matches hand-shrunk baseline exactly)
# new_violations: 4 ambient pre-existing edges (evaluation->connectors, evaluation->swarm,
#   swarm->cli, utils->caching) - identical on clean origin/main, unrelated to this PR

$ python3 -m pytest tests/events/test_security_events.py tests/events/test_security_dispatcher.py \
    tests/debate/test_security_debate.py tests/debate/test_security_response.py \
    tests/handlers/codebase/security/test_events.py -q
# 234 passed

$ AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke
# Smoke tests passed!

$ PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke
# 138 passed, 230644 deselected in 235.73s - Test tier 'smoke' completed successfully!

$ make lint && ruff format --check aragora/ tests/ scripts/
# All checks passed!

$ mypy --ignore-missing-imports --follow-imports=skip --show-error-codes <6 changed aragora/ files>
# Success: no issues found in 6 source files
```

`bash scripts/typecheck_differential.sh` reports `new=130 > recorded floor=66`, but this is 100% ambient sibling-fleet drift unrelated to this PR: none of the 130 reported lines touch any file this PR changes (verified via direct grep of the full mypy output against the 6 changed `aragora/` files), and the actual required CI changed-file typecheck gate (replicated above) is clean. This matches the documented drift-growth pattern in mission `library/environment.md` (floor intentionally frozen at 66, ambient measured 89->97->98->115->117->130 over the mission's history, entirely in `scripts/*` automation + non-mission `aragora/` files). No floor bump taken (reserved for the P7 scrutiny boundary).

## Risks

- Any external code importing the 2 removed compat wrappers (`aragora.events.build_security_debate_question` / `aragora.events.trigger_security_debate`) or relying on `security_events._ensure_default_security_debate_runner_registered` directly would break. A repo-wide grep found zero remaining callers/imports of either (only a stale historical docstring reference in one doc, left untouched as non-blocking).
- `aragora/server/handlers/` (Tier-3) was NOT touched - confirmed no touched file matches any `TIER_3_PREFIXES`/`TIER_3_TITLE_KEYWORDS` prefix in `aragora/cli/commands/review_queue.py`.
- No `docs/METRICS.md` / `aragora/module_tiers.yaml` regen (path-frozen per mission policy; this PR does not change module structure/counts anyway).

Branch: `structex/p4a-security-debate-unification`. Tier 1-2, self-merge head-bound (`--squash --match-head-commit`, never `--admin`).

## Reviewer context (why the 2 compat-wrapper removals are intentional, not an oversight)

`docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md` §6.3 ("SPLIT-moved symbols") is the binding charter for the whole P4a events/queue layering effort. Its `aragora/events/__init__.py` eager re-export DROP list is explicit and MANDATORY:

> `trigger_security_debate` | `aragora/debate/security_response.py` | ... | E7a
> `build_security_debate_question` | `aragora/debate/security_response.py` | ... | E7a
> ... No `__getattr__` fallback / lazy re-export is added (that would also re-create the edge - grimp counts lazy chains).

E7a (PR #8827) landed via operator settlement WITHOUT this drop - it kept both symbols as compat wrapper re-exports (in both `events/__init__.py` and `security_events.py`), reversing the charter's §6.3 mandate. This mission's incident #5 adjudication (`library/operator-approvals.md`) treats that as unauthorized fix-forward debt, not a redesign, and the ORCHESTRATOR ADDENDUM for this feature explicitly mandates: "Delete the 2 compat wrappers and repoint any callers/tests to aragora.debate.security_response directly (consumer census in PR body)." This PR is that mandated fix-forward, not a new API-compatibility decision - see `docs/architecture/charters.yaml` `ARCH-036` (concern: removal-intent; authority: `docs/architecture/INTENDED_ARCHITECTURE.md#3` + `charters.yaml`; disposition: adopt) for the general removal-intent charter this specific §6.3 drop falls under.

**Consumer census:** repo-wide grep for `build_security_debate_question` and `trigger_security_debate` (as of this PR's head) finds zero remaining runtime or test importers of the `aragora.events`-side paths. The only runtime caller of `trigger_security_debate` was always the emitter itself (`security_events.py`), already decoupled to a callback in E7a; `aragora.debate.security_debate` already calls the `aragora.debate.security_response` versions directly (domain-internal, layering-legal). No `sdk/` or `aragora/server/handlers/` consumer references either symbol via the events-side path.

The `tests/handlers/codebase/security/test_events.py::TestEmitScanEventsColdRunnerRegistration` contract change (replacing its single self-heal test with two tests for the new composition-root-registration + genuinely-cold-fail-soft contract) is the ORCHESTRATOR ADDENDUM #2 item (c) reconciliation with #9002, justified by the same incident #5 fix-forward mandate: the old pinned test asserted the exact events-side lazy-import fallback this PR removes per the charter above.
