### PR TITLE
fix(types): narrow feature handler inputs (#9099)

### DIFF
--- a/aragora/server/handlers/features/audio.py
+++ b/aragora/server/handlers/features/audio.py
@@ -199,7 +199,7 @@ class AudioHandler(BaseHandler):
         # Validate debate ID to prevent path traversal
         valid, error = validate_debate_id(debate_id)
         if not valid:
-            return error_response(error, status=400)
+            return error_response(error or "Invalid debate ID", status=400)
 
         # Get audio file path
         audio_path = audio_store.get_path(debate_id)

--- a/aragora/server/handlers/features/audit_sessions.py
+++ b/aragora/server/handlers/features/audit_sessions.py
@@ -681,8 +681,8 @@ class AuditSessionsHandler(SecureHandler):
                         document_id=f.get("document_id", ""),
                         chunk_id=f.get("chunk_id"),
                         evidence_text=f.get("evidence_text", ""),
-                        evidence_location=f.get("evidence_location"),
-                        recommendation=f.get("recommendation"),
+                        evidence_location=f.get("evidence_location") or "",
+                        recommendation=f.get("recommendation") or "",
                         status=FindingStatus(f.get("status", "open")),
                     )
                     finding_objects.append(finding_obj)

--- a/aragora/server/handlers/features/broadcast.py
+++ b/aragora/server/handlers/features/broadcast.py
@@ -10,8 +10,9 @@ Endpoints:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any, TypeVar
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 
 T = TypeVar("T")
 
@@ -35,21 +36,30 @@ from aragora.rbac.decorators import require_permission
 logger = logging.getLogger(__name__)
 
 # Optional imports for broadcast functionality
+broadcast_debate: Callable[..., Coroutine[Any, Any, Path | None]] | None
 try:
-    from aragora.broadcast import broadcast_debate
+    from aragora.broadcast import broadcast_debate as _broadcast_debate
 
+    broadcast_debate = _broadcast_debate
     BROADCAST_AVAILABLE = True
 except ImportError:
     BROADCAST_AVAILABLE = False
     broadcast_debate = None
 
-BroadcastPipeline: Any = None
-BroadcastOptions: Any = None
+BroadcastPipeline: Any
+BroadcastOptions: Any
 try:
-    from aragora.broadcast.pipeline import BroadcastOptions, BroadcastPipeline
+    from aragora.broadcast.pipeline import (
+        BroadcastOptions as _BroadcastOptions,
+        BroadcastPipeline as _BroadcastPipeline,
+    )
 
+    BroadcastPipeline = _BroadcastPipeline
+    BroadcastOptions = _BroadcastOptions
     PIPELINE_AVAILABLE = True
 except ImportError:
+    BroadcastPipeline = None
+    BroadcastOptions = None
     PIPELINE_AVAILABLE = False
 
 try:
