### PR TITLE
fix(evidence): post exact-head missing reviewer family

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -251,7 +251,12 @@ def fetch_pr_tier(repo: str, pr: int) -> int | None:
 
 
 def fetch_merge_packet_entry(
-    repo: str, pr: int, *, require_tier: bool = False
+    repo: str,
+    pr: int,
+    *,
+    require_tier: bool = False,
+    required_fields: tuple[str, ...] = (),
+    fail_on_ambiguous: bool = False,
 ) -> dict[str, Any] | None:
     """Return the requested PR's current local merge-packet entry."""
     try:
@@ -300,17 +305,26 @@ def fetch_merge_packet_entry(
     # single-PR --json shape always discloses pr_number, so a multi-PR envelope
     # can never resolve the wrong PR (which would mis-gate posting).
     def _eligible(entry: Any) -> bool:
-        return isinstance(entry, dict) and (not require_tier or entry.get("tier") is not None)
+        return (
+            isinstance(entry, dict)
+            and (not require_tier or entry.get("tier") is not None)
+            and all(field in entry and entry.get(field) is not None for field in required_fields)
+        )
 
-    for entry in entries:
-        if _eligible(entry) and _coerce(entry.get("pr_number")) == pr:
-            return entry
+    def _select(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if fail_on_ambiguous and len(candidates) != 1:
+            return None
+        return candidates[0] if candidates else None
+
+    matching = [
+        entry for entry in entries if _eligible(entry) and _coerce(entry.get("pr_number")) == pr
+    ]
+    if matching:
+        return _select(matching)
     # Fall back to the first entry only when NO row carries a pr_number
     # (forward-compat shapes such as a bare list or single entry).
     if not any(isinstance(e, dict) and e.get("pr_number") is not None for e in entries):
-        for entry in entries:
-            if _eligible(entry):
-                return entry
+        return _select([entry for entry in entries if _eligible(entry)])
     return None
 
 
@@ -396,7 +410,12 @@ def fetch_live_evidence_state(
     fail closed if comments and packet do not describe the same PR head.
     """
     comments = fetch_evidence_comments(repo, pr, head_sha, head_committed_at)
-    entry = fetch_merge_packet_entry(repo, pr)
+    entry = fetch_merge_packet_entry(
+        repo,
+        pr,
+        required_fields=("head_sha", "unresolved_dissent"),
+        fail_on_ambiguous=True,
+    )
     if entry is None:
         raise RuntimeError(f"merge packet unavailable for {repo}#{pr}")
     packet_head = str(entry.get("head_sha") or "").strip()

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -22,6 +22,7 @@ from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
     PacketClassification,
     QuorumRun,
+    counted_reviewer_ids,
     parse_ci_packet_classification,
 )
 
@@ -249,8 +250,8 @@ def fetch_pr_tier(repo: str, pr: int) -> int | None:
     return packet.tier if packet is not None else None
 
 
-def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassification | None:
-    """Best-effort current local merge-packet classification for one PR."""
+def fetch_merge_packet_entry(repo: str, pr: int) -> dict[str, Any] | None:
+    """Return the requested PR's current local merge-packet entry."""
     try:
         proc = run(
             [
@@ -293,42 +294,46 @@ def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassificatio
         except (TypeError, ValueError):
             return None
 
-    def _packet(entry: dict[str, Any]) -> PacketClassification | None:
-        tier = _coerce(entry.get("tier"))
-        pr_value = _coerce(entry.get("pr_number"))
-        if pr_value is None:
-            pr_value = pr
-        if pr_value != pr or entry.get("tier") is None:
-            return None
-        return PacketClassification(
-            source="local",
-            pr_number=pr_value,
-            head_sha=str(entry.get("head_sha") or ""),
-            tier=tier,
-            status=str(entry.get("status") or ""),
-            verdict=str(entry.get("verdict") or ""),
-            requires_human_risk_settlement=bool(entry.get("requires_human_risk_settlement")),
-        )
-
     # Prefer the row whose pr_number matches the requested PR. The normal
     # single-PR --json shape always discloses pr_number, so a multi-PR envelope
-    # can never resolve the wrong PR's tier (which would mis-gate posting).
+    # can never resolve the wrong PR (which would mis-gate posting).
     for entry in entries:
-        if not isinstance(entry, dict):
-            continue
-        packet = _packet(entry)
-        if packet is not None and _coerce(entry.get("pr_number")) == pr:
-            return packet
-    # Fall back to the first disclosed tier only when NO row carries a pr_number
+        if isinstance(entry, dict) and _coerce(entry.get("pr_number")) == pr:
+            return entry
+    # Fall back to the first entry only when NO row carries a pr_number
     # (forward-compat shapes such as a bare list or single entry).
     if not any(isinstance(e, dict) and e.get("pr_number") is not None for e in entries):
         for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            packet = _packet(entry)
-            if packet is not None:
-                return packet
+            if isinstance(entry, dict):
+                return entry
     return None
+
+
+def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassification | None:
+    """Best-effort current local merge-packet classification for one PR."""
+    entry = fetch_merge_packet_entry(repo, pr)
+    if entry is None:
+        return None
+    raw_tier = entry.get("tier")
+    if raw_tier is None:
+        return None
+    try:
+        tier = int(raw_tier)
+        raw_pr = entry.get("pr_number")
+        pr_value = pr if raw_pr is None else int(raw_pr)
+    except (TypeError, ValueError):
+        return None
+    if pr_value != pr:
+        return None
+    return PacketClassification(
+        source="local",
+        pr_number=pr_value,
+        head_sha=str(entry.get("head_sha") or ""),
+        tier=tier,
+        status=str(entry.get("status") or ""),
+        verdict=str(entry.get("verdict") or ""),
+        requires_human_risk_settlement=bool(entry.get("requires_human_risk_settlement")),
+    )
 
 
 def fetch_quorum_run_packet_classification(
@@ -374,6 +379,29 @@ def fetch_evidence_comments(
             )
         )
     return results
+
+
+def fetch_live_evidence_state(
+    repo: str, pr: int, head_sha: str, head_committed_at: str
+) -> dict[str, Any]:
+    """Return same-head countable comment families plus blocking-dissent state.
+
+    Comment families come from the canonical ``evidence-lint`` path. The merge
+    packet supplies the current head and unresolved-dissent verdict, so callers
+    fail closed if comments and packet do not describe the same PR head.
+    """
+    comments = fetch_evidence_comments(repo, pr, head_sha, head_committed_at)
+    entry = fetch_merge_packet_entry(repo, pr)
+    if entry is None:
+        raise RuntimeError(f"merge packet unavailable for {repo}#{pr}")
+    packet_head = str(entry.get("head_sha") or "").strip()
+    if not packet_head:
+        raise RuntimeError(f"merge packet missing head SHA for {repo}#{pr}")
+    return {
+        "head_sha": packet_head,
+        "counting_families": counted_reviewer_ids(comments),
+        "unresolved_dissent": bool(entry.get("unresolved_dissent")),
+    }
 
 
 def _evidence_lint_args(

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -417,15 +417,17 @@ def fetch_live_evidence_state(
         fail_on_ambiguous=True,
     )
     if entry is None:
-        raise RuntimeError(f"merge packet unavailable for {repo}#{pr}")
+        raise RuntimeError(
+            f"merge packet has no unique complete head/dissent entry for {repo}#{pr}"
+        )
     packet_head = str(entry.get("head_sha") or "").strip()
     if not packet_head:
         raise RuntimeError(f"merge packet missing head SHA for {repo}#{pr}")
     return {
         "head_sha": packet_head,
         "counting_families": counted_reviewer_ids(comments),
-        # Preserve the packet's tri-state value. Callers require literal False,
-        # so an omitted/unknown field cannot be laundered into "no dissent."
+        # Keep the explicit packet value. The selector rejects missing/unknown
+        # values, and callers still require literal False before posting.
         "unresolved_dissent": entry.get("unresolved_dissent"),
     }
 

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -400,7 +400,9 @@ def fetch_live_evidence_state(
     return {
         "head_sha": packet_head,
         "counting_families": counted_reviewer_ids(comments),
-        "unresolved_dissent": bool(entry.get("unresolved_dissent")),
+        # Preserve the packet's tri-state value. Callers require literal False,
+        # so an omitted/unknown field cannot be laundered into "no dissent."
+        "unresolved_dissent": entry.get("unresolved_dissent"),
     }
 
 

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -250,7 +250,9 @@ def fetch_pr_tier(repo: str, pr: int) -> int | None:
     return packet.tier if packet is not None else None
 
 
-def fetch_merge_packet_entry(repo: str, pr: int) -> dict[str, Any] | None:
+def fetch_merge_packet_entry(
+    repo: str, pr: int, *, require_tier: bool = False
+) -> dict[str, Any] | None:
     """Return the requested PR's current local merge-packet entry."""
     try:
         proc = run(
@@ -297,21 +299,24 @@ def fetch_merge_packet_entry(repo: str, pr: int) -> dict[str, Any] | None:
     # Prefer the row whose pr_number matches the requested PR. The normal
     # single-PR --json shape always discloses pr_number, so a multi-PR envelope
     # can never resolve the wrong PR (which would mis-gate posting).
+    def _eligible(entry: Any) -> bool:
+        return isinstance(entry, dict) and (not require_tier or entry.get("tier") is not None)
+
     for entry in entries:
-        if isinstance(entry, dict) and _coerce(entry.get("pr_number")) == pr:
+        if _eligible(entry) and _coerce(entry.get("pr_number")) == pr:
             return entry
     # Fall back to the first entry only when NO row carries a pr_number
     # (forward-compat shapes such as a bare list or single entry).
     if not any(isinstance(e, dict) and e.get("pr_number") is not None for e in entries):
         for entry in entries:
-            if isinstance(entry, dict):
+            if _eligible(entry):
                 return entry
     return None
 
 
 def fetch_merge_packet_classification(repo: str, pr: int) -> PacketClassification | None:
     """Best-effort current local merge-packet classification for one PR."""
-    entry = fetch_merge_packet_entry(repo, pr)
+    entry = fetch_merge_packet_entry(repo, pr, require_tier=True)
     if entry is None:
         return None
     raw_tier = entry.get("tier")

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2715,7 +2715,7 @@ def apply_prepared_evidence(
     if not outcome.has_supportive_quorum:
         try:
             live_state = live_evidence_fetcher(repo, pr, head_sha, head_committed_at) or {}
-        except Exception as exc:
+        except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
             outcome.action = "prepare"
             outcome.action_reason = (
                 f"{outcome.incomplete_quorum_reason}; live current-head evidence "
@@ -2785,7 +2785,7 @@ def apply_prepared_evidence(
     try:
         recheck_head = str((context_fetcher(repo, pr) or {}).get("head_sha") or "").strip()
         recheck_tier = tier_fetcher(repo, pr)
-    except Exception as exc:
+    except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
         outcome.action = "prepare"
         outcome.action_reason = (
             f"could not re-verify head/tier before posting ({str(exc)[:120]}); prepared only"

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -528,6 +528,8 @@ class CollectOutcome:
     timed_out_families: list[str] = field(default_factory=list)
     overall_timeout_seconds: float | None = None
     adjudication: dict[str, Any] | None = None
+    live_evidence_head_sha: str = ""
+    live_counting_families: list[str] = field(default_factory=list)
     # Captured ONCE at construction (not re-read from os.environ per property
     # access) so a security-relevant gate decision stays deterministic within a
     # single settlement flow even if the process env mutates mid-run.
@@ -540,6 +542,16 @@ class CollectOutcome:
     @property
     def supportive_families(self) -> list[str]:
         return [item.family for item in self.items if item.supportive]
+
+    @property
+    def combined_counting_families(self) -> list[str]:
+        """Distinct prepared plus same-head live comment families."""
+        return sorted({*self.counting_families, *self.live_counting_families})
+
+    @property
+    def combined_supportive_families(self) -> list[str]:
+        """Supportive prepared families plus canonical live countable families."""
+        return sorted({*self.supportive_families, *self.live_counting_families})
 
     @property
     def dissenting_families(self) -> list[str]:
@@ -556,7 +568,7 @@ class CollectOutcome:
         unknown/None tier, fail-safe) need two distinct WESTERN families.
         """
         rule = tier_quorum_rule(self.tier, tiered_gate=self.tiered_gate)
-        return rule.is_satisfied_by(self.supportive_families)
+        return rule.is_satisfied_by(self.combined_supportive_families)
 
     @property
     def incomplete_quorum_reason(self) -> str:
@@ -567,7 +579,7 @@ class CollectOutcome:
         rather than a misleading ``(n/2)`` distinct-family denominator.
         """
         rule = tier_quorum_rule(self.tier, tiered_gate=self.tiered_gate)
-        supportive = {str(f).strip().lower() for f in self.supportive_families}
+        supportive = {str(f).strip().lower() for f in self.combined_supportive_families}
         counted = rule.counted_families(supportive)
         if rule.requires_western_frontier and not (counted & WESTERN_FRONTIER_FAMILIES):
             return (
@@ -604,6 +616,9 @@ class CollectOutcome:
             "action": self.action,
             "action_reason": self.action_reason,
             "counting_families": self.counting_families,
+            "live_evidence_head_sha": self.live_evidence_head_sha,
+            "live_counting_families": list(self.live_counting_families),
+            "combined_counting_families": self.combined_counting_families,
             "supportive_families": self.supportive_families,
             "dissenting_families": self.dissenting_families,
             "has_supportive_quorum": self.has_supportive_quorum,
@@ -680,6 +695,9 @@ class CollectPreflightTransportError(RuntimeError):
                 "GitHub transport blocked before reviewer execution; prepared evidence only"
             ),
             "counting_families": [],
+            "live_evidence_head_sha": "",
+            "live_counting_families": [],
+            "combined_counting_families": [],
             "supportive_families": [],
             "dissenting_families": [],
             "has_supportive_quorum": False,
@@ -786,6 +804,8 @@ def collect_outcome_from_dict(data: dict[str, Any]) -> CollectOutcome:
         failures=[_reviewer_result_from_dict(failure) for failure in data.get("failures") or []],
         posted=_string_list(data.get("posted_families")),
         post_errors=_string_list(data.get("post_errors")),
+        live_evidence_head_sha=str(data.get("live_evidence_head_sha") or ""),
+        live_counting_families=_string_list(data.get("live_counting_families")),
         quorum_rerun=data.get("quorum_rerun")
         if isinstance(data.get("quorum_rerun"), dict)
         else None,
@@ -2565,6 +2585,9 @@ def apply_prepared_evidence(
     linter: Callable[..., dict[str, Any]] = default_linter,
     poster: Callable[[str, int, str], None] = default_poster,
     quorum_reconciler: Callable[[str, int], dict[str, Any] | None] | None = None,
+    live_evidence_fetcher: Callable[[str, int, str, str], dict[str, Any]] = (
+        merge_quorum_io.fetch_live_evidence_state
+    ),
     env: dict[str, str] | None = None,
 ) -> CollectOutcome:
     """Post an exact-head prepared artifact without re-running reviewers.
@@ -2688,12 +2711,71 @@ def apply_prepared_evidence(
         )
         _record_review_adjudication_if_applicable(outcome)
         return outcome
+    used_live_quorum = False
     if not outcome.has_supportive_quorum:
-        outcome.action = "prepare"
-        outcome.action_reason = outcome.incomplete_quorum_reason
-        _record_review_adjudication_if_applicable(outcome)
-        return outcome
+        try:
+            live_state = live_evidence_fetcher(repo, pr, head_sha, head_committed_at) or {}
+        except Exception as exc:
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                f"{outcome.incomplete_quorum_reason}; live current-head evidence "
+                f"could not be verified ({str(exc)[:120]})"
+            )
+            _record_review_adjudication_if_applicable(outcome)
+            return outcome
 
+        live_head = str(live_state.get("head_sha") or "").strip()
+        raw_live_families = live_state.get("counting_families")
+        if live_head != head_sha or not isinstance(raw_live_families, list):
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                "live evidence state does not match the current head or family schema; "
+                "prepared evidence only"
+            )
+            _record_review_adjudication_if_applicable(outcome)
+            return outcome
+        if live_state.get("unresolved_dissent") is not False:
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                "live current-head blocking dissent present; prepared evidence only"
+            )
+            _record_review_adjudication_if_applicable(outcome)
+            return outcome
+
+        live_families: set[str] = set()
+        for raw_family in raw_live_families:
+            family = canonical_family(str(raw_family))
+            if family not in FAMILY_PROVIDERS:
+                outcome.action = "prepare"
+                outcome.action_reason = (
+                    f"live evidence reported unsupported reviewer family {family or 'empty'}; "
+                    "prepared evidence only"
+                )
+                _record_review_adjudication_if_applicable(outcome)
+                return outcome
+            live_families.add(family)
+        outcome.live_evidence_head_sha = live_head
+        outcome.live_counting_families = sorted(live_families)
+
+        if not outcome.has_supportive_quorum:
+            outcome.action = "prepare"
+            outcome.action_reason = outcome.incomplete_quorum_reason
+            _record_review_adjudication_if_applicable(outcome)
+            return outcome
+        if not (set(outcome.supportive_families) - live_families):
+            outcome.action = "prepare"
+            outcome.action_reason = (
+                "all supportive prepared families already count on the current head; "
+                "nothing new to post"
+            )
+            _record_review_adjudication_if_applicable(outcome)
+            return outcome
+        used_live_quorum = True
+
+    # Keep this as the last network-backed guard before posting. In the
+    # live-plus-prepared path, the comment and packet reads above may take long
+    # enough for the branch to move; evidence for the old head must then remain
+    # prepared-only.
     try:
         recheck_head = str((context_fetcher(repo, pr) or {}).get("head_sha") or "").strip()
         recheck_tier = tier_fetcher(repo, pr)
@@ -2715,11 +2797,18 @@ def apply_prepared_evidence(
         _record_review_adjudication_if_applicable(outcome)
         return outcome
 
-    outcome.action_reason = (
-        "prepared exact-head evidence artifact; posting without reviewer regeneration"
-    )
+    if used_live_quorum:
+        outcome.action_reason = (
+            "prepared exact-head evidence plus live current-head families satisfies quorum; "
+            "posting only missing families without reviewer regeneration"
+        )
+    else:
+        outcome.action_reason = (
+            "prepared exact-head evidence artifact; posting without reviewer regeneration"
+        )
+    live_families = set(outcome.live_counting_families)
     for item in outcome.items:
-        if not item.supportive:
+        if not item.supportive or item.family in live_families:
             continue
         try:
             poster(repo, pr, item.body)
@@ -2742,6 +2831,8 @@ def _render_outcome(outcome: CollectOutcome) -> str:
         f"  head: {outcome.head_sha[:10]}  tier: {outcome.tier}",
         f"  action: {outcome.action} ({outcome.action_reason})",
         f"  counting families: {', '.join(outcome.counting_families) or 'none'}",
+        f"  live counting families: {', '.join(outcome.live_counting_families) or 'none'}",
+        f"  combined counting families: {', '.join(outcome.combined_counting_families) or 'none'}",
         f"  supportive families: {', '.join(outcome.supportive_families) or 'none'}",
         f"  dissenting families: {', '.join(outcome.dissenting_families) or 'none'}",
     ]

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2734,11 +2734,17 @@ def apply_prepared_evidence(
             )
             _record_review_adjudication_if_applicable(outcome)
             return outcome
-        if live_state.get("unresolved_dissent") is not False:
+        dissent_state = live_state.get("unresolved_dissent")
+        if dissent_state is not False:
             outcome.action = "prepare"
-            outcome.action_reason = (
-                "live current-head blocking dissent present; prepared evidence only"
-            )
+            if dissent_state is True:
+                outcome.action_reason = (
+                    "live current-head blocking dissent present; prepared evidence only"
+                )
+            else:
+                outcome.action_reason = (
+                    "live current-head dissent state could not be verified; prepared evidence only"
+                )
             _record_review_adjudication_if_applicable(outcome)
             return outcome
 

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -2170,7 +2170,7 @@ def collect_evidence(
         try:
             recheck_head = str((context_fetcher(repo, pr) or {}).get("head_sha") or "").strip()
             recheck_tier = tier_fetcher(repo, pr)
-        except Exception as exc:
+        except (RuntimeError, OSError, ValueError, subprocess.SubprocessError) as exc:
             outcome.action = "prepare"
             outcome.action_reason = (
                 f"could not re-verify head/tier before posting ({str(exc)[:120]}); prepared only"

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -124,7 +124,7 @@ def test_fetch_live_evidence_state_combines_linted_comments_and_packet(monkeypat
     monkeypatch.setattr(
         m,
         "fetch_merge_packet_entry",
-        lambda repo, pr: {
+        lambda repo, pr, **kwargs: {
             "pr_number": pr,
             "head_sha": "abc123",
             "unresolved_dissent": False,
@@ -145,7 +145,7 @@ def test_fetch_live_evidence_state_fails_when_packet_has_no_head(monkeypatch) ->
     monkeypatch.setattr(
         m,
         "fetch_merge_packet_entry",
-        lambda repo, pr: {"pr_number": pr, "unresolved_dissent": False},
+        lambda repo, pr, **kwargs: {"pr_number": pr, "unresolved_dissent": False},
     )
 
     with pytest.raises(RuntimeError, match="missing head SHA"):
@@ -157,12 +157,46 @@ def test_fetch_live_evidence_state_preserves_unknown_dissent(monkeypatch) -> Non
     monkeypatch.setattr(
         m,
         "fetch_merge_packet_entry",
-        lambda repo, pr: {"pr_number": pr, "head_sha": "abc123"},
+        lambda repo, pr, **kwargs: {"pr_number": pr, "head_sha": "abc123"},
     )
 
     state = m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
 
     assert state["unresolved_dissent"] is None
+
+
+def test_fetch_live_evidence_state_skips_partial_duplicate_row(monkeypatch) -> None:
+    payload = {
+        "entries": [
+            {"pr_number": 7754, "head_sha": "stale-partial"},
+            {
+                "pr_number": 7754,
+                "head_sha": "abc123",
+                "unresolved_dissent": False,
+            },
+        ]
+    }
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(payload)))
+    monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: [])
+
+    state = m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
+
+    assert state["head_sha"] == "abc123"
+    assert state["unresolved_dissent"] is False
+
+
+def test_fetch_live_evidence_state_fails_on_ambiguous_complete_rows(monkeypatch) -> None:
+    payload = {
+        "entries": [
+            {"pr_number": 7754, "head_sha": "abc123", "unresolved_dissent": False},
+            {"pr_number": 7754, "head_sha": "abc123", "unresolved_dissent": False},
+        ]
+    }
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(payload)))
+    monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: [])
+
+    with pytest.raises(RuntimeError, match="merge packet unavailable"):
+        m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
 
 
 def test_fetch_quorum_run_packet_classification_parses_log(monkeypatch) -> None:

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -195,7 +195,7 @@ def test_fetch_live_evidence_state_fails_on_ambiguous_complete_rows(monkeypatch)
     monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(payload)))
     monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: [])
 
-    with pytest.raises(RuntimeError, match="merge packet unavailable"):
+    with pytest.raises(RuntimeError, match="no unique complete head/dissent entry"):
         m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
 
 

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -136,6 +136,19 @@ def test_fetch_live_evidence_state_fails_when_packet_has_no_head(monkeypatch) ->
         m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
 
 
+def test_fetch_live_evidence_state_preserves_unknown_dissent(monkeypatch) -> None:
+    monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: [])
+    monkeypatch.setattr(
+        m,
+        "fetch_merge_packet_entry",
+        lambda repo, pr: {"pr_number": pr, "head_sha": "abc123"},
+    )
+
+    state = m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
+
+    assert state["unresolved_dissent"] is None
+
+
 def test_fetch_quorum_run_packet_classification_parses_log(monkeypatch) -> None:
     log = (
         "PR #7754 | Tier 4 | status=human_preapproval_required | "

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -95,6 +95,22 @@ def test_fetch_merge_packet_classification_reads_semantic_fields(monkeypatch) ->
     assert packet.requires_human_risk_settlement is False
 
 
+def test_fetch_merge_packet_classification_skips_partial_duplicate_row(monkeypatch) -> None:
+    payload = {
+        "entries": [
+            {"pr_number": 7754, "head_sha": "stale-partial"},
+            {"pr_number": 7754, "head_sha": "abc123", "tier": 2},
+        ]
+    }
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(payload)))
+
+    packet = m.fetch_merge_packet_classification("o/r", 7754)
+
+    assert packet is not None
+    assert packet.head_sha == "abc123"
+    assert packet.tier == 2
+
+
 def test_fetch_live_evidence_state_combines_linted_comments_and_packet(monkeypatch) -> None:
     comments = [
         m.EvidenceComment(

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 import subprocess
 
+import pytest
+
 from aragora.swarm import merge_quorum_io as m
 
 
@@ -93,6 +95,47 @@ def test_fetch_merge_packet_classification_reads_semantic_fields(monkeypatch) ->
     assert packet.requires_human_risk_settlement is False
 
 
+def test_fetch_live_evidence_state_combines_linted_comments_and_packet(monkeypatch) -> None:
+    comments = [
+        m.EvidenceComment(
+            created_at="2026-07-09T12:00:00Z",
+            would_count=True,
+            reviewer_id="openai",
+            is_dogfood=True,
+        )
+    ]
+    monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: comments)
+    monkeypatch.setattr(
+        m,
+        "fetch_merge_packet_entry",
+        lambda repo, pr: {
+            "pr_number": pr,
+            "head_sha": "abc123",
+            "unresolved_dissent": False,
+        },
+    )
+
+    state = m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
+
+    assert state == {
+        "head_sha": "abc123",
+        "counting_families": ["openai"],
+        "unresolved_dissent": False,
+    }
+
+
+def test_fetch_live_evidence_state_fails_when_packet_has_no_head(monkeypatch) -> None:
+    monkeypatch.setattr(m, "fetch_evidence_comments", lambda *args: [])
+    monkeypatch.setattr(
+        m,
+        "fetch_merge_packet_entry",
+        lambda repo, pr: {"pr_number": pr, "unresolved_dissent": False},
+    )
+
+    with pytest.raises(RuntimeError, match="missing head SHA"):
+        m.fetch_live_evidence_state("o/r", 7754, "abc123", "2026-07-09T11:00:00Z")
+
+
 def test_fetch_quorum_run_packet_classification_parses_log(monkeypatch) -> None:
     log = (
         "PR #7754 | Tier 4 | status=human_preapproval_required | "
@@ -136,6 +179,15 @@ def test_fetch_pr_tier_accepts_bare_list(monkeypatch) -> None:
 
 def test_fetch_pr_tier_accepts_single_entry_dict(monkeypatch) -> None:
     monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps({"tier": 1})))
+    assert m.fetch_pr_tier("o/r", 1) == 1
+
+
+def test_fetch_pr_tier_accepts_null_pr_number_in_single_entry(monkeypatch) -> None:
+    monkeypatch.setattr(
+        m,
+        "run",
+        lambda *a, **k: _proc(json.dumps({"pr_number": None, "tier": 1})),
+    )
     assert m.fetch_pr_tier("o/r", 1) == 1
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2400,6 +2400,124 @@ def test_apply_prepared_evidence_refuses_stale_live_family_state(
     assert posted == []
 
 
+def test_apply_prepared_evidence_refuses_unavailable_live_family_state(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    posted: list[str] = []
+
+    def unavailable(repo: str, pr: int, head_sha: str, committed_at: str) -> dict:
+        raise RuntimeError("packet unavailable")
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=unavailable,
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "could not be verified" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_refuses_unknown_live_dissent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["openai"],
+        },
+    )
+
+    assert outcome.action == "prepare"
+    assert "blocking dissent" in outcome.action_reason
+    assert outcome.posted == []
+
+
+def test_apply_prepared_evidence_refuses_unsupported_live_family(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["openai", "fusion"],
+            "unresolved_dissent": False,
+        },
+    )
+
+    assert outcome.action == "prepare"
+    assert "unsupported reviewer family fusion" in outcome.action_reason
+    assert outcome.posted == []
+
+
 def test_apply_prepared_evidence_rechecks_head_after_live_family_lookup(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2475,7 +2475,7 @@ def test_apply_prepared_evidence_refuses_unknown_live_dissent(
     )
 
     assert outcome.action == "prepare"
-    assert "blocking dissent" in outcome.action_reason
+    assert "dissent state could not be verified" in outcome.action_reason
     assert outcome.posted == []
 
 

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2242,13 +2242,16 @@ def _prepared_outcome_file(
     *,
     items: list[EvidenceItem] | None = None,
     adjudication: dict | None = None,
+    tier: int = 1,
+    tiered_gate: bool | None = None,
 ) -> Path:
+    kwargs = {} if tiered_gate is None else {"tiered_gate": tiered_gate}
     outcome = CollectOutcome(
         repo="o/r",
         pr=1,
         head_sha=HEAD,
         head_committed_at=COMMITTED,
-        tier=1,
+        tier=tier,
         action="prepare",
         action_reason="dry-run; re-run with --apply to post",
         items=items
@@ -2257,6 +2260,7 @@ def _prepared_outcome_file(
             EvidenceItem("grok", _prepared_body("grok"), True, ["grok"], [], "pass"),
         ],
         adjudication=adjudication,
+        **kwargs,
     )
     path = tmp_path / "prepared.json"
     path.write_text(json.dumps(outcome.to_dict()), encoding="utf-8")
@@ -2301,6 +2305,226 @@ def test_apply_prepared_evidence_posts_without_rerunning_reviewers(tmp_path) -> 
     assert "without reviewer regeneration" in outcome.action_reason
     assert outcome.posted == ["claude", "grok"]
     assert posted == [("o/r", _prepared_body("claude")), ("o/r", _prepared_body("grok"))]
+
+
+def test_apply_prepared_evidence_posts_missing_family_with_live_same_head_quorum(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        families=["claude"],
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["openai"],
+            "unresolved_dissent": False,
+        },
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "post"
+    assert "posting only missing families" in outcome.action_reason
+    assert outcome.counting_families == ["claude"]
+    assert outcome.live_evidence_head_sha == HEAD
+    assert outcome.live_counting_families == ["openai"]
+    assert outcome.combined_counting_families == ["claude", "openai"]
+    assert outcome.has_supportive_quorum is True
+    assert outcome.posted == ["claude"]
+    assert posted == [_prepared_body("claude")]
+    payload = outcome.to_dict()
+    assert payload["live_counting_families"] == ["openai"]
+    assert payload["combined_counting_families"] == ["claude", "openai"]
+
+
+def test_apply_prepared_evidence_refuses_stale_live_family_state(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": "different-head",
+            "counting_families": ["openai"],
+            "unresolved_dissent": False,
+        },
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "does not match the current head" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_rechecks_head_after_live_family_lookup(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    heads = iter([HEAD, "moved-after-live-lookup"])
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": next(heads),
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["openai"],
+            "unresolved_dissent": False,
+        },
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "head/tier changed before posting" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_refuses_live_blocking_dissent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["openai"],
+            "unresolved_dissent": True,
+        },
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "blocking dissent" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
+
+
+def test_apply_prepared_evidence_does_not_repost_already_live_family(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "0")
+    prepared = _prepared_outcome_file(
+        tmp_path,
+        items=[EvidenceItem("claude", _prepared_body("claude"), True, ["claude"], [], "pass")],
+        tier=2,
+        tiered_gate=False,
+    )
+    posted: list[str] = []
+
+    outcome = qe.apply_prepared_evidence(
+        repo="o/r",
+        pr=1,
+        prepared_json=prepared,
+        author="me",
+        apply=True,
+        context_fetcher=lambda repo, pr: {
+            "head_sha": HEAD,
+            "head_committed_at": COMMITTED,
+        },
+        tier_fetcher=lambda repo, pr: 2,
+        linter=lambda *args, **kwargs: {
+            "would_count": True,
+            "counted_reviewer_ids": ["claude"],
+            "problems": [],
+        },
+        live_evidence_fetcher=lambda repo, pr, head_sha, committed_at: {
+            "head_sha": HEAD,
+            "counting_families": ["claude", "openai"],
+            "unresolved_dissent": False,
+        },
+        poster=lambda repo, pr, body: posted.append(body),
+    )
+
+    assert outcome.action == "prepare"
+    assert "already count on the current head" in outcome.action_reason
+    assert outcome.posted == []
+    assert posted == []
 
 
 def test_apply_prepared_evidence_recomputes_exact_head_adjudication(


### PR DESCRIPTION
## Summary
- combine freshly linted prepared evidence with canonical same-head live PR evidence for Tier <=2 apply decisions
- fail closed on stale, partial, or ambiguous packet rows; unknown or unresolved dissent; unsupported families; duplicate families; and branch movement before posting
- report prepared, live, combined, and posted reviewer families in collector output

## Safety invariants
- prepared artifacts are re-linted and exact-head matched as before
- live families come from canonical evidence-lint results and one unique complete merge-packet row for the same PR
- missing packet dissent state remains unknown and therefore blocks posting
- a final head/tier recheck runs after live evidence lookup and immediately before posting
- Tier 3/4 behavior remains prepare-only

## Validation
- `python3 -m pytest tests/swarm/test_merge_quorum_io.py tests/swarm/test_quorum_evidence.py -q` (245 passed on head `622d158e5f`)
- initial adjacent governance suite excluding one confirmed main-baseline assertion (417 passed, 1 deselected)
- code-quality ratchet passes at `except Exception: 898/900`
- CI-equivalent changed-file mypy, Ruff, format check, `git diff --check`, push hooks, and `scripts/automation_pr_preflight.sh origin/main HEAD`
- charter checker: no binding violations; advisory CHR-X-039 because `aragora/swarm/` is covered by the parked fleet-packaging decision

## Adversarial review repairs
- repaired tri-state dissent coercion, partial/ambiguous packet selection, inaccurate unknown-dissent text, and post-live head recheck ordering
- narrowed all changed apply-path exception guards; unsupported-family handling remains deliberately fail closed
- last pre-cleanup exact-head review had a Claude PASS with P3 advisories only; Grok returned incomplete text, so no evidence was posted

## Exact remaining gate
- recollect two-family dry evidence on exact head `622d158e5f`
- Tier 4 requires repo-visible human risk settlement; do not apply evidence or merge without it

## Baseline notes
- `tests/scripts/test_auto_evidence_cycle.py::test_routing_record_fields_are_honest` also fails on untouched `origin/main`: the test expects `claude,grok`, while current configuration reports `claude,openai`.
- `make ci-required` reaches a stale full-repo mypy invocation and reports 2647 existing errors; the required changed-file mypy path and push hook pass for this branch.

Closes #9036