### PR TITLE
fix(integrations): drain 14 main-red mypy diagnostics

### DIFF
--- a/aragora/integrations/email_rate_limiter.py
+++ b/aragora/integrations/email_rate_limiter.py
@@ -310,6 +310,8 @@ class EmailRateLimiter:
     ) -> RateLimitResult:
         """Acquire using Redis for distributed coordination."""
         redis = self._redis
+        if redis is None:
+            return await self._acquire_local(tenant_id, provider, limits, count)
         now = time.time()
         # now_dt could be used for logging in the future
 

--- a/aragora/integrations/email_reply_loop.py
+++ b/aragora/integrations/email_reply_loop.py
@@ -58,6 +58,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_EMAIL_REDIS_ERRORS: tuple[type[Exception], ...] = (
+    *REDIS_CONNECTION_ERRORS,
+    RuntimeError,
+    ValueError,
+)
+
 # Configuration from environment
 EMAIL_INBOUND_SECRET = os.environ.get("EMAIL_INBOUND_SECRET", "")
 SENDGRID_INBOUND_SECRET = os.environ.get("SENDGRID_INBOUND_SECRET", EMAIL_INBOUND_SECRET)
@@ -558,7 +564,7 @@ def register_email_origin(
                 "Redis library not installed (pip install redis)",
             )
         logger.debug("Redis not available, using SQLite/PostgreSQL only")
-    except (*REDIS_CONNECTION_ERRORS, RuntimeError, ValueError) as e:
+    except _EMAIL_REDIS_ERRORS as e:
         if is_distributed_state_required():
             raise DistributedStateError(
                 "email_reply_loop",
@@ -589,7 +595,7 @@ async def get_origin_by_reply(in_reply_to: str) -> EmailReplyOrigin | None:
             if origin:
                 _reply_origins[in_reply_to] = origin  # Cache locally
                 return origin
-        except (*REDIS_CONNECTION_ERRORS, RuntimeError, ValueError) as e:
+        except _EMAIL_REDIS_ERRORS as e:
             logger.debug("Redis email origin lookup not available: %s: %s", type(e).__name__, e)
 
         # Try PostgreSQL if configured

--- a/aragora/integrations/exporters/exporter.py
+++ b/aragora/integrations/exporters/exporter.py
@@ -279,8 +279,7 @@ class DecisionExporter:
         level_order = {"critical": 4, "high": 3, "medium": 2, "low": 1}
         for risk in risks:
             level_str = getattr(risk, "level", None)
-            if hasattr(level_str, "value"):
-                level_str = level_str.value
+            level_str = getattr(level_str, "value", level_str)
             # Associate with all tasks if risk metadata contains task_id
             related_task = getattr(risk, "task_id", None) or (
                 getattr(risk, "metadata", {}) or {}

--- a/aragora/integrations/langchain/tools.py
+++ b/aragora/integrations/langchain/tools.py
@@ -57,6 +57,12 @@ def _FieldStub(*args: Any, **kwargs: Any) -> Any:
     return kwargs.get("default", None)
 
 
+# Public compatibility aliases can resolve to either the optional dependency
+# types or the local stubs at runtime.
+BaseTool: type[Any]
+BaseModel: type[Any]
+
+
 # LangChain imports with fallback
 try:
     try:
@@ -90,7 +96,7 @@ except ImportError:
     _LCBaseTool = _BaseToolStub  # type: ignore[misc,assignment]
     BaseTool = _LCBaseTool
     _PydanticBaseModel = _BaseModelStub  # type: ignore[misc,assignment]
-    BaseModel = _PydanticBaseModel  # type: ignore[misc]
+    BaseModel = _PydanticBaseModel
     Field = _FieldStub
     AsyncCallbackManagerForToolRun = None  # type: ignore[misc,assignment]
     CallbackManagerForToolRun = None  # type: ignore[misc,assignment]

--- a/aragora/integrations/langchain/tools.py
+++ b/aragora/integrations/langchain/tools.py
@@ -89,7 +89,8 @@ except ImportError:
     # of the real library types.
     _LCBaseTool = _BaseToolStub  # type: ignore[misc,assignment]
     BaseTool = _LCBaseTool
-    BaseModel = _BaseModelStub  # type: ignore[misc,assignment]
+    _PydanticBaseModel = _BaseModelStub  # type: ignore[misc,assignment]
+    BaseModel = _PydanticBaseModel  # type: ignore[misc]
     Field = _FieldStub
     AsyncCallbackManagerForToolRun = None  # type: ignore[misc,assignment]
     CallbackManagerForToolRun = None  # type: ignore[misc,assignment]
@@ -105,7 +106,7 @@ def get_langchain_version() -> str | None:
         return None
 
 
-class AragoraToolInput(BaseModel):
+class AragoraToolInput(_PydanticBaseModel):
     """Input schema for Aragora debate tool (compatible API)."""
 
     question: str = Field(description="The question or task to debate")
@@ -127,7 +128,7 @@ class AragoraToolInput(BaseModel):
     )
 
 
-class AragoraDebateInput(BaseModel):
+class AragoraDebateInput(_PydanticBaseModel):
     """Input schema for Aragora debate tool."""
 
     task: str = Field(description="The question or task to debate")
@@ -160,7 +161,7 @@ class AragoraDebateTool(_LCBaseTool):
         "Use this when you need multiple perspectives on a complex question. "
         "The debate reaches consensus through structured argumentation."
     )
