### PR TITLE
fix(swarm): drain main-red mypy surface

### DIFF
--- a/aragora/swarm/boss_freshness.py
+++ b/aragora/swarm/boss_freshness.py
@@ -162,7 +162,7 @@ def check_runner_freshness(
         allowed_profiles=allowed_profile_set or None,
         rotation_interval_seconds=rotation_interval_seconds,
     )
-    probe_summary = {
+    probe_summary: dict[str, Any] = {
         "auto_probe_triggered": False,
         "attempted": 0,
         "passed": 0,

--- a/aragora/swarm/boss_loop_selection.py
+++ b/aragora/swarm/boss_loop_selection.py
@@ -11,7 +11,7 @@ import asyncio
 import json as _json
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from aragora.config.secrets import get_secret_presence
 
@@ -146,6 +146,8 @@ def select_issues_for_batch(
     )
 
     blocked_scope_entries = set(blocked_scopes or set())
+    eligible_skip_labels = cast(set[str] | None, skip_labels)
+    eligible_require_labels = cast(set[str] | None, require_labels)
 
     if limit is not None and limit <= 1:
         if issue_number is not None:
@@ -153,8 +155,8 @@ def select_issues_for_batch(
             selected = (
                 select_eligible_issue(
                     [target],
-                    skip_labels=skip_labels,
-                    require_labels=require_labels,
+                    skip_labels=eligible_skip_labels,
+                    require_labels=eligible_require_labels,
                     blocked_scopes=blocked_scope_entries,
                 )
                 if target is not None
@@ -163,8 +165,8 @@ def select_issues_for_batch(
             return [selected] if selected is not None else []
         selected = select_eligible_issue(
             issues,
-            skip_labels=skip_labels,
-            require_labels=require_labels,
+            skip_labels=eligible_skip_labels,
+            require_labels=eligible_require_labels,
             blocked_scopes=blocked_scope_entries,
         )
         return [selected] if selected is not None else []
@@ -174,8 +176,8 @@ def select_issues_for_batch(
         selected = (
             select_eligible_issue(
                 [target],
-                skip_labels=skip_labels,
-                require_labels=require_labels,
+                skip_labels=eligible_skip_labels,
+                require_labels=eligible_require_labels,
                 blocked_scopes=blocked_scope_entries,
             )
             if target is not None
@@ -196,8 +198,8 @@ def select_issues_for_batch(
     for issue in issues:
         candidate = select_eligible_issue(
             [issue],
-            skip_labels=skip_labels,
-            require_labels=require_labels,
+            skip_labels=eligible_skip_labels,
+            require_labels=eligible_require_labels,
             blocked_scopes=claimed_scopes,
         )
         if candidate is None:

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from collections.abc import Generator
-from typing import Any
+from typing import Any, cast
 
 from aragora.agents.base import create_agent
 from aragora.agents.errors import AgentConnectionError, CLISubprocessError
@@ -908,7 +908,11 @@ class CampaignPlanner:
                 ]
             }
             try:
-                agent = create_agent(self.review_model, name="campaign-crosscheck", role="critic")
+                agent = cast(Any, create_agent)(
+                    self.review_model,
+                    name="campaign-crosscheck",
+                    role="critic",
+                )
                 response = asyncio.run(agent.generate(json.dumps(prompt, sort_keys=True)))
                 for finding in _extract_json_list(response):
                     findings.append(f"crosscheck: {finding}")
@@ -2092,7 +2096,7 @@ class CampaignExecutor:
             outcome = self._resolve_dispatch_outcome(
                 {"run": run_dict},
                 run_dict=run_dict,
-                deliverable=_extract_deliverable(run_dict),
+                deliverable=cast(dict[str, Any], _extract_deliverable(run_dict)),
             )
             if outcome in {
                 CampaignRunOutcome.DELIVERABLE_CREATED.value,

--- a/aragora/swarm/debate_gate.py
+++ b/aragora/swarm/debate_gate.py
@@ -15,7 +15,7 @@ import subprocess
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.worker_process import is_ignored_changed_path
@@ -195,7 +195,7 @@ class DebateGate:
             try:
                 from aragora.agents.base import create_agent
 
-                agent = create_agent(
+                agent = cast(Any, create_agent)(
                     agent_type,
                     name="debate-publish-gate",
                     role="critic",

--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -70,7 +70,6 @@ class OutcomeSignal:
     needed_human_rescue: bool = False
 
     # Provenance
-    debate_id: str = ""
     timestamp: str = ""
     correlation_id: str = ""
 

--- a/aragora/swarm/session_coordinator.py
+++ b/aragora/swarm/session_coordinator.py
@@ -15,7 +15,7 @@ side worktrees still share the same coordination state.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aragora.coordination import (
     ClaimManager,
@@ -180,7 +180,7 @@ def list_findings(
                 "kind": event_kind,
                 "message": str(payload.get("message") or ""),
                 "pr": event_pr,
-                "scope": list(payload.get("scope") or []),
+                "scope": list(cast(Any, payload.get("scope") or [])),
             }
         )
         if len(findings) >= limit:

--- a/aragora/swarm/tranche_review.py
+++ b/aragora/swarm/tranche_review.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aragora.swarm.campaign import CampaignProject, CampaignReviewer, _changed_files_from_run
 from aragora.swarm.tranche import (
@@ -291,7 +291,7 @@ def run_verification_passed(run_dict: dict[str, Any], *, has_verification_comman
         item.get("exit_code") for item in work_orders if item.get("exit_code") is not None
     ]
     if exit_codes:
-        return all(int(code) == 0 for code in exit_codes)
+        return all(int(cast(Any, code)) == 0 for code in exit_codes)
     return not has_verification_commands
 
 

--- a/aragora/swarm/tranche_submit.py
+++ b/aragora/swarm/tranche_submit.py
@@ -4,7 +4,7 @@ import json
 import re
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aragora.swarm.campaign import CampaignPlanner
 from aragora.swarm.spec import SwarmSpec
@@ -170,7 +170,10 @@ def submit_intake_bundle(
     )
     inspector = TrancheInspector(
         repo_root=repo_path,
-        reference_client=_StaticOpenReferenceClient() if skip_github_resolution else client,
+        reference_client=cast(
+            Any,
+            _StaticOpenReferenceClient() if skip_github_resolution else client,
+        ),
     )
     inspection = inspector.inspect(manifest)
     _write_yaml_like(inspection_path, dict(inspection))

--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aragora.nomic.dev_coordination import (
     DevCoordinationStore,
@@ -957,7 +957,8 @@ def _apply_dispatch_payload(state: TrancheRunState, payload: Any) -> None:
             lane_state.worktree_path,
             item.get("worktree_path"),
         )
-        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        raw_metadata = item.get("metadata")
+        metadata = cast(dict[str, Any], raw_metadata) if isinstance(raw_metadata, dict) else {}
         lane_state.receipt_id = _prefer_text(lane_state.receipt_id, metadata.get("receipt_id"))
         lane_state.lease_id = _prefer_text(lane_state.lease_id, metadata.get("lease_id"))
         lane_state.pr_url = _prefer_text(lane_state.pr_url, metadata.get("pr_url"))


### PR DESCRIPTION
## Summary
- remove the duplicate OutcomeSignal debate_id declaration while retaining the original field position
- make mixed swarm summary and metadata dictionaries explicit
- isolate agent-factory and duck-typed client stub gaps behind no-op casts
- preserve all selection, freshness, dispatch, review, receipt, and lane-state behavior
- remove the complete aragora/swarm main-red mypy bucket

## Exact-base evidence
- base: 3fe2e5cf561fc094221008d064040ac84625bd4e
- scoped mypy: 22 errors -> 0
- full-repo error-set identity: 22 errors and 3 attached notes removed, 0 lines added
- full after-output SHA-256: 293239b59a0a618f1c93f62bd65d0800595d357e8382272b3574296b00effb47

## Validation
- 281 direct swarm tests passed
- four untouched worker_launcher auto-commit tests fail identically on an exact pinned-main control worktree
- Ruff and format checks passed for all 9 files
- changed-file pre-push mypy hook passed
- commit hooks, push hooks, and automation PR preflight passed

## Coordination
- parent incident: #9099
- main-red halt remains active
- source-only draft; no dispatch-state, receipt, test, schema, baseline, workflow, dependency, halt, readiness, settlement, or merge mutation