### PR TITLE
fix(types): main-red mypy slice - Telegram callbacks

### DIFF
--- a/aragora/server/handlers/social/telegram/callbacks.py
+++ b/aragora/server/handlers/social/telegram/callbacks.py
@@ -7,7 +7,7 @@ Handles button presses (votes, view details) and inline bot queries.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...base import HandlerResult, json_response
 from ..chat_events import emit_message_received, emit_vote_received
@@ -26,6 +26,15 @@ def _tg():
 
 class TelegramCallbacksMixin:
     """Mixin providing callback query and inline query handling for Telegram."""
+
+    if TYPE_CHECKING:
+        # Supplied by sibling mixins in TelegramHandler's runtime composition.
+        _answer_callback_async: Any
+        _answer_inline_query_async: Any
+        _check_telegram_user_permission: Any
+        _deny_telegram_permission: Any
+        _handle_command: Any
+        _send_message_async: Any
 
     def _handle_message(self, message: dict[str, Any]) -> HandlerResult:
         """Handle incoming text message.
@@ -90,7 +99,7 @@ class TelegramCallbacksMixin:
 
         RBAC Permission Required: telegram:callbacks:handle
         """
-        callback_id = callback.get("id")
+        callback_id = str(callback.get("id") or "")
         data = callback.get("data", "")
         user = callback.get("from", {})
         user_id = user.get("id")

--- a/tests/handlers/social/telegram/test_callbacks.py
+++ b/tests/handlers/social/telegram/test_callbacks.py
@@ -1126,6 +1126,21 @@ class TestEdgeCases:
         assert _status(result) == 200
 
     @pytest.mark.usefixtures("_full_patch")
+    def test_vote_callback_without_id_uses_empty_string(self, handler):
+        """A malformed vote callback never passes None as the callback ID."""
+        cb = _make_callback("vote:debate1:agree")
+        del cb["id"]
+        with patch.object(
+            handler,
+            "_handle_vote",
+            return_value=MagicMock(status_code=200, body=b'{"ok":true}'),
+        ) as handle_vote:
+            result = handler._handle_callback_query(cb)
+
+        assert _status(result) == 200
+        handle_vote.assert_called_once_with("", CHAT_ID, USER_ID, USERNAME, "debate1", "agree")
+
+    @pytest.mark.usefixtures("_full_patch")
     def test_vote_with_empty_debate_id(self, handler, _patch_tg, _patch_events):
         """Vote with empty debate_id still processes."""
         with patch("aragora.server.handlers.social.telegram.callbacks.record_vote"):


### PR DESCRIPTION
## Summary

- declare sibling-mixin attributes consumed by `TelegramCallbacksMixin` under `TYPE_CHECKING`
- normalize missing callback IDs to an empty string before typed vote/details dispatch
- add a regression test for malformed vote callbacks without an ID
- remove the 20 mypy identities claimed in #9099

## Main-red campaign

- Coordination: #9099
- Claim: https://github.com/synaptent/aragora/issues/9099#issuecomment-4932056503
- Pinned base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- Claimed files: `aragora/server/handlers/social/telegram/callbacks.py`, `tests/handlers/social/telegram/test_callbacks.py`
- File-disjoint from #9105. The active halt, workflows, `.mypy-baseline`, and branch protection are untouched. This draft requests no settlement or merge.

## Verification

- Provisional #9101 profile, fresh caches: full `aragora/` mypy errors `2634 -> 2614`
- Error-set diff: exactly 20 removed identities in the claimed source file; zero added identities
- Focused mypy on `aragora/server/handlers/social/telegram/callbacks.py`: clean
- `python -m pytest tests/handlers/social/telegram/test_callbacks.py -q`: 105 passed (pre-existing coroutine/deprecation warnings)
- Ruff check and format check on both touched files
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- Commit and push hooks passed, including changed-file mypy and RBAC coverage

## Risk

Low and bounded. `TYPE_CHECKING` declarations do not exist at runtime. Valid callback IDs are unchanged; malformed or absent IDs are normalized from `None` to the empty string before Telegram callback dispatch.