@@ -189,7 +199,7 @@ class BroadcastHandler(BaseHandler):
 
         Rate limited to 3 requests/min due to high CPU usage for TTS.
         """
-        if not BROADCAST_AVAILABLE:
+        if not BROADCAST_AVAILABLE or broadcast_debate is None:
             return error_response("Broadcast module not available", status=503)
 
         storage = self.get_storage()

--- a/aragora/server/handlers/features/cloud_storage.py
+++ b/aragora/server/handlers/features/cloud_storage.py
@@ -80,7 +80,7 @@ MAX_REDIRECT_URI_LENGTH = 2048
 _PATH_TRAVERSAL_SEQUENCES = ("..", "~", "\x00")
 
 # In-memory token storage (use Redis/DB in production)
-_tokens: dict[str, dict[str, str]] = {}
+_tokens: dict[str, dict[str, str | None]] = {}
 
 
 def _validate_path(path: str) -> str | None:

--- a/aragora/server/handlers/features/connectors.py
+++ b/aragora/server/handlers/features/connectors.py
@@ -367,6 +367,7 @@ class ConnectorsHandler(SecureHandler):
     async def _get_connector(self, request: Any, connector_id: str) -> dict[str, Any]:
         """Get details for a specific connector."""
         store = await _get_store()
+        connector: dict[str, Any]
 
         if store:
             config = await store.get_connector(connector_id)
@@ -401,9 +402,10 @@ class ConnectorsHandler(SecureHandler):
                 for j in history
             ]
         else:
-            connector = _connectors.get(connector_id)
-            if not connector:
+            cached_connector = _connectors.get(connector_id)
+            if not cached_connector:
                 return self._error_response(404, f"Connector {connector_id} not found")
+            connector = cached_connector
 
             # Add recent sync history
             connector["recent_syncs"] = [
@@ -852,11 +854,15 @@ class ConnectorsHandler(SecureHandler):
                 from datetime import timedelta
 
                 one_day_ago = datetime.now(timezone.utc) - timedelta(days=1)
-                syncs_24h = sum(1 for h in history if h.started_at and h.started_at >= one_day_ago)
+                syncs_24h = sum(
+                    1 for h in history if h.started_at is not None and h.started_at >= one_day_ago
+                )
                 failures_24h = sum(
                     1
                     for h in history
-                    if h.started_at and h.started_at >= one_day_ago and h.status == "failed"
+                    if h.started_at is not None
+                    and h.started_at >= one_day_ago
+                    and h.status == "failed"
                 )
 
                 connectors_health.append(

--- a/aragora/server/handlers/features/control_plane.py
+++ b/aragora/server/handlers/features/control_plane.py
@@ -437,7 +437,7 @@ class AgentDashboardHandler(SecureHandler):
                     task_index = i
                     break
 
-            if not task:
+            if task is None or task_index is None:
                 return self._error_response(404, f"Task {task_id} not found")
 
             # Update priority

--- a/aragora/server/handlers/features/devops/__init__.py
+++ b/aragora/server/handlers/features/devops/__init__.py
@@ -355,8 +355,12 @@ class DevOpsHandler(BaseHandler):
         )
         if err:
             return error_response(err, 400)
+        if title is None:
+            return error_response("title is required", 400)
 
         service_id = body.get("service_id")
+        if not isinstance(service_id, str):
+            return error_response("service_id must be a string", 400)
         ok, err = _validate_pagerduty_id(service_id, "service_id")
         if not ok:
             return error_response(err or "Invalid service_id", 400)

--- a/aragora/server/handlers/features/devops/handler.py
+++ b/aragora/server/handlers/features/devops/handler.py
@@ -399,12 +399,16 @@ class DevOpsHandler(SecureHandler):
         )
         if err:
             return error_response(err, 400)
+        if title is None:
+            return error_response("title is required", 400)
 
         # Validate service_id
-        is_valid, err = validate_pagerduty_id(body.get("service_id", ""), "service_id")
+        service_id = body.get("service_id")
+        if not isinstance(service_id, str):
+            return error_response("service_id must be a string", 400)
+        is_valid, err = validate_pagerduty_id(service_id, "service_id")
         if not is_valid:
-            return error_response(err, 400)
-        service_id = body["service_id"]
+            return error_response(err or "Invalid service_id", 400)
 
         # Validate urgency
         urgency_str = validate_urgency(body.get("urgency"))
@@ -421,14 +425,14 @@ class DevOpsHandler(SecureHandler):
         if escalation_policy_id:
             is_valid, err = validate_pagerduty_id(escalation_policy_id, "escalation_policy_id")
             if not is_valid:
-                return error_response(err, 400)
+                return error_response(err or "Invalid escalation_policy_id", 400)
 
         # Validate priority_id (optional)
         priority_id = body.get("priority_id")
         if priority_id:
             is_valid, err = validate_pagerduty_id(priority_id, "priority_id")
             if not is_valid:
-                return error_response(err, 400)
+                return error_response(err or "Invalid priority_id", 400)
 
         try:
             from aragora.connectors.devops.pagerduty import (
@@ -488,7 +492,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -538,7 +542,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -584,7 +588,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -640,7 +644,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -669,7 +673,7 @@ class DevOpsHandler(SecureHandler):
         if escalation_policy_id:
             is_valid, err = validate_pagerduty_id(escalation_policy_id, "escalation_policy_id")
             if not is_valid:
-                return error_response(err, 400)
+                return error_response(err or "Invalid escalation_policy_id", 400)
 
         try:
             incident = await connector.reassign_incident(
@@ -710,7 +714,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -733,6 +737,8 @@ class DevOpsHandler(SecureHandler):
         )
         if err:
             return error_response(err, 400)
+        if validated_source_ids is None:
+            return error_response("source_incident_ids is required", 400)
 
         try:
             incident = await connector.merge_incidents(incident_id, validated_source_ids)
@@ -769,7 +775,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -823,7 +829,7 @@ class DevOpsHandler(SecureHandler):
         # Validate incident_id
         is_valid, err = validate_pagerduty_id(incident_id, "incident_id")
         if not is_valid:
-            return error_response(err, 400)
+            return error_response(err or "Invalid incident_id", 400)
 
         # Check circuit breaker
         circuit_breaker = get_devops_circuit_breaker()
@@ -842,6 +848,8 @@ class DevOpsHandler(SecureHandler):
         )
         if err:
             return error_response(err, 400)
+        if content is None:
+            return error_response("content is required", 400)
 
         try:
             note = await connector.add_note(incident_id, content)
@@ -892,7 +900,7 @@ class DevOpsHandler(SecureHandler):
             for sid in schedule_ids[:20]:  # Limit to 20 schedule IDs
                 is_valid, err = validate_pagerduty_id(sid, "schedule_id")
                 if not is_valid:
-                    return error_response(err, 400)
+                    return error_response(err or "Invalid schedule_id", 400)
             schedule_ids = schedule_ids[:20]
 
         try:

--- a/aragora/server/handlers/features/documents.py
+++ b/aragora/server/handlers/features/documents.py
@@ -131,6 +131,8 @@ class DocumentHandler(BaseHandler):
             doc_id, err = self.extract_path_param(path, 4, "document_id")
             if err:
                 return err
+            if doc_id is None:
+                return error_response("Missing document_id in path", 400)
             return self._get_document(doc_id)
 
         return None
@@ -169,6 +171,8 @@ class DocumentHandler(BaseHandler):
             doc_id, err = self.extract_path_param(path, 4, "document_id")
             if err:
                 return err
+            if doc_id is None:
+                return error_response("Missing document_id in path", 400)
             return self._delete_document(doc_id)
         return None
 

--- a/aragora/server/handlers/features/email_webhooks.py
+++ b/aragora/server/handlers/features/email_webhooks.py
@@ -782,6 +782,8 @@ class EmailWebhooksHandler(BaseHandler):
         """
         try:
             body = await self._get_json_body(request)
