### PR TITLE
test(docs-site): allowlist archival Tier-4 adjudicator packet from specs mirror (misc-docs-tooling-3)

### DIFF
--- a/tests/scripts/test_docs_site_sync_links.py
+++ b/tests/scripts/test_docs_site_sync_links.py
@@ -325,11 +325,19 @@ def test_ambiguous_readme_basename_links_resolve_to_valid_targets() -> None:
 
 # docs/specs/*.md files that are deliberately excluded from the docs-site
 # mirror (e.g. a draft or an operator-gated spec not meant for public
-# publication). Empty today -- every current docs/specs/*.md file is
-# mirrored -- but test_docs_specs_directory_is_mirrored consults this set so a
-# future deliberate exclusion has an explicit, reviewable home instead of a
-# silent special case grown into the assertion logic below.
-DOCS_SPECS_MIRROR_ALLOWLIST: frozenset[str] = frozenset()
+# publication). test_docs_specs_directory_is_mirrored consults this set so a
+# deliberate exclusion has an explicit, reviewable home instead of a silent
+# special case grown into the assertion logic below.
+DOCS_SPECS_MIRROR_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        # Archival Tier-4 adjudicator-wiring repair packet (#8748): internal
+        # operator merge-authority working material (PREPARE-ONLY, not a public
+        # spec). Stays off the public docs-site like other operator-gated docs
+        # (e.g. docs/RECEIPT_CONTRACT.md). Landed via a foreign commit (#9020)
+        # after PR #8958's glob-completeness test.
+        "2026-07-01-adjudicator-wiring-tier4-packet.md",
+    }
+)
 
 
 def _default_specs_mirror_dest(source_name: str) -> str:


### PR DESCRIPTION
## Summary

Fixes the pre-existing `docs-site-tooling-test` failure on `origin/main` (found by `misc-reference-mirror-boundary`, 2026-07-09): `test_docs_specs_directory_is_mirrored` failed because `docs/specs/2026-07-01-adjudicator-wiring-tier4-packet.md` had neither a `DOC_MAP` entry in `docs-site/scripts/sync-docs.js` nor a `DOCS_SPECS_MIRROR_ALLOWLIST` entry.

## Premise re-verified on current `origin/main`

- Confirmed the test is **red** on a clean `origin/main` checkout (commit `3c0c63a109`):
  ```
  AssertionError: docs/specs/*.md file(s) missing a DOC_MAP entry in
  docs-site/scripts/sync-docs.js: ['2026-07-01-adjudicator-wiring-tier4-packet.md'].
  ```
- Confirmed `DOCS_SPECS_MIRROR_ALLOWLIST` was `frozenset()` (empty) and no `DOC_MAP` entry exists for the file. The entry had not been added meanwhile.

## Content decision: internal operator material (allowlist path)

Read `docs/specs/2026-07-01-adjudicator-wiring-tier4-packet.md` end to end. It is explicitly:

> **Status:** ARCHIVAL / PREPARE-ONLY. This packet preserves the B5 design record ... It is not a current implementation prompt: later work shipped observe-only adjudicator recording ... any packet consumption remains Tier 4 merge-authority work requiring fresh exact-head human authorization.

It is an archival Tier-4 repair/adjudication packet (ReviewAdjudicator quorum-stall path, epic #8748), describing proposed call-site wiring into `quorum_evidence.py` / `review_queue.py` plus Tier-4 rollout preconditions and live evidence. This is **internal operator working material**, not a public spec. The correct disposition is therefore the **allowlist path** (tests-only), consistent with the precedent that operator-gated docs such as `docs/RECEIPT_CONTRACT.md` stay off the public docs-site. A `DOC_MAP` entry (the JS-change, parked operator-review path) is **not** warranted.

## What changed

`tests/scripts/test_docs_site_sync_links.py` only:

- Added `"2026-07-01-adjudicator-wiring-tier4-packet.md"` to `DOCS_SPECS_MIRROR_ALLOWLIST` with a multi-line comment explaining the deliberate exclusion (archival Tier-4 operator merge-authority packet, PREPARE-ONLY, not a public spec; precedent: `RECEIPT_CONTRACT.md`; landed via foreign commit #9020 after PR #8958's glob-completeness test).
- Updated the now-inaccurate "Empty today -- every current docs/specs/*.md file is mirrored" prose above the set so it no longer claims the set is empty.

No changes to `docs-site/scripts/sync-docs.js`, no mirror regeneration, no docs touched. This is a **tests-only** change.

## Verification

- `node --check docs-site/scripts/sync-docs.js` -> OK (syntax unchanged, just a guard).
- `docs-site-tooling-test` gate (per `services.yaml`):
  ```
  python -m pytest tests/scripts/test_docs_site_sync_links.py tests/scripts/test_docs_sync_drift_detector.py tests/scripts/test_doc_stats.py -q
  -> 51 passed
  ```
  (was 1 failed before the change; the previously-failing `test_docs_specs_directory_is_mirrored` is now green.)
- `ruff check tests/scripts/test_docs_site_sync_links.py` -> All checks passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok.

## Overlap with open PR #9066

PR #9066 (`factory/pum-misc-reference-mirror-boundary`, "close docs/reference/** mirror boundary gap") touches the **same test file** but a **different section**: it appends new `DOCS_REFERENCE_*` constants and `test_docs_reference_*` tests at the **end** of the file (after `test_architecture_charter_links_resolve_to_absolute_repo_urls`, line ~539+). This PR edits the `DOCS_SPECS_MIRROR_ALLOWLIST` section near line ~332. There is **no textual conflict** — the two edits land in disjoint regions. When #9066 merges, this PR's one-region edit re-applies cleanly (and vice versa); a `git merge origin/main` (never rebase) is the recovery path if main moved.

## Merge policy

Tests-only change (touches a single `tests/scripts/*.py` file, no `aragora/**`/`scripts/**`/`docs-site/scripts/*.js`/docs). Per the mission merge policy this is **auto-merge eligible** (Tier 0). `gh pr merge --auto --squash` armed.

## Notes

- Any failures attributable to composing #9066 (e.g. its new `test_docs_reference_*` tests if #9066 lands first and this branch is rebased/merged) are from #9066's additions, not this change; this PR adds no new reference tests and does not touch the `reference/` sections.
- No gated/operator files changed (no workflows, no schema, no `RECEIPT_CONTRACT.md`, no `sync-docs.js`).
