### PR TITLE
fix(workflow): drain main-red mypy surface

### DIFF
--- a/aragora/workflow/nodes/human_checkpoint.py
+++ b/aragora/workflow/nodes/human_checkpoint.py
@@ -16,7 +16,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Any, cast
 from collections.abc import Callable
 
 from aragora.workflow.safe_eval import SafeEvalError, safe_eval_bool
@@ -577,10 +577,9 @@ class HumanCheckpointStep(BaseStep):
             from aragora.approvals.chat import send_chat_approval_request
 
             metadata = context.metadata if isinstance(context.metadata, dict) else {}
+            raw_plan_meta = metadata.get("plan_metadata")
             plan_meta = (
-                metadata.get("plan_metadata")
-                if isinstance(metadata.get("plan_metadata"), dict)
-                else {}
+                cast(dict[str, Any], raw_plan_meta) if isinstance(raw_plan_meta, dict) else {}
             )
 
             targets = (

--- a/aragora/workflow/nodes/implementation.py
+++ b/aragora/workflow/nodes/implementation.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from aragora.workflow.step import BaseStep, WorkflowContext
 
@@ -79,10 +79,9 @@ class ImplementationStep(BaseStep):
             from aragora.implement.types import ImplementTask
 
             metadata = context.metadata if isinstance(context.metadata, dict) else {}
+            raw_plan_meta = metadata.get("plan_metadata")
             plan_meta = (
-                metadata.get("plan_metadata")
-                if isinstance(metadata.get("plan_metadata"), dict)
-                else {}
+                cast(dict[str, Any], raw_plan_meta) if isinstance(raw_plan_meta, dict) else {}
             )
             profile_payload = (
                 metadata.get("implementation_profile")

--- a/aragora/workflow/nodes/knowledge_pipeline.py
+++ b/aragora/workflow/nodes/knowledge_pipeline.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 from aragora.workflow.step import BaseStep, WorkflowContext
 
@@ -230,7 +230,7 @@ class KnowledgePipelineStep(BaseStep):
             if file_path.is_file() and self._is_supported_file(file_path):
                 try:
                     content = file_path.read_text(encoding="utf-8", errors="ignore")
-                    result = await self._pipeline.process_document(
+                    result = await cast(Any, self._pipeline).process_document(
                         content=content,
                         filename=file_path.name,
                         metadata={"path": str(file_path)},
@@ -250,7 +250,7 @@ class KnowledgePipelineStep(BaseStep):
     async def _process_file(self, file_path: Path) -> dict[str, Any]:
         """Process a single file."""
         content = file_path.read_text(encoding="utf-8", errors="ignore")
-        result = await self._pipeline.process_document(
+        result = await cast(Any, self._pipeline).process_document(
             content=content,
             filename=file_path.name,
             metadata={"path": str(file_path)},
@@ -283,7 +283,7 @@ class KnowledgePipelineStep(BaseStep):
             connector = WebConnector(**web_config)
             content = await connector.fetch(url)
 
-            result = await self._pipeline.process_document(
+            result = await cast(Any, self._pipeline).process_document(
                 content=content,
                 filename=url.split("/")[-1] or "web_document",
                 metadata={"url": url},
@@ -342,7 +342,7 @@ class KnowledgePipelineStep(BaseStep):
             chunks_created = 0
 
             for doc in documents:
-                result = await self._pipeline.process_document(
+                result = await cast(Any, self._pipeline).process_document(
                     content=doc.get("content", ""),
                     filename=doc.get("filename", "document"),
                     metadata=doc.get("metadata", {}),

--- a/aragora/workflow/nodes/nomic.py
+++ b/aragora/workflow/nodes/nomic.py
@@ -182,7 +182,7 @@ class NomicLoopStep(BaseStep):
                 debate_config = DebateConfig(rounds=DebateSettings().default_rounds)
 
             if config.get("debate_rounds"):
-                debate_config.rounds = int(config.get("debate_rounds"))
+                debate_config.rounds = int(cast(Any, config.get("debate_rounds")))
             if config.get("consensus_mechanism"):
                 debate_config.consensus_mode = str(config.get("consensus_mechanism"))
 

--- a/aragora/workflow/queue/queue.py
+++ b/aragora/workflow/queue/queue.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from collections.abc import Callable
 
 if TYPE_CHECKING:
@@ -379,7 +379,7 @@ class TaskQueue:
         # Collect results
         task_ids = self._workflows.get(workflow_id, set())
         return {
-            tid: self._tasks[tid].result
+            tid: cast(TaskResult, self._tasks[tid].result)
             for tid in task_ids
             if tid in self._tasks and self._tasks[tid].result
         }

--- a/aragora/workflow/queue/scheduler.py
+++ b/aragora/workflow/queue/scheduler.py
@@ -322,9 +322,9 @@ class DependencyScheduler:
         # Schedule initial tasks (those with no dependencies)
         ready_tasks = graph.get_ready_tasks(set())
         for task_id in ready_tasks:
-            task = self._tasks.get(task_id)
-            if task:
-                await self._schedule_task(task)
+            scheduled_task = self._tasks.get(task_id)
+            if scheduled_task:
+                await self._schedule_task(scheduled_task)
 
         logger.info("Submitted workflow %s with %s tasks", workflow_id, len(tasks))
         return workflow_id

--- a/aragora/workflow/step.py
+++ b/aragora/workflow/step.py
@@ -433,7 +433,9 @@ class AgentStep(BaseStep):
         if selection_strategy in {"best_score", "power_law"}:
             best = max(
                 candidates,
-                key=lambda c: float(c.get("score")) if c.get("score") is not None else 0.0,
+                key=lambda c: float(cast(Any, c.get("score")))
+                if c.get("score") is not None
+                else 0.0,
             )
 
         output: dict[str, Any] = {


### PR DESCRIPTION
## Summary
- narrow task results after existing truthy filters and avoid optional local reuse
- narrow score and debate-round values after existing presence checks
- expose the lazily initialized knowledge pipeline through no-op casts
- make implementation and approval plan metadata explicit after existing dict checks
- preserve approval routing, checkpoint recovery, execution transitions, scheduling, task results, and knowledge processing
- remove the complete aragora/workflow main-red mypy bucket

## Exact-base evidence
- base: 3fe2e5cf561fc094221008d064040ac84625bd4e
- scoped mypy: 16 errors -> 0
- full-repo error-set identity: 16 errors removed, 0 lines added
- full after-output SHA-256: 1b95384fe33e7e2bed4975997aeac3fd31f22cba113e967866eeee10d4e06854
- file-disjoint from the active server-workflow claim

## Validation
- 289 direct workflow tests passed
- Ruff and format checks passed for all 7 files
- changed-file pre-push mypy hook passed
- commit hooks, push hooks, and automation PR preflight passed

## Coordination
- parent incident: #9099
- main-red halt remains active
- source-only draft; no approval, checkpoint, execution, scheduling, test, schema, baseline, .github workflow, dependency, halt, readiness, settlement, or merge mutation