### PR TITLE
docs(readme): export demo receipt by file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Current source checkout:
 python3 -m pip install -e .
 aragora demo --offline --receipt aragora-demo-receipt.json
 aragora receipt verify aragora-demo-receipt.json
+aragora receipt export aragora-demo-receipt.json --format odr -o receipt.odr.json
 ```
 
 Live review with a provider key:
@@ -124,7 +125,6 @@ Live review with a provider key:
 ```bash
 export ANTHROPIC_API_KEY=...        # provider credential for live model review
 aragora review-pr 123               # multi-agent review of a GitHub PR
-aragora receipt export aragora-demo-receipt.json --format odr -o receipt.odr.json   # portable receipt
 ```
 
 ## Core workflows

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Live review with a provider key:
 ```bash
 export ANTHROPIC_API_KEY=...        # provider credential for live model review
 aragora review-pr 123               # multi-agent review of a GitHub PR
-aragora receipt export <id> --format odr -o receipt.odr.json   # portable receipt
+aragora receipt export aragora-demo-receipt.json --format odr -o receipt.odr.json   # portable receipt
 ```
 
 ## Core workflows

--- a/tests/cli/test_public_demo_onboarding_docs.py
+++ b/tests/cli/test_public_demo_onboarding_docs.py
@@ -31,6 +31,11 @@ def test_readme_advertises_current_pypi_receipt_round_trip() -> None:
         "Current source checkout:",
         "Live review with a provider key:",
     )
+    live_review = _section_between(
+        readme,
+        "Live review with a provider key:",
+        "## Core workflows",
+    )
     pypi_table_row = _line_containing(readme, "Run the current PyPI zero-key receipt demo")
 
     assert "pip install aragora && aragora demo --offline" in readme
@@ -43,6 +48,11 @@ def test_readme_advertises_current_pypi_receipt_round_trip() -> None:
     assert "PyPI `aragora` 2.9.0 supports the explicit offline demo receipt round trip" in readme
     assert "aragora demo --offline --receipt aragora-demo-receipt.json" in source_try_it_now
     assert "aragora receipt verify aragora-demo-receipt.json" in source_try_it_now
+    assert (
+        "aragora receipt export aragora-demo-receipt.json --format odr -o receipt.odr.json"
+        in source_try_it_now
+    )
+    assert "aragora receipt export" not in live_review
 
 
 def test_quickstart_advertises_current_pypi_receipt_round_trip() -> None:


### PR DESCRIPTION
## Summary
- replace the broken demo-receipt ID export example with the file path emitted by `aragora demo --offline`
- keep the change scoped to the README first-hour workflow

## Validation
- fresh `aragora demo --offline --receipt aragora-demo-receipt.json`
- `aragora receipt export aragora-demo-receipt.json --format odr -o receipt.odr.json`
- exported ODR reports `odr_version=0.1`, the demo receipt ID, claim, and quorum
- `python3 -m pytest -q tests/cli/test_public_demo_onboarding_docs.py` (2 passed)
- `python3 scripts/check_docs_consistency.py --root .`
- `python3 scripts/report_code_quality.py --check`
- `git diff --check origin/main HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Refs #9186.