### PR TITLE
fix(types): fail closed in debate handlers (#9099)

### DIFF
--- a/aragora/server/handlers/debates/batch.py
+++ b/aragora/server/handlers/debates/batch.py
@@ -114,7 +114,7 @@ class BatchOperationsMixin:
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, BATCH_SUBMIT_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid batch request", 400)
 
         items_data = body.get("items", [])
         if not items_data:
@@ -366,7 +366,7 @@ class BatchOperationsMixin:
         """
         is_valid, err = validate_path_segment(batch_id, "batch id", SAFE_ID_PATTERN)
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid batch id", 400)
 
         from aragora.server.debate_queue import get_debate_queue_sync
 

--- a/aragora/server/handlers/debates/checkpoints.py
+++ b/aragora/server/handlers/debates/checkpoints.py
@@ -229,6 +229,8 @@ def register_checkpoint_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         manager = _get_manager(request)
         return await handle_checkpoint_pause(debate_id, context, checkpoint_manager=manager)
 
@@ -239,6 +241,8 @@ def register_checkpoint_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         manager = _get_manager(request)
         return await handle_checkpoint_resume(
             debate_id,
@@ -253,6 +257,8 @@ def register_checkpoint_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         manager = _get_manager(request)
         return await handle_list_checkpoints(
             debate_id, context, limit=limit, checkpoint_manager=manager

--- a/aragora/server/handlers/debates/crud.py
+++ b/aragora/server/handlers/debates/crud.py
@@ -138,6 +138,8 @@ class CrudOperationsMixin:
         Cached for 30 seconds. Cache key includes org_id for per-org isolation.
         """
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debates = storage.list_recent(limit=limit, org_id=org_id, offset=offset)
         # Convert DebateMetadata objects to dicts and normalize for SDK compatibility
         debates_list = [
@@ -291,6 +293,8 @@ class CrudOperationsMixin:
         """
         # First check persistent storage
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debate = storage.get_debate(slug)
         if debate:
             # Public playground debates are accessible without authentication
@@ -460,6 +464,8 @@ class CrudOperationsMixin:
             Paginated list of messages with metadata
         """
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         # Clamp limit
         limit = min(max(1, limit), 200)
         offset = max(0, offset)
@@ -581,10 +587,12 @@ class CrudOperationsMixin:
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, DEBATE_UPDATE_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid debate update", 400)
 
         # Get storage and find debate
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             debate = storage.get_debate(debate_id)
             if not debate:
@@ -593,6 +601,8 @@ class CrudOperationsMixin:
             # ABAC: Check if user has write access to this debate
             user = self.get_current_user(handler)
             if user:
+                if not user.user_id:
+                    return error_response("Authenticated user ID required", 401)
                 debate_owner_id = debate.get("user_id") or debate.get("owner_id")
                 debate_workspace_id = debate.get("workspace_id") or debate.get("org_id")
 
@@ -833,6 +843,8 @@ class CrudOperationsMixin:
             JSON confirmation with deleted debate ID.
         """
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             debate = storage.get_debate(debate_id)
             if not debate:
@@ -841,6 +853,8 @@ class CrudOperationsMixin:
             # ABAC: Check if user has delete access to this debate
             user = self.get_current_user(handler)
             if user:
+                if not user.user_id:
+                    return error_response("Authenticated user ID required", 401)
                 debate_owner_id = debate.get("user_id") or debate.get("owner_id")
                 debate_workspace_id = debate.get("workspace_id") or debate.get("org_id")
 

--- a/aragora/server/handlers/debates/decision_package.py
+++ b/aragora/server/handlers/debates/decision_package.py
@@ -739,6 +739,8 @@ class DecisionPackageHandler(BaseHandler):
         package, err = self._assemble_package(debate_id)
         if err:
             return err
+        if package is None:
+            return error_response("Decision package unavailable", 500)
         md = _build_markdown(package)
         return HandlerResult(
             status_code=200,

--- a/aragora/server/handlers/debates/evidence.py
+++ b/aragora/server/handlers/debates/evidence.py
@@ -102,6 +102,8 @@ class EvidenceOperationsMixin:
     def _get_impasse(self: _DebatesHandlerProtocol, handler: Any, debate_id: str) -> HandlerResult:
         """Detect impasse in a debate."""
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debate = storage.get_debate(debate_id)
         if not debate:
             return error_response(f"Debate not found: {debate_id}", 404)
@@ -163,6 +165,8 @@ class EvidenceOperationsMixin:
     ) -> HandlerResult:
         """Get convergence status for a debate."""
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debate = storage.get_debate(debate_id)
         if not debate:
             return error_response(f"Debate not found: {debate_id}", 404)
@@ -222,6 +226,8 @@ class EvidenceOperationsMixin:
         useful for analyzing claim quality and feedback loop effectiveness.
         """
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debate = storage.get_debate(debate_id)
         if not debate:
             return error_response(f"Debate not found: {debate_id}", 404)
@@ -295,6 +301,8 @@ class EvidenceOperationsMixin:
         from aragora.debate.summarizer import summarize_debate
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         debate = storage.get_debate(debate_id)
         if not debate:
             return error_response(f"Debate not found: {debate_id}", 404)
@@ -360,6 +368,8 @@ class EvidenceOperationsMixin:
         """
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             debate = storage.get_debate(debate_id)
             if not debate:
@@ -462,6 +472,8 @@ class EvidenceOperationsMixin:
         """
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
 
         try:
             debate = storage.get_debate(debate_id)

--- a/aragora/server/handlers/debates/export.py
+++ b/aragora/server/handlers/debates/export.py
@@ -541,6 +541,8 @@ class ExportOperationsMixin:
             return error_response(f"Invalid format: {format}. Valid: {valid_formats}", 400)
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             debate = storage.get_debate(debate_id)
             if not debate:

--- a/aragora/server/handlers/debates/fork.py
+++ b/aragora/server/handlers/debates/fork.py
@@ -115,13 +115,15 @@ class ForkOperationsMixin:
 
         validation = validate_against_schema(body, FORK_REQUEST_SCHEMA)
         if not validation.is_valid:
-            return error_response(validation.error, 400)
+            return error_response(validation.error or "Invalid fork request", 400)
 
         branch_point = body.get("branch_point", 0)
         modified_context = body.get("modified_context")
 
         # Get the original debate
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             debate = storage.get_debate(debate_id)
             if not debate:
@@ -320,6 +322,8 @@ class ForkOperationsMixin:
             List of follow-up suggestions with priority and suggested task
         """
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
 
         try:
             debate = storage.get_debate(debate_id)
@@ -458,6 +462,8 @@ class ForkOperationsMixin:
             return error_response("Either crux_id or task is required", 400)
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
 
         try:
             # Get parent debate

--- a/aragora/server/handlers/debates/graph_debates.py
+++ b/aragora/server/handlers/debates/graph_debates.py
@@ -248,9 +248,12 @@ class GraphDebatesHandler(SecureHandler):
             if isinstance(args[0], str):
                 path = args[0]
                 handler = args[2]
-                data, error = self.read_json_body_validated(handler)
+                parsed_data, error = self.read_json_body_validated(handler)
                 if error:
                     return error
+                if parsed_data is None:
+                    return error_response("Invalid request body", 400)
+                data = parsed_data
             else:
                 handler = args[0]
                 path = args[1]
@@ -262,9 +265,12 @@ class GraphDebatesHandler(SecureHandler):
             if handler is None:
                 return error_response("Invalid request", 400)
             if not data:
-                data, error = self.read_json_body_validated(handler)
+                parsed_data, error = self.read_json_body_validated(handler)
                 if error:
                     return error
+                if parsed_data is None:
+                    return error_response("Invalid request body", 400)
+                data = parsed_data
 
         normalized = strip_version_prefix(path)
         if normalized.startswith("/api/graph-debates"):

--- a/aragora/server/handlers/debates/handler.py
+++ b/aragora/server/handlers/debates/handler.py
@@ -231,7 +231,7 @@ class DebatesHandler(
                 # Validate debate ID for export
                 is_valid, err = validate_debate_id(debate_id)
                 if not is_valid:
-                    return error_response(err, 400)
+                    return error_response(err or "Invalid debate id", 400)
                 export_format = parts[5]  # Index 5 for unversioned paths
                 # Validate export format
                 if export_format not in self.ALLOWED_EXPORT_FORMATS:

--- a/aragora/server/handlers/debates/intervention.py
+++ b/aragora/server/handlers/debates/intervention.py
@@ -468,6 +468,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         return await handle_pause_debate(debate_id, context)
 
     async def resume_debate(request: Any) -> HandlerResult:
@@ -475,6 +477,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         return await handle_resume_debate(debate_id, context)
 
     async def inject_argument(request: Any) -> HandlerResult:
@@ -484,6 +488,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         return await handle_inject_argument(
             debate_id,
             context,
@@ -500,6 +506,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         try:
             weight = float(data.get("weight", 1.0))
         except (ValueError, TypeError):
@@ -519,6 +527,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         try:
             threshold = float(data.get("threshold", 0.75))
         except (ValueError, TypeError):
@@ -535,6 +545,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         return await handle_get_intervention_state(debate_id, context)
 
     async def get_log(request: Any) -> HandlerResult:
@@ -543,6 +555,8 @@ def register_intervention_routes(router: Any) -> None:
         context, err = await _require_context(request)
         if err:
             return err
+        if context is None:
+            return error_response("Authentication required", 401)
         return await handle_get_intervention_log(debate_id, context, limit)
 
     # Register legacy and versioned API routes for compatibility.

--- a/aragora/server/handlers/debates/interventions.py
+++ b/aragora/server/handlers/debates/interventions.py
@@ -174,6 +174,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         manager = self._get_or_create_manager(debate_id, handler)
         if manager is None:
@@ -213,6 +215,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         manager = self._get_or_create_manager(debate_id, handler)
         if manager is None:
@@ -252,6 +256,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         body = self.read_json_body(handler)
         if body is None:
@@ -303,6 +309,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         body = self.read_json_body(handler)
         if body is None:
@@ -352,6 +360,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         body = self.read_json_body(handler)
         if body is None:
@@ -402,6 +412,8 @@ class DebateInterventionsHandler(BaseHandler):
         debate_id, err = _extract_debate_id_from_path(path)
         if err:
             return error_response(err, 400)
+        if debate_id is None:
+            return error_response("Invalid debate id", 400)
 
         from aragora.debate.intervention import get_intervention_manager
 

--- a/aragora/server/handlers/debates/matrix_debates.py
+++ b/aragora/server/handlers/debates/matrix_debates.py
@@ -205,9 +205,12 @@ class MatrixDebatesHandler(SecureHandler):
             if isinstance(args[0], str):
                 path = args[0]
                 handler = args[2]
-                data, error = self.read_json_body_validated(handler)
+                parsed_data, error = self.read_json_body_validated(handler)
                 if error:
                     return error
+                if parsed_data is None:
+                    return error_response("Invalid request body", 400)
+                data = parsed_data
             else:
                 handler = args[0]
                 path = args[1]
@@ -219,9 +222,12 @@ class MatrixDebatesHandler(SecureHandler):
             if handler is None:
                 return error_response("Invalid request", 400)
             if not data:
-                data, error = self.read_json_body_validated(handler)
+                parsed_data, error = self.read_json_body_validated(handler)
                 if error:
                     return error
+                if parsed_data is None:
+                    return error_response("Invalid request body", 400)
+                data = parsed_data
 
         normalized = strip_version_prefix(path)
         if normalized.startswith("/api/matrix-debates"):

--- a/aragora/server/handlers/debates/search.py
+++ b/aragora/server/handlers/debates/search.py
@@ -133,6 +133,8 @@ class SearchOperationsMixin:
                 return error_response(validation_result.error or "Invalid search query", 400)
 
         storage = self.get_storage()
+        if storage is None:
+            return error_response("Storage not available", 503)
         try:
             # Use efficient SQL search if query provided
             if query:


### PR DESCRIPTION
## Summary

- repairs the complete claimed 13-file `aragora/server/handlers/debates/` pinned-mypy partition
- mirrors the existing `@require_storage` contract with explicit fail-closed storage narrowing inside decorated methods
- rejects impossible nullable authentication, debate-ID, request-body, validation-message, and decision-package states instead of allowing downstream `None` failures

All successful-path behavior and public handler signatures remain unchanged.

## Pinned identity evidence

Base: `3fe2e5cf561fc094221008d064040ac84625bd4e`

Profile: Python 3.12.12, mypy 2.2.0, mypy-baseline 0.7.4, PyJWT 2.13.0, and the #9101 pinned stub versions, using independent isolated caches.

- full `aragora/`: **2,634 -> 2,587** errors
- claimed debate-handler partition: **47 -> 0**
- removed normalized identities: **47**, all under the 13 claimed files
- added normalized identities anywhere: **0**
- error-code mix removed: 24 `arg-type`, 19 `union-attr`, 4 `assignment`
- before raw SHA-256: `5fbf2dda3a8b1824a6af43c6e30e0698655aae49fcad740bc8b073e293fb158c`
- before normalized SHA-256: `c527deb2818b4de416567a24bff7ff5716cb940587e4fac1e70b7ab6b00b0034`
- after raw SHA-256: `ec1ee3e5098363209ce76a1d3113365d7aa1b23a221b08bc9547f4c4277a399e`
- after normalized SHA-256: `da11ff8d4265a41ffa33bbd3efb3efe380271a02634be0dbdf8a425c9884627a`
- removed-set SHA-256: `dbef37627648af97ef716041db715c7df8dbef914a0e237ac8200ef4ab7b9e97`

Normalization removes only line numbers from mypy error records and retains path, message, and error code before `LC_ALL=C` sorting.

## Validation

- targeted mypy over all 13 claimed sources: `Success: no issues found in 13 source files`
- independent fresh-cache full mypy runs: `2,634 -> 2,587`, 47 claimed removals, 0 additions
- focused handler suites: **1,911 passed**
- Ruff check and format on all touched files: passed
- `git diff --check`: passed
- commit hooks: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed
- push hooks, including changed-file mypy and RBAC coverage: passed

The first broad handler-suite run exposed only a missing `starlette` package in the disposable test environment; installing the repository-declared version there produced the clean 1,911-test run. No repository dependency or test file changed.

## Scope fences

Source-only incident unit. This draft does not modify tests, dependencies, `.mypy-baseline`, workflows, route baselines/specs, generated SDKs, branch protection, `.aragora/merge_executor.halt`, evidence, settlement, readiness, or merge state. CI was not manually rerun.

Contributes one isolated partition to #9099; closes no issue.
