### PR TITLE
fix(handlers): main-red mypy slice - bots partition (25 identities, #9099)

### DIFF
--- a/aragora/bots/commands.py
+++ b/aragora/bots/commands.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 from collections.abc import Callable, Coroutine
 
 from aragora.bots.base import (
@@ -334,15 +334,15 @@ async def _route_via_decision_router(
     Returns a ``CommandResult`` on success or failure, or ``None`` if the
     router is unavailable and the caller should fall back to HTTP.
     """
-    from aragora.core import (
+    from aragora.core.decision_models import (
         DecisionConfig,
         DecisionRequest,
-        DecisionType,
-        InputSource,
         RequestContext,
         ResponseChannel,
-        get_decision_router,
     )
+    from aragora.core import get_decision_router
+    from aragora.core.decision_router import DecisionRouter
+    from aragora.core.decision_types import DecisionType, InputSource
 
     platform_to_source: dict[Platform, InputSource] = {
         Platform.DISCORD: InputSource.DISCORD,
@@ -384,7 +384,8 @@ async def _route_via_decision_router(
 
     _register_debate_origin_best_effort(request.request_id, ctx, topic)
 
-    router = get_decision_router()
+    router_factory = cast(Callable[[], DecisionRouter], get_decision_router)
+    router = router_factory()
     result = await router.route(request)
 
     if result.request_id and result.request_id != request.request_id:

--- a/aragora/bots/discord_bot.py
+++ b/aragora/bots/discord_bot.py
@@ -81,19 +81,21 @@ class AragoraDiscordBot:
         intents = discord.Intents.default()
         intents.message_content = True
 
-        self._client = discord.Client(intents=intents)
-        self._tree = app_commands.CommandTree(self._client)
+        client = discord.Client(intents=intents)
+        tree = app_commands.CommandTree(client)
+        self._client = client
+        self._tree = tree
 
         # Register event handlers
-        @self._client.event
+        @client.event
         async def on_ready():
-            logger.info("Discord bot logged in as %s", self._client.user)
+            logger.info("Discord bot logged in as %s", client.user)
             # Sync slash commands
             if self.application_id:
-                await self._tree.sync()
+                await tree.sync()
                 logger.info("Discord slash commands synced")
 
-        @self._client.event
+        @client.event
         async def on_message(message: discord.Message):
             # Ignore bot messages
             if message.author.bot:
@@ -102,7 +104,7 @@ class AragoraDiscordBot:
             # Handle DMs or mentions
             if isinstance(message.channel, discord.DMChannel):
                 await self._handle_dm(message)
-            elif self._client.user and self._client.user.mentioned_in(message):
+            elif client.user and client.user.mentioned_in(message):
                 await self._handle_mention(message)
 
         # Register slash commands
@@ -113,7 +115,11 @@ class AragoraDiscordBot:
         import discord
         from discord import app_commands
 
-        @self._tree.command(name="aragora", description="Aragora multi-agent debate commands")
+        tree = self._tree
+        if tree is None:
+            raise RuntimeError("Discord command tree is not initialized; call setup() first")
+
+        @tree.command(name="aragora", description="Aragora multi-agent debate commands")
         @app_commands.describe(
             command="The command to run (debate, gauntlet, status, help)",
             args="Arguments for the command",
@@ -125,17 +131,17 @@ class AragoraDiscordBot:
         ):
             await self._handle_slash_command(interaction, command, args or "")
 
-        @self._tree.command(name="debate", description="Start a multi-agent debate on a topic")
+        @tree.command(name="debate", description="Start a multi-agent debate on a topic")
         @app_commands.describe(topic="The topic to debate")
         async def debate_command(interaction: discord.Interaction, topic: str):
             await self._handle_slash_command(interaction, "debate", topic)
 
-        @self._tree.command(name="gauntlet", description="Run adversarial stress-test validation")
+        @tree.command(name="gauntlet", description="Run adversarial stress-test validation")
         @app_commands.describe(statement="The statement to validate")
         async def gauntlet_command(interaction: discord.Interaction, statement: str):
             await self._handle_slash_command(interaction, "gauntlet", statement)
 
-        @self._tree.command(name="status", description="Check Aragora system status")
+        @tree.command(name="status", description="Check Aragora system status")
         async def status_command(interaction: discord.Interaction):
             await self._handle_slash_command(interaction, "status", "")
 
@@ -349,11 +355,15 @@ class AragoraDiscordBot:
 
     async def run(self) -> None:
         """Run the Discord bot."""
-        if not self._client:
+        if self._client is None:
             await self.setup()
 
+        client = self._client
+        if client is None:
+            raise RuntimeError("Discord client initialization failed")
+
         logger.info("Starting Discord bot...")
-        await self._client.start(self.token)
+        await client.start(self.token)
 
     async def close(self) -> None:
         """Close the Discord bot connection."""

--- a/aragora/bots/slack_bot.py
+++ b/aragora/bots/slack_bot.py
@@ -107,12 +107,16 @@ class AragoraSlackBot:
     def _register_event_handlers(self) -> None:
         """Register Slack event handlers."""
 
-        @self._app.event("app_mention")
+        app = self._app
+        if app is None:
+            raise RuntimeError("Slack app is not initialized; call setup() first")
+
+        @app.event("app_mention")
         async def handle_app_mention(event: dict[str, Any], say: Callable) -> None:
             """Handle @mentions of the bot."""
             await self._handle_mention(event, say)
 
-        @self._app.event("message")
+        @app.event("message")
         async def handle_message(event: dict[str, Any], say: Callable) -> None:
             """Handle direct messages and channel messages."""
             # Skip bot messages and thread replies to avoid loops
@@ -127,7 +131,11 @@ class AragoraSlackBot:
     def _register_slash_commands(self) -> None:
         """Register Slack slash commands."""
 
-        @self._app.command("/aragora")
+        app = self._app
+        if app is None:
+            raise RuntimeError("Slack app is not initialized; call setup() first")
+
+        @app.command("/aragora")
         async def handle_aragora_command(
             ack: Callable, body: dict[str, Any], respond: Callable
         ) -> None:
@@ -139,7 +147,7 @@ class AragoraSlackBot:
             args = parts[1] if len(parts) > 1 else ""
             await self._handle_slash_command(body, command, args, respond)
 
-        @self._app.command("/debate")
+        @app.command("/debate")
         async def handle_debate_command(
             ack: Callable, body: dict[str, Any], respond: Callable
         ) -> None:
@@ -148,7 +156,7 @@ class AragoraSlackBot:
             topic = body.get("text", "").strip()
             await self._handle_slash_command(body, "debate", topic, respond)
 
-        @self._app.command("/gauntlet")
+        @app.command("/gauntlet")
         async def handle_gauntlet_command(
             ack: Callable, body: dict[str, Any], respond: Callable
         ) -> None:
@@ -157,7 +165,7 @@ class AragoraSlackBot:
             statement = body.get("text", "").strip()
             await self._handle_slash_command(body, "gauntlet", statement, respond)
 
-        @self._app.command("/aragora-status")
+        @app.command("/aragora-status")
         async def handle_status_command(
             ack: Callable, body: dict[str, Any], respond: Callable
         ) -> None:


### PR DESCRIPTION
## Summary

- remove the complete 25-error `aragora/bots` partition from the pinned #9099 mypy inventory;
- import decision request types from their concrete modules while preserving the public `aragora.core.get_decision_router` injection seam;
- bind initialized Discord/Slack clients before decorator registration and fail closed if registration/run is called without successful setup;
- use no ignores, baseline changes, workflow changes, or public API signature changes.

## Campaign claim

- Parent: #9099
- Claim: https://github.com/synaptent/aragora/issues/9099#issuecomment-4932112214
- Pinned base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- Scope: `aragora/bots/commands.py`, `aragora/bots/discord_bot.py`, `aragora/bots/slack_bot.py`

This 25-error slice is below the preferred 30-error target but is the smallest coherent complete module partition; #9099 explicitly permits smaller slices when module boundaries make that safer.

## Pinned environment

- Python 3.12.12
- mypy 2.2.0
- mypy-baseline 0.7.4
- PyJWT 2.13.0
- `types-jsonschema==4.26.0.20260518`
- `types-python-dateutil==2.9.0.20260518`
- `types-PyYAML==6.0.12.20260518`
- `types-redis==4.6.0.20241004`
- `types-requests==2.33.0.20260518`
- `types-setuptools==83.0.0.20260706`

Fresh-cache baseline reproduction matched #9101 exactly:

- 2,634 errors in 649 files;
- normalized identity SHA256 `a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609`.

Fresh-cache post-repair result:

- 2,609 errors in 646 files;
- 25 removed identities;
- 0 added identities;
- post-repair identity SHA256 `674828a07bb46bb9eb2681d9141673ee19230b5768ba9d81ad31fdda84b7d0eb`.

<details>
<summary>Removed identities (25)</summary>

```text
aragora/bots/commands.py:347: error: Variable "aragora.core.InputSource" is not valid as a type  [valid-type]
aragora/bots/commands.py:348: error: Any? has no attribute "DISCORD"  [attr-defined]
aragora/bots/commands.py:349: error: Any? has no attribute "TEAMS"  [attr-defined]
aragora/bots/commands.py:350: error: Any? has no attribute "SLACK"  [attr-defined]
aragora/bots/commands.py:351: error: Any? has no attribute "TELEGRAM"  [attr-defined]
aragora/bots/commands.py:352: error: Any? has no attribute "WHATSAPP"  [attr-defined]
aragora/bots/commands.py:354: error: Any? has no attribute "HTTP_API"  [attr-defined]
aragora/bots/commands.py:356: error: Any? not callable  [misc]
aragora/bots/commands.py:363: error: Any? not callable  [misc]
aragora/bots/commands.py:370: error: Any? not callable  [misc]
aragora/bots/commands.py:374: error: Any? has no attribute "DEBATE"  [attr-defined]
aragora/bots/commands.py:383: error: Any? not callable  [misc]
aragora/bots/commands.py:387: error: Any? not callable  [misc]
aragora/bots/discord_bot.py:105: error: Item "None" of "Any | None" has no attribute "user"  [union-attr]
aragora/bots/discord_bot.py:116: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/discord_bot.py:128: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/discord_bot.py:133: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/discord_bot.py:138: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/discord_bot.py:356: error: Item "None" of "Any | None" has no attribute "start"  [union-attr]
aragora/bots/slack_bot.py:110: error: Item "None" of "Any | None" has no attribute "event"  [union-attr]
aragora/bots/slack_bot.py:115: error: Item "None" of "Any | None" has no attribute "event"  [union-attr]
aragora/bots/slack_bot.py:130: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/slack_bot.py:142: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/slack_bot.py:151: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
aragora/bots/slack_bot.py:160: error: Item "None" of "Any | None" has no attribute "command"  [union-attr]
```

</details>

## Validation

- complete `tests/bots` package: 105 passed;
- targeted pinned mypy on all three files: clean;
- full pinned mypy identity comparison: exactly `-25/+0`;
- Ruff format/check: passed;
- code-quality ratchet: passed;
- metrics drift check: passed;
- `automation_pr_preflight.sh origin/main HEAD`: passed;
- normal commit hooks passed.

The initial plugin-disabled pytest run was intentionally discarded because it removed `pytest-asyncio`; the normal repository plugin environment passed all 105 tests. A focused test also caught and prevented bypassing the public router injection seam.

## Next disjoint candidate

After re-grounding live #9099 claims, the next coherent multi-file candidate is the six-file `aragora/services` partition (33 pinned identities). It must be rechecked for ownership and split by semantic subdomain if the full partition is not one-shot coherent.

## Boundaries

Draft only. No workflow, `.mypy-baseline`, branch protection, active halt, CI rerun, evidence, settlement, or merge mutation.

## Current-base restack (2026-07-11)

- Merged current `origin/main` `a0f0c417916203d7ed0232ebd178a318495d1c23` normally; no rebase or history rewrite.
- Exact restack head: `f40cd7df954f23daa7d22a9a3b19f6e7d9311c29`.
- Canonical Python 3.12.12 / mypy 2.2.0 / mypy-baseline 0.7.4 / PyJWT 2.13.0 proof: `2634 -> 2609` errors, exactly 25 removed identities in the three claimed `aragora/bots` files, and 0 added identities.
- Identity SHA-256: base `a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609`; candidate `674828a07bb46bb9eb2681d9141673ee19230b5768ba9d81ad31fdda84b7d0eb`; removed `a477848fec107e4fc105852f57afc47c6337267413c328db5fb4f86fdba33c6d`; added `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
- Targeted mypy clean; `tests/bots`: 105 passed; repo-pinned Ruff 0.14.14 check/format, `git diff --check`, automation preflight, and push hooks passed.

The active main-red halt and #9198 WIP freeze remain unchanged. No evidence, settlement, readiness-state change, CI rerun, or merge action was performed.