### PR TITLE
test: tolerate FastAPI included router wrapper in swarm-status route check

### DIFF
--- a/tests/server/fastapi/routes/test_swarm_status.py
+++ b/tests/server/fastapi/routes/test_swarm_status.py
@@ -243,10 +243,13 @@ def test_register_routes_adds_swarm_status_endpoints() -> None:
 
     swarm_status.register_routes(app)
 
-    route_paths = {route.path for route in app.routes}
-    assert "/api/v1/swarm/status" in route_paths
-    assert "/api/v1/swarm/preflight" in route_paths
-    assert "/api/v1/swarm/preflight/receipts" in route_paths
+    # FastAPI 0.138+ stores included routers behind an internal wrapper, so
+    # direct app.routes path inspection is version- and import-order-dependent
+    # (the '_IncludedRouter has no attribute path' shard failure). Assert the
+    # supported route-lookup contract instead.
+    assert str(app.url_path_for("get_swarm_status")) == "/api/v1/swarm/status"
+    assert str(app.url_path_for("run_swarm_preflight")) == "/api/v1/swarm/preflight"
+    assert str(app.url_path_for("get_preflight_receipts")) == "/api/v1/swarm/preflight/receipts"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Salvages stranded commit `6f4a72226d` (2026-06-25, never merged). FastAPI 0.138+ wraps included routers, making direct `app.routes` path inspection version- and import-order-dependent — the exact `'_IncludedRouter' object has no attribute 'path'` failure that blocks the server-rest shard on #9073, #8809, and #9064 while the test passes in isolation. The test now asserts the supported `url_path_for` lookup contract.

Test-only, three assertions swapped; the server shard stays enforcing (per the cross-validated remedy: fix the brittle assertion, don't make "passes alone" equivalent to success).

#### Test plan
- [x] tests/server/fastapi/routes/test_swarm_status.py green (17 tests)
- [x] ruff check/format clean; automation preflight ok

Generated with [Devin](https://devin.ai)