+            if body is None:
+                return error_response("Invalid request body", 400)
 
             provider_str = body.get("provider", "").lower()
             if provider_str not in ["gmail", "outlook"]:
@@ -886,6 +888,8 @@ class EmailWebhooksHandler(BaseHandler):
         """
         try:
             body = await self._get_json_body(request)
+            if body is None:
+                return error_response("Invalid request body", 400)
             subscription_id = body.get("subscription_id", "")
 
             if not subscription_id:

--- a/aragora/server/handlers/features/evidence.py
+++ b/aragora/server/handlers/features/evidence.py
@@ -38,7 +38,6 @@ from aragora.server.handlers.base import (
     PaginatedHandlerMixin,
     error_response,
     get_float_param,
-    get_int_param,
     get_string_param,
     json_response,
     safe_error_message,
@@ -255,6 +254,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             debate_id, err = self.extract_path_param(normalized, 4, "debate_id", SAFE_ID_PATTERN)
             if err:
                 return err
+            if debate_id is None:
+                return error_response("Missing debate_id in path", 400)
             return self._handle_get_debate_evidence(debate_id, query_params)
 
         # GET /api/evidence/:id
@@ -271,6 +272,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             )
             if err:
                 return err
+            if evidence_id is None:
+                return error_response("Missing evidence_id in path", 400)
             return self._handle_get_evidence(evidence_id)
 
         # GET /api/evidence - list all
@@ -302,6 +305,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             body, err = self._read_json_body_lenient(handler)
             if err:
                 return err
+            if body is None:
+                return error_response("Invalid JSON body", 400)
             return self._handle_search(body)
 
         # POST /api/evidence/collect
@@ -309,6 +314,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             body, err = self._read_json_body_lenient(handler)
             if err:
                 return err
+            if body is None:
+                return error_response("Invalid JSON body", 400)
             return await self._handle_collect(body)
 
         # POST /api/evidence/debate/:debate_id
@@ -318,9 +325,13 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             debate_id, err = self.extract_path_param(normalized, 4, "debate_id", SAFE_ID_PATTERN)
             if err:
                 return err
+            if debate_id is None:
+                return error_response("Missing debate_id in path", 400)
             body, err = self._read_json_body_lenient(handler)
             if err:
                 return err
+            if body is None:
+                return error_response("Invalid JSON body", 400)
             return self._handle_associate_evidence(debate_id, body)
 
         return None
@@ -355,6 +366,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
             )
             if err:
                 return err
+            if evidence_id is None:
+                return error_response("Missing evidence_id in path", 400)
             return self._handle_delete_evidence(evidence_id)
 
         return None
@@ -452,7 +465,15 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
         if not is_valid:
             return error_response(err or "Invalid debate ID", 400)
 
-        round_number = get_int_param(query_params, "round", None)
+        round_number: int | None = None
+        raw_round = query_params.get("round")
+        if isinstance(raw_round, list):
+            raw_round = raw_round[0] if raw_round else None
+        if raw_round is not None:
+            try:
+                round_number = int(raw_round)
+            except (TypeError, ValueError):
+                pass
 
         store = self._get_evidence_store()
         evidence_list = store.get_debate_evidence(debate_id, round_number)
@@ -525,14 +546,24 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
         if not task:
             return error_response("Task/topic is required", 400)
 
-        enabled_connectors = body.get("connectors")  # Optional list
+        raw_connectors = body.get("connectors")
+        enabled_connectors: list[str] | None = None
+        if raw_connectors is not None:
+            if not isinstance(raw_connectors, list) or not all(
+                isinstance(connector, str) for connector in raw_connectors
+            ):
+                return error_response("connectors must be a list of strings", 400)
+            enabled_connectors = list(raw_connectors)
         debate_id = body.get("debate_id")  # Optional association
         round_number = body.get("round")
 
         collector = self._get_evidence_collector()
 
         try:
-            evidence_pack = await collector.collect_evidence(task, enabled_connectors)
+            if enabled_connectors is None:
+                evidence_pack = await collector.collect_evidence(task)
+            else:
+                evidence_pack = await collector.collect_evidence(task, enabled_connectors)
         except (ValueError, TypeError) as e:
             logger.warning("Evidence collection failed (invalid params): %s", e)
             return error_response(safe_error_message(e, "Evidence collection"), 400)

--- a/aragora/server/handlers/features/folder_upload.py
+++ b/aragora/server/handlers/features/folder_upload.py
@@ -210,10 +210,12 @@ class FolderUploadHandler(BaseHandler):
 
         # GET /api/v1/documents/folders/{folder_id}
         if path.startswith("/api/v1/documents/folders/"):
-            folder_id, err = self.extract_path_param(path, 5, "folder_id")
+            extracted_folder_id, err = self.extract_path_param(path, 5, "folder_id")
             if err:
                 return err
-            return self._get_folder(folder_id)
+            if extracted_folder_id is None:
+                return error_response("Missing folder_id in path", 400)
+            return self._get_folder(extracted_folder_id)
 
         return None
 
@@ -238,6 +240,8 @@ class FolderUploadHandler(BaseHandler):
             folder_id, err = self.extract_path_param(path, 5, "folder_id")
             if err:
                 return err
+            if folder_id is None:
+                return error_response("Missing folder_id in path", 400)
             return self._delete_folder(folder_id, handler=handler)
         return None
 
@@ -261,6 +265,8 @@ class FolderUploadHandler(BaseHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Invalid JSON body", 400)
 
         folder_path = body.get("path")
         if not folder_path:
@@ -277,6 +283,8 @@ class FolderUploadHandler(BaseHandler):
             else:
                 status_code = 400
             return error_response(error_msg, status_code)
+        if path is None:
+            return error_response("Invalid folder path", 400)
 
         # Build config from request
         config_data = body.get("config", {})
@@ -338,6 +346,8 @@ class FolderUploadHandler(BaseHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Invalid JSON body", 400)
 
         folder_path = body.get("path")
         if not folder_path:
@@ -354,6 +364,8 @@ class FolderUploadHandler(BaseHandler):
             else:
                 status_code = 400
             return error_response(error_msg, status_code)
+        if path is None:
+            return error_response("Invalid folder path", 400)
 
         # Create job
         folder_id = str(uuid.uuid4())

--- a/aragora/server/handlers/features/gmail_ingest.py
+++ b/aragora/server/handlers/features/gmail_ingest.py
@@ -178,6 +178,8 @@ class GmailIngestHandler(SecureHandler):
         user_id, org_id, auth_error = self._get_authenticated_user(handler)
         if auth_error:
             return auth_error
+        if user_id is None:
+            return error_response("Authentication required", 401)
 
         if path == "/api/v1/gmail/status":
             return await self._get_status(user_id)
@@ -233,6 +235,8 @@ class GmailIngestHandler(SecureHandler):
         user_id, org_id, auth_error = self._get_authenticated_user(handler)
         if auth_error:
             return auth_error
+        if user_id is None:
+            return error_response("Authentication required", 401)
 
         if path == "/api/v1/gmail/connect":
             return self._start_connect(body, user_id)

--- a/aragora/server/handlers/features/integrations.py
+++ b/aragora/server/handlers/features/integrations.py
@@ -223,6 +223,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized)
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.get_integration(integration_type, user_id=user_id or "default")
 
         return error_response("Not found", status=404)
@@ -268,6 +270,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized.rsplit("/test", 1)[0])
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.test_integration(integration_type, user_id=user_id or "default")
 
         if normalized.endswith("/sync"):
@@ -280,6 +284,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized.rsplit("/sync", 1)[0])
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.sync_integration(integration_type, user_id=user_id or "default")
 
         return error_response("Not found", status=404)
@@ -311,6 +317,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized)
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.configure_integration(
                 integration_type, data, user_id=user_id or "default"
             )
@@ -343,6 +351,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized)
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.update_integration(
                 integration_type, data, user_id=user_id or "default"
             )
@@ -371,6 +381,8 @@ class IntegrationsHandler(SecureHandler):
             integration_type, err = self._extract_integration_type(normalized)
             if err:
                 return err
+            if integration_type is None:
+                return error_response("Integration type is required", status=400)
             return await self.delete_integration(integration_type, user_id=user_id or "default")
         return error_response("Not found", status=404)
 

--- a/aragora/server/handlers/features/marketplace/handler.py
+++ b/aragora/server/handlers/features/marketplace/handler.py
@@ -186,7 +186,7 @@ class MarketplaceHandler:
                     # Validate template ID
                     valid, err = _validate_template_id(template_id)
                     if not valid:
-                        return error_response(err, 400)
+                        return error_response(err or "Invalid template ID", 400)
 
                     if len(parts) == 6:
                         if method == "GET":
@@ -210,7 +210,7 @@ class MarketplaceHandler:
 
                     valid, err = _validate_deployment_id(deployment_id)
                     if not valid:
-                        return error_response(err, 400)
+                        return error_response(err or "Invalid deployment ID", 400)
 
                     if len(parts) == 6:
                         if method == "GET":

--- a/aragora/server/handlers/features/plugins.py
+++ b/aragora/server/handlers/features/plugins.py
@@ -432,7 +432,7 @@ class PluginsHandler(BaseHandler):
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, PLUGIN_RUN_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid plugin input", 400)
 
         input_data = body.get("input", {})
         config = body.get("config", {})
@@ -622,7 +622,7 @@ class PluginsHandler(BaseHandler):
         # Validate manifest against schema (enforces name format, length limits, entry_point pattern)
         validation_result = validate_against_schema(manifest, PLUGIN_MANIFEST_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid plugin manifest", 400)
 
         name = manifest.get("name", "")
 

--- a/aragora/server/handlers/features/provenance.py
+++ b/aragora/server/handlers/features/provenance.py
@@ -47,7 +47,10 @@ def get_provenance_store() -> ProvenanceStore:
     """Get or create the global ProvenanceStore instance."""
     if _provenance_store is not None:
         return _provenance_store
-    return _provenance_store_lazy.get()
+    store = _provenance_store_lazy.get()
+    if store is None:
+        raise RuntimeError("Provenance store is unavailable")
+    return store
 
 
 def get_provenance_manager(debate_id: str) -> ProvenanceManager:

--- a/aragora/server/handlers/features/pulse.py
+++ b/aragora/server/handlers/features/pulse.py
@@ -30,12 +30,14 @@ from typing import Any
 from aragora.config import DEFAULT_CONSENSUS, DEFAULT_ROUNDS
 
 # Pre-declare optional import names for type safety
-httpx: Any = None
+httpx: Any
 
 try:
-    import httpx  # noqa: F401 - Optionally imported for availability check
+    import httpx as _httpx
+
+    httpx = _httpx
 except ImportError:
-    pass
+    httpx = None
 
 from aragora.server.http_utils import run_async
 
@@ -280,7 +282,7 @@ class PulseHandler(BaseHandler):
             if category:
                 is_valid, err = validate_path_segment(category, "category", SAFE_ID_PATTERN)
                 if not is_valid:
-                    return error_response(err, 400)
+                    return error_response(err or "Invalid category", 400)
             return self._suggest_debate_topic(category)
 
         if path == "/api/v1/pulse/analytics":
@@ -306,7 +308,7 @@ class PulseHandler(BaseHandler):
                 topic_id = segments[5]
                 is_valid, err = validate_path_segment(topic_id, "topic_id", SAFE_ID_PATTERN)
                 if not is_valid:
-                    return error_response(err, 400)
+                    return error_response(err or "Invalid topic_id", 400)
                 return self._get_topic_outcomes(topic_id)
 
         return None

--- a/aragora/server/handlers/features/support.py
+++ b/aragora/server/handlers/features/support.py
@@ -819,6 +819,8 @@ class SupportHandler(SecureHandler):
         else:
             tickets_to_triage = []
             for tid in ticket_ids:
+                if not isinstance(platform, str):
+                    continue
                 connector = await self._get_connector(platform)
                 if connector:
                     try:

--- a/aragora/server/handlers/features/unified_inbox/triage.py
+++ b/aragora/server/handlers/features/unified_inbox/triage.py
@@ -54,7 +54,8 @@ async def triage_single_message(
 ) -> TriageResult:
     """Triage a single message using multi-agent debate."""
     try:
-        from aragora.debate import Arena, Environment, DebateProtocol  # noqa: F401
+        from aragora.core import Environment
+        from aragora.debate import Arena, DebateProtocol  # noqa: F401
 
         # Build debate environment
         Environment(


### PR DESCRIPTION
## Summary

Refs #9099.

This source-only main-red remediation narrows optional request values and optional dependency imports across the claimed `aragora/server/handlers/features/` unit. It preserves successful runtime paths, fails closed when required values are absent, and adds no blanket type ignores.

- Pinned base: `3fe2e5cf561fc094221008d064040ac84625bd4e`
- Claimed unit: 20 error-bearing source files in `aragora/server/handlers/features/`
- Targeted profile: Python 3.12.12, mypy 2.2.0, mypy-baseline 0.7.4, PyJWT 2.13.0
- No baseline, workflow, test, dependency, route/spec, SDK, halt, protection, evidence, settlement, or merge-state edits

## Mypy Evidence

Targeted package before:

```text
Found 76 errors in 20 files (checked 76 source files)
```

Targeted package after:

```text
Success: no issues found in 76 source files
```

Fresh-cache full-repo before:

```text
Found 2634 errors in 649 files (checked 4250 source files)
raw sha256: 5fbf2dda3a8b1824a6af43c6e30e0698655aae49fcad740bc8b073e293fb158c
normalized sha256: c527deb2818b4de416567a24bff7ff5716cb940587e4fac1e70b7ab6b00b0034
```

Two independent fresh-cache full-repo after runs produced identical output:

```text
Found 2558 errors in 629 files (checked 4250 source files)
raw sha256: 6c9b2e3d21d137a9533891addd0171ecfa0581335b9abb09f159215c9b2ecd20
normalized sha256: 3b366171e4c274c0724f0c801ae76705179da5e6300355d2e82be7409935052e
```

Identity comparison:

```text
removed identities: 76
added identities: 0
removed identities outside the 20 claimed files: 0
```

## Validation

- Focused handler suites: `1868 passed`
- Broadcast plus changed pulse validation paths after optional-import alias repair: `25 passed`
- Targeted mypy: `Success: no issues found in 76 source files`
- Pre-push changed-file mypy policy: passed
- Ruff on all 20 touched files: passed
- Ruff format check on all 20 touched files: passed
- `git diff --check`: passed

An initial broader focused run reported `2022 passed, 12 failed`; all 12 failures are the same `aragora.pulse` lazy-root patch-target import failure. The representative failure reproduces unchanged in a clean detached worktree at the pinned base, while all three tests that exercise the modified pulse validation branches pass. No test or package-root repair is included here because that is outside this source-only claim.