### PR TITLE
style(verify): ruff format 4 aragora-verify test files (misc-docs-tooling-3)

### DIFF
--- a/aragora-verify/tests/test_example_live_receipt.py
+++ b/aragora-verify/tests/test_example_live_receipt.py
@@ -2,6 +2,7 @@
 external proof: aragora-verify (zero Aragora dependency) confirms a receipt
 that aragora/gauntlet/odr_export.py produced. The example JSON is the only
 artifact crossing the package boundary."""
+
 from __future__ import annotations
 
 import json

--- a/aragora-verify/tests/test_example_merge_quorum_receipt.py
+++ b/aragora-verify/tests/test_example_merge_quorum_receipt.py
@@ -2,6 +2,7 @@
 external proof: a heterogeneous-model PR review, bridged to a DecisionReceipt
 and exported to ODR, is verified by aragora-verify with zero Aragora dependency.
 The committed example JSON is the only artifact crossing the package boundary."""
+
 from __future__ import annotations
 
 import json

--- a/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
+++ b/aragora-verify/tests/test_example_signed_and_chain_fixtures.py
@@ -230,9 +230,7 @@ def test_chain_anchored_variant_exits_zero_with_warn(
 def test_chain_not_anchored_variant_exits_one_with_not_anchored_detail(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    rc = main(
-        [str(SIGNED), "--pubkey", str(PUBKEY), "--chain", str(CHAIN_NOT_ANCHORED), "--json"]
-    )
+    rc = main([str(SIGNED), "--pubkey", str(PUBKEY), "--chain", str(CHAIN_NOT_ANCHORED), "--json"])
     assert rc == 1
     payload = json.loads(capsys.readouterr().out)
     checks_by_name = {c["name"]: c for c in payload["checks"]}

--- a/aragora-verify/tests/test_example_unsigned_state_fixtures.py
+++ b/aragora-verify/tests/test_example_unsigned_state_fixtures.py
@@ -103,9 +103,7 @@ def test_abstained_fixture_json_warnings_name_expected_categories(capsys) -> Non
     assert "reasoning: absent" in joined
 
 
-def test_quorum_consistency_tamper_cli_exits_one_with_failing_check(
-    tmp_path: Path, capsys
-) -> None:
+def test_quorum_consistency_tamper_cli_exits_one_with_failing_check(tmp_path: Path, capsys) -> None:
     doc = _load("example-blocked.odr.json")
     doc["quorum"]["dissent"]["dissenting_agents"] = ["ghost-agent"]
     doc["quorum"]["dissent"]["present"] = True


### PR DESCRIPTION
## Summary

Tests-only formatting cleanup: fixes pre-existing `ruff format --check` drift in 4
`aragora-verify/tests/*.py` files, first surfaced by PR #8970's investigation
(m5-packaging-deps-pr):

- `aragora-verify/tests/test_example_live_receipt.py`
- `aragora-verify/tests/test_example_merge_quorum_receipt.py`
- `aragora-verify/tests/test_example_signed_and_chain_fixtures.py`
- `aragora-verify/tests/test_example_unsigned_state_fixtures.py`

Ran `ruff format` on exactly these 4 files. No other files touched.

## Premise re-verification (per AGENTS.md re-verify rule)

Re-checked against current `origin/main` (not an inherited/stale premise):

```
$ ruff format --check aragora-verify/tests/*.py
Would reformat: aragora-verify/tests/test_example_live_receipt.py
Would reformat: aragora-verify/tests/test_example_merge_quorum_receipt.py
Would reformat: aragora-verify/tests/test_example_signed_and_chain_fixtures.py
Would reformat: aragora-verify/tests/test_example_unsigned_state_fixtures.py
4 files would be reformatted, 6 files already formatted
```

Exactly the 4 named files fail; the other 6 files in the directory are already clean.

## Ruff config-root note (did NOT need to compose PR #8970's branch)

The feature brief flagged a risk that PR #8970's ruff config-root change (adding
`[tool.ruff.*]` to `aragora-verify/pyproject.toml`, which makes that file its own
config root and stops cascading from the repo root) might need to land first for
`line-length=100` to apply stably.

I verified this empirically instead of assuming it: on current `origin/main`,
`aragora-verify/pyproject.toml` has **no** `[tool.ruff]` section at all (PR #8970 is
still unmerged), so Ruff's config discovery walks up and resolves the **root**
`pyproject.toml`'s `[tool.ruff]` table (`line-length = 100`) for these files today:

```
$ ruff check --show-settings aragora-verify/tests/test_example_live_receipt.py | grep line_length
linter.line_length = 100
linter.pycodestyle.max_line_length = 100
```

So formatting is already stable with `line-length=100` on plain `origin/main`, and
this PR is based on `origin/main` directly (not on #8970's branch). Basing on
#8970's branch would have pulled in its unrelated `pyproject.toml`
(cryptography floor bump), `verifier.py` docstring, `CHANGELOG.md`, and
`docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` changes too, which would disqualify this
PR from tests-only auto-merge.

## Overlap with PR #8970 (expected, benign)

PR #8970 (`factory/pum-m5-packaging-deps-pr`, still open/parked — it bumps a
runtime dependency floor and touches non-test files, so it is **not** auto-merge
eligible) happens to include this exact same 4-file formatting fix as a side
effect of establishing its own config root. This PR's diff for those 4 files is
byte-identical to the corresponding hunks in #8970.

This is intentional: it extracts the safe, tests-only slice of that drift into its
own small, independently auto-mergeable PR instead of leaving it stuck behind
#8970's operator review. Whichever of the two merges first, the other becomes a
clean no-op for these 4 files (content already matches — no conflict).

## Verification

- `ruff format --check` (4 files, explicit paths): **clean** after the fix
  (`4 files already formatted`).
- **Zero semantic diff**: parsed each file's `origin/main` content and the
  formatted content with `ast.dump(ast.parse(...), include_attributes=False)` —
  identical for all 4 files (formatting-only change, no behavior change).
- `ruff check --ignore S101` on the 4 files: all checks passed (matches the
  skill's documented self-check convention — `aragora-verify/tests/**` has no
  ruff lint gate wired into `services.yaml` today).
- `mypy --ignore-missing-imports --follow-imports=skip` on the 4 files: no issues.
- `aragora-verify` suite (`test-verifier`): **92 passed** (baseline unchanged).
- In-tree receipt/verify suite (`test`): **247 passed**, zero failures.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: `preflight: ok`.

### Note on the literal `ruff format --check aragora-verify/tests/` directory form

The root `pyproject.toml`'s `[tool.ruff] exclude = ["aragora-verify*"]` prunes the
entire `aragora-verify/tests/` subtree during directory-based discovery (this
exclude only applies to recursive discovery, not to explicitly-named file
arguments — that's why formatting/lint via explicit file paths, as used
throughout this PR's verification, still works correctly). So
`ruff format --check aragora-verify/tests/` always reports "No Python files found
under the given path(s)" (exit 0) regardless of file content, both before and
after this fix — this is pre-existing and unrelated to this change. The
substantive check is the explicit-file-path form shown above.

## Path-freeze check

`gh pr list --state open` re-checked immediately before push: only #8970 (analyzed
above) and #8823 (touches `aragora-verify/tests/test_verifier.py`, a different
file) intersect `aragora-verify/tests/`. No other open PR collides with the 4
files this PR touches.

## Merge

Tests-only change (4 files under `aragora-verify/tests/`, formatting only) →
auto-merge eligible per `AGENTS.md` merge policy.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
