### PR TITLE
fix(observability): drain 14 main-red mypy diagnostics

### DIFF
--- a/aragora/observability/handler_instrumentation.py
+++ b/aragora/observability/handler_instrumentation.py
@@ -150,7 +150,7 @@ def track_request(
         )
 
     try:
-        if hasattr(span, "__enter__"):
+        if span is not None and hasattr(span, "__enter__"):
             span.__enter__()
         yield context
     except Exception as e:  # noqa: BLE001 - instrumentation must catch all to record metrics before re-raising
@@ -230,7 +230,7 @@ def instrument_handler(
                 span = _safe_start_span(name, attrs)
 
             try:
-                if hasattr(span, "__enter__"):
+                if span is not None and hasattr(span, "__enter__"):
                     span.__enter__()
                 result = func(*args, **kwargs)
 
@@ -344,7 +344,7 @@ class MetricsMiddleware:
             )
 
         try:
-            if hasattr(span, "__enter__"):
+            if span is not None and hasattr(span, "__enter__"):
                 span.__enter__()
             result = func(*args, **kwargs)
 

--- a/aragora/observability/memory_profiler.py
+++ b/aragora/observability/memory_profiler.py
@@ -31,7 +31,7 @@ import gc
 import logging
 import time
 import tracemalloc
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import wraps
@@ -522,23 +522,23 @@ class KMMemoryProfiler:
     def __init__(self):
         self.profiles: list[MemoryProfileResult] = []
 
-    def profile_store(self, operation: str = "km_store") -> Generator[MemoryProfiler, None, None]:
+    def profile_store(self, operation: str = "km_store") -> AbstractContextManager[MemoryProfiler]:
         """Profile a KM store operation."""
         return profile_memory(operation, MemoryCategory.KM_STORE)
 
-    def profile_query(self, operation: str = "km_query") -> Generator[MemoryProfiler, None, None]:
+    def profile_query(self, operation: str = "km_query") -> AbstractContextManager[MemoryProfiler]:
         """Profile a KM query operation."""
         return profile_memory(operation, MemoryCategory.KM_QUERY)
 
     def profile_retrieval(
         self, operation: str = "km_retrieval"
-    ) -> Generator[MemoryProfiler, None, None]:
+    ) -> AbstractContextManager[MemoryProfiler]:
         """Profile a KM retrieval operation."""
         return profile_memory(operation, MemoryCategory.KM_RETRIEVAL)
 
     def profile_embedding(
         self, operation: str = "km_embedding"
-    ) -> Generator[MemoryProfiler, None, None]:
+    ) -> AbstractContextManager[MemoryProfiler]:
         """Profile embedding generation."""
         return profile_memory(operation, MemoryCategory.KM_EMBEDDING)
 
@@ -592,19 +592,19 @@ class ConsensusMemoryProfiler:
 
     def profile_store(
         self, operation: str = "consensus_store"
-    ) -> Generator[MemoryProfiler, None, None]:
+    ) -> AbstractContextManager[MemoryProfiler]:
         """Profile a consensus store operation."""
         return profile_memory(operation, MemoryCategory.CONSENSUS_STORE)
 
     def profile_query(
         self, operation: str = "consensus_query"
-    ) -> Generator[MemoryProfiler, None, None]:
+    ) -> AbstractContextManager[MemoryProfiler]:
         """Profile a consensus query operation."""
         return profile_memory(operation, MemoryCategory.CONSENSUS_QUERY)
 
     def profile_dissent(
         self, operation: str = "consensus_dissent"
-    ) -> Generator[MemoryProfiler, None, None]:
+    ) -> AbstractContextManager[MemoryProfiler]:
         """Profile dissent retrieval."""
         return profile_memory(operation, MemoryCategory.CONSENSUS_DISSENT)
 

--- a/aragora/observability/security_audit.py
+++ b/aragora/observability/security_audit.py
@@ -697,7 +697,7 @@ async def audit_security_incident(
     description: str,
     actor: str | None = None,
     ip_address: str | None = None,
-    affected_resources: list[dict[str, str] | None] = None,
+    affected_resources: list[dict[str, str] | None] | None = None,
     **details: Any,
 ) -> AuditEntry:
     """

--- a/aragora/observability/tracing.py
+++ b/aragora/observability/tracing.py
@@ -744,11 +744,15 @@ def trace_decision(func: F) -> F:
         # Extract attributes from request
         request_id = getattr(request, "request_id", "unknown")
         decision_type = getattr(request, "decision_type", None)
-        decision_type_str = getattr(decision_type, "value", str(decision_type))
+        decision_type_str = (
+            getattr(decision_type, "value")
+            if hasattr(decision_type, "value")
+            else str(decision_type)
+        )
         source = getattr(request, "source", None)
-        source_str = getattr(source, "value", str(source))
+        source_str = getattr(source, "value") if hasattr(source, "value") else str(source)
         priority = getattr(request, "priority", None)
-        priority_str = getattr(priority, "value", str(priority))
+        priority_str = getattr(priority, "value") if hasattr(priority, "value") else str(priority)
 
         with tracer.start_as_current_span("decision.route") as span:
             span.set_attribute("decision.request_id", request_id)

--- a/aragora/observability/tracing.py
+++ b/aragora/observability/tracing.py
@@ -744,13 +744,11 @@ def trace_decision(func: F) -> F:
         # Extract attributes from request
         request_id = getattr(request, "request_id", "unknown")
         decision_type = getattr(request, "decision_type", None)
-        decision_type_str = (
-            decision_type.value if hasattr(decision_type, "value") else str(decision_type)
-        )
+        decision_type_str = getattr(decision_type, "value", str(decision_type))
         source = getattr(request, "source", None)
-        source_str = source.value if hasattr(source, "value") else str(source)
+        source_str = getattr(source, "value", str(source))
         priority = getattr(request, "priority", None)
-        priority_str = priority.value if hasattr(priority, "value") else str(priority)
+        priority_str = getattr(priority, "value", str(priority))
 
         with tracer.start_as_current_span("decision.route") as span:
             span.set_attribute("decision.request_id", request_id)

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -189,6 +189,33 @@ class TestDebateTracing:
 class TestDecisionTracing:
     """Tests for decision routing tracing."""
 
+    def test_trace_decision_does_not_eagerly_stringify_enum_like_values(self):
+        """Values with a ``value`` attribute must not evaluate ``__str__``."""
+        import asyncio
+
+        from aragora.observability.tracing import trace_decision
+
+        class EnumLike:
+            def __init__(self, value: str) -> None:
+                self.value = value
+
+            def __str__(self) -> str:
+                raise AssertionError("enum-like values must use .value")
+
+        class Request:
+            request_id = "req-lazy-value"
+            decision_type = EnumLike("debate")
+            source = EnumLike("api")
+            priority = EnumLike("high")
+            content = "test"
+
+        @trace_decision
+        async def route(_self, request):
+            return request
+
+        request = Request()
+        assert asyncio.run(route(object(), request)) is request
+
     def test_trace_decision_routing(self):
         """Test trace_decision_routing context manager."""
         from aragora.observability.tracing import trace_decision_routing


### PR DESCRIPTION
## Summary
- type specialized memory-profiler helpers as context managers
- preserve enum-like decision attributes through explicit fallback lookup
- make the security-incident resource list explicitly optional
- narrow optional tracing spans before entering their context managers

## Main-red evidence
- exact base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- exact head: `250a9f853d8b9e594780fd84f32d803810997125`
- scoped `aragora/observability` diagnostics: 14 -> 0
- full diagnostic set: 14 errors and 2 attached notes removed, 0 lines added
- pinned after-output SHA-256: `4234c3da3deefee0ec956a5a25e9e43e8cd2b2da6b29fc1abdfff771ed6d76b4`
- main-red halt remains active; this PR is intentionally draft-only

## Validation
- `python3 -m pytest tests/observability -q` (1,646 passed)
- focused four-module plus edge tests (217 passed)
- scoped fresh-cache mypy: 0 errors
- exact full-repo mypy set comparison: 14 errors and 2 notes removed, 0 added
- Ruff check/format, automation preflight, commit hooks, and push hooks passed

Refs #9099