### PR TITLE
fix(types): main-red knowledge-chat slice (#9099)

### DIFF
--- a/aragora/server/handlers/knowledge_chat.py
+++ b/aragora/server/handlers/knowledge_chat.py
@@ -493,6 +493,8 @@ class KnowledgeChatHandler(BaseHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Invalid JSON body", 400)
 
         if path == "/api/v1/chat/knowledge/search":
             query = body.get("query")


### PR DESCRIPTION
## Summary

- fail closed if `read_json_body_validated()` ever violates its documented `(dict, None)` success contract
- prove the POST body is non-optional before dispatching knowledge search, injection, or storage
- remove the 19-error knowledge-chat slice from the pinned main-red mypy profile

Part of #9099. Claim: https://github.com/synaptent/aragora/issues/9099#issuecomment-4936097261

## Pinned Profile

- `origin/main`: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- before: 2,634 errors across 649 files
- after: 2,615 errors across 648 files
- slice: 19 -> 0
- added identities: 0
- removed non-target identities: 0
- before normalized SHA-256: `a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609`
- after normalized SHA-256: `66047d73ea2e2eec38373b8a0432dd6420f95f33b330190595652786205fec4f`
- removed identity SHA-256: `432afed8845f0dc472751f5677f822d96d380ebdb2745d62c406faa2365ad8a3`

<details>
<summary>Exact removed identities (after list is empty)</summary>

```text
aragora/server/handlers/knowledge_chat.py:498: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:502: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:509: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:513: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:520: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:523: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:526: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:529: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:532: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:549: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:555: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:564: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:567: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:579: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:585: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:588: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:591: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:594: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
aragora/server/handlers/knowledge_chat.py:597: error: Item "None" of "dict[str, Any] | None" has no attribute "get"  [union-attr]
```
</details>

## Validation

- targeted pinned mypy and exact changed-file pre-push mypy: clean
- focused knowledge-chat handler suites: 193 passed
- Ruff check and format check: pass
- code-quality ratchet: pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass

## Inherited Main Blocker

The strict SDK-parity command fails identically on this branch and clean `origin/main`: stale Python SDK debt is `53 > 51`, while missing-from-both remains `0`. The only output differences are checkout paths in deprecation warnings. This is the already-tracked #9086 date-boundary incident; draft repair #9112 still requires its exact one-file grant extension. This PR does not touch SDK or parity surfaces.
