### PR TITLE
fix(skills): drain 14 main-red mypy diagnostics

### DIFF
--- a/aragora/skills/builtin/evidence_fetch.py
+++ b/aragora/skills/builtin/evidence_fetch.py
@@ -394,9 +394,7 @@ class EvidenceFetchSkill(Skill):
             facts = store.query_facts(claim)[:5]
             for fact in facts:
                 validation_status = getattr(fact, "validation_status", None)
-                status_value = (
-                    validation_status.value if hasattr(validation_status, "value") else "unknown"
-                )
+                status_value = getattr(validation_status, "value", "unknown")
                 results.append(
                     {
                         "claim": getattr(fact, "statement", str(fact)),

--- a/aragora/skills/builtin/file_analysis.py
+++ b/aragora/skills/builtin/file_analysis.py
@@ -251,6 +251,11 @@ class FileAnalysisSkill(Skill):
                 file_name = path.name
                 size_bytes = path.stat().st_size
             else:
+                if not isinstance(content, str):
+                    return SkillResult.create_failure(
+                        "'content' must be a string",
+                        error_code="invalid_input",
+                    )
                 encoding = "utf-8"
                 size_bytes = len(content.encode("utf-8"))
 

--- a/aragora/skills/builtin/pr_reviewer.py
+++ b/aragora/skills/builtin/pr_reviewer.py
@@ -107,11 +107,22 @@ class PRReviewerSkill(Skill):
                     error_code="FETCH_FAILED",
                 )
 
+        if not isinstance(diff, str):
+            return SkillResult.create_failure(
+                error_message="Diff must be a string",
+                error_code="INVALID_INPUT",
+            )
+
         # Step 2: Run the review
         findings, error = await self._run_review(diff)
         if error:
             return SkillResult.create_failure(
                 error_message=f"Review failed: {error}",
+                error_code="REVIEW_FAILED",
+            )
+        if findings is None:
+            return SkillResult.create_failure(
+                error_message="Review returned no findings",
                 error_code="REVIEW_FAILED",
             )
 

--- a/aragora/skills/builtin/pr_reviewer.py
+++ b/aragora/skills/builtin/pr_reviewer.py
@@ -122,7 +122,7 @@ class PRReviewerSkill(Skill):
             )
         if findings is None:
             return SkillResult.create_failure(
-                error_message="Review returned no findings",
+                error_message="Review failed: no structured result returned by review engine",
                 error_code="REVIEW_FAILED",
             )
 
@@ -176,6 +176,8 @@ class PRReviewerSkill(Skill):
             from aragora.cli.review import run_review_on_diff  # type: ignore[attr-defined]
 
             findings = await run_review_on_diff(diff, demo=self._demo)
+            if findings is None:
+                return None, "review engine returned no structured result"
             return findings, None
         except ImportError:
             # Fallback: run as subprocess

--- a/aragora/skills/registry.py
+++ b/aragora/skills/registry.py
@@ -662,8 +662,20 @@ class SkillRegistry:
             if not _ensure_audit_imports():
                 return
 
+            audit_log_cls = _audit_log_cls
+            audit_event_cls = _audit_event_cls
+            audit_category_cls = _audit_category_cls
+            audit_outcome_cls = _audit_outcome_cls
+            if (
+                audit_log_cls is None
+                or audit_event_cls is None
+                or audit_category_cls is None
+                or audit_outcome_cls is None
+            ):
+                return
+
             outcome_str = _skill_status_to_audit_outcome(result.status)
-            outcome = _audit_outcome_cls(outcome_str)
+            outcome = audit_outcome_cls(outcome_str)
 
             details: dict[str, Any] = {
                 "skill_name": skill_name,
@@ -675,8 +687,8 @@ class SkillRegistry:
             if error_message or result.error_message:
                 details["error"] = error_message or result.error_message
 
-            event = _audit_event_cls(
-                category=_audit_category_cls.ACCESS,
+            event = audit_event_cls(
+                category=audit_category_cls.ACCESS,
                 action="skill_invoke",
                 actor_id=context.user_id or "anonymous",
                 resource_type="skill",
@@ -688,7 +700,7 @@ class SkillRegistry:
                 reason=error_message or "",
             )
 
-            audit_log = _audit_log_cls()
+            audit_log = audit_log_cls()
             audit_log.log(event)
         except (ImportError, AttributeError, RuntimeError, TypeError):
             logger.debug(

--- a/tests/skills/builtin/test_pr_reviewer.py
+++ b/tests/skills/builtin/test_pr_reviewer.py
@@ -1,0 +1,35 @@
+"""Focused tests for the built-in PR reviewer skill."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aragora.skills.base import SkillContext
+from aragora.skills.builtin.pr_reviewer import PRReviewerSkill
+
+
+@pytest.mark.asyncio
+async def test_empty_structured_findings_are_successful(monkeypatch: pytest.MonkeyPatch) -> None:
+    skill = PRReviewerSkill(post_comment=False)
+    monkeypatch.setattr(skill, "_run_review", AsyncMock(return_value=({}, None)))
+
+    result = await skill.execute({"diff": "diff --git a/a.py b/a.py"}, SkillContext())
+
+    assert result.success is True
+    assert result.data is not None
+    assert result.data["findings"] == {}
+
+
+@pytest.mark.asyncio
+async def test_missing_structured_result_is_protocol_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = PRReviewerSkill(post_comment=False)
+    monkeypatch.setattr(skill, "_run_review", AsyncMock(return_value=(None, None)))
+
+    result = await skill.execute({"diff": "diff --git a/a.py b/a.py"}, SkillContext())
+
+    assert result.success is False
+    assert result.error_code == "REVIEW_FAILED"
+    assert result.error_message is not None
+    assert "no structured result" in result.error_message


### PR DESCRIPTION
## Summary
- narrow file-analysis content before string operations
- bind optional audit classes locally before event emission
- reject missing/non-string review diffs and missing findings cleanly
- preserve unknown local fact validation statuses without optional attribute access

## Main-red evidence
- exact base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- exact head: `977aaf9cf66c9119f4a7e0aa5b5fffa28883a430`
- scoped `aragora/skills` diagnostics: 14 -> 0
- full diagnostic set: 14 removed, 0 added
- pinned after-output SHA-256: `576f897b9797fcae61fd96f8f9d0ae0c27ff7b19840bfe4aa76fb54fbcf8a512`
- main-red halt remains active; this PR is intentionally draft-only

## Validation
- `python3 -m pytest tests/skills -q` (718 passed)
- focused skill/audit tests (100 passed)
- scoped fresh-cache mypy (0 errors)
- exact full-repo mypy set comparison (14 removed, 0 added)
- `ruff check` and `ruff format --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- local commit and push hooks

Refs #9099