### PR TITLE
fix(types): mypy slice - debate/phases analytics/feedback/training (#9099)

### DIFF
--- a/aragora/debate/phases/analytics_phase.py
+++ b/aragora/debate/phases/analytics_phase.py
@@ -122,7 +122,7 @@ class AnalyticsPhase:
         if ctx.cancellation_token and ctx.cancellation_token.is_cancelled:
             from aragora.debate.cancellation import DebateCancelled
 
-            raise DebateCancelled(ctx.cancellation_token.reason)
+            raise DebateCancelled(ctx.cancellation_token.reason or "Debate cancelled")
 
         if not ctx.result:
             logger.warning("AnalyticsPhase called without result")
@@ -205,10 +205,13 @@ class AnalyticsPhase:
 
     def _record_metrics(self, ctx: DebateContext) -> None:
         """Record debate metrics for observability."""
+        result = ctx.result
+        if result is None:
+            return
+
         try:
             from aragora.server.prometheus import record_debate_completed
 
-            result = ctx.result
             record_debate_completed(
                 duration_seconds=result.duration_seconds,
                 rounds_used=result.rounds_used,
@@ -288,10 +291,14 @@ class AnalyticsPhase:
         if not ctx.vote_tally:
             return
 
+        result = ctx.result
+        if result is None:
+            return
+
         try:
             winner_agent = max(ctx.vote_tally.items(), key=lambda x: x[1])[0]
             ctx.winner_agent = winner_agent
-            ctx.result.winner = winner_agent
+            result.winner = winner_agent
         except (RuntimeError, AttributeError, TypeError) as e:  # noqa: BLE001
             logger.debug("Winner determination failed: %s", e)
 
@@ -301,6 +308,9 @@ class AnalyticsPhase:
             return
 
         result = ctx.result
+        if result is None:
+            return
+
         debate_id = getattr(result, "id", None) or ctx.env.task[:50]
 
         self._update_agent_relationships(
@@ -327,6 +337,9 @@ class AnalyticsPhase:
             return
 
         result = ctx.result
+        if result is None:
+            return
+
         if not result.votes:
             return
 
@@ -388,6 +401,9 @@ class AnalyticsPhase:
             return
 
         result = ctx.result
+        if result is None:
+            return
+
         result.disagreement_report = self._generate_disagreement_report(
             votes=result.votes,
             critiques=result.critiques,
@@ -412,6 +428,9 @@ class AnalyticsPhase:
             return
 
         result = ctx.result
+        if result is None:
+            return
+
         result.grounded_verdict = self._create_grounded_verdict(result)
 
         if result.grounded_verdict:
@@ -491,6 +510,9 @@ class AnalyticsPhase:
     def _log_completion(self, ctx: DebateContext) -> None:
         """Log completion and formatted conclusion."""
         result = ctx.result
+        if result is None:
+            return
+
         logger.info(
             f"debate_completed duration={result.duration_seconds:.1f}s "
             f"rounds={result.rounds_used} consensus={result.consensus_reached}"
@@ -505,8 +527,11 @@ class AnalyticsPhase:
         if not self.recorder:
             return
 
+        result = ctx.result
+        if result is None:
+            return
+
         try:
-            result = ctx.result
             verdict = result.final_answer[:100] if result.final_answer else "incomplete"
             self.recorder.finalize(verdict, ctx.vote_tally)
         except (RuntimeError, AttributeError, TypeError) as e:  # noqa: BLE001

--- a/aragora/debate/phases/feedback_phase.py
+++ b/aragora/debate/phases/feedback_phase.py
@@ -812,7 +812,9 @@ class FeedbackPhase:
         try:
             from aragora.pipeline.pr_generator import DecisionMemo
 
-            debate_id = getattr(result, "id", None) or getattr(ctx, "debate_id", "unknown")
+            debate_id = str(
+                getattr(result, "id", None) or getattr(ctx, "debate_id", None) or "unknown"
+            )
             task = getattr(ctx.env, "task", "") if ctx.env else ""
 
             proposals = getattr(result, "proposals", {})
@@ -897,6 +899,10 @@ class FeedbackPhase:
         This is a fire-and-forget task so it doesn't block debate completion.
         Failures are logged but don't affect the debate result.
         """
+        workflow = self.post_debate_workflow
+        if workflow is None:
+            return
+
         try:
             from aragora.workflow.engine import get_workflow_engine
 
@@ -915,7 +921,7 @@ class FeedbackPhase:
             }
 
             workflow_result = await engine.execute(
-                definition=self.post_debate_workflow,
+                definition=workflow,
                 inputs=workflow_input,
             )
 
@@ -1166,7 +1172,7 @@ class FeedbackPhase:
             self.event_emitter.emit(
                 StreamEvent(
                     type=StreamEventType.SELECTION_FEEDBACK,
-                    loop_id=self.loop_id,
+                    loop_id=self.loop_id or "unknown",
                     data={
                         "debate_id": ctx.debate_id,
                         "adjustments": adjustments,
@@ -1240,6 +1246,10 @@ class FeedbackPhase:
         This is a fire-and-forget task so it doesn't block debate completion.
         Failures are logged but don't affect the debate result.
         """
+        broadcast_pipeline = self.broadcast_pipeline
+        if broadcast_pipeline is None:
+            return
+
         try:
             from aragora.broadcast.pipeline import BroadcastOptions
 
@@ -1248,7 +1258,7 @@ class FeedbackPhase:
                 generate_rss_episode=True,
             )
 
-            pipeline_result = await self.broadcast_pipeline.run(
+            pipeline_result = await broadcast_pipeline.run(
                 ctx.debate_id,
                 options,
             )
@@ -1289,7 +1299,7 @@ class FeedbackPhase:
                 self.event_emitter.emit(
                     StreamEvent(
                         type=StreamEventType.RISK_WARNING,
-                        loop_id=self.loop_id,
+                        loop_id=self.loop_id or "unknown",
                         data={
                             "level": risk.level.value,
                             "domain": risk.domain,
@@ -1649,6 +1659,9 @@ class FeedbackPhase:
             return
 
         result = ctx.result
+        if result is None:
+            return
+
         if not result.final_answer:
             return
 
@@ -1671,9 +1684,11 @@ class FeedbackPhase:
         if not self.relationship_tracker:
             return
 
-        try:
-            result = ctx.result
+        result = ctx.result
+        if result is None:
+            return
 
+        try:
             # Extract critiques from messages
             critiques = []
             if result.messages:
@@ -1707,9 +1722,11 @@ class FeedbackPhase:
         if not self.moment_detector:
             return
 
-        try:
-            result = ctx.result
+        result = ctx.result
+        if result is None:
+            return
 
+        try:
             # Upset victories
             if result.winner and self.elo_system:
                 for agent in ctx.agents:
@@ -1750,9 +1767,11 @@ class FeedbackPhase:
         if not self.debate_embeddings:
             return
 
-        try:
-            result = ctx.result
+        result = ctx.result
+        if result is None:
+            return
 
+        try:
             # Build transcript
             transcript_parts = []
             if result.messages:
@@ -1824,7 +1843,7 @@ class FeedbackPhase:
                 self.event_emitter.emit(
                     StreamEvent(
                         type=StreamEventType.FLIP_DETECTED,
-                        loop_id=self.loop_id,
+                        loop_id=self.loop_id or "unknown",
                         data={
                             "agent": agent_name,
                             "flip_type": getattr(flip, "flip_type", "unknown"),

--- a/aragora/debate/phases/training_emitter.py
+++ b/aragora/debate/phases/training_emitter.py
@@ -184,6 +184,9 @@ class TrainingEmitter:
             SFT training record or None if not suitable
         """
         result = ctx.result
+        if result is None:
+            return None
+
         if not result.final_answer:
             return None
 
@@ -220,6 +223,9 @@ class TrainingEmitter:
         """
         result = ctx.result
         records: list[dict[str, Any]] = []
+
+        if result is None:
+            return records
 
         if not result.winner or not result.messages:
             return records
@@ -280,6 +286,9 @@ class TrainingEmitter:
         result = ctx.result
         records: list[dict[str, Any]] = []
 
+        if result is None:
+            return records
+
         if not result.votes or not result.winner:
             return records
 
@@ -322,7 +331,7 @@ class TrainingEmitter:
             self.event_emitter.emit(
                 StreamEvent(
                     type=StreamEventType.TRAINING_DATA_EXPORTED,
-                    loop_id=self.loop_id,
+                    loop_id=self.loop_id or "unknown",
                     data={
                         "debate_id": ctx.debate_id,
                         "records_exported": record_count,


### PR DESCRIPTION
## Summary

- narrow optional debate results at private analytics, feedback, and training method boundaries
- snapshot optional workflow/broadcast dependencies before asynchronous execution
- provide stable fallback values for cancellation and event correlation identifiers

Relates to #9099.

## Pinned scope

- Base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- Head: `7c125e0e7cae9e090eca0cfb60779ddafdcdc0ac`
- Claim: https://github.com/synaptent/aragora/issues/9099#issuecomment-4932032020
- Files: analytics phase, feedback phase, and training emitter only

No workflow, `.mypy-baseline`, branch-protection, halt, evidence, settlement, or merge state is changed.

## Mypy identity proof

| Scope | Base | Head | Removed |
|---|---:|---:|---:|
| Full `aragora/` | 2,634 errors / 649 files | 2,564 errors / 646 files | 70 |
| `analytics_phase.py` | 28 | 0 | 28 |
| `feedback_phase.py` | 24 | 0 | 24 |
| `training_emitter.py` | 18 | 0 | 18 |

Added identities anywhere: **0**.

<details>
<summary>Removed identities (70)</summary>

```text
aragora/debate/phases/analytics_phase.py:125: error: Argument 1 to "DebateCancelled" has incompatible type "str | None"; expected "str"  [arg-type]
aragora/debate/phases/analytics_phase.py:213: error: Item "None" of "DebateResult | None" has no attribute "duration_seconds"  [union-attr]
aragora/debate/phases/analytics_phase.py:214: error: Item "None" of "DebateResult | None" has no attribute "rounds_used"  [union-attr]
aragora/debate/phases/analytics_phase.py:215: error: Item "None" of "DebateResult | None" has no attribute "consensus_reached"  [union-attr]
aragora/debate/phases/analytics_phase.py:294: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/analytics_phase.py:310: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/analytics_phase.py:330: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/analytics_phase.py:336: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/analytics_phase.py:342: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/analytics_phase.py:343: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/analytics_phase.py:391: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:392: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/analytics_phase.py:393: error: Item "None" of "DebateResult | None" has no attribute "critiques"  [union-attr]
aragora/debate/phases/analytics_phase.py:397: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:398: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:401: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:403: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:406: error: Item "None" of "DebateResult | None" has no attribute "disagreement_report"  [union-attr]
aragora/debate/phases/analytics_phase.py:415: error: Item "None" of "DebateResult | None" has no attribute "grounded_verdict"  [union-attr]
aragora/debate/phases/analytics_phase.py:417: error: Item "None" of "DebateResult | None" has no attribute "grounded_verdict"  [union-attr]
aragora/debate/phases/analytics_phase.py:418: error: Item "None" of "DebateResult | None" has no attribute "grounded_verdict"  [union-attr]
aragora/debate/phases/analytics_phase.py:419: error: Item "None" of "DebateResult | None" has no attribute "grounded_verdict"  [union-attr]
aragora/debate/phases/analytics_phase.py:420: error: Item "None" of "DebateResult | None" has no attribute "grounded_verdict"  [union-attr]
aragora/debate/phases/analytics_phase.py:422: error: Argument 1 to "_emit_grounded_verdict_event" of "AnalyticsPhase" has incompatible type "DebateResult | None"; expected "DebateResult"  [arg-type]
aragora/debate/phases/analytics_phase.py:495: error: Item "None" of "DebateResult | None" has no attribute "duration_seconds"  [union-attr]
aragora/debate/phases/analytics_phase.py:496: error: Item "None" of "DebateResult | None" has no attribute "consensus_reached"  [union-attr]
aragora/debate/phases/analytics_phase.py:496: error: Item "None" of "DebateResult | None" has no attribute "rounds_used"  [union-attr]
aragora/debate/phases/analytics_phase.py:510: error: Item "None" of "DebateResult | None" has no attribute "final_answer"  [union-attr]
aragora/debate/phases/feedback_phase.py:1169: error: Argument "loop_id" to "StreamEvent" has incompatible type "str | None"; expected "str"  [arg-type]
aragora/debate/phases/feedback_phase.py:1251: error: Item "None" of "BroadcastPipelineProtocol | None" has no attribute "run"  [union-attr]
aragora/debate/phases/feedback_phase.py:1292: error: Argument "loop_id" to "StreamEvent" has incompatible type "str | None"; expected "str"  [arg-type]
aragora/debate/phases/feedback_phase.py:1652: error: Item "None" of "DebateResult | None" has no attribute "final_answer"  [union-attr]
aragora/debate/phases/feedback_phase.py:1660: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1679: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/feedback_phase.py:1680: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/feedback_phase.py:1691: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/feedback_phase.py:1698: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1714: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1716: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1718: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1728: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/feedback_phase.py:1731: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1758: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/feedback_phase.py:1759: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/feedback_phase.py:1768: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/feedback_phase.py:1769: error: Item "None" of "DebateResult | None" has no attribute "final_answer"  [union-attr]
aragora/debate/phases/feedback_phase.py:1770: error: Item "None" of "DebateResult | None" has no attribute "confidence"  [union-attr]
aragora/debate/phases/feedback_phase.py:1773: error: Item "None" of "DebateResult | None" has no attribute "rounds_used"  [union-attr]
aragora/debate/phases/feedback_phase.py:1774: error: Item "None" of "DebateResult | None" has no attribute "consensus_reached"  [union-attr]
aragora/debate/phases/feedback_phase.py:1827: error: Argument "loop_id" to "StreamEvent" has incompatible type "str | None"; expected "str"  [arg-type]
aragora/debate/phases/feedback_phase.py:829: error: Argument "debate_id" to "DecisionMemo" has incompatible type "Any | None"; expected "str"  [arg-type]
aragora/debate/phases/feedback_phase.py:918: error: Argument "definition" to "execute" of "WorkflowEngine" has incompatible type "Any | None"; expected "WorkflowDefinition"  [arg-type]
aragora/debate/phases/training_emitter.py:187: error: Item "None" of "DebateResult | None" has no attribute "final_answer"  [union-attr]
aragora/debate/phases/training_emitter.py:194: error: Item "None" of "DebateResult | None" has no attribute "final_answer"  [union-attr]
aragora/debate/phases/training_emitter.py:203: error: Item "None" of "DebateResult | None" has no attribute "confidence"  [union-attr]
aragora/debate/phases/training_emitter.py:204: error: Item "None" of "DebateResult | None" has no attribute "rounds_used"  [union-attr]
aragora/debate/phases/training_emitter.py:205: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:224: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/training_emitter.py:224: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:229: error: Item "None" of "DebateResult | None" has no attribute "messages"  [union-attr]
aragora/debate/phases/training_emitter.py:241: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:248: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:262: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:264: error: Item "None" of "DebateResult | None" has no attribute "confidence"  [union-attr]
aragora/debate/phases/training_emitter.py:283: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/training_emitter.py:283: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:286: error: Item "None" of "DebateResult | None" has no attribute "votes"  [union-attr]
aragora/debate/phases/training_emitter.py:292: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:304: error: Item "None" of "DebateResult | None" has no attribute "winner"  [union-attr]
aragora/debate/phases/training_emitter.py:325: error: Argument "loop_id" to "StreamEvent" has incompatible type "str | None"; expected "str"  [arg-type]
```
</details>

<details>
<summary>Added identities</summary>

```text
(none)
```
</details>

## Validation

- Exact provisional #9101 profile: Python 3.12.12, mypy 2.2.0, mypy-baseline 0.7.4, PyJWT 2.13.0, and pinned stubs.
- Full mypy with independent fresh caches: `2,634 -> 2,564`; exactly 70 removed, zero added.
- Targeted mypy on all three files: clean.
- `python3 -m pytest tests/debate/phases/test_analytics_phase.py tests/debate/phases/test_feedback_phase.py tests/debate/phases/test_training_emitter.py -q`: **193 passed**.
- `ruff check` and `ruff format --check` on touched files: pass.
- `git diff --check`: pass.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass.
- Commit and push hooks, including changed-file mypy: pass.

## Risk

This is an internal main-red remediation slice. Existing successful paths are unchanged. New branches only handle already-invalid optional states by returning early or using the established `"unknown"` event identifier fallback. The repository halt remains active; this draft requests no settlement or merge.
