### PR TITLE
fix(swarm): surface evidence-lint infra failures + reviewer severity-verdict contract

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -406,6 +406,32 @@ def _evidence_lint_args(
     return args
 
 
+def _lint_infra_failure(reason: str) -> dict[str, Any]:
+    """Explicit fail-closed lint result for an evidence-lint INFRA failure.
+
+    A broken lint subprocess must stay non-counting (fail-closed), but it must
+    be distinguishable from a substantive rejection: an empty ``{}`` renders as
+    ``DOES NOT count ()`` and silently zeroes evidence that may have counted
+    (observed live 2026-07-09: claude items recorded ``would_count=False,
+    problems=[]`` while the same body relinted offline with three real
+    problems). The ``evidence_lint_infra_failure:`` prefix tells operators and
+    reconcile tooling to re-lint rather than treat the family as rejected.
+    """
+    return {
+        "would_count": False,
+        "counted_reviewer_ids": [],
+        "problems": [f"evidence_lint_infra_failure: {reason}"],
+    }
+
+
+# Retry the evidence-lint subprocess ONLY on infra failure (timeout / nonzero
+# exit / empty stdout / undecodable JSON), mirroring the reviewer-side
+# ``_run_reviewer_with_infra_retry`` semantics: a lint that returned a parsed
+# result — counting or not — is never retried, so a substantive rejection can
+# never be "retried away".
+_EVIDENCE_LINT_INFRA_RETRIES = 1
+
+
 def lint_comment(
     pr: int,
     head_sha: str,
@@ -421,16 +447,27 @@ def lint_comment(
             body_file = fh.name
             fh.write(body)
         args = _evidence_lint_args(pr, head_sha, head_committed_at, author, body_file)
-        try:
-            proc = run(args, env=env, timeout=_EVIDENCE_LINT_TIMEOUT)
-        except subprocess.TimeoutExpired:
-            return {}
-        if proc.returncode != 0 or not proc.stdout.strip():
-            return {}
-        try:
-            return json.loads(proc.stdout)
-        except json.JSONDecodeError:
-            return {}
+        failure: dict[str, Any] = _lint_infra_failure("lint subprocess never ran")
+        for _ in range(1 + _EVIDENCE_LINT_INFRA_RETRIES):
+            try:
+                proc = run(args, env=env, timeout=_EVIDENCE_LINT_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                failure = _lint_infra_failure(
+                    f"evidence-lint timed out after {_EVIDENCE_LINT_TIMEOUT}s"
+                )
+                continue
+            if proc.returncode != 0 or not proc.stdout.strip():
+                stderr = (proc.stderr or "").strip()[:120]
+                failure = _lint_infra_failure(
+                    f"evidence-lint exit {proc.returncode}" + (f": {stderr}" if stderr else "")
+                )
+                continue
+            try:
+                return json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                failure = _lint_infra_failure("evidence-lint emitted undecodable JSON")
+                continue
+        return failure
     finally:
         if body_file:
             try:

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -469,17 +469,32 @@ def lint_comment(
                     f"evidence-lint timed out after {_EVIDENCE_LINT_TIMEOUT}s"
                 )
                 continue
-            if proc.returncode != 0 or not proc.stdout.strip():
+            # The evidence-lint CLI exits 1 BY DESIGN on every substantive
+            # rejection while still printing the parsed JSON result
+            # (review_queue.py: ``return 0 if result["would_count"] else 1``).
+            # The exit code is therefore a verdict signal, not a health
+            # signal: parse stdout first, and treat only empty/undecodable/
+            # non-dict output as infra failure. Gating on returncode here was
+            # the original root cause of every rejection collapsing to ``{}``.
+            stdout = (proc.stdout or "").strip()
+            if not stdout:
                 stderr = (proc.stderr or "").strip()[:120]
                 failure = _lint_infra_failure(
-                    f"evidence-lint exit {proc.returncode}" + (f": {stderr}" if stderr else "")
+                    f"evidence-lint exit {proc.returncode} with empty stdout"
+                    + (f": {stderr}" if stderr else "")
                 )
                 continue
             try:
-                return _enforce_reason_invariant(json.loads(proc.stdout))
+                parsed = json.loads(stdout)
             except json.JSONDecodeError:
                 failure = _lint_infra_failure("evidence-lint emitted undecodable JSON")
                 continue
+            if not isinstance(parsed, dict):
+                failure = _lint_infra_failure(
+                    f"evidence-lint emitted non-dict JSON ({type(parsed).__name__})"
+                )
+                continue
+            return _enforce_reason_invariant(parsed)
         return failure
     finally:
         if body_file:

--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -432,6 +432,19 @@ def _lint_infra_failure(reason: str) -> dict[str, Any]:
 _EVIDENCE_LINT_INFRA_RETRIES = 1
 
 
+def _enforce_reason_invariant(lint: dict[str, Any]) -> dict[str, Any]:
+    """Enforce ``would_count == False => problems is non-empty``.
+
+    Every non-counting lint result must carry a diagnosable reason; a parsed
+    result that rejects with an empty problems list would still render as the
+    unanswerable ``DOES NOT count ()``. Counting/eligibility are unchanged —
+    this only guarantees the reason channel is never silently empty."""
+    if isinstance(lint, dict) and not lint.get("would_count") and not lint.get("problems"):
+        lint = dict(lint)
+        lint["problems"] = ["evidence_lint_rejection_without_reason"]
+    return lint
+
+
 def lint_comment(
     pr: int,
     head_sha: str,
@@ -463,7 +476,7 @@ def lint_comment(
                 )
                 continue
             try:
-                return json.loads(proc.stdout)
+                return _enforce_reason_invariant(json.loads(proc.stdout))
             except json.JSONDecodeError:
                 failure = _lint_infra_failure("evidence-lint emitted undecodable JSON")
                 continue

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -1134,7 +1134,11 @@ def build_review_prompt(
         "bullet list of concrete findings, each tagged [P1]/[P2]/[P3] with a location. Include "
         "ONLY priority levels that have a real finding: if a level has none, OMIT it entirely "
         "-- never write a '[P1] None', '[P2] N/A', or similar no-finding line (it is misread as "
-        "a blocking finding). If there are no findings at all, write 'No findings.' Be concise.\n\n"
+        "a blocking finding). Severity contract: [P1] and [P2] findings are BLOCKING -- if you "
+        "report any [P1] or [P2], your verdict MUST be 'Verdict: CHANGES-REQUESTED' (a PASS "
+        "carrying a [P1]/[P2] line is self-contradictory and will not be counted). Use [P3] for "
+        "non-blocking observations; [P3]-only findings may accompany a PASS. "
+        "If there are no findings at all, write 'No findings.' Be concise.\n\n"
         f"=== CHANGED FILES (complete list, {file_count} file(s)) ===\n{file_list}\n\n"
         f"{body_header}\n{bounded}\n"
     )

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -237,3 +237,29 @@ def test_lint_comment_reason_invariant_leaves_counting_results_alone(monkeypatch
     counting = {"would_count": True, "problems": [], "counted_reviewer_ids": ["claude"]}
     monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(counting)))
     assert m.lint_comment(*_LINT_ARGS) == counting
+
+
+def test_lint_comment_exit1_with_json_is_a_verdict_not_infra_failure(monkeypatch) -> None:
+    """The evidence-lint CLI exits 1 BY DESIGN on substantive rejections while
+    printing the parsed JSON (review_queue: 'return 0 if would_count else 1').
+    The exit code must never be treated as a health signal (#9129 claude P1)."""
+    calls = []
+    rejection = {"would_count": False, "problems": ["blocking_or_negative_verdict"]}
+
+    def _exit1(*a, **k):
+        calls.append(1)
+        return _proc(json.dumps(rejection), returncode=1)
+
+    monkeypatch.setattr(m, "run", _exit1)
+    assert m.lint_comment(*_LINT_ARGS) == rejection
+    assert len(calls) == 1  # a verdict, even at exit 1, is final: no retry
+
+
+def test_lint_comment_non_dict_json_is_infra_failure(monkeypatch) -> None:
+    for payload in ("null", "[]", '"oops"'):
+        monkeypatch.setattr(m, "run", lambda *a, _p=payload, **k: _proc(_p))
+        lint = m.lint_comment(*_LINT_ARGS)
+        assert lint["would_count"] is False
+        assert lint["problems"][0].startswith(
+            "evidence_lint_infra_failure: evidence-lint emitted non-dict JSON"
+        )

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -162,3 +162,62 @@ def test_fetch_pr_tier_none_on_timeout(monkeypatch) -> None:
 
     monkeypatch.setattr(m, "run", _boom)
     assert m.fetch_pr_tier("o/r", 1) is None
+
+
+# --- lint_comment: infra failures are explicit and retried once, never {} ---
+
+
+_LINT_ARGS = (9073, "a" * 40, "2026-07-09T22:44:49Z", "an0mium", "## body", {})
+
+
+def test_lint_comment_timeout_returns_explicit_infra_failure(monkeypatch) -> None:
+    calls = []
+
+    def _boom(*a, **k):
+        calls.append(1)
+        raise subprocess.TimeoutExpired(cmd="lint", timeout=1)
+
+    monkeypatch.setattr(m, "run", _boom)
+    lint = m.lint_comment(*_LINT_ARGS)
+    assert lint["would_count"] is False
+    assert lint["counted_reviewer_ids"] == []
+    assert len(lint["problems"]) == 1
+    assert lint["problems"][0].startswith("evidence_lint_infra_failure:")
+    assert len(calls) == 1 + m._EVIDENCE_LINT_INFRA_RETRIES  # retried, then explicit
+
+
+def test_lint_comment_retries_infra_failure_then_returns_parsed_result(monkeypatch) -> None:
+    calls = []
+    good = {"would_count": True, "problems": [], "counted_reviewer_ids": ["claude"]}
+
+    def _flaky(*a, **k):
+        calls.append(1)
+        if len(calls) == 1:
+            return _proc("", returncode=1)
+        return _proc(json.dumps(good))
+
+    monkeypatch.setattr(m, "run", _flaky)
+    assert m.lint_comment(*_LINT_ARGS) == good
+    assert len(calls) == 2
+
+
+def test_lint_comment_never_retries_a_parsed_rejection(monkeypatch) -> None:
+    calls = []
+    rejection = {"would_count": False, "problems": ["blocking_or_negative_verdict"]}
+
+    def _reject(*a, **k):
+        calls.append(1)
+        return _proc(json.dumps(rejection))
+
+    monkeypatch.setattr(m, "run", _reject)
+    assert m.lint_comment(*_LINT_ARGS) == rejection
+    assert len(calls) == 1  # a substantive rejection is final, never retried
+
+
+def test_lint_comment_bad_json_returns_explicit_infra_failure(monkeypatch) -> None:
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc("not json"))
+    lint = m.lint_comment(*_LINT_ARGS)
+    assert lint["would_count"] is False
+    assert lint["problems"] == [
+        "evidence_lint_infra_failure: evidence-lint emitted undecodable JSON"
+    ]

--- a/tests/swarm/test_merge_quorum_io.py
+++ b/tests/swarm/test_merge_quorum_io.py
@@ -221,3 +221,19 @@ def test_lint_comment_bad_json_returns_explicit_infra_failure(monkeypatch) -> No
     assert lint["problems"] == [
         "evidence_lint_infra_failure: evidence-lint emitted undecodable JSON"
     ]
+
+
+def test_lint_comment_enforces_reason_invariant_on_parsed_rejection(monkeypatch) -> None:
+    """would_count == False must ALWAYS carry a reason: a parsed rejection with
+    an empty problems list would still render as 'DOES NOT count ()'."""
+    bare = {"would_count": False, "problems": [], "counted_reviewer_ids": []}
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(bare)))
+    lint = m.lint_comment(*_LINT_ARGS)
+    assert lint["would_count"] is False
+    assert lint["problems"] == ["evidence_lint_rejection_without_reason"]
+
+
+def test_lint_comment_reason_invariant_leaves_counting_results_alone(monkeypatch) -> None:
+    counting = {"would_count": True, "problems": [], "counted_reviewer_ids": ["claude"]}
+    monkeypatch.setattr(m, "run", lambda *a, **k: _proc(json.dumps(counting)))
+    assert m.lint_comment(*_LINT_ARGS) == counting

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -2979,6 +2979,20 @@ def test_build_review_prompt_keeps_all_added_paths_when_deletion_sorts_first() -
         assert path in prompt
 
 
+def test_build_review_prompt_states_severity_verdict_contract() -> None:
+    """The prompt must teach reviewers the linter's counting contract: [P1]/[P2]
+    findings are blocking, so they require CHANGES-REQUESTED; [P3]-only may
+    accompany PASS. Without this, reviewers emit 'Verdict: PASS' + [P2] bodies
+    that has_blocking_or_negative_verdict rejects and the family never counts
+    (observed live on every claude review of 2026-07-09)."""
+    prompt = qe.build_review_prompt(
+        repo="o/r", pr=9073, head_sha=HEAD, diff_text="diff", name_status="M\tf.py"
+    )
+    assert "Severity contract" in prompt
+    assert "MUST be 'Verdict: CHANGES-REQUESTED'" in prompt
+    assert "[P3]-only findings may accompany a PASS" in prompt
+
+
 def test_build_review_prompt_never_truncates_complete_file_list_header() -> None:
     diff, name_status, added = _diff_with_deletion_before_additions()
     prompt = qe.build_review_prompt(


### PR DESCRIPTION
## Summary
Diagnoses and fixes the two mechanisms behind the systematic `DOES NOT count ()` claude-evidence zeroing observed on every settlement round of 2026-07-09 (artifacts saved from the live batch; both mechanisms reproduced offline against the recorded bodies):

1. **Infra failures were indistinguishable from rejections.** `merge_quorum_io.lint_comment` returned `{}` on any subprocess failure (timeout / nonzero exit / empty stdout / bad JSON), rendered downstream as `would_count=False, problems=[]`. Proof: the 2026-07-09 prepared artifact for #9073 records claude at `would_count=False, problems=[]`, while the identical body relinted offline returns three real problems in 0.26s. Now: explicit `evidence_lint_infra_failure: <reason>` problem (still fail-closed) + one bounded retry on infra failure only, mirroring `_run_reviewer_with_infra_retry` — a parsed rejection is final and can never be retried away.

2. **Reviewer/linter contract gap.** `has_blocking_or_negative_verdict` treats any `[P0]/[P1]/[P2]` finding line as blocking regardless of the `Verdict: PASS` label (`_DEFAULT_BLOCKING_MARKER`), but `build_review_prompt` never told reviewers this. Claude emitted `Verdict: PASS` + `[P2]` advisory notes on every review that day — self-contradictory bodies that lint as `blocking_or_negative_verdict` → `no_counted_model_family`. The prompt now states the severity contract: **[P1]/[P2] ⇒ CHANGES-REQUESTED; [P3]-only may accompany PASS.** (Verified boundary: PASS+P3-only and clean PASS both count today; PASS+P2 does not.)

**Load-bearing target (freeze rule):** restores claude as a countable quorum lineage on live product-PR settlements — #9073, #9064, and #8766 all lost their claude signal to these mechanisms this week, halving effective quorum.

**Tier note:** touches merge-authority surfaces (`quorum_evidence.py`, `merge_quorum_io.py`) — prepared for exact-head operator settlement per the Tier-4 contract; both changes are fail-closed-preserving (no path counts evidence that previously didn't; infra failures remain non-counting, just diagnosable).

#### Test plan
- [x] 4 new tests: timeout → explicit infra problems; infra failure → one retry then parsed result; parsed rejection never retried (call count pinned); bad JSON → explicit reason
- [x] 1 new test: prompt states the severity-verdict contract
- [x] Full suites: tests/swarm/test_merge_quorum_io.py + test_quorum_evidence.py — 235 passed
- [x] ruff check/format clean; git diff --check clean; scripts/check_portability.py clean; automation_pr_preflight.sh ok

Generated with [Devin](https://devin.ai)