### PR TITLE
fix(types): main-red workspace slice (#9099)

### DIFF
--- a/aragora/server/handlers/workspace/crud.py
+++ b/aragora/server/handlers/workspace/crud.py
@@ -14,6 +14,7 @@ Stability: STABLE
 from __future__ import annotations
 
 import logging
+from collections.abc import Coroutine
 from typing import Any, TYPE_CHECKING
 
 from aragora.events.handler_events import emit_handler_event, CREATED, DELETED
@@ -23,6 +24,8 @@ from aragora.server.handlers.openapi_decorator import api_endpoint
 from aragora.server.handlers.utils.rate_limit import rate_limit
 
 if TYPE_CHECKING:
+    from aragora.billing.auth.context import UserAuthContext
+    from aragora.privacy import DataIsolationManager, PrivacyAuditLog
     from aragora.protocols import HTTPRequestHandler
     from aragora.server.handlers.base import HandlerResult
 
@@ -46,7 +49,33 @@ class WorkspaceCrudMixin:
     - _run_async(coro)
     - _check_rbac_permission(handler, perm, auth_ctx)
     - read_json_body(handler)
+
+    The ``TYPE_CHECKING`` declarations mirror the shared workspace host
+    protocol without changing the runtime MRO.
     """
+
+    if TYPE_CHECKING:
+
+        def _get_user_store(self) -> Any: ...
+
+        def _get_isolation_manager(self) -> DataIsolationManager: ...
+
+        def _get_audit_log(self) -> PrivacyAuditLog: ...
+
+        def _run_async(self, coro: Coroutine[Any, Any, Any]) -> Any: ...
+
+        def _check_rbac_permission(
+            self,
+            handler: HTTPRequestHandler,
+            permission_key: str,
+            auth_ctx: UserAuthContext | None = ...,
+        ) -> HandlerResult | None: ...
+
+        def read_json_body(
+            self,
+            handler: Any,
+            max_size: int | None = ...,
+        ) -> dict[str, Any] | None: ...
 
     @api_endpoint(
         method="POST",

--- a/aragora/workspace/bead.py
+++ b/aragora/workspace/bead.py
@@ -164,7 +164,7 @@ class BeadManager:
                     auto_commit=False,
                 )
 
-    async def _ensure_nomic_store(self) -> None:
+    async def _ensure_nomic_store(self) -> NomicBeadStore:
         if self._nomic_store is None:
             if self._canonical_stores is None:
                 bead_dir = str(self._storage_dir) if self._storage_dir else None
@@ -174,9 +174,13 @@ class BeadManager:
                     auto_commit=False,
                 )
             self._nomic_store = await self._canonical_stores.bead_store()
-        if self._nomic_store and not self._nomic_initialized:
-            await self._nomic_store.initialize()
+        store = self._nomic_store
+        if store is None:
+            raise RuntimeError("Canonical bead store initialization returned no store")
+        if not self._nomic_initialized:
+            await store.initialize()
             self._nomic_initialized = True
+        return store
 
     def _to_nomic_status(self, status: BeadStatus) -> NomicBeadStatus:
         return workspace_bead_status_to_nomic(status)
@@ -214,34 +218,34 @@ class BeadManager:
             payload=payload or {},
             depends_on=depends_on or [],
         )
-        await self._ensure_nomic_store()
-        await self._nomic_store.create(self._to_nomic_bead(bead))
+        store = await self._ensure_nomic_store()
+        await store.create(self._to_nomic_bead(bead))
         return bead
 
     async def get_bead(self, bead_id: str) -> Bead | None:
         """Get a bead by ID."""
-        await self._ensure_nomic_store()
-        nomic_bead = await self._nomic_store.get(bead_id)
+        store = await self._ensure_nomic_store()
+        nomic_bead = await store.get(bead_id)
         return self._from_nomic_bead(nomic_bead) if nomic_bead else None
 
     async def assign_bead(self, bead_id: str, agent_id: str) -> Bead | None:
         """Assign a bead to an agent."""
-        await self._ensure_nomic_store()
-        success = await self._nomic_store.claim(bead_id, agent_id)
+        store = await self._ensure_nomic_store()
+        success = await store.claim(bead_id, agent_id)
         if not success:
             return None
-        nomic_bead = await self._nomic_store.get(bead_id)
+        nomic_bead = await store.get(bead_id)
         if not nomic_bead:
             return None
         nomic_bead.metadata.update({"workspace_status": BeadStatus.ASSIGNED.value})
-        await self._nomic_store.update(nomic_bead)
+        await store.update(nomic_bead)
         return self._from_nomic_bead(nomic_bead)
 
     async def start_bead(self, bead_id: str) -> Bead | None:
         """Mark a bead as running."""
-        await self._ensure_nomic_store()
-        await self._nomic_store.update_status(bead_id, NomicBeadStatus.RUNNING)
-        nomic_bead = await self._nomic_store.get(bead_id)
+        store = await self._ensure_nomic_store()
+        await store.update_status(bead_id, NomicBeadStatus.RUNNING)
+        nomic_bead = await store.get(bead_id)
         if not nomic_bead:
             return None
         nomic_bead.metadata.update(
@@ -250,7 +254,7 @@ class BeadManager:
                 "started_at": time.time(),
             }
         )
-        await self._nomic_store.update(nomic_bead)
+        await store.update(nomic_bead)
         return self._from_nomic_bead(nomic_bead)
 
     async def complete_bead(
@@ -259,9 +263,9 @@ class BeadManager:
         result: dict[str, Any] | None = None,
     ) -> Bead | None:
         """Mark a bead as done with an optional result."""
-        await self._ensure_nomic_store()
-        await self._nomic_store.update_status(bead_id, NomicBeadStatus.COMPLETED)
-        nomic_bead = await self._nomic_store.get(bead_id)
+        store = await self._ensure_nomic_store()
+        await store.update_status(bead_id, NomicBeadStatus.COMPLETED)
+        nomic_bead = await store.get(bead_id)
         if not nomic_bead:
             return None
         nomic_bead.metadata.update(
@@ -271,14 +275,14 @@ class BeadManager:
                 "completed_at": time.time(),
             }
         )
-        await self._nomic_store.update(nomic_bead)
+        await store.update(nomic_bead)
         return self._from_nomic_bead(nomic_bead)
 
     async def fail_bead(self, bead_id: str, error: str) -> Bead | None:
         """Mark a bead as failed."""
-        await self._ensure_nomic_store()
-        await self._nomic_store.update_status(bead_id, NomicBeadStatus.FAILED, error_message=error)
-        nomic_bead = await self._nomic_store.get(bead_id)
+        store = await self._ensure_nomic_store()
+        await store.update_status(bead_id, NomicBeadStatus.FAILED, error_message=error)
+        nomic_bead = await store.get(bead_id)
         if not nomic_bead:
             return None
         nomic_bead.metadata.update(
@@ -287,7 +291,7 @@ class BeadManager:
                 "completed_at": time.time(),
             }
         )
-        await self._nomic_store.update(nomic_bead)
+        await store.update(nomic_bead)
         return self._from_nomic_bead(nomic_bead)
 
     async def list_beads(
@@ -297,8 +301,8 @@ class BeadManager:
         agent_id: str | None = None,
     ) -> list[Bead]:
         """List beads with optional filters."""
-        await self._ensure_nomic_store()
-        beads = await self._nomic_store.list_all()
+        store = await self._ensure_nomic_store()
+        beads = await store.list_all()
         results: list[Bead] = []
         for nomic_bead in beads:
             workspace_bead = self._from_nomic_bead(nomic_bead)
@@ -313,8 +317,8 @@ class BeadManager:
 
     async def get_ready_beads(self, convoy_id: str) -> list[Bead]:
         """Get beads that are ready to execute (dependencies met)."""
-        await self._ensure_nomic_store()
-        ready = await self._nomic_store.list_pending_runnable()
+        store = await self._ensure_nomic_store()
+        ready = await store.list_pending_runnable()
         results: list[Bead] = []
         for nomic_bead in ready:
             workspace_bead = self._from_nomic_bead(nomic_bead)


### PR DESCRIPTION
## Summary

- return the initialized canonical bead store from the existing ensure helper, so callers operate on a proven non-optional store
- mirror the established workspace host protocol in the CRUD mixin under `TYPE_CHECKING`, leaving the runtime MRO unchanged
- remove the 38-error workspace/CRUD slice from the pinned main-red mypy profile

Part of #9099. Claim: https://github.com/synaptent/aragora/issues/9099#issuecomment-4935312878

## Pinned Profile

- `origin/main`: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- before: 2,634 errors across 649 files
- after: 2,596 errors across 647 files
- slice: 38 -> 0
- added identities: 0
- removed non-target identities: 0
- before normalized SHA-256: `a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609`
- after normalized SHA-256: `4a8d0270c61454c5838c95d0e323ca1ff217aaabf83c8137c1d97973133563fa`
- removed identity SHA-256: `f19f766230a9981a29480883bb70aeac55f6722af30a149d64eb6e6efe1bd5e1`

<details>
<summary>Exact removed identity list (after list is empty)</summary>

```text
aragora/server/handlers/workspace/crud.py:100: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:110: error: "WorkspaceCrudMixin" has no attribute "_get_audit_log"  [attr-defined]
aragora/server/handlers/workspace/crud.py:111: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:147: error: "WorkspaceCrudMixin" has no attribute "_get_user_store"  [attr-defined]
aragora/server/handlers/workspace/crud.py:152: error: "WorkspaceCrudMixin" has no attribute "_check_rbac_permission"  [attr-defined]
aragora/server/handlers/workspace/crud.py:172: error: "WorkspaceCrudMixin" has no attribute "_get_isolation_manager"  [attr-defined]
aragora/server/handlers/workspace/crud.py:173: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:200: error: "WorkspaceCrudMixin" has no attribute "_get_user_store"  [attr-defined]
aragora/server/handlers/workspace/crud.py:205: error: "WorkspaceCrudMixin" has no attribute "_check_rbac_permission"  [attr-defined]
aragora/server/handlers/workspace/crud.py:209: error: "WorkspaceCrudMixin" has no attribute "_get_isolation_manager"  [attr-defined]
aragora/server/handlers/workspace/crud.py:211: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:238: error: "WorkspaceCrudMixin" has no attribute "_get_user_store"  [attr-defined]
aragora/server/handlers/workspace/crud.py:243: error: "WorkspaceCrudMixin" has no attribute "_check_rbac_permission"  [attr-defined]
aragora/server/handlers/workspace/crud.py:247: error: "WorkspaceCrudMixin" has no attribute "read_json_body"  [attr-defined]
aragora/server/handlers/workspace/crud.py:250: error: "WorkspaceCrudMixin" has no attribute "_get_isolation_manager"  [attr-defined]
aragora/server/handlers/workspace/crud.py:252: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:264: error: "WorkspaceCrudMixin" has no attribute "_get_audit_log"  [attr-defined]
aragora/server/handlers/workspace/crud.py:265: error: "WorkspaceCrudMixin" has no attribute "_run_async"  [attr-defined]
aragora/server/handlers/workspace/crud.py:64: error: "WorkspaceCrudMixin" has no attribute "_get_user_store"  [attr-defined]
aragora/server/handlers/workspace/crud.py:69: error: "WorkspaceCrudMixin" has no attribute "_check_rbac_permission"  [attr-defined]
aragora/server/handlers/workspace/crud.py:73: error: "WorkspaceCrudMixin" has no attribute "read_json_body"  [attr-defined]
aragora/server/handlers/workspace/crud.py:99: error: "WorkspaceCrudMixin" has no attribute "_get_isolation_manager"  [attr-defined]
aragora/workspace/bead.py:218: error: Item "None" of "BeadStore | None" has no attribute "create"  [union-attr]
aragora/workspace/bead.py:224: error: Item "None" of "BeadStore | None" has no attribute "get"  [union-attr]
aragora/workspace/bead.py:230: error: Item "None" of "BeadStore | None" has no attribute "claim"  [union-attr]
aragora/workspace/bead.py:233: error: Item "None" of "BeadStore | None" has no attribute "get"  [union-attr]
aragora/workspace/bead.py:237: error: Item "None" of "BeadStore | None" has no attribute "update"  [union-attr]
aragora/workspace/bead.py:243: error: Item "None" of "BeadStore | None" has no attribute "update_status"  [union-attr]
aragora/workspace/bead.py:244: error: Item "None" of "BeadStore | None" has no attribute "get"  [union-attr]
aragora/workspace/bead.py:253: error: Item "None" of "BeadStore | None" has no attribute "update"  [union-attr]
aragora/workspace/bead.py:263: error: Item "None" of "BeadStore | None" has no attribute "update_status"  [union-attr]
aragora/workspace/bead.py:264: error: Item "None" of "BeadStore | None" has no attribute "get"  [union-attr]
aragora/workspace/bead.py:274: error: Item "None" of "BeadStore | None" has no attribute "update"  [union-attr]
aragora/workspace/bead.py:280: error: Item "None" of "BeadStore | None" has no attribute "update_status"  [union-attr]
aragora/workspace/bead.py:281: error: Item "None" of "BeadStore | None" has no attribute "get"  [union-attr]
aragora/workspace/bead.py:290: error: Item "None" of "BeadStore | None" has no attribute "update"  [union-attr]
aragora/workspace/bead.py:301: error: Item "None" of "BeadStore | None" has no attribute "list_all"  [union-attr]
aragora/workspace/bead.py:317: error: Item "None" of "BeadStore | None" has no attribute "list_pending_runnable"  [union-attr]
```
</details>

## Validation

- targeted pinned mypy: clean
- exact changed-file pre-push mypy hook: pass
- focused workspace, bead, CRUD, and host-composition tests: 243 passed
- Ruff check and format check: pass
- code-quality ratchet: pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass

The change is source-only. Existing focused suites cover the initialized canonical-store lifecycle and CRUD mixin behavior.
