### PR TITLE
fix(ci): propagate OpenAPI route validator exit status (#9082)

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -370,6 +370,7 @@ jobs:
 
       - name: Validate handler route coverage
         run: |
+          set -o pipefail
           python scripts/validate_openapi_routes.py \
             --spec docs/api/openapi.json \
             --fail-on-missing \

--- a/tests/workflows/test_openapi_route_coverage_policy.py
+++ b/tests/workflows/test_openapi_route_coverage_policy.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/openapi.yml"
+STEP_NAME = "Validate handler route coverage"
+
+
+def _route_coverage_run_block() -> str:
+    workflow = yaml.load(WORKFLOW_PATH.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(workflow, dict)
+
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps", [])
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict) and step.get("name") == STEP_NAME:
+                return str(step["run"])
+
+    raise AssertionError(f"workflow step not found: {STEP_NAME}")
+
+
+def test_route_coverage_pipeline_fails_closed_and_preserves_report(tmp_path: Path) -> None:
+    run_block = _route_coverage_run_block()
+    commands = [line.strip() for line in run_block.splitlines() if line.strip()]
+
+    assert commands[0] == "set -o pipefail"
+    validator_index = next(
+        index for index, command in enumerate(commands) if "validate_openapi_routes.py" in command
+    )
+    assert validator_index > 0
+    assert "--json | tee /tmp/route-coverage.json" in run_block
+
+    report = tmp_path / "route-coverage.json"
+    payload = '{"coverage_percentage": 97.0}\n'
+    producer = f"(printf %s {shlex.quote(payload)}; exit 7)"
+    result = subprocess.run(
+        [
+            "bash",
+            "-e",
+            "-c",
+            f"{commands[0]}\n{producer} | tee {shlex.quote(str(report))} >/dev/null",
+        ],
+        check=False,
+    )
+
+    assert result.returncode == 7
+    assert report.read_text(encoding="utf-8") == payload


### PR DESCRIPTION
## Summary

Tier-4 workflow-policy repair for #9082. The `Validate handler route coverage` step now enables Bash `pipefail` before running `validate_openapi_routes.py | tee`, preserving `/tmp/route-coverage.json` while propagating a nonzero validator status.

The focused policy test parses the live workflow, pins `pipefail` before the validator pipeline, verifies the artifact path remains present, and executes a failing synthetic producer to prove the report is written while the pipeline returns the producer's nonzero status.

## Tier-4 authorization

Operator authorization: https://github.com/synaptent/aragora/issues/9082#issuecomment-4931712425

> Tier-4 Human Implementation Authorization
>
> Issue: #9082
> Exact affected main head: 43fea520f53b47c58b2d0085705aa6880d9ef375
>
> I authorize one isolated draft repair PR that preserves the route-coverage JSON artifact while propagating any nonzero validate_openapi_routes.py exit status, with focused workflow-policy regression coverage. Keep route-baseline changes separate.
>
> Do not remove/re-arm .aragora/merge_executor.halt, manually rerun CI, merge, mark ready, or modify branch protection.

The affected pipeline remained unchanged on implementation base `3c0c63a10999653b89715f05286346fb384288fc`.

## Verification

- `python3 -m pytest -q tests/workflows/test_openapi_route_coverage_policy.py tests/workflows/test_aragora_merge_quorum_workflow.py` -> `3 passed`
- `python3 -m ruff check tests/workflows/test_openapi_route_coverage_policy.py` -> `All checks passed!`
- `python3 -m ruff format --check tests/workflows/test_openapi_route_coverage_policy.py` -> `1 file already formatted`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/openapi.yml', encoding='utf-8'))"` -> exit `0`
- `actionlint .github/workflows/openapi.yml` -> exit `0`
- `python3 scripts/check_workflow_checkout_integrity_policy.py` -> passed
- `python3 scripts/check_required_check_priority_policy.py` -> passed
- `bash -c 'set -o pipefail; false | tee /tmp/9082-pf-check >/dev/null; printf "exit=%s\\n" "$?"'` -> `exit=1`
- `git diff --check origin/main...HEAD` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> `preflight: ok`
- Commit and pre-push hooks -> passed, including YAML, Ruff, gitleaks, portability, and triggered mypy

## Deliberately untouched

- `scripts/baselines/validate_openapi_routes.json` and all route baselines
- `.aragora/merge_executor.halt` and halt/re-arm logic
- required-check lists or branch-protection configuration
- merge, settlement, evidence, and ready-state tooling
- all other workflow steps and workflow files

This PR must remain draft. The now-truthful route validator is expected to expose the existing route-baseline failure; repairing that separate data condition requires its own bounded justification and review.
