### PR TITLE
fix(types): narrow workflow handler boundaries (#9099)

### DIFF
--- a/aragora/server/fastapi/routes/workflows.py
+++ b/aragora/server/fastapi/routes/workflows.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
@@ -250,7 +250,7 @@ def _workflow_to_summary(wf: Any) -> WorkflowSummary:
     """Convert a workflow object to a summary."""
     if isinstance(wf, dict):
         return WorkflowSummary(
-            id=wf.get("id", wf.get("workflow_id", "")),
+            id=cast(str, wf.get("id", wf.get("workflow_id", ""))),
             name=wf.get("name", ""),
             description=wf.get("description", ""),
             status=wf.get("status", "pending"),
@@ -294,7 +294,7 @@ def _workflow_to_detail(wf: Any) -> WorkflowDetail:
                 )
 
         return WorkflowDetail(
-            id=wf.get("id", wf.get("workflow_id", "")),
+            id=cast(str, wf.get("id", wf.get("workflow_id", ""))),
             name=wf.get("name", ""),
             description=wf.get("description", ""),
             status=wf.get("status", "pending"),
@@ -419,7 +419,7 @@ async def list_workflow_templates(
                 if isinstance(t, dict):
                     templates.append(
                         TemplateSummary(
-                            name=t.get("name", t.get("id", "")),
+                            name=cast(str, t.get("name", t.get("id", ""))),
                             description=t.get("description", ""),
                             category=t.get("category", ""),
                             node_count=len(t.get("nodes", [])),
@@ -754,7 +754,7 @@ async def get_workflow_history(
             if isinstance(entry, dict):
                 executions.append(
                     HistoryEntry(
-                        execution_id=entry.get("execution_id", entry.get("id", "")),
+                        execution_id=cast(str, entry.get("execution_id", entry.get("id", ""))),
                         status=entry.get("status", "completed"),
                         started_at=entry.get("started_at"),
                         completed_at=entry.get("completed_at"),

--- a/aragora/server/handlers/workflow_templates.py
+++ b/aragora/server/handlers/workflow_templates.py
@@ -890,7 +890,10 @@ class TemplateRecommendationsHandler(BaseHandler):
         """Get recommended templates for a use case."""
         from aragora.workflow.templates import get_template
 
-        use_case = get_bounded_string_param(query_params, "use_case", "general", max_length=50)
+        use_case = (
+            get_bounded_string_param(query_params, "use_case", "general", max_length=50)
+            or "general"
+        )
         limit = get_clamped_int_param(query_params, "limit", 4, min_val=1, max_val=10)
 
         # Get recommendations for the use case

--- a/aragora/server/handlers/workflows/__init__.py
+++ b/aragora/server/handlers/workflows/__init__.py
@@ -27,6 +27,8 @@ Backward Compatibility:
 
 from __future__ import annotations
 
+from typing import Any
+
 # Core utilities (for internal use and advanced users)
 from .core import (
     logger,
@@ -96,18 +98,27 @@ from .approvals import (
 )
 
 # Human approval helpers (for patching in tests)
+get_pending_approvals: Any
+get_approval_request: Any
+_resolve: Any
+ApprovalStatus: Any
 try:
     from aragora.workflow.nodes.human_checkpoint import (
-        get_pending_approvals,
-        get_approval_request,
-        resolve_approval as _resolve,
-        ApprovalStatus,
+        get_pending_approvals as _get_pending_approvals,
+        get_approval_request as _get_approval_request,
+        resolve_approval as _resolve_approval,
+        ApprovalStatus as _ApprovalStatus,
     )
+
+    get_pending_approvals = _get_pending_approvals
+    get_approval_request = _get_approval_request
+    _resolve = _resolve_approval
+    ApprovalStatus = _ApprovalStatus
 except ImportError:  # pragma: no cover - optional dependency
-    get_pending_approvals = None  # type: ignore[assignment]
-    get_approval_request = None  # type: ignore[assignment]
-    _resolve = None  # type: ignore[assignment]
-    ApprovalStatus = None  # type: ignore[misc]
+    get_pending_approvals = None
+    get_approval_request = None
+    _resolve = None
+    ApprovalStatus = None
 
 # HTTP handlers
 from .handler import (
@@ -116,13 +127,24 @@ from .handler import (
 )
 
 # Optional RBAC helpers for tests and patching
+extract_user_from_request: Any
 try:
-    from aragora.billing.auth import extract_user_from_request
+    from aragora.billing.auth import extract_user_from_request as _extract_user_from_request
+
+    extract_user_from_request = _extract_user_from_request
 except ImportError:  # pragma: no cover - optional dependency
     extract_user_from_request = None
 
+check_permission: Any
+get_role_permissions: Any
 try:
-    from aragora.rbac import check_permission, get_role_permissions
+    from aragora.rbac import (
+        check_permission as _check_permission,
+        get_role_permissions as _get_role_permissions,
+    )
+
+    check_permission = _check_permission
+    get_role_permissions = _get_role_permissions
 except ImportError:  # pragma: no cover - optional dependency
     check_permission = None
     get_role_permissions = None

--- a/aragora/server/handlers/workflows/builder.py
+++ b/aragora/server/handlers/workflows/builder.py
@@ -12,7 +12,7 @@ Provides endpoints for the visual workflow builder:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aragora.server.handlers.base import (
     BaseHandler,
@@ -80,6 +80,7 @@ class WorkflowBuilderHandler(BaseHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        body = cast(dict[str, Any], body)
 
         if path == "/api/v1/workflows/generate":
             return self._generate_workflow(body)

--- a/aragora/server/handlers/workflows/handler.py
+++ b/aragora/server/handlers/workflows/handler.py
@@ -7,7 +7,8 @@ with the unified server.
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, cast, TYPE_CHECKING, TypeVar
 import sys
 
 from aragora.server.handlers.base import (
@@ -60,6 +61,14 @@ from .approvals import (
 
 if TYPE_CHECKING:
     from aragora.rbac import AuthorizationContext
+
+_HandlerMethod = TypeVar("_HandlerMethod", bound=Callable[..., Any])
+
+
+def _typed_handle_errors(context: str) -> Callable[[_HandlerMethod], _HandlerMethod]:
+    """Preserve handler signatures across the legacy decorator union type."""
+    return cast(Callable[[_HandlerMethod], _HandlerMethod], handle_errors(context))
+
 
 # Import RBAC components conditionally
 if RBAC_AVAILABLE:
@@ -444,7 +453,7 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
                 and context.org_id
             ):
                 return context.org_id
-        return get_string_param(query_params, "tenant_id", "default")
+        return cast(str, get_string_param(query_params, "tenant_id", "default"))
 
     @track_handler("workflows/main", method="GET")
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
@@ -576,6 +585,7 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        body = cast(dict[str, Any], body)
 
         # POST /api/workflows/{id}/execute
         if path.endswith("/execute"):
@@ -635,6 +645,7 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        body = cast(dict[str, Any], body)
 
         workflow_id = self._extract_id(path)
         if workflow_id:
@@ -650,7 +661,7 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
         """Handle PUT requests (same as PATCH for workflows)."""
         return self.handle_patch(path, query_params, handler)
 
-    @handle_errors
+    @_typed_handle_errors("handle_delete")
     def handle_delete(
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
@@ -815,10 +826,11 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
             tenant_id = self._get_tenant_id(handler, query_params)
             # Get user_id from auth context if available
             auth_context = self._get_auth_context(handler) if self._rbac_enabled() else None
-            created_by = (
+            created_by = cast(
+                str,
                 auth_context.user_id
                 if auth_context and not isinstance(auth_context, str)
-                else get_string_param(query_params, "user_id", "")
+                else get_string_param(query_params, "user_id", ""),
             )
 
             result = self._run_async_fn()(
@@ -1319,10 +1331,11 @@ class WorkflowHandler(BaseHandler, PaginatedHandlerMixin):
         try:
             # Get responder from auth context if available
             auth_context = self._get_auth_context(handler) if self._rbac_enabled() else None
-            responder_id = (
+            responder_id = cast(
+                str,
                 auth_context.user_id
                 if auth_context and not isinstance(auth_context, str)
-                else get_string_param(query_params, "user_id", "")
+                else get_string_param(query_params, "user_id", ""),
             )
 
             resolved = self._run_async_fn()(

--- a/aragora/server/handlers/workflows/registry.py
+++ b/aragora/server/handlers/workflows/registry.py
@@ -11,7 +11,7 @@ Provides endpoints for the public template registry:
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aragora.server.handlers.base import (
     BaseHandler,
@@ -137,6 +137,7 @@ class TemplateRegistryHandler(BaseHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        body = cast(dict[str, Any], body)
 
         # POST /api/v1/templates/registry/{id}/install
         if listing_id and path.endswith("/install"):

--- a/aragora/server/handlers/workflows/templates.py
+++ b/aragora/server/handlers/workflows/templates.py
@@ -7,7 +7,8 @@ and registering built-in templates.
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Awaitable
+from typing import Any, cast
 
 from .core import (
     logger,
@@ -357,7 +358,7 @@ async def load_yaml_templates_async() -> None:
         for template_id, template in templates.items():
             existing = await store.get_template(template_id)  # type: ignore[misc]  # WorkflowStoreType union: async/sync method variance
             if not existing:
-                await store.save_template(template)
+                await cast(Awaitable[None], store.save_template(template))
                 loaded += 1
         if loaded > 0:
             logger.info("Loaded %s new YAML templates into database (async)", loaded)
@@ -386,7 +387,7 @@ async def register_builtin_templates_async() -> None:
             template.is_template = True
             existing = await store.get_template(template.id)  # type: ignore[misc]  # WorkflowStoreType union: async/sync method variance
             if not existing:
-                await store.save_template(template)
+                await cast(Awaitable[None], store.save_template(template))
                 logger.debug("Registered built-in template: %s", template.id)
     except (OSError, ValueError, KeyError, TypeError, RuntimeError) as e:
         logger.warning("Failed to register built-in templates (async): %s", e)


### PR DESCRIPTION
## Summary

Refs #9099.

This source-only main-red remediation narrows the workflow handler/API boundary without changing request routing or business behavior:

- preserve optional compatibility exports with explicitly typed aliases instead of fallback assignment errors;
- preserve validated JSON-body, identifier, tenant, and actor contracts with runtime-no-op casts;
- preserve the legacy `handle_errors` runtime wrapper while retaining the decorated method signature for mypy;
- narrow the async template-store method union at the existing PostgreSQL-only await sites;
- preserve the recommendation fallback for an absent or empty use-case value.

Pinned base: `3fe2e5cf561fc094221008d064040ac84625bd4e`.

No tests, dependencies, `.github` workflows, `.mypy-baseline`, route baselines/specs, generated SDKs, halt state, branch protection, evidence, settlement, readiness, or merge state changed.

## Mypy Evidence

Pinned profile: Python 3.12.12, mypy 2.2.0, mypy-baseline 0.7.4, PyJWT 2.13.0.

Targeted before:

```text
Found 30 errors in 7 files (checked 7 source files)
```

Targeted after:

```text
Success: no issues found in 7 source files
```

Fresh-cache full before:

```text
Found 2634 errors in 649 files (checked 4250 source files)
raw sha256: 5fbf2dda3a8b1824a6af43c6e30e0698655aae49fcad740bc8b073e293fb158c
sorted error-identity sha256: a74630d72378df4854a1bc596b5072feb267eb8e11f9c437b4f7cafa39853609
```

Two independent fresh-cache full after runs were byte-identical:

```text
Found 2604 errors in 642 files (checked 4250 source files)
raw sha256: 429e45b5e4c8dee8f8b0b0046c93365a29bb0b097b26886db429428d0bd37740
sorted error-identity sha256: 24aba750306cf2aae04d74394a1f908ae1a886bfa1ab83089d91027c67efb732
removed identities: 30
added identities: 0
removed identities outside the seven claimed files: 0
```

Removed identities by claimed file:

```text
4 aragora/server/fastapi/routes/workflows.py
1 aragora/server/handlers/workflow_templates.py
4 aragora/server/handlers/workflows/__init__.py
5 aragora/server/handlers/workflows/builder.py
9 aragora/server/handlers/workflows/handler.py
5 aragora/server/handlers/workflows/registry.py
2 aragora/server/handlers/workflows/templates.py
```

## Validation

- Focused workflow handler/template/FastAPI suites: `1417 passed`
- Targeted mypy: clean
- Changed-file pre-push mypy policy: passed
- Ruff check and format: passed
- `git diff --check`: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed
- Commit and push hooks: passed

The focused test venv was disposable; `fastapi==0.139.0` was installed only into that temporary environment to satisfy test collection. No repository dependency file changed.

Exact head at publication: `447b3b201b8ba0b8ef32af702afcbc9df2c619fc`.