-    args_schema: type[BaseModel] = AragoraDebateInput
+    args_schema: type[_PydanticBaseModel] = AragoraDebateInput
 
     # Configuration
     aragora_url: str = "http://localhost:8080"
@@ -250,7 +251,7 @@ class AragoraDebateTool(_LCBaseTool):
             return f"Error running debate: {e}"
 
 
-class AragoraKnowledgeInput(BaseModel):
+class AragoraKnowledgeInput(_PydanticBaseModel):
     """Input schema for Aragora knowledge tool."""
 
     query: str = Field(description="Search query for the knowledge base")
@@ -278,7 +279,7 @@ class AragoraKnowledgeTool(_LCBaseTool):
         "Use this to find documents, past decisions, and institutional knowledge. "
         "Returns the most relevant results with confidence scores."
     )
-    args_schema: type[BaseModel] = AragoraKnowledgeInput
+    args_schema: type[_PydanticBaseModel] = AragoraKnowledgeInput
 
     # Configuration
     aragora_url: str = "http://localhost:8080"
@@ -351,7 +352,7 @@ class AragoraKnowledgeTool(_LCBaseTool):
             return f"Error querying knowledge: {e}"
 
 
-class AragoraDecisionInput(BaseModel):
+class AragoraDecisionInput(_PydanticBaseModel):
     """Input schema for Aragora decision tool."""
 
     question: str = Field(description="The decision question")
@@ -379,7 +380,7 @@ class AragoraDecisionTool(_LCBaseTool):
         "Use this for important decisions that need audit trails. "
         "Returns a decision with rationale and confidence."
     )
-    args_schema: type[BaseModel] = AragoraDecisionInput
+    args_schema: type[_PydanticBaseModel] = AragoraDecisionInput
 
     # Configuration
     aragora_url: str = "http://localhost:8080"

--- a/aragora/integrations/langchain/tools.py
+++ b/aragora/integrations/langchain/tools.py
@@ -87,7 +87,8 @@ except ImportError:
     # Stubs replace LangChain/pydantic types when the optional dependency is not
     # installed. The type mismatches are unavoidable since stubs are not subclasses
     # of the real library types.
-    BaseTool = _BaseToolStub  # type: ignore[misc,assignment]
+    _LCBaseTool = _BaseToolStub  # type: ignore[misc,assignment]
+    BaseTool = _LCBaseTool
     BaseModel = _BaseModelStub  # type: ignore[misc,assignment]
     Field = _FieldStub
     AsyncCallbackManagerForToolRun = None  # type: ignore[misc,assignment]
@@ -140,7 +141,7 @@ class AragoraDebateInput(BaseModel):
     )
 
 
-class AragoraDebateTool(BaseTool):
+class AragoraDebateTool(_LCBaseTool):
     """
     LangChain Tool for running Aragora debates.
 
@@ -259,7 +260,7 @@ class AragoraKnowledgeInput(BaseModel):
     )
 
 
-class AragoraKnowledgeTool(BaseTool):
+class AragoraKnowledgeTool(_LCBaseTool):
     """
     LangChain Tool for querying Aragora Knowledge Mound.
 
@@ -360,7 +361,7 @@ class AragoraDecisionInput(BaseModel):
     )
 
 
-class AragoraDecisionTool(BaseTool):
+class AragoraDecisionTool(_LCBaseTool):
     """
     LangChain Tool for making decisions with Aragora.
 
@@ -457,7 +458,7 @@ class AragoraDecisionTool(BaseTool):
 def get_aragora_tools(
     aragora_url: str = "http://localhost:8080",
     api_token: str | None = None,
-) -> list[BaseTool]:
+) -> list[_LCBaseTool]:
     """
     Get all Aragora LangChain tools.
 

--- a/aragora/integrations/platform_resilience.py
+++ b/aragora/integrations/platform_resilience.py
@@ -678,9 +678,15 @@ def with_platform_resilience(
             # Check circuit breaker
             if not circuit.can_proceed():
                 health = circuit.get_health()
+                underlying_circuit = circuit._circuit
+                cooldown_remaining = (
+                    underlying_circuit.cooldown_remaining()
+                    if underlying_circuit is not None
+                    else 0.0
+                )
                 logger.warning(
                     f"Platform {platform} circuit open, skipping {func.__name__}. "
-                    f"Retry in {circuit._circuit.cooldown_remaining():.1f}s"
+                    f"Retry in {cooldown_remaining:.1f}s"
                 )
                 # Optionally queue to DLQ
                 if use_dlq and args:

--- a/aragora/integrations/receipt_webhooks.py
+++ b/aragora/integrations/receipt_webhooks.py
@@ -101,7 +101,7 @@ class ReceiptWebhookNotifier:
         """Get the webhook dispatcher (lazy initialization)."""
         if self._dispatcher is None:
             self._dispatcher = get_webhook_dispatcher()
-        return self._dispatcher
+        return cast(WebhookDispatcher, self._dispatcher)
 
     def _emit(self, payload: ReceiptWebhookPayload) -> None:
         """Emit a webhook event via the dispatcher."""

--- a/aragora/integrations/teams_debate.py
+++ b/aragora/integrations/teams_debate.py
@@ -44,7 +44,7 @@ import uuid
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 from aragora.utils.public_urls import public_receipt_url
 
@@ -1077,7 +1077,7 @@ class TeamsDebateLifecycle:
             }
 
         debate_id = result_dict.get("debate_id", "")
-        topic = result_dict.get("topic", result_dict.get("task", ""))
+        topic = cast(str, result_dict.get("topic", result_dict.get("task", "")))
 
         card = _build_consensus_card(
             topic=topic,


### PR DESCRIPTION
## Summary
- narrow exporter, Redis, Teams, platform-circuit, and receipt-dispatcher optional boundaries
- replace starred Redis exception clauses with one typed exception tuple
- use the same imported-or-stub LangChain/Pydantic classes as stable static bases
- preserve runtime fallback and optional-dependency behavior

## Main-red evidence
- exact base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- exact head: `7a7bcf6a8d49865285309e2be72a148ad6b6c5ad`
- scoped `aragora/integrations` diagnostics: 14 -> 0
- full diagnostic set: 14 errors and 4 attached notes removed, 0 lines added
- pinned after-output SHA-256: `c1964c2bd50b5ba6bd24046b1a09294663d7e07d663fa20e035d7cf793594389`
- main-red halt remains active; this PR is intentionally draft-only

## Validation
- direct changed-surface integrations: 359 passed
- LangChain compatibility after strict-hook extension: 40 passed
- full `tests/integrations`: 8 failed, 1,458 passed
- the exact same eight untouched Discord/email-root tests reproduce on exact main; none exercises a changed file
- scoped fresh-cache mypy: 0 errors
- exact full-repo mypy set comparison: 14 errors and 4 notes removed, 0 added
- actual changed-file pre-push mypy hook passed
- Ruff check/format, automation preflight, commit hooks, and final push hooks passed

Refs #9099

## Current-main RESTACK proof

Restacked by normal merge, without rewriting published history, onto current origin/main `c155951acb529e6a48c9a7c43eed499f5693ace0`. Exact candidate head: `1d5d1ae50f801089c0d2e4e9c0a319597b21c6d2`.

Pinned Python 3.12.12 / mypy 2.2.0 / mypy-baseline 0.7.4 / PyJWT 2.13.0 comparison with independent fresh caches:

- current main: 2,601 errors / 317 notes; raw SHA-256 `16ef5a2834db6200e884c69af083d5b25142ba6a7cce1617cb046d734a8f245a`; sorted error identity SHA-256 `a7f6bd613c58ff1b998cba2b2955747b2445c7730022a3787f728856b2a61546`
- candidate: 2,587 errors / 313 notes; two full runs byte-identical; raw SHA-256 `c8a234f2464125a10c822a6531d7e849a76ea1485904b873a6f6eb4c6c23e7b4`; sorted error identity SHA-256 `c08f72305fde87d292737383189483b25d35fef9d03711003ecc5e87c2743305`
- removed: exactly 14 errors plus four attached notes, all in the seven claimed source files; removed error-set SHA-256 `59c5ebbfb225f84430b2b412014035af30483b16ff1ac7d36e5dad26a131c98f`
- added: 0 errors and 0 notes; empty-set SHA-256 `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
- targeted pinned mypy: clean
- complete optional-dependency environment: 367 direct changed-surface tests and 40 LangChain compatibility tests passed
- sparse environment failures matched exact current main: one missing-Redis failure and thirteen missing-LangChain failures
- repo-pinned Ruff 0.14.14 check/format, git diff check, automation preflight, and all push hooks: passed

The PR remains draft under the active WIP freeze and main-red halt. No source change beyond the existing slice, new claim/branch/PR, test edit, dependency, baseline, workflow, branch-protection, halt, evidence, settlement, readiness, or PR merge mutation was performed.