### PR TITLE
feat(scripts): add OpenRouter fallback for Fable goal cycles

### DIFF
--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -536,7 +536,7 @@ def consult(
     _validate_timeout(timeout, "timeout")
     if overall_timeout is not None:
         _validate_timeout(overall_timeout, "overall_timeout")
-    prompt = _compose_prompt(prompt, system)
+    cli_prompt = _compose_prompt(prompt, system)
     attempts: list[dict] = []
     started = time.monotonic()
     if overall_timeout is None:
@@ -551,7 +551,7 @@ def consult(
     if attempt_timeout <= 0:
         _append_budget_exhausted(attempts, model=model, backend="cli")
     else:
-        result = _run_cli(prompt, model, attempt_timeout)
+        result = _run_cli(cli_prompt, model, attempt_timeout)
         attempts.append({"model": model, **result})
         if result.get("ok"):
             return {**result, "model": model, "attempts": attempts}
@@ -560,7 +560,7 @@ def consult(
         if attempt_timeout <= 0:
             _append_budget_exhausted(attempts, model=fallback_model, backend="cli")
         else:
-            result = _run_cli(prompt, fallback_model, attempt_timeout)
+            result = _run_cli(cli_prompt, fallback_model, attempt_timeout)
             attempts.append({"model": fallback_model, **result})
             if result.get("ok"):
                 return {**result, "model": fallback_model, "attempts": attempts}
@@ -575,7 +575,7 @@ def consult(
             if attempt_timeout <= 0:
                 _append_budget_exhausted(attempts, model=api_model, backend="api")
                 continue
-            result = _run_api(prompt, api_model, attempt_timeout, system=None)
+            result = _run_api(prompt, api_model, attempt_timeout, system=system)
             attempts.append({"model": api_model, **result})
             if result.get("ok"):
                 return {**result, "model": api_model, "attempts": attempts}
@@ -584,7 +584,7 @@ def consult(
         if attempt_timeout <= 0:
             _append_budget_exhausted(attempts, model=openrouter_model, backend="openrouter")
         else:
-            result = _run_openrouter_api(prompt, openrouter_model, attempt_timeout, system=None)
+            result = _run_openrouter_api(prompt, openrouter_model, attempt_timeout, system=system)
             attempts.append({"model": openrouter_model, **result})
             if result.get("ok"):
                 return {**result, "model": openrouter_model, "attempts": attempts}

--- a/scripts/consult_claude.py
+++ b/scripts/consult_claude.py
@@ -15,6 +15,11 @@ Backends, in order:
    after CLI attempts fail. The key comes from ``ANTHROPIC_API_KEY`` or the
    aragora secrets manager; if neither is present the attempt is recorded as a
    normal failed backend attempt.
+3. OpenRouter Chat Completions API — used only with explicit
+   ``--openrouter-fallback`` opt-in after CLI/API attempts fail. This is useful
+   when the Claude subscription CLI is quota-exhausted but an OpenRouter key is
+   available. The key comes from ``OPENROUTER_API_KEY`` or the aragora secrets
+   manager.
 
 Output is the raw model text on stdout, or a JSON envelope with ``--json``.
 Exit codes: 0 ok, 2 all backends timed out, 3 no prompt, 4 all backends failed
@@ -26,6 +31,7 @@ Examples::
     python scripts/consult_claude.py --prompt-file /tmp/question.md --json
     echo "$QUESTION" | python scripts/consult_claude.py --timeout 300 --overall-timeout 1200
     python scripts/consult_claude.py --api-fallback --prompt-file /tmp/question.md
+    python scripts/consult_claude.py --openrouter-fallback --prompt-file /tmp/question.md
 """
 
 from __future__ import annotations
@@ -54,6 +60,11 @@ DEFAULT_MODEL = "claude-fable-5"
 FALLBACK_MODEL = "claude-opus-4-8"
 DEFAULT_TIMEOUT_SECONDS = 600
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
+OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_OPENROUTER_MODEL = os.environ.get(
+    "ARAGORA_CONSULT_OPENROUTER_MODEL",
+    os.environ.get("OPENROUTER_FABLE_MODEL", "anthropic/claude-opus-4.1"),
+)
 API_MAX_TOKENS = 8192
 MAX_API_RESPONSE_BYTES = 4 * 1024 * 1024
 API_UNSUPPORTED_MODELS = {"claude-fable-5"}
@@ -218,6 +229,18 @@ def _resolve_api_key() -> str | None:
         return None
 
 
+def _resolve_openrouter_api_key() -> str | None:
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if key:
+        return key
+    try:
+        from aragora.config.secrets import get_secret
+
+        return get_secret("OPENROUTER_API_KEY")
+    except Exception:
+        return None
+
+
 def _response_socket(response):
     fp = getattr(response, "fp", None)
     raw = getattr(fp, "raw", None)
@@ -343,6 +366,101 @@ def _run_api(prompt: str, model: str, timeout: float, system: str | None) -> dic
     return {"ok": True, "backend": "api", "elapsed_s": elapsed, "text": text}
 
 
+def _run_openrouter_api(prompt: str, model: str, timeout: float, system: str | None) -> dict:
+    """One bounded OpenRouter Chat Completions attempt. Never raises."""
+    key = _resolve_openrouter_api_key()
+    if not key:
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "error": "no OPENROUTER_API_KEY available",
+        }
+    messages: list[dict[str, str]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    payload = {
+        "model": model,
+        "max_tokens": API_MAX_TOKENS,
+        "messages": messages,
+    }
+    request = urllib.request.Request(
+        OPENROUTER_API_URL,
+        data=json.dumps(payload).encode(),
+        headers={
+            "authorization": f"Bearer {key}",
+            "content-type": "application/json",
+            "http-referer": "https://github.com/synaptent/aragora",
+            "x-title": "Aragora bounded consult",
+        },
+    )
+    started = time.monotonic()
+    deadline = started + timeout
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = _read_api_response_with_deadline(response, deadline=deadline)
+            if len(raw) > MAX_API_RESPONSE_BYTES:
+                return {
+                    "ok": False,
+                    "backend": "openrouter",
+                    "error": _safe_api_error(
+                        "OpenRouter response exceeds maximum size: response body redacted"
+                    ),
+                }
+            body = json.loads(raw.decode())
+            if not isinstance(body, dict):
+                raise ValueError("OpenRouter response JSON is not an object")
+    except urllib.error.HTTPError as exc:
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "error": _safe_api_error(f"OpenRouter HTTP {exc.code}: response body redacted"),
+        }
+    except (json.JSONDecodeError, UnicodeError, ValueError):
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "error": _safe_api_error("OpenRouter response parse failed: response body redacted"),
+        }
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        timed_out = "timed out" in str(exc).lower() or isinstance(exc, TimeoutError)
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "timed_out": timed_out,
+            "error": _safe_api_error(f"OpenRouter request failed: {type(exc).__name__}"),
+        }
+    elapsed = round(time.monotonic() - started, 1)
+    choices = body.get("choices", [])
+    if not isinstance(choices, list):
+        choices = []
+    text_parts: list[str] = []
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message", {})
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content", "")
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            text_parts.extend(
+                block.get("text", "")
+                for block in content
+                if isinstance(block, dict) and isinstance(block.get("text"), str)
+            )
+    text = "".join(text_parts).strip()
+    if not text:
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "elapsed_s": elapsed,
+            "error": "OpenRouter returned no text",
+        }
+    return {"ok": True, "backend": "openrouter", "elapsed_s": elapsed, "text": text}
+
+
 def _remaining_timeout(started: float, overall_timeout: float, per_attempt_timeout: float) -> float:
     remaining = overall_timeout - (time.monotonic() - started)
     return max(0.0, min(per_attempt_timeout, remaining))
@@ -368,19 +486,32 @@ def _api_models(model: str, fallback_model: str | None) -> list[str]:
     return models
 
 
-def _planned_attempt_count(*, model: str, fallback_model: str | None, api_fallback: bool) -> int:
+def _planned_attempt_count(
+    *,
+    model: str,
+    fallback_model: str | None,
+    api_fallback: bool,
+    openrouter_fallback: bool,
+) -> int:
     cli_attempts = 1 + int(bool(fallback_model and fallback_model != model))
     api_attempts = len(_api_models(model, fallback_model)) if api_fallback else 0
-    return cli_attempts + api_attempts
+    openrouter_attempts = int(openrouter_fallback)
+    return cli_attempts + api_attempts + openrouter_attempts
 
 
 def _default_overall_timeout(
-    *, timeout: float, model: str, fallback_model: str | None, api_fallback: bool
+    *,
+    timeout: float,
+    model: str,
+    fallback_model: str | None,
+    api_fallback: bool,
+    openrouter_fallback: bool,
 ) -> float:
     return timeout * _planned_attempt_count(
         model=model,
         fallback_model=fallback_model,
         api_fallback=api_fallback,
+        openrouter_fallback=openrouter_fallback,
     )
 
 
@@ -392,6 +523,8 @@ def consult(
     fallback_model: str | None = FALLBACK_MODEL,
     system: str | None = None,
     api_fallback: bool = False,
+    openrouter_fallback: bool = False,
+    openrouter_model: str = DEFAULT_OPENROUTER_MODEL,
 ) -> dict:
     """Run the consult across backends and return the first success.
 
@@ -412,6 +545,7 @@ def consult(
             model=model,
             fallback_model=fallback_model,
             api_fallback=api_fallback,
+            openrouter_fallback=openrouter_fallback,
         )
     attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
     if attempt_timeout <= 0:
@@ -445,6 +579,15 @@ def consult(
             attempts.append({"model": api_model, **result})
             if result.get("ok"):
                 return {**result, "model": api_model, "attempts": attempts}
+    if openrouter_fallback:
+        attempt_timeout = _remaining_timeout(started, overall_timeout, timeout)
+        if attempt_timeout <= 0:
+            _append_budget_exhausted(attempts, model=openrouter_model, backend="openrouter")
+        else:
+            result = _run_openrouter_api(prompt, openrouter_model, attempt_timeout, system=None)
+            attempts.append({"model": openrouter_model, **result})
+            if result.get("ok"):
+                return {**result, "model": openrouter_model, "attempts": attempts}
     timed_out = all(a.get("timed_out") for a in attempts) and bool(attempts)
     budget_exhausted = any(a.get("budget_exhausted") for a in attempts)
     return {
@@ -542,6 +685,30 @@ def main(argv: list[str] | None = None) -> int:
         action="store_false",
         help=argparse.SUPPRESS,
     )
+    parser.set_defaults(openrouter_fallback=False)
+    openrouter_fallback_group = parser.add_mutually_exclusive_group()
+    openrouter_fallback_group.add_argument(
+        "--openrouter-fallback",
+        dest="openrouter_fallback",
+        action="store_true",
+        help=(
+            "Opt in to OpenRouter fallback when CLI/API attempts fail "
+            "(requires OPENROUTER_API_KEY and may use paid API credits)"
+        ),
+    )
+    openrouter_fallback_group.add_argument(
+        "--no-openrouter-fallback",
+        dest="openrouter_fallback",
+        action="store_false",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "--openrouter-model",
+        default=DEFAULT_OPENROUTER_MODEL,
+        help=(
+            f"OpenRouter model id for --openrouter-fallback (default: {DEFAULT_OPENROUTER_MODEL})"
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit a JSON result envelope")
     args = parser.parse_args(argv)
 
@@ -590,6 +757,8 @@ def main(argv: list[str] | None = None) -> int:
             fallback_model=args.fallback_model or None,
             system=args.system,
             api_fallback=args.api_fallback,
+            openrouter_fallback=args.openrouter_fallback,
+            openrouter_model=args.openrouter_model,
         )
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/scripts/fable_goal_cycle.py
+++ b/scripts/fable_goal_cycle.py
@@ -71,13 +71,13 @@ ACTIVE_PROCESS_SCRIPT_NAMES = frozenset(
         "settle_tier4_pr.py",
     }
 )
-ACTIVE_PROCESS_COMMAND_PATTERNS = (
+ACTIVE_PROCESS_COMMAND_PATTERNS: tuple[tuple[str, ...], ...] = (
     ("aragora", "review-queue", "collect-evidence"),
     ("aragora", "review-queue", "merge-packet"),
     ("gh", "pr", "merge"),
     ("droid", "exec"),
 )
-ACTIVE_PROCESS_TOKEN_PATTERNS = (
+ACTIVE_PROCESS_TOKEN_PATTERNS: tuple[str, ...] = (
     "claude-fable",
     "overnight-conductor",
     "overnight_conductor",
@@ -262,14 +262,17 @@ def _active_process_label(command: str) -> str | None:
             return f"{executable} {basename}"
 
     lowered = [word.lower() for word in words]
-    for pattern in ACTIVE_PROCESS_COMMAND_PATTERNS:
-        if len(lowered) >= len(pattern) and tuple(lowered[: len(pattern)]) == pattern:
-            return " ".join(pattern)
+    for command_pattern in ACTIVE_PROCESS_COMMAND_PATTERNS:
+        if (
+            len(lowered) >= len(command_pattern)
+            and tuple(lowered[: len(command_pattern)]) == command_pattern
+        ):
+            return " ".join(command_pattern)
 
     command_lower = " ".join(lowered)
-    for pattern in ACTIVE_PROCESS_TOKEN_PATTERNS:
-        if pattern in command_lower:
-            return pattern
+    for token_pattern in ACTIVE_PROCESS_TOKEN_PATTERNS:
+        if token_pattern in command_lower:
+            return token_pattern
 
     return None
 
@@ -535,8 +538,17 @@ def extract_next_prompt(response: str) -> str | None:
     return section.strip() or None
 
 
-def run_consult(consult_script: Path, packet_path: Path, model: str, timeout: float) -> dict:
-    overall_timeout = timeout * 2
+def run_consult(
+    consult_script: Path,
+    packet_path: Path,
+    model: str,
+    timeout: float,
+    *,
+    openrouter_fallback: bool = False,
+    openrouter_model: str | None = None,
+) -> dict:
+    enabled_attempts = 2 + int(openrouter_fallback)
+    overall_timeout = timeout * enabled_attempts
     command = [
         sys.executable,
         str(consult_script),
@@ -550,6 +562,10 @@ def run_consult(consult_script: Path, packet_path: Path, model: str, timeout: fl
         str(overall_timeout),
         "--json",
     ]
+    if openrouter_fallback:
+        command.append("--openrouter-fallback")
+        if openrouter_model:
+            command.extend(["--openrouter-model", openrouter_model])
     # Outer bound gives the consult helper a small cleanup/reporting grace
     # around its own overall timeout.
     ok, out = _run(command, overall_timeout + 60)
@@ -588,6 +604,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--max-prs", type=int, default=30)
     parser.add_argument("--skip-digest", action="store_true", help="Skip the session digest step")
+    parser.add_argument(
+        "--openrouter-fallback",
+        action="store_true",
+        help=(
+            "Opt in to consult_claude.py OpenRouter fallback when Claude CLI attempts fail "
+            "(requires OPENROUTER_API_KEY and may use paid API credits)"
+        ),
+    )
+    parser.add_argument(
+        "--openrouter-model",
+        default=None,
+        help="OpenRouter model id for --openrouter-fallback (defaults to consult_claude.py)",
+    )
     parser.add_argument(
         "--output-dir",
         default=None,
@@ -634,7 +663,14 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(result, indent=2) if args.json else result["error"], file=sys.stderr)
         return EXIT_CONSULT_FAILED
 
-    consult = run_consult(consult_script, packet_path, args.model, args.timeout)
+    consult = run_consult(
+        consult_script,
+        packet_path,
+        args.model,
+        args.timeout,
+        openrouter_fallback=args.openrouter_fallback,
+        openrouter_model=args.openrouter_model,
+    )
     result["consult"] = {
         k: consult.get(k) for k in ("ok", "model", "backend", "elapsed_s", "error")
     }

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -178,18 +178,21 @@ def test_consult_api_fallback_skips_cli_only_model(monkeypatch) -> None:
 def test_consult_openrouter_fallback_is_explicit(monkeypatch) -> None:
     cli_models: list[str] = []
     openrouter_models: list[str] = []
+    openrouter_prompts: list[str] = []
+    openrouter_systems: list[str | None] = []
 
     def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
         cli_models.append(model)
         return {"ok": False, "backend": "cli", "error": f"{model} unavailable"}
 
     def fake_openrouter(
-        _prompt: str,
+        prompt: str,
         model: str,
         _timeout: float,
         system: str | None,
     ) -> dict:
-        del system
+        openrouter_prompts.append(prompt)
+        openrouter_systems.append(system)
         openrouter_models.append(model)
         return {
             "ok": True,
@@ -203,6 +206,7 @@ def test_consult_openrouter_fallback_is_explicit(monkeypatch) -> None:
 
     result = consult_claude.consult(
         "question",
+        system="system instructions",
         openrouter_fallback=True,
         openrouter_model="anthropic/claude-test",
     )
@@ -212,6 +216,8 @@ def test_consult_openrouter_fallback_is_explicit(monkeypatch) -> None:
     assert result["backend"] == "openrouter"
     assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
     assert openrouter_models == ["anthropic/claude-test"]
+    assert openrouter_prompts == ["question"]
+    assert openrouter_systems == ["system instructions"]
 
 
 def test_run_openrouter_api_redacts_http_error_body(monkeypatch) -> None:

--- a/tests/scripts/test_consult_claude.py
+++ b/tests/scripts/test_consult_claude.py
@@ -135,8 +135,12 @@ def test_consult_default_is_cli_only(monkeypatch) -> None:
     def fake_api(*_args, **_kwargs) -> dict:
         raise AssertionError("API fallback must be explicit")
 
+    def fake_openrouter(*_args, **_kwargs) -> dict:
+        raise AssertionError("OpenRouter fallback must be explicit")
+
     monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
     monkeypatch.setattr(consult_claude, "_run_api", fake_api)
+    monkeypatch.setattr(consult_claude, "_run_openrouter_api", fake_openrouter)
 
     result = consult_claude.consult("question")
 
@@ -169,6 +173,72 @@ def test_consult_api_fallback_skips_cli_only_model(monkeypatch) -> None:
     assert result["model"] == consult_claude.FALLBACK_MODEL
     assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
     assert api_models == [consult_claude.FALLBACK_MODEL]
+
+
+def test_consult_openrouter_fallback_is_explicit(monkeypatch) -> None:
+    cli_models: list[str] = []
+    openrouter_models: list[str] = []
+
+    def fake_cli(_prompt: str, model: str, _timeout: float) -> dict:
+        cli_models.append(model)
+        return {"ok": False, "backend": "cli", "error": f"{model} unavailable"}
+
+    def fake_openrouter(
+        _prompt: str,
+        model: str,
+        _timeout: float,
+        system: str | None,
+    ) -> dict:
+        del system
+        openrouter_models.append(model)
+        return {
+            "ok": True,
+            "backend": "openrouter",
+            "text": "openrouter answer",
+            "elapsed_s": 0.1,
+        }
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_openrouter_api", fake_openrouter)
+
+    result = consult_claude.consult(
+        "question",
+        openrouter_fallback=True,
+        openrouter_model="anthropic/claude-test",
+    )
+
+    assert result["ok"] is True
+    assert result["model"] == "anthropic/claude-test"
+    assert result["backend"] == "openrouter"
+    assert cli_models == [consult_claude.DEFAULT_MODEL, consult_claude.FALLBACK_MODEL]
+    assert openrouter_models == ["anthropic/claude-test"]
+
+
+def test_run_openrouter_api_redacts_http_error_body(monkeypatch) -> None:
+    class RaisingUrlopen:
+        def __call__(self, *_args, **_kwargs):
+            raise consult_claude.urllib.error.HTTPError(
+                url=consult_claude.OPENROUTER_API_URL,
+                code=429,
+                msg="Too Many Requests",
+                hdrs={},
+                fp=io.BytesIO(b"profile=/secret/path token=secret prompt text"),
+            )
+
+    monkeypatch.setattr(consult_claude, "_resolve_openrouter_api_key", lambda: "test-key")
+    monkeypatch.setattr(consult_claude.urllib.request, "urlopen", RaisingUrlopen())
+
+    result = consult_claude._run_openrouter_api(
+        "secret prompt",
+        "anthropic/claude-test",
+        1.0,
+        None,
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "API OpenRouter HTTP 429: response body redacted"
+    assert "secret" not in json.dumps(result)
+    assert "profile" not in json.dumps(result).lower()
 
 
 def test_run_api_redacts_http_error_body(monkeypatch) -> None:
@@ -521,6 +591,50 @@ def test_consult_explicit_api_fallback_has_budget_for_supported_models(monkeypat
         consult_claude.DEFAULT_MODEL,
         consult_claude.FALLBACK_MODEL,
         consult_claude.FALLBACK_MODEL,
+    ]
+    assert attempt_timeouts == [10, 10, 10]
+
+
+def test_consult_explicit_openrouter_fallback_has_budget(monkeypatch) -> None:
+    attempt_timeouts: list[float] = []
+    monotonic_values = iter([0.0, 0.0, 10.0, 20.0])
+
+    def fake_cli(_prompt: str, model: str, timeout: float) -> dict:
+        attempt_timeouts.append(timeout)
+        return {
+            "ok": False,
+            "backend": "cli",
+            "timed_out": True,
+            "error": f"{model} timed out",
+        }
+
+    def fake_openrouter(
+        _prompt: str,
+        model: str,
+        timeout: float,
+        system: str | None,
+    ) -> dict:
+        del model, system
+        attempt_timeouts.append(timeout)
+        return {
+            "ok": False,
+            "backend": "openrouter",
+            "timed_out": True,
+            "error": "openrouter timed out",
+        }
+
+    monkeypatch.setattr(consult_claude, "_run_cli", fake_cli)
+    monkeypatch.setattr(consult_claude, "_run_openrouter_api", fake_openrouter)
+    monkeypatch.setattr(consult_claude.time, "monotonic", lambda: next(monotonic_values))
+
+    result = consult_claude.consult("question", timeout=10, openrouter_fallback=True)
+
+    assert result["ok"] is False
+    assert result["timed_out"] is True
+    assert [attempt["backend"] for attempt in result["attempts"]] == [
+        "cli",
+        "cli",
+        "openrouter",
     ]
     assert attempt_timeouts == [10, 10, 10]
 

--- a/tests/scripts/test_fable_goal_cycle.py
+++ b/tests/scripts/test_fable_goal_cycle.py
@@ -395,3 +395,31 @@ def test_run_consult_rejects_success_without_text(monkeypatch, tmp_path: Path) -
 
     assert result["ok"] is False
     assert "without text" in result["error"]
+
+
+def test_run_consult_can_enable_openrouter_fallback(monkeypatch, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(command, timeout, cwd=None):
+        captured["command"] = command
+        captured["timeout"] = timeout
+        captured["cwd"] = cwd
+        return True, json.dumps({"ok": True, "text": "advice"})
+
+    monkeypatch.setattr(fable_goal_cycle, "_run", fake_run)
+
+    result = fable_goal_cycle.run_consult(
+        tmp_path / "consult_claude.py",
+        tmp_path / "packet.md",
+        "claude-fable-5",
+        timeout=12.5,
+        openrouter_fallback=True,
+        openrouter_model="anthropic/claude-test",
+    )
+
+    command = captured["command"]
+    assert result["ok"] is True
+    assert "--openrouter-fallback" in command
+    assert command[command.index("--openrouter-model") + 1] == "anthropic/claude-test"
+    assert command[command.index("--overall-timeout") + 1] == "37.5"
+    assert captured["timeout"] == 97.5


### PR DESCRIPTION
## Summary
- add an explicit OpenRouter fallback backend to scripts/consult_claude.py for Claude CLI quota exhaustion
- expose --openrouter-fallback / --openrouter-model through scripts/fable_goal_cycle.py
- keep defaults CLI-only and redact OpenRouter error bodies like the existing API fallback

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/scripts/test_consult_claude.py tests/scripts/test_fable_goal_cycle.py -q
- python3 -m ruff check scripts/consult_claude.py scripts/fable_goal_cycle.py tests/scripts/test_consult_claude.py tests/scripts/test_fable_goal_cycle.py
- python3 -m ruff format --check scripts/consult_claude.py scripts/fable_goal_cycle.py tests/scripts/test_consult_claude.py tests/scripts/test_fable_goal_cycle.py
- python3 -m mypy scripts/consult_claude.py scripts/fable_goal_cycle.py
- git diff --check
- python3 scripts/check_portability.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD