### PR TITLE
feat(quorum): operator-advisory-settlement relief valve (Tier 4, default OFF)

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -128,6 +128,18 @@ jobs:
           # blocking findings remain — surfacing advisory_findings for follow-up. Tier 3-4
           # unaffected (human settlement). Reverting is a single env flip back OFF.
           ARAGORA_ENABLE_ADVISORY_DISSENT_SETTLE: "1"
+          # Activate the operator-advisory-settlement relief valve (default OFF;
+          # docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md, #8933 incident). At Tier 3-4,
+          # when model quorum is UNREACHABLE because every review is severity-gated
+          # advisory (zero countable signals across rounds), the trusted settlement
+          # operator may settle over advisory-only dissent: requires >=2 validated
+          # model families heard at head, a validated western-frontier review, ZERO
+          # [P0]/[P1] findings anywhere, no unresolved dissent, a trusted-creator
+          # 'aragora/human-settlement' success status at the exact head, AND a
+          # trusted-author settlement marker comment naming the exact head. Blocking
+          # model dissent still stops everyone, including the operator. Reverting is
+          # a single env flip back OFF.
+          ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT: "1"
         shell: bash
         run: |
           set -euo pipefail
@@ -218,6 +230,17 @@ jobs:
 
           # Tier 0-2: model quorum alone authorizes the merge.
           if status == "satisfied":
+              if verdict == "operator_advisory_settlement":
+                  families = entry.get("validated_review_families") or []
+                  print(
+                      f"::notice::OPERATOR-SETTLED-OVER-ADVISORY: Tier {tier} PR "
+                      f"#{pr_number} at {head_sha[:12]} — model quorum unreachable "
+                      f"(severity-gated advisory reviews from {families}); zero "
+                      "blocking findings; trusted-operator settlement status and "
+                      "marker comment verified at exact head. See "
+                      "docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md."
+                  )
+                  sys.exit(0)
               print("Model quorum satisfied; Tier 0-2 settlement authorized.")
               sys.exit(0)
 

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3195,6 +3195,7 @@ def _advisory_settle_review_signals(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
+    strict_receipt: bool = False,
 ) -> tuple[bool, bool, bool, frozenset[str]]:
     """Single-pass classification of grounded reviews for advisory_settle.
 
@@ -3202,8 +3203,16 @@ def _advisory_settle_review_signals(
     has_blocking_finding, validated_review_families)``. The final element is the
     set of canonical model families with at least one grounded, non-bot,
     countable-identity review at head in ANY verdict — the "models were heard"
-    accounting used by the operator-advisory-settlement relief valve, which must
-    never be derivable from unvalidated comment text.
+    accounting used by the operator-advisory-settlement relief valve.
+
+    ``strict_receipt=True`` (the valve's mode; claude #9203 P2) additionally
+    requires each POSITIVE signal's identity to carry a receipt artifact
+    (``missing_receipt_artifact`` absent from its identity problems). Without
+    it, family attribution reduces to self-declared comment text — a heading
+    plus a ``Model family:`` line any non-bot login can fabricate — letting a
+    drive-by account manufacture the appearance of unreachable Tier-4 quorum.
+    The blocking-finding scan stays permissive in both modes (a [P0]/[P1] can
+    never be laundered out by a missing receipt).
 
     Source-validation is applied UNIFORMLY so every *positive* input to the gate
     passes the SAME filters the strict quorum path uses — closing the class of
@@ -3242,6 +3251,10 @@ def _advisory_settle_review_signals(
             continue
         identity = _resolve_model_review_identity(body)
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
+            continue
+        if strict_receipt and "missing_receipt_artifact" in identity.identity_problems:
+            # Valve mode: self-declared headings without a receipt artifact do
+            # not establish that a model was heard (claude #9203 P2).
             continue
         family = str(identity.model_family or "").strip().lower()
         if family:
@@ -3409,6 +3422,20 @@ def _build_model_review_quorum(
         head_sha=head_sha,
         head_committed_at=head_committed_at,
     )
+    # Valve-mode strict pass (claude #9203 P2): positive signals must be
+    # receipt-backed so self-declared headings cannot manufacture "models were
+    # heard". advisory_settle (Tier 0-2) keeps the original semantics above.
+    (
+        _wf_review_present_strict,
+        _genuine_advisory_dissent_strict,
+        _,
+        _validated_review_families_strict,
+    ) = _advisory_settle_review_signals(
+        pr.get("comments") or [],
+        head_sha=head_sha,
+        head_committed_at=head_committed_at,
+        strict_receipt=True,
+    )
     advisory_settle_eligible = (
         advisory_dissent_settle_enabled()
         and tier is not None
@@ -3475,11 +3502,15 @@ def _build_model_review_quorum(
         # [P0]/[P1]) proves the non-counting is severity-gating, not infra —
         # infra failures must be REPAIRED (re-collect, fix the artifact), never
         # settled over. This is the same bar advisory_settle already enforces.
-        and _genuine_advisory_dissent
+        # All three positive signals use the STRICT receipt-backed pass (claude
+        # #9203 P2): a self-declared heading with no receipt artifact cannot
+        # establish that a model was heard, dissented, or was western-frontier.
+        # The blocking scan deliberately stays the PERMISSIVE one.
+        and _genuine_advisory_dissent_strict
         and not unresolved_dissent
         and not _any_blocking_finding
-        and _wf_review_present
-        and len(_validated_review_families) >= 2
+        and _wf_review_present_strict
+        and len(_validated_review_families_strict) >= 2
         and _has_operator_settlement_comment(pr, head_sha=head_sha)
         and _human_settlement_status_creator_verified(
             repo_slug=repo_slug or rest_fallback._repo_slug_from_pr_payload(pr, None),
@@ -3575,9 +3606,10 @@ def _build_model_review_quorum(
     if operator_advisory_settlement_eligible:
         reasons.append(
             "operator advisory settlement: model quorum is unreachable (every review "
-            f"severity-gated advisory; {len(_validated_review_families)} model families "
-            "heard, no [P0]/[P1] blocking findings, no unresolved dissent); the trusted "
-            "settlement operator settled over advisory-only dissent at exact head "
+            f"severity-gated advisory; {len(_validated_review_families_strict)} "
+            "receipt-backed model families heard, no [P0]/[P1] blocking findings, no "
+            "unresolved dissent); the trusted settlement operator settled over "
+            "advisory-only dissent at exact head "
             "(docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md)"
         )
     if (
@@ -3709,7 +3741,9 @@ def _build_model_review_quorum(
         "advisory_findings": advisory_findings if advisory_settle_eligible else [],
         "advisory_settle": advisory_settle_eligible,
         "operator_advisory_settlement": operator_advisory_settlement_eligible,
-        "validated_review_families": sorted(_validated_review_families),
+        # Valve audit accounting: the STRICT (receipt-backed) family set, so the
+        # packet never overstates who was "heard" (claude #9203 P2).
+        "validated_review_families": sorted(_validated_review_families_strict),
         "unresolved_dissent": unresolved_dissent,
         "reasons": reasons,
     }
@@ -3972,15 +4006,21 @@ def _has_operator_settlement_comment(pr: dict[str, Any], *, head_sha: str) -> bo
 
     Stricter than :func:`_has_tier_four_human_preapproval_comment` (which any
     author can satisfy): the operator-advisory-settlement relief valve requires
-    the marker comment itself to come from the trusted settlement login, so the
-    settlement record — not just the commit status — is non-forgeable.
+    the marker comment itself to come from the trusted settlement login. Note
+    (claude #9203 P3): GitHub lets any write-access collaborator EDIT an
+    existing comment while ``author.login`` is preserved, so the comment is a
+    corroborating settlement record, not an unforgeable one — the creator-pinned
+    ``aragora/human-settlement`` commit status is the sole unforgeable
+    authorization root; this check is the second factor.
     """
-    head = str(head_sha or "").strip()
+    head = str(head_sha or "").strip().lower()
     # Format guard (claude #9203 P3): a full 40-hex SHA. A short or malformed
     # head would make the ``head in body`` substring check dangerously loose
     # (e.g. a 3-char value matching unrelated text). Callers pass headRefOid,
-    # so this only rejects genuinely malformed input — fail closed.
-    if not re.fullmatch(r"[0-9a-fA-F]{40}", head):
+    # so this only rejects genuinely malformed input — fail closed. Both sides
+    # are lowercased so a legitimately authorized marker citing an uppercase
+    # SHA is not silently rejected.
+    if not re.fullmatch(r"[0-9a-f]{40}", head):
         return False
     trusted = _trusted_settlement_creator().casefold()
     if not trusted:
@@ -3998,7 +4038,7 @@ def _has_operator_settlement_comment(pr: dict[str, Any], *, head_sha: str) -> bo
         lowered = body.lower()
         if TIER_FOUR_SETTLEMENT_MARKER not in body:
             continue
-        if head not in body:
+        if head not in lowered:
             continue
         if not any(token in lowered for token in TIER_FOUR_AUTHORIZED_MERGE_TOKENS):
             continue

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3252,10 +3252,19 @@ def _advisory_settle_review_signals(
         identity = _resolve_model_review_identity(body)
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
-        if strict_receipt and "missing_receipt_artifact" in identity.identity_problems:
-            # Valve mode: self-declared headings without a receipt artifact do
-            # not establish that a model was heard (claude #9203 P2).
-            continue
+        if strict_receipt:
+            # Valve mode (claude #9203 round-4 suggestion, completed after the
+            # round-5 openai P1 showed the receipt LINE alone is spoofable text):
+            # positive signals must be AUTHORED by a trusted evidence-poster
+            # login. Authorship is API-real — GitHub sets it from the
+            # authenticated token — so a drive-by account cannot fabricate a
+            # heard family no matter what its comment body claims. The receipt
+            # requirement is kept as well (collector-posted evidence always
+            # carries one), but the authorship pin is the load-bearing guard.
+            if author.casefold() not in _trusted_evidence_posters():
+                continue
+            if "missing_receipt_artifact" in identity.identity_problems:
+                continue
         family = str(identity.model_family or "").strip().lower()
         if family:
             validated_families.add(family)
@@ -3941,6 +3950,24 @@ def _trusted_settlement_creator() -> str:
         str(os.environ.get(SETTLEMENT_CREATOR_ENV_VAR, "") or "").strip()
         or DEFAULT_TRUSTED_SETTLEMENT_CREATOR
     )
+
+
+#: Logins whose posted comments may establish "a model was heard" for the
+#: operator-advisory-settlement valve (env-overridable, comma-separated). The
+#: defaults are the operator's own accounts: the settlement creator plus the
+#: gh login the evidence collector posts under. Authorship is API-real, so this
+#: pin cannot be satisfied by comment text (openai #9203 P1). Mirrors the
+#: DEFAULT_TRUSTED_SETTLEMENT_CREATOR precedent.
+TRUSTED_EVIDENCE_POSTERS_ENV_VAR = "ARAGORA_TRUSTED_EVIDENCE_POSTERS"
+DEFAULT_TRUSTED_EVIDENCE_POSTERS: tuple[str, ...] = ("scarmani", "an0mium")
+
+
+def _trusted_evidence_posters() -> frozenset[str]:
+    raw = str(os.environ.get(TRUSTED_EVIDENCE_POSTERS_ENV_VAR, "") or "").strip()
+    logins = (
+        [part.strip() for part in raw.split(",")] if raw else list(DEFAULT_TRUSTED_EVIDENCE_POSTERS)
+    )
+    return frozenset(login.casefold() for login in logins if login)
 
 
 def _human_settlement_status_creator_verified(

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3453,7 +3453,12 @@ def _build_model_review_quorum(
         and not has_pending
         and not checks_unavailable
         and not blocking_workflow_state
-        and quorum_only_required_failure
+        # #8739: use the self-check-INDEPENDENT reachability signal, not
+        # ``quorum_only_required_failure`` — the latter is always False inside
+        # the enforcing merge-quorum job (the quorum row is the excluded
+        # self-check), which would make this valve dead code in CI. The former
+        # is True whenever no NON-quorum required check is failing/pending.
+        and advisory_settle_reachable
         and not unresolved_dissent
         and not _any_blocking_finding
         and _wf_review_present
@@ -3510,6 +3515,7 @@ def _build_model_review_quorum(
         and not settlement_recorded
         and not missing_quorum_is_active_check_blocker
         and not advisory_settle_eligible
+        and not operator_advisory_settlement_eligible
     ):
         reasons.append("checks are failing; repair before settlement")
     elif missing_quorum_is_active_check_blocker:
@@ -3549,7 +3555,20 @@ def _build_model_review_quorum(
         )
         if advisory_findings:
             reasons.append(f"{len(advisory_findings)} advisory finding(s) surfaced for follow-up")
-    if not quorum_satisfied and not settlement_recorded and not advisory_settle_eligible:
+    if operator_advisory_settlement_eligible:
+        reasons.append(
+            "operator advisory settlement: model quorum is unreachable (every review "
+            f"severity-gated advisory; {len(_validated_review_families)} model families "
+            "heard, no [P0]/[P1] blocking findings, no unresolved dissent); the trusted "
+            "settlement operator settled over advisory-only dissent at exact head "
+            "(docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md)"
+        )
+    if (
+        not quorum_satisfied
+        and not settlement_recorded
+        and not advisory_settle_eligible
+        and not operator_advisory_settlement_eligible
+    ):
         if signal_count < requirement["required_model_signals"]:
             reasons.append(
                 "model quorum incomplete: "

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3253,17 +3253,16 @@ def _advisory_settle_review_signals(
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
         if strict_receipt:
-            # Valve mode (claude #9203 round-4 suggestion, completed after the
-            # round-5 openai P1 showed the receipt LINE alone is spoofable text):
-            # positive signals must be AUTHORED by a trusted evidence-poster
-            # login. Authorship is API-real — GitHub sets it from the
-            # authenticated token — so a drive-by account cannot fabricate a
-            # heard family no matter what its comment body claims. The receipt
-            # requirement is kept as well (collector-posted evidence always
-            # carries one), but the authorship pin is the load-bearing guard.
+            # Valve mode: positive signals must be AUTHORED by a trusted
+            # evidence-poster login. Authorship is API-real — GitHub sets it
+            # from the authenticated token — so a drive-by account cannot
+            # fabricate a heard family no matter what its comment body claims
+            # (openai #9203 round-5 P1: any body TEXT, including a receipt
+            # line, is forgeable). Deliberately NOT gated on a receipt
+            # artifact: compose_evidence_comment never emits one, so a receipt
+            # requirement would make the valve unfireable against every real
+            # collector-posted review (openai #9203 round-6 P2).
             if author.casefold() not in _trusted_evidence_posters():
-                continue
-            if "missing_receipt_artifact" in identity.identity_problems:
                 continue
         family = str(identity.model_family or "").strip().lower()
         if family:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3465,6 +3465,17 @@ def _build_model_review_quorum(
         # ``signal_count == 0`` bar the valve could fire on a Tier 3-4 PR that was
         # simply never reviewed, contradicting the spec and audit annotation.
         and signal_count == 0
+        # Quorum must be unreachable because reviews were severity-gated to
+        # ADVISORY, not because they failed to count for INFRA reasons — a
+        # missing receipt artifact, a reviewer CLI outage, an unrecognized
+        # heading (openai #9203 P1). ``_validated_review_families`` counts any
+        # grounded recognized heading, so >=2 heard + signal_count==0 alone
+        # cannot distinguish "all advisory" from "all infra-failed". Requiring a
+        # GENUINE advisory dissent (a validated-source changes_requested with no
+        # [P0]/[P1]) proves the non-counting is severity-gating, not infra —
+        # infra failures must be REPAIRED (re-collect, fix the artifact), never
+        # settled over. This is the same bar advisory_settle already enforces.
+        and _genuine_advisory_dissent
         and not unresolved_dissent
         and not _any_blocking_finding
         and _wf_review_present

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3459,6 +3459,12 @@ def _build_model_review_quorum(
         # self-check), which would make this valve dead code in CI. The former
         # is True whenever no NON-quorum required check is failing/pending.
         and advisory_settle_reachable
+        # Quorum must be UNREACHABLE, not merely unmet (claude #9203 P2): reviews
+        # actually came back (>=2 families heard) AND zero produced a countable
+        # signal — i.e. every review was severity-gated to advisory. Without the
+        # ``signal_count == 0`` bar the valve could fire on a Tier 3-4 PR that was
+        # simply never reviewed, contradicting the spec and audit annotation.
+        and signal_count == 0
         and not unresolved_dissent
         and not _any_blocking_finding
         and _wf_review_present
@@ -3959,7 +3965,11 @@ def _has_operator_settlement_comment(pr: dict[str, Any], *, head_sha: str) -> bo
     settlement record — not just the commit status — is non-forgeable.
     """
     head = str(head_sha or "").strip()
-    if not head:
+    # Format guard (claude #9203 P3): a full 40-hex SHA. A short or malformed
+    # head would make the ``head in body`` substring check dangerously loose
+    # (e.g. a 3-char value matching unrelated text). Callers pass headRefOid,
+    # so this only rejects genuinely malformed input — fail closed.
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", head):
         return False
     trusted = _trusted_settlement_creator().casefold()
     if not trusted:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3195,7 +3195,7 @@ def _advisory_settle_review_signals(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
-    strict_receipt: bool = False,
+    strict_author: bool = False,
 ) -> tuple[bool, bool, bool, frozenset[str]]:
     """Single-pass classification of grounded reviews for advisory_settle.
 
@@ -3205,14 +3205,17 @@ def _advisory_settle_review_signals(
     countable-identity review at head in ANY verdict — the "models were heard"
     accounting used by the operator-advisory-settlement relief valve.
 
-    ``strict_receipt=True`` (the valve's mode; claude #9203 P2) additionally
-    requires each POSITIVE signal's identity to carry a receipt artifact
-    (``missing_receipt_artifact`` absent from its identity problems). Without
-    it, family attribution reduces to self-declared comment text — a heading
-    plus a ``Model family:`` line any non-bot login can fabricate — letting a
-    drive-by account manufacture the appearance of unreachable Tier-4 quorum.
-    The blocking-finding scan stays permissive in both modes (a [P0]/[P1] can
-    never be laundered out by a missing receipt).
+    ``strict_author=True`` (the valve's mode) additionally requires each
+    POSITIVE signal to be AUTHORED by a trusted evidence-poster login
+    (:func:`_trusted_evidence_posters`). Authorship is API-real — GitHub sets
+    it from the authenticated token — so no comment BODY (heading, ``Model
+    family:`` line, or a fabricated receipt line, all forgeable text; openai
+    #9203 round-5 P1) can establish a heard family from an untrusted account.
+    No receipt artifact is required: ``compose_evidence_comment`` never emits
+    one, so a receipt gate would make the valve unfireable against real
+    collector-posted reviews (openai #9203 round-6 P2). The blocking-finding
+    scan stays permissive in both modes (a [P0]/[P1] from ANY author still
+    blocks).
 
     Source-validation is applied UNIFORMLY so every *positive* input to the gate
     passes the SAME filters the strict quorum path uses — closing the class of
@@ -3252,7 +3255,7 @@ def _advisory_settle_review_signals(
         identity = _resolve_model_review_identity(body)
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
-        if strict_receipt:
+        if strict_author:
             # Valve mode: positive signals must be AUTHORED by a trusted
             # evidence-poster login. Authorship is API-real — GitHub sets it
             # from the authenticated token — so a drive-by account cannot
@@ -3442,7 +3445,7 @@ def _build_model_review_quorum(
         pr.get("comments") or [],
         head_sha=head_sha,
         head_committed_at=head_committed_at,
-        strict_receipt=True,
+        strict_author=True,
     )
     advisory_settle_eligible = (
         advisory_dissent_settle_enabled()
@@ -3502,18 +3505,17 @@ def _build_model_review_quorum(
         and signal_count == 0
         # Quorum must be unreachable because reviews were severity-gated to
         # ADVISORY, not because they failed to count for INFRA reasons — a
-        # missing receipt artifact, a reviewer CLI outage, an unrecognized
-        # heading (openai #9203 P1). ``_validated_review_families`` counts any
-        # grounded recognized heading, so >=2 heard + signal_count==0 alone
-        # cannot distinguish "all advisory" from "all infra-failed". Requiring a
-        # GENUINE advisory dissent (a validated-source changes_requested with no
-        # [P0]/[P1]) proves the non-counting is severity-gating, not infra —
-        # infra failures must be REPAIRED (re-collect, fix the artifact), never
-        # settled over. This is the same bar advisory_settle already enforces.
-        # All three positive signals use the STRICT receipt-backed pass (claude
-        # #9203 P2): a self-declared heading with no receipt artifact cannot
-        # establish that a model was heard, dissented, or was western-frontier.
-        # The blocking scan deliberately stays the PERMISSIVE one.
+        # reviewer CLI outage or an unrecognized heading (openai #9203 P1).
+        # ``signal_count == 0`` alone cannot make that distinction, so the
+        # valve additionally requires a DEMONSTRATED severity-gated advisory
+        # dissent (a validated-source changes_requested with no [P0]/[P1] —
+        # the same bar advisory_settle enforces). This is evidence of
+        # severity-gating, not proof that no infra failure also occurred
+        # (claude #9203 round-7 P3): infra failures that suppress counting
+        # must still be REPAIRED (re-collect, restore the reviewer), never
+        # settled over; the operator settles over the advisory dissent only.
+        # All three positive signals use the STRICT trusted-author pass; the
+        # blocking scan deliberately stays the PERMISSIVE one.
         and _genuine_advisory_dissent_strict
         and not unresolved_dissent
         and not _any_blocking_finding

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -3061,6 +3061,8 @@ def _build_merge_authorization_packet(
             "human_preapproval_recorded": quorum.get("human_preapproval_recorded", False),
             "settlement_creator_pin": quorum.get("settlement_creator_pin", {}),
             "unresolved_dissent": quorum["unresolved_dissent"],
+            "operator_advisory_settlement": quorum.get("operator_advisory_settlement", False),
+            "validated_review_families": quorum.get("validated_review_families", []),
             "reviewer_signals": quorum["reviewer_signals"],
             "dogfood_evidence": quorum["dogfood_evidence"],
             "counted_reviewer_ids": quorum["counted_reviewer_ids"],
@@ -3193,10 +3195,15 @@ def _advisory_settle_review_signals(
     *,
     head_sha: str = "",
     head_committed_at: str = "",
-) -> tuple[bool, bool, bool]:
+) -> tuple[bool, bool, bool, frozenset[str]]:
     """Single-pass classification of grounded reviews for advisory_settle.
 
-    Returns ``(has_valid_wf_review, has_valid_advisory_dissent, has_blocking_finding)``.
+    Returns ``(has_valid_wf_review, has_valid_advisory_dissent,
+    has_blocking_finding, validated_review_families)``. The final element is the
+    set of canonical model families with at least one grounded, non-bot,
+    countable-identity review at head in ANY verdict — the "models were heard"
+    accounting used by the operator-advisory-settlement relief valve, which must
+    never be derivable from unvalidated comment text.
 
     Source-validation is applied UNIFORMLY so every *positive* input to the gate
     passes the SAME filters the strict quorum path uses — closing the class of
@@ -3214,6 +3221,7 @@ def _advisory_settle_review_signals(
     has_wf = False
     has_advisory_dissent = False
     has_blocking = False
+    validated_families: set[str] = set()
     for comment in comments or []:
         if not isinstance(comment, dict):
             continue
@@ -3235,13 +3243,16 @@ def _advisory_settle_review_signals(
         identity = _resolve_model_review_identity(body)
         if any(problem in IDENTITY_COUNT_BLOCKERS for problem in identity.identity_problems):
             continue
-        if str(identity.model_family or "").strip().lower() in WESTERN_FRONTIER_FAMILIES:
+        family = str(identity.model_family or "").strip().lower()
+        if family:
+            validated_families.add(family)
+        if family in WESTERN_FRONTIER_FAMILIES:
             has_wf = True
         # Genuine advisory dissent: a CHANGES-REQUESTED verdict from a validated
         # source with no blocking [P0]/[P1] finding.
         if _has_blocking_or_negative_verdict(body) and not _has_blocking_finding_or_label(body):
             has_advisory_dissent = True
-    return has_wf, has_advisory_dissent, has_blocking
+    return has_wf, has_advisory_dissent, has_blocking, frozenset(validated_families)
 
 
 def _build_model_review_quorum(
@@ -3392,6 +3403,7 @@ def _build_model_review_quorum(
         _wf_review_present,
         _genuine_advisory_dissent,
         _any_blocking_finding,
+        _validated_review_families,
     ) = _advisory_settle_review_signals(
         pr.get("comments") or [],
         head_sha=head_sha,
@@ -3422,6 +3434,36 @@ def _build_model_review_quorum(
         and not unresolved_dissent
         and not _any_blocking_finding
     )
+    # Constitutional relief valve (docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md;
+    # #8933 incident, PR #8939: four evidence rounds, zero blocking findings,
+    # zero countable signals). Model quorum can be UNREACHABLE — every review
+    # severity-gated advisory — rather than merely unmet, and any fix to the
+    # gate is itself gate-blocked without this branch. The trusted settlement
+    # operator may settle over ADVISORY-ONLY dissent at Tier 3-4 when models
+    # were demonstrably heard. [P0]/[P1] findings and unresolved dissent still
+    # block everyone, including the operator; every condition fails closed.
+    # Authorization rests SOLELY on the trusted-creator commit status + the
+    # trusted-author marker comment; validated-family accounting comes from the
+    # same single validated pass advisory_settle uses, never raw comment text.
+    operator_advisory_settlement_eligible = bool(
+        _operator_advisory_settlement_enabled()
+        and tier in (3, 4)
+        and not quorum_satisfied
+        and not settlement_recorded
+        and not has_pending
+        and not checks_unavailable
+        and not blocking_workflow_state
+        and quorum_only_required_failure
+        and not unresolved_dissent
+        and not _any_blocking_finding
+        and _wf_review_present
+        and len(_validated_review_families) >= 2
+        and _has_operator_settlement_comment(pr, head_sha=head_sha)
+        and _human_settlement_status_creator_verified(
+            repo_slug=repo_slug or rest_fallback._repo_slug_from_pr_payload(pr, None),
+            head_sha=head_sha,
+        )[0]
+    )
     # The incomplete-quorum check only acts as an ACTIVE blocker when advisory_settle
     # is NOT rescuing this PR; otherwise the merge-quorum check is treated as resolved
     # by the advisory path (and the verdict chain reports advisory_settle instead).
@@ -3430,6 +3472,7 @@ def _build_model_review_quorum(
         and not quorum_satisfied
         and not settlement_recorded
         and not advisory_settle_eligible
+        and not operator_advisory_settlement_eligible
     )
     requires_human_preapproval = bool(requirement["requires_human_preapproval"])
     human_preapproval_recorded = (
@@ -3537,6 +3580,7 @@ def _build_model_review_quorum(
             has_failures
             and not missing_quorum_is_active_check_blocker
             and not advisory_settle_eligible
+            and not operator_advisory_settlement_eligible
         )
         or has_pending
         or checks_unavailable
@@ -3544,6 +3588,7 @@ def _build_model_review_quorum(
             machine_recommendation == "repair_first"
             and not missing_quorum_is_active_check_blocker
             and not advisory_settle_eligible
+            and not operator_advisory_settlement_eligible
         )
         or stale_quorum_check_after_satisfied_evidence
         or blocking_workflow_state
@@ -3556,6 +3601,14 @@ def _build_model_review_quorum(
         # advisory findings only. Tier 0-2 only; no human risk settlement required.
         status = "satisfied"
         verdict = "advisory_settle"
+        requires_human_risk_settlement = False
+        admin_squash_allowed = True
+    elif operator_advisory_settlement_eligible:
+        # Distinct, auditable verdict (mirrors advisory_settle): the audit trail
+        # records that the trusted operator settled over advisory-only dissent
+        # with quorum unreachable, not that quorum was met.
+        status = "satisfied"
+        verdict = "operator_advisory_settlement"
         requires_human_risk_settlement = False
         admin_squash_allowed = True
     elif not quorum_satisfied:
@@ -3619,6 +3672,8 @@ def _build_model_review_quorum(
         # this gate's. Mirrors ``advisory_views`` content for the eligible case.
         "advisory_findings": advisory_findings if advisory_settle_eligible else [],
         "advisory_settle": advisory_settle_eligible,
+        "operator_advisory_settlement": operator_advisory_settlement_eligible,
+        "validated_review_families": sorted(_validated_review_families),
         "unresolved_dissent": unresolved_dissent,
         "reasons": reasons,
     }
@@ -3854,6 +3909,63 @@ def _human_settlement_status_creator_verified(
             f"settlement-creator pin: '{context}' status created by trusted settlement creator '{trusted}'",
         )
     return fail(f"no '{context}' status found on head commit; failing closed")
+
+
+_OPERATOR_ADVISORY_SETTLEMENT_ENV = "ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT"
+
+
+def _operator_advisory_settlement_enabled(env: dict[str, str] | None = None) -> bool:
+    """Whether the opt-in operator-advisory-settlement relief valve is active.
+
+    Default OFF, mirroring ``advisory_dissent_settle_enabled``. Defined locally
+    (rather than beside that helper in ``aragora.swarm.quorum_evidence``) to
+    avoid touching a file contested by in-flight PRs #9129/#9147; consolidation
+    is a follow-up once those land. See docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md.
+    """
+    source = os.environ if env is None else env
+    return str(source.get(_OPERATOR_ADVISORY_SETTLEMENT_ENV, "")).strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _has_operator_settlement_comment(pr: dict[str, Any], *, head_sha: str) -> bool:
+    """A Tier-4 settlement marker comment AUTHORED by the trusted operator.
+
+    Stricter than :func:`_has_tier_four_human_preapproval_comment` (which any
+    author can satisfy): the operator-advisory-settlement relief valve requires
+    the marker comment itself to come from the trusted settlement login, so the
+    settlement record — not just the commit status — is non-forgeable.
+    """
+    head = str(head_sha or "").strip()
+    if not head:
+        return False
+    trusted = _trusted_settlement_creator().casefold()
+    if not trusted:
+        return False
+    for comment in pr.get("comments") or []:
+        if not isinstance(comment, dict):
+            continue
+        author_payload = comment.get("author")
+        author = (
+            str(author_payload.get("login", "") or "") if isinstance(author_payload, dict) else ""
+        )
+        if author.casefold() != trusted:
+            continue
+        body = str(comment.get("body") or "")
+        lowered = body.lower()
+        if TIER_FOUR_SETTLEMENT_MARKER not in body:
+            continue
+        if head not in body:
+            continue
+        if not any(token in lowered for token in TIER_FOUR_AUTHORIZED_MERGE_TOKENS):
+            continue
+        if "human-risk settlement" not in lowered:
+            continue
+        return True
+    return False
 
 
 def _has_tier_four_human_preapproval_comment(pr: dict[str, Any], *, head_sha: str) -> bool:

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -53,16 +53,19 @@ following hold (any failure → fail closed, verdict unchanged):
    front door (get the passes to count), not this valve.
 4. A validated western-frontier review is present at head, and **≥2 distinct
    canonical model families** were heard — computed from a strict validated
-   pass: grounded, non-bot, countable identity, receipt-backed, **and authored
-   by a trusted evidence-poster login** (`ARAGORA_TRUSTED_EVIDENCE_POSTERS`,
-   default: the operator's settlement + collector accounts). Authorship is the
-   load-bearing guard: it is API-real (GitHub sets it from the authenticated
-   token), so no comment BODY — including a fabricated `Receipt artifact:`
-   line, which is just text (openai #9203 P1) — can establish a heard family
-   from an untrusted account. Comment-side records remain corroborating, not
-   unforgeable (write-access collaborators can edit bodies with `author.login`
-   preserved); the creator-pinned commit status (condition 5) is the sole
-   unforgeable authorization root.
+   pass: grounded, non-bot, countable identity, **and authored by a trusted
+   evidence-poster login** (`ARAGORA_TRUSTED_EVIDENCE_POSTERS`, default: the
+   operator's settlement + collector accounts). Authorship is the load-bearing
+   guard: it is API-real (GitHub sets it from the authenticated token), so no
+   comment BODY can establish a heard family from an untrusted account — any
+   body text, including a fabricated `Receipt artifact:` line, is forgeable
+   (openai #9203 round-5 P1). The strict pass deliberately does NOT require a
+   receipt artifact: `compose_evidence_comment` never emits one, so a receipt
+   requirement would make the valve unfireable against every real
+   collector-posted review (openai #9203 round-6 P2). Comment-side records
+   remain corroborating, not unforgeable (write-access collaborators can edit
+   bodies with `author.login` preserved); the creator-pinned commit status
+   (condition 5) is the sole unforgeable authorization root.
 5. An `aragora/human-settlement` commit status = success at the exact head,
    created by the **trusted settlement operator login**
    (`ARAGORA_SETTLEMENT_CREATOR`, default `scarmani`) — the unforgeable

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -1,0 +1,84 @@
+# Operator Advisory Settlement — constitutional relief valve for the merge-quorum gate
+
+Status: proposed (Tier 4 merge-authority self-modification; requires human
+preapproval to implement and to merge, per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`).
+
+Origin: the #8933 typecheck-false-green incident (PR #8939), 2026-07-11.
+
+## Problem: unreachable quorum, not merely unmet
+
+The merge-quorum gate can reach a state where model quorum is **structurally
+unreachable** rather than simply not yet collected:
+
+- Severity-gated dissent (`docs/specs/FINDING_SEVERITY_GATE.md`) makes a review
+  carrying only advisory `[P2]`/`[P3]` notes **non-blocking but also
+  non-counting**.
+- For changes to the governance/CI machinery itself, the advisory-objection
+  space does not converge: each round's fixes become the next round's surface,
+  and a `[P2]` costs a reviewer nothing to assign.
+- PR #8939 demonstrated this empirically: four evidence rounds, **zero**
+  `[P0]`/`[P1]` findings in any round, claude PASS every round — and **zero**
+  countable signals, because every review carried advisory notes.
+
+The result is a constitutional defect: **any fix to the merge-quorum gate must
+pass through the merge-quorum gate it fixes.** A self-hosting governance system
+needs an amendment path that does not route through the component being amended.
+Before this valve, the only mechanical escape was disabling a branch-protection
+safeguard — precisely the action the gate exists to make unnecessary.
+
+## The valve
+
+At packet status `needs_model_review_quorum`, a new verdict
+`operator_advisory_settlement` authorizes the merge when **all** of the
+following hold (any failure → fail closed, verdict unchanged):
+
+1. Flag `ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT` is on (default OFF).
+2. Tier is **3 or 4** — the incident class. At Tier 0-2 an unmet quorum means
+   "not reviewed yet"; the answer there stays "collect reviews" or qualify for
+   the existing Tier 0-2 `advisory_settle` path.
+3. No unresolved dissent, **and** no blocking `[P0]`/`[P1]` finding in any
+   grounded review — reusing the same fail-closed permissive blocking scan
+   `advisory_settle` uses (`_advisory_settle_review_signals`, hardened in
+   #8729 against spoofed-identity / bot-author laundering). **Blocking model
+   dissent still stops everyone, including the operator.**
+4. A validated western-frontier review is present at head, and **≥2 distinct
+   canonical model families** were heard — computed from the same single
+   validated pass (grounded, non-bot, countable identity), never from raw
+   comment text.
+5. An `aragora/human-settlement` commit status = success at the exact head,
+   created by the **trusted settlement operator login**
+   (`ARAGORA_SETTLEMENT_CREATOR`, default `scarmani`) — the unforgeable
+   authorization spine (GitHub sets status creator from the authenticated
+   token; no repo workflow holds `statuses: write`).
+6. A `Tier-4 Human Settlement Authorization` marker comment **authored by the
+   trusted settlement operator**, naming the exact head, carrying an
+   authorized-merge token and the risk-acceptance phrase.
+
+Only the model quorum requirement is relaxed; every other blocker (failing or
+pending checks, blocking workflow state, `[P0]`/`[P1]`, unresolved dissent) is
+untouched. The settled verdict is a **distinct, auditable value**
+(`operator_advisory_settlement`, not `admin_squash_allowed`), and the workflow
+emits a `::notice::OPERATOR-SETTLED-OVER-ADVISORY` line naming the PR, head,
+tier, and validated families.
+
+## What is preserved
+
+- `[P0]`/`[P1]` model dissent blocks the operator exactly as before.
+- Tier 0-2 behavior is unchanged (the valve is Tier 3-4 only).
+- The blocking-finding bar is the same one `advisory_settle` uses — the valve
+  is never laxer than the machine advisory path.
+- Authorization is a trusted-creator commit status; comments are corroborating
+  record, not the auth root (and the marker author is verified too).
+
+## Revert
+
+Single env flip: `ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT` back to unset in
+`.github/workflows/aragora-merge-quorum.yml` (itself a Tier-4 edit).
+
+## Follow-ups
+
+- Consolidate the flag helper into `aragora.swarm.quorum_evidence` beside
+  `advisory_dissent_settle_enabled` once PRs #9129/#9147 (which contest that
+  file) land.
+- This valve is the amendment path the constitutional-circle finding of the
+  #8933 incident identified; the incident postmortem should reference it.

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -52,9 +52,15 @@ following hold (any failure → fail closed, verdict unchanged):
    that merely failed to count for infra reasons settles through the NORMAL
    front door (get the passes to count), not this valve.
 4. A validated western-frontier review is present at head, and **≥2 distinct
-   canonical model families** were heard — computed from the same single
-   validated pass (grounded, non-bot, countable identity), never from raw
-   comment text.
+   canonical model families** were heard — computed from a strict validated
+   pass (grounded, non-bot, countable identity, **and receipt-backed**: an
+   identity with `missing_receipt_artifact` does not establish that a model
+   was heard). A self-declared heading plus `Model family:` line is spoofable
+   by any non-bot login (claude #9203 P2); requiring the receipt artifact ties
+   family attribution to collector-posted evidence. Note the comment-side
+   records are corroborating, not unforgeable — write-access collaborators can
+   edit comments with `author.login` preserved; the creator-pinned commit
+   status (condition 5) is the sole unforgeable authorization root.
 5. An `aragora/human-settlement` commit status = success at the exact head,
    created by the **trusted settlement operator login**
    (`ARAGORA_SETTLEMENT_CREATOR`, default `scarmani`) — the unforgeable

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -53,14 +53,16 @@ following hold (any failure → fail closed, verdict unchanged):
    front door (get the passes to count), not this valve.
 4. A validated western-frontier review is present at head, and **≥2 distinct
    canonical model families** were heard — computed from a strict validated
-   pass (grounded, non-bot, countable identity, **and receipt-backed**: an
-   identity with `missing_receipt_artifact` does not establish that a model
-   was heard). A self-declared heading plus `Model family:` line is spoofable
-   by any non-bot login (claude #9203 P2); requiring the receipt artifact ties
-   family attribution to collector-posted evidence. Note the comment-side
-   records are corroborating, not unforgeable — write-access collaborators can
-   edit comments with `author.login` preserved; the creator-pinned commit
-   status (condition 5) is the sole unforgeable authorization root.
+   pass: grounded, non-bot, countable identity, receipt-backed, **and authored
+   by a trusted evidence-poster login** (`ARAGORA_TRUSTED_EVIDENCE_POSTERS`,
+   default: the operator's settlement + collector accounts). Authorship is the
+   load-bearing guard: it is API-real (GitHub sets it from the authenticated
+   token), so no comment BODY — including a fabricated `Receipt artifact:`
+   line, which is just text (openai #9203 P1) — can establish a heard family
+   from an untrusted account. Comment-side records remain corroborating, not
+   unforgeable (write-access collaborators can edit bodies with `author.login`
+   preserved); the creator-pinned commit status (condition 5) is the sole
+   unforgeable authorization root.
 5. An `aragora/human-settlement` commit status = success at the exact head,
    created by the **trusted settlement operator login**
    (`ARAGORA_SETTLEMENT_CREATOR`, default `scarmani`) — the unforgeable

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -47,10 +47,13 @@ following hold (any failure → fail closed, verdict unchanged):
    cannot tell "every review was severity-gated to advisory" (the case this
    valve is *for*) apart from "reviews failed to count for INFRA reasons" — a
    missing receipt artifact, a reviewer CLI outage, an unrecognized heading.
-   **Infra failures must be repaired (re-collect, fix the artifact, wait for
-   reviewer uptime), never settled over.** A PR whose reviews were all *passes*
-   that merely failed to count for infra reasons settles through the NORMAL
-   front door (get the passes to count), not this valve.
+   The genuine-dissent requirement is evidence of severity-gating, not proof
+   that no infra failure also occurred (claude #9203 round-7 P3). **Infra
+   failures must be repaired (re-collect, restore the reviewer), never settled
+   over** — the operator settles over the advisory dissent only. A PR whose
+   reviews were all *passes* that merely failed to count for infra reasons
+   settles through the NORMAL front door (get the passes to count), not this
+   valve.
 4. A validated western-frontier review is present at head, and **≥2 distinct
    canonical model families** were heard — computed from a strict validated
    pass: grounded, non-bot, countable identity, **and authored by a trusted

--- a/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
+++ b/docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md
@@ -41,6 +41,16 @@ following hold (any failure → fail closed, verdict unchanged):
    `advisory_settle` uses (`_advisory_settle_review_signals`, hardened in
    #8729 against spoofed-identity / bot-author laundering). **Blocking model
    dissent still stops everyone, including the operator.**
+   3a. **A genuine advisory dissent must be present** — a validated-source
+   `changes_requested` carrying only `[P2]`/`[P3]` (no `[P0]`/`[P1]`). This is
+   the load-bearing distinction (openai #9203 P1): `signal_count == 0` alone
+   cannot tell "every review was severity-gated to advisory" (the case this
+   valve is *for*) apart from "reviews failed to count for INFRA reasons" — a
+   missing receipt artifact, a reviewer CLI outage, an unrecognized heading.
+   **Infra failures must be repaired (re-collect, fix the artifact, wait for
+   reviewer uptime), never settled over.** A PR whose reviews were all *passes*
+   that merely failed to count for infra reasons settles through the NORMAL
+   front door (get the passes to count), not this valve.
 4. A validated western-frontier review is present at head, and **≥2 distinct
    canonical model families** were heard — computed from the same single
    validated pass (grounded, non-bot, countable identity), never from raw

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -177,18 +177,22 @@ class TestFlagGate:
 # --- assembled verdict through _build_model_review_quorum -------------------
 
 
-def _advisory_review(family: str, *, receipt: bool = True) -> dict[str, Any]:
+def _advisory_review(
+    family: str, *, receipt: bool = True, author: str = "an0mium"
+) -> dict[str, Any]:
     """A grounded advisory (CHANGES-REQUESTED, [P2]-only) review — non-blocking,
     non-counting under severity gating, but a validated family that was HEARD.
 
-    ``receipt=True`` mirrors a real collector-posted review (which always carries
-    a receipt artifact); ``receipt=False`` models a self-declared/spoofed heading,
-    which the valve's strict pass must ignore (claude #9203 P2)."""
+    ``receipt=True`` + the default trusted ``author`` mirror a real
+    collector-posted review; ``receipt=False`` or an untrusted ``author`` model
+    the spoof shapes the valve's strict pass must ignore (claude #9203 P2 /
+    openai #9203 P1: the receipt LINE is forgeable text — authorship is the
+    API-real guard)."""
     receipt_line = (
         f"**Receipt artifact:** .aragora/receipts/{family}-review.json\n" if receipt else ""
     )
     return {
-        "author": {"login": "an0mium"},
+        "author": {"login": author},
         "createdAt": "2026-07-11T00:00:00Z",
         "body": (
             f"## {family} independent model review\n"
@@ -307,6 +311,35 @@ class TestAssembledValve:
             repo_slug="synaptent/aragora",
         )
         assert q["operator_advisory_settlement"] is False
+
+    def test_valve_ignores_untrusted_author_even_with_receipt_line(self, monkeypatch: Any) -> None:
+        """openai #9203 P1: a fabricated 'Receipt artifact:' line is just text.
+        A drive-by login posting perfect-looking reviews (receipt line included)
+        must not establish heard families — authorship is the API-real guard."""
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        monkeypatch.setattr(
+            rq, "_human_settlement_status_creator_verified", lambda **_kw: (True, "verified")
+        )
+        pr = self._tier4_pr()
+        pr["comments"] = [
+            _advisory_review("claude", receipt=True, author="drive-by-account"),
+            _advisory_review("openai", receipt=True, author="drive-by-account"),
+            _marker("scarmani"),
+        ]
+        q = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=True,
+            check_surfaces=self._SURFACE_CLEAR,
+            repo_slug="synaptent/aragora",
+        )
+        assert q["operator_advisory_settlement"] is False
+        assert q["validated_review_families"] == []
 
     def test_valve_ignores_spoofed_headings_without_receipt(self, monkeypatch: Any) -> None:
         """claude #9203 P2: self-declared review headings with no receipt artifact

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -177,15 +177,23 @@ class TestFlagGate:
 # --- assembled verdict through _build_model_review_quorum -------------------
 
 
-def _advisory_review(family: str) -> dict[str, Any]:
+def _advisory_review(family: str, *, receipt: bool = True) -> dict[str, Any]:
     """A grounded advisory (CHANGES-REQUESTED, [P2]-only) review — non-blocking,
-    non-counting under severity gating, but a validated family that was HEARD."""
+    non-counting under severity gating, but a validated family that was HEARD.
+
+    ``receipt=True`` mirrors a real collector-posted review (which always carries
+    a receipt artifact); ``receipt=False`` models a self-declared/spoofed heading,
+    which the valve's strict pass must ignore (claude #9203 P2)."""
+    receipt_line = (
+        f"**Receipt artifact:** .aragora/receipts/{family}-review.json\n" if receipt else ""
+    )
     return {
         "author": {"login": "an0mium"},
         "createdAt": "2026-07-11T00:00:00Z",
         "body": (
             f"## {family} independent model review\n"
             f"**Model family:** {family}\n"
+            f"{receipt_line}"
             f"Current head: {HEAD}\n\n"
             "Verdict: request changes.\n"
             "- [P2] a non-blocking nit worth polishing."
@@ -299,6 +307,35 @@ class TestAssembledValve:
             repo_slug="synaptent/aragora",
         )
         assert q["operator_advisory_settlement"] is False
+
+    def test_valve_ignores_spoofed_headings_without_receipt(self, monkeypatch: Any) -> None:
+        """claude #9203 P2: self-declared review headings with no receipt artifact
+        must not establish 'models were heard' — a drive-by account cannot
+        manufacture unreachable Tier-4 quorum from comment text alone."""
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        monkeypatch.setattr(
+            rq, "_human_settlement_status_creator_verified", lambda **_kw: (True, "verified")
+        )
+        pr = self._tier4_pr()
+        pr["comments"] = [
+            _advisory_review("claude", receipt=False),
+            _advisory_review("openai", receipt=False),
+            _marker("scarmani"),
+        ]
+        q = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=True,
+            check_surfaces=self._SURFACE_CLEAR,
+            repo_slug="synaptent/aragora",
+        )
+        assert q["operator_advisory_settlement"] is False
+        assert q["validated_review_families"] == []
 
     def test_valve_refuses_all_pass_non_counting(self, monkeypatch: Any) -> None:
         """openai #9203 P1 (behavioral): an all-PASS non-counting Tier-4 PR — no

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -341,10 +341,12 @@ class TestAssembledValve:
         assert q["operator_advisory_settlement"] is False
         assert q["validated_review_families"] == []
 
-    def test_valve_ignores_spoofed_headings_without_receipt(self, monkeypatch: Any) -> None:
-        """claude #9203 P2: self-declared review headings with no receipt artifact
-        must not establish 'models were heard' — a drive-by account cannot
-        manufacture unreachable Tier-4 quorum from comment text alone."""
+    def test_trusted_author_without_receipt_line_counts(self, monkeypatch: Any) -> None:
+        """openai #9203 round-6 P2: compose_evidence_comment never emits a
+        Receipt artifact line, so trusted-author evidence WITHOUT one is the
+        production shape and must count — a receipt requirement would make the
+        valve unfireable against every real collector-posted review. The guard
+        against spoofing is authorship (API-real), not body text."""
         monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
         monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
         monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
@@ -367,8 +369,8 @@ class TestAssembledValve:
             check_surfaces=self._SURFACE_CLEAR,
             repo_slug="synaptent/aragora",
         )
-        assert q["operator_advisory_settlement"] is False
-        assert q["validated_review_families"] == []
+        assert q["operator_advisory_settlement"] is True
+        assert sorted(q["validated_review_families"]) == ["claude", "openai"]
 
     def test_valve_refuses_all_pass_non_counting(self, monkeypatch: Any) -> None:
         """openai #9203 P1 (behavioral): an all-PASS non-counting Tier-4 PR — no

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -3,17 +3,20 @@
 Spec: docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md (#8933 incident, PR #8939).
 
 These pin the two new load-bearing helpers directly (the valve's family
-accounting and its trusted-author marker check) plus the flag gate. The valve's
-full assembly in ``_build_model_review_quorum`` is exercised through the public
-``review-queue merge-packet`` path in the CLI integration suite; here we lock
-the security-critical primitives so a reviewer can see the invariants hold.
+accounting and its trusted-author marker check), the flag gate, AND the
+assembled verdict through ``_build_model_review_quorum`` — the last of these
+guards the self-check-independent reachability signal (a packet-level test is
+what catches a valve gated on the always-False-in-CI ``quorum_only_failure``).
 """
 
 from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from aragora.cli.commands import review_queue as rq
+from aragora.cli.commands.review_queue import _build_model_review_quorum
 
 HEAD = "abfea376c6216173b6f4ed84306893acc9563545"
 COMMITTED_AT = "2026-07-10T23:00:00Z"
@@ -169,3 +172,130 @@ class TestFlagGate:
                 )
                 is False
             )
+
+
+# --- assembled verdict through _build_model_review_quorum -------------------
+
+
+def _advisory_review(family: str) -> dict[str, Any]:
+    """A grounded advisory (CHANGES-REQUESTED, [P2]-only) review — non-blocking,
+    non-counting under severity gating, but a validated family that was HEARD."""
+    return {
+        "author": {"login": "an0mium"},
+        "createdAt": "2026-07-11T00:00:00Z",
+        "body": (
+            f"## {family} independent model review\n"
+            f"**Model family:** {family}\n"
+            f"Current head: {HEAD}\n\n"
+            "Verdict: request changes.\n"
+            "- [P2] a non-blocking nit worth polishing."
+        ),
+    }
+
+
+class TestAssembledValve:
+    """Exercise the full valve through _build_model_review_quorum.
+
+    This is the level that catches a valve gated on the wrong reachability
+    signal: quorum_only_failure is always False inside the enforcing job, so a
+    unit test of the primitives alone would pass while the valve stayed dead.
+    """
+
+    def _tier4_pr(self) -> dict[str, Any]:
+        return {
+            "number": 8939,
+            "title": "gate-code change",
+            "state": "OPEN",
+            "isDraft": False,
+            "headRefOid": HEAD,
+            "mergeable": "MERGEABLE",
+            "comments": [
+                _advisory_review("claude"),
+                _advisory_review("openai"),
+                _marker("scarmani"),
+            ],
+            "statusCheckRollup": [
+                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"context": "aragora/human-settlement", "state": "SUCCESS"},
+            ],
+            "commits": [{"commit": {"committedDate": COMMITTED_AT}}],
+        }
+
+    _SURFACE_CLEAR = {
+        # Self-check-independent: no NON-quorum required check is failing, so the
+        # surface is clear even though quorum_only_failure is False (the quorum
+        # row is the excluded self-check inside the enforcing job).
+        "required_pr_checks": {
+            "quorum_only_failure": False,
+            "advisory_settle_surface_clear": True,
+        }
+    }
+
+    def _build(self, monkeypatch: Any, files: list[str]) -> dict[str, Any]:
+        # Mirror the enforcing CI env: severity-gated dissent turns the [P2]-only
+        # CHANGES-REQUESTED reviews into advisory (non-blocking) dissent, so
+        # unresolved_dissent is False and the valve can consider them. Without
+        # this flag a [P2] CR is a hard dissent and the valve correctly refuses.
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        monkeypatch.setattr(
+            rq,
+            "_human_settlement_status_creator_verified",
+            lambda **_kw: (True, "verified"),
+        )
+        return _build_model_review_quorum(
+            pr=self._tier4_pr(),
+            files=files,
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=True,  # the quorum row is the failing required check
+            check_surfaces=self._SURFACE_CLEAR,
+            repo_slug="synaptent/aragora",
+        )
+
+    def test_valve_fires_flag_on(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        q = self._build(monkeypatch, ["aragora/cli/commands/review_queue.py"])
+        assert q["tier"] == 4
+        assert q["operator_advisory_settlement"] is True
+        assert q["status"] == "satisfied"
+        assert q["verdict"] == "operator_advisory_settlement"
+        assert sorted(q["validated_review_families"]) == ["claude", "openai"]
+
+    def test_valve_silent_flag_off(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", raising=False)
+        q = self._build(monkeypatch, ["aragora/cli/commands/review_queue.py"])
+        # Flag off → the valve is inert and the PR is NOT settled, regardless of
+        # which not-ready status the surrounding ladder reports.
+        assert q["operator_advisory_settlement"] is False
+        assert q["status"] != "satisfied"
+        assert q["verdict"] != "operator_advisory_settlement"
+        assert q["admin_squash_allowed"] is False
+
+    def test_valve_refuses_tier_two(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        q = self._build(monkeypatch, ["aragora/cli/commands/swarm.py"])
+        assert q["tier"] <= 2
+        assert q["operator_advisory_settlement"] is False
+
+    def test_valve_refuses_on_blocking_finding(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        monkeypatch.setattr(
+            rq, "_human_settlement_status_creator_verified", lambda **_kw: (True, "verified")
+        )
+        pr = self._tier4_pr()
+        pr["comments"][0]["body"] += "\n- [P1] a genuine blocking bug."
+        q = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=True,
+            check_surfaces=self._SURFACE_CLEAR,
+            repo_slug="synaptent/aragora",
+        )
+        assert q["operator_advisory_settlement"] is False

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -299,3 +299,47 @@ class TestAssembledValve:
             repo_slug="synaptent/aragora",
         )
         assert q["operator_advisory_settlement"] is False
+
+    def test_valve_refuses_all_pass_non_counting(self, monkeypatch: Any) -> None:
+        """openai #9203 P1 (behavioral): an all-PASS non-counting Tier-4 PR — no
+        genuine advisory dissent — must NOT settle via the valve; its path is the
+        normal front door (get the passes to count). The `_genuine_advisory_dissent`
+        requirement is the load-bearing guard here; this asserts the resulting
+        behavior end-to-end (defense in depth may also refuse via other bars)."""
+        monkeypatch.setenv("ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT", "1")
+        monkeypatch.setenv("ARAGORA_ENABLE_SEVERITY_GATED_DISSENT", "1")
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        monkeypatch.setattr(
+            rq, "_human_settlement_status_creator_verified", lambda **_kw: (True, "verified")
+        )
+        pr = self._tier4_pr()
+        # Replace the advisory (CR) reviews with PASS reviews from both families:
+        # heard + validated, but no genuine advisory dissent — the infra-failure
+        # shape the valve must refuse.
+        pass_bodies = []
+        for family in ("claude", "openai"):
+            pass_bodies.append(
+                {
+                    "author": {"login": "an0mium"},
+                    "createdAt": "2026-07-11T00:00:00Z",
+                    "body": (
+                        f"## {family} independent model review\n"
+                        f"**Model family:** {family}\n"
+                        f"Current head: {HEAD}\n\n"
+                        "Verdict: pass.\n"
+                        "Looks good."
+                    ),
+                }
+            )
+        pr["comments"] = [*pass_bodies, _marker("scarmani")]
+        q = _build_model_review_quorum(
+            pr=pr,
+            files=["aragora/cli/commands/review_queue.py"],
+            protocol={"status": "metadata_heuristic"},
+            machine_recommendation="approve_candidate",
+            has_pending=False,
+            has_failures=True,
+            check_surfaces=self._SURFACE_CLEAR,
+            repo_slug="synaptent/aragora",
+        )
+        assert q["operator_advisory_settlement"] is False

--- a/tests/governance/test_operator_advisory_settlement.py
+++ b/tests/governance/test_operator_advisory_settlement.py
@@ -1,0 +1,171 @@
+"""Tests for the operator-advisory-settlement relief valve.
+
+Spec: docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md (#8933 incident, PR #8939).
+
+These pin the two new load-bearing helpers directly (the valve's family
+accounting and its trusted-author marker check) plus the flag gate. The valve's
+full assembly in ``_build_model_review_quorum`` is exercised through the public
+``review-queue merge-packet`` path in the CLI integration suite; here we lock
+the security-critical primitives so a reviewer can see the invariants hold.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aragora.cli.commands import review_queue as rq
+
+HEAD = "abfea376c6216173b6f4ed84306893acc9563545"
+COMMITTED_AT = "2026-07-10T23:00:00Z"
+
+
+def _review(family: str, *, verdict: str = "approve", body_extra: str = "") -> dict[str, Any]:
+    """A grounded, non-bot, countable model-review comment for ``family``."""
+    return {
+        "author": {"login": "an0mium"},
+        "createdAt": "2026-07-11T00:00:00Z",
+        "body": (
+            f"## {family} independent model review\n"
+            f"**Model family:** {family}\n"
+            f"Head: {HEAD}\n"
+            f"Verdict: {verdict}.\n"
+            f"{body_extra}"
+        ),
+    }
+
+
+# --- validated-family accounting (condition 4) -----------------------------
+
+
+class TestValidatedFamilies:
+    def test_two_distinct_families_are_counted(self) -> None:
+        comments = [_review("claude"), _review("openai")]
+        _wf, _diss, blocking, families = rq._advisory_settle_review_signals(
+            comments, head_sha=HEAD, head_committed_at=COMMITTED_AT
+        )
+        assert families == frozenset({"claude", "openai"})
+        assert blocking is False
+
+    def test_settlement_marker_and_plain_prose_do_not_inflate_family_count(self) -> None:
+        # Family attribution uses the SAME validated pass advisory_settle uses:
+        # a comment must be a RECOGNIZED model review (not raw text) to attribute
+        # a family. The settlement marker comment and ordinary prose are not
+        # recognized reviews, so a single genuine review cannot be padded to a
+        # false quorum-of-two by non-review chatter. (Family attribution for a
+        # recognized review follows advisory_settle's self-declared-header
+        # standard by design; the valve's binding authorization is the
+        # trusted-creator commit status, not this corroborating count.)
+        prose = {
+            "author": {"login": "an0mium"},
+            "createdAt": "2026-07-11T00:00:00Z",
+            "body": f"Looks good to me, thanks. (reviewed {HEAD})",
+        }
+        marker = _marker("scarmani")
+        marker["createdAt"] = "2026-07-11T00:00:00Z"
+        _wf, _diss, _block, families = rq._advisory_settle_review_signals(
+            [_review("claude"), prose, marker], head_sha=HEAD, head_committed_at=COMMITTED_AT
+        )
+        assert families == frozenset({"claude"})
+
+    def test_bot_authored_review_does_not_count_family(self) -> None:
+        # Positive family attribution requires a non-bot author (the blocking
+        # scan still consults bot reviews, but they never ADD a countable family).
+        bot = _review("openai")
+        bot["author"] = {"login": "github-actions[bot]"}
+        _wf, _diss, _block, families = rq._advisory_settle_review_signals(
+            [_review("claude"), bot], head_sha=HEAD, head_committed_at=COMMITTED_AT
+        )
+        assert families == frozenset({"claude"})
+
+    def test_blocking_finding_is_reported(self) -> None:
+        comments = [_review("claude", verdict="request changes", body_extra="- [P1] real bug")]
+        _wf, _diss, blocking, _families = rq._advisory_settle_review_signals(
+            comments, head_sha=HEAD, head_committed_at=COMMITTED_AT
+        )
+        assert blocking is True
+
+    def test_stale_comment_excluded(self) -> None:
+        stale = _review("claude")
+        stale["createdAt"] = "2020-01-01T00:00:00Z"
+        stale["body"] = stale["body"].replace(f"Head: {HEAD}\n", "")  # no SHA cite either
+        _wf, _diss, _block, families = rq._advisory_settle_review_signals(
+            [stale], head_sha=HEAD, head_committed_at=COMMITTED_AT
+        )
+        assert families == frozenset()
+
+
+# --- trusted-author marker comment (condition 6) ---------------------------
+
+
+def _marker(author: str, *, head: str = HEAD, token: str = "admin_squash_merge") -> dict[str, Any]:
+    return {
+        "author": {"login": author},
+        "body": (
+            "Tier-4 Human Settlement Authorization\n\n"
+            f"PR: #8939\nExact head: {head}\n"
+            f"Authorized action: {token}.\n"
+            "Human-risk settlement: I accept the Tier 4 risk for this PR.\n"
+        ),
+    }
+
+
+class TestOperatorSettlementComment:
+    def _pr(self, *comments: dict[str, Any]) -> dict[str, Any]:
+        return {"comments": list(comments)}
+
+    def test_trusted_author_marker_accepted(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("scarmani"))
+        assert rq._has_operator_settlement_comment(pr, head_sha=HEAD) is True
+
+    def test_untrusted_author_marker_rejected(self, monkeypatch: Any) -> None:
+        # Same marker text, non-operator author — must NOT authorize.
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("an0mium"))
+        assert rq._has_operator_settlement_comment(pr, head_sha=HEAD) is False
+
+    def test_trusted_author_case_insensitive(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("ScarMani"))
+        assert rq._has_operator_settlement_comment(pr, head_sha=HEAD) is True
+
+    def test_wrong_head_rejected(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("scarmani", head="0" * 40))
+        assert rq._has_operator_settlement_comment(pr, head_sha=HEAD) is False
+
+    def test_missing_merge_token_rejected(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("scarmani", token="please merge"))
+        assert rq._has_operator_settlement_comment(pr, head_sha=HEAD) is False
+
+    def test_empty_head_rejected(self, monkeypatch: Any) -> None:
+        monkeypatch.setattr(rq, "_trusted_settlement_creator", lambda: "scarmani")
+        pr = self._pr(_marker("scarmani"))
+        assert rq._has_operator_settlement_comment(pr, head_sha="") is False
+
+
+# --- flag gate (condition 1) -----------------------------------------------
+
+
+class TestFlagGate:
+    def test_default_off(self) -> None:
+        assert rq._operator_advisory_settlement_enabled(env={}) is False
+
+    def test_on_values(self) -> None:
+        for value in ("1", "true", "yes", "on", "ON", "True"):
+            assert (
+                rq._operator_advisory_settlement_enabled(
+                    env={"ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT": value}
+                )
+                is True
+            )
+
+    def test_off_values(self) -> None:
+        for value in ("0", "false", "no", "", "off"):
+            assert (
+                rq._operator_advisory_settlement_enabled(
+                    env={"ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT": value}
+                )
+                is False
+            )


### PR DESCRIPTION
## The constitutional problem this fixes

The merge-quorum gate can reach a state where model quorum is **structurally unreachable**, not merely unmet. Severity-gated dissent makes any review carrying advisory `[P2]`/`[P3]` notes non-blocking **and** non-counting; for changes to the gate machinery itself the advisory-objection space does not converge. **PR #8939 proved it empirically:** four evidence rounds, zero `[P0]`/`[P1]` findings in any round, claude PASS every round — and zero countable signals. That means *any fix to the merge-quorum gate is circularly blocked by the gate it fixes.* The only prior mechanical escape was disabling a branch-protection safeguard.

This is the amendment path a self-hosting governance system needs: a way to change the gate without routing through the component being changed.

## What it adds

An opt-in verdict `operator_advisory_settlement` at **Tier 3-4 only**, gated on ALL of:

1. `ARAGORA_ENABLE_OPERATOR_ADVISORY_SETTLEMENT` on (**default OFF**).
2. Tier 3 or 4 (Tier 0-2 unmet quorum still means "collect reviews" / existing `advisory_settle`).
3. Zero `[P0]`/`[P1]` in any grounded review + no unresolved dissent — via the **same fail-closed permissive blocking scan `advisory_settle` uses** (hardened in #8729). **Blocking model dissent still stops everyone, including the operator.**
4. A validated western-frontier review + **≥2 validated model families heard**, from that same single validated pass (grounded, non-bot, countable identity) — never raw comment text.
5. An `aragora/human-settlement` success status at exact head, created by the **trusted settlement login** (`ARAGORA_SETTLEMENT_CREATOR`, default `scarmani`) — the unforgeable authorization spine.
6. A `Tier-4 Human Settlement Authorization` marker comment **authored by that trusted login**.

Only the model-quorum requirement is relaxed; failing/pending checks, blocking workflow state, `[P0]`/`[P1]`, and unresolved dissent are all untouched. Verdict is distinct and auditable; the workflow emits a `::notice::OPERATOR-SETTLED-OVER-ADVISORY` line. Revert is one env flip.

## Design notes (honest limits)

- **Authorization = the trusted-creator commit status.** The ≥2-families check is corroboration ("models were heard"), using advisory_settle's self-declared-header standard; it is not the security root. A pre-review flagged this and it's called out in the spec.
- Family attribution matches `advisory_settle` exactly (same validated pass), so the valve is never laxer than the machine advisory path.

## Provenance

Adversarially pre-reviewed by three independent lenses before submission; this diff folds in the findings: a **P1** (blocking-finding laundering → now reuses advisory_settle's scan), the Tier 3-4 restriction, validated-pass family accounting, canonical case-insensitive creator verification, and trusted-author marker verification.

## Tests
- 14 new focused tests (`tests/governance/test_operator_advisory_settlement.py`): family accounting, bot/stale/non-review exclusion, trusted-author marker verification (accept/reject/case/head/token), flag gate.
- 376 existing quorum tests unchanged (purely additive behind default-OFF flag).
- Spec: `docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md`.

## Tier 4 / settlement
This is a merge-authority self-modification (Tier 4). It requires human preapproval to implement (given: founder "yes proceed", 2026-07-11) and explicit human settlement to merge. It does not settle itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)