### PR TITLE
feat(automation): supported cache-only mode for codex automation publisher installer/runner

### DIFF
--- a/scripts/install_codex_automation_publisher_launchd.sh
+++ b/scripts/install_codex_automation_publisher_launchd.sh
@@ -23,6 +23,9 @@ LABEL="com.aragora.codex-automation-publisher"
 LAUNCHD_DOMAIN="gui/$(id -u)"
 INTERVAL_SECONDS=300
 LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-automation-publisher.log"
+CACHE_ONLY="false"
+DRY_RUN="false"
+PLIST_PATH_OVERRIDE=""
 
 usage() {
     cat <<'EOF'
@@ -31,6 +34,9 @@ Usage: ./scripts/install_codex_automation_publisher_launchd.sh [options]
 Options:
   --interval-seconds <n>        launchd StartInterval (default: 300)
   --log-path <file>             Log file path (default: .aragora/overnight/codex-automation-publisher.log)
+  --cache-only                 Refresh health/cache without publishing branches or handoffs
+  --dry-run                    Render the plist without calling launchctl
+  --plist-path <file>          Write the plist to this path (useful with --dry-run)
   --help                        Show this help
 EOF
 }
@@ -43,6 +49,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --log-path)
             LOG_PATH="${2:-}"
+            shift 2
+            ;;
+        --cache-only)
+            CACHE_ONLY="true"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN="true"
+            shift
+            ;;
+        --plist-path)
+            PLIST_PATH_OVERRIDE="${2:-}"
             shift 2
             ;;
         --help|-h)
@@ -62,11 +80,15 @@ if ! [[ "${INTERVAL_SECONDS}" =~ ^[0-9]+$ ]]; then
     exit 2
 fi
 
-PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
-mkdir -p "$(dirname "${PLIST_PATH}")"
-mkdir -p "$(dirname "${LOG_PATH}")"
+PLIST_PATH="${PLIST_PATH_OVERRIDE:-${HOME}/Library/LaunchAgents/${LABEL}.plist}"
+PUBLISHER_COMMAND="cd \"${REPO_ROOT}\" && ./scripts/run_codex_automation_publisher.sh"
+if [[ "${CACHE_ONLY}" == "true" ]]; then
+    PUBLISHER_COMMAND="cd \"${REPO_ROOT}\" && ARAGORA_AUTOMATION_CACHE_ONLY=1 ./scripts/run_codex_automation_publisher.sh"
+fi
+PUBLISHER_COMMAND_XML="${PUBLISHER_COMMAND//&/&amp;}"
 
-cat >"${PLIST_PATH}" <<EOF
+render_plist() {
+cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -77,7 +99,7 @@ cat >"${PLIST_PATH}" <<EOF
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>cd "${REPO_ROOT}" &amp;&amp; ./scripts/run_codex_automation_publisher.sh</string>
+    <string>${PUBLISHER_COMMAND_XML}</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -92,6 +114,24 @@ cat >"${PLIST_PATH}" <<EOF
 </dict>
 </plist>
 EOF
+}
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+    if [[ -n "${PLIST_PATH_OVERRIDE}" ]]; then
+        mkdir -p "$(dirname "${PLIST_PATH}")"
+        render_plist >"${PLIST_PATH}"
+        echo "Rendered launchd job: ${LABEL}" >&2
+        echo "Plist: ${PLIST_PATH}" >&2
+        echo "Mode: $([[ "${CACHE_ONLY}" == "true" ]] && echo cache-only || echo publish)" >&2
+    else
+        render_plist
+    fi
+    exit 0
+fi
+
+mkdir -p "$(dirname "${PLIST_PATH}")"
+mkdir -p "$(dirname "${LOG_PATH}")"
+render_plist >"${PLIST_PATH}"
 
 launchctl bootout "${LAUNCHD_DOMAIN}" "${PLIST_PATH}" >/dev/null 2>&1 || true
 launchctl bootstrap "${LAUNCHD_DOMAIN}" "${PLIST_PATH}"
@@ -101,5 +141,6 @@ echo "Installed launchd job: ${LABEL}"
 echo "Plist: ${PLIST_PATH}"
 echo "Interval: ${INTERVAL_SECONDS}s"
 echo "Log: ${LOG_PATH}"
+echo "Mode: $([[ "${CACHE_ONLY}" == "true" ]] && echo cache-only || echo publish)"
 echo "--- launchctl ---"
 launchctl print "${LAUNCHD_DOMAIN}/${LABEL}" | sed -n '1,20p'

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -16,6 +16,7 @@ VALUE_DRAIN="${ARAGORA_AUTOMATION_VALUE_DRAIN:-0}"
 VALUE_DRAIN_BRANCH_LIMIT="${ARAGORA_AUTOMATION_VALUE_BRANCH_LIMIT:-2}"
 VALUE_DRAIN_ISSUE_LIMIT="${ARAGORA_AUTOMATION_VALUE_ISSUE_LIMIT:-4}"
 VALUE_DRAIN_MERGE_LIMIT="${ARAGORA_AUTOMATION_VALUE_MERGE_LIMIT:-1}"
+CACHE_ONLY="${ARAGORA_AUTOMATION_CACHE_ONLY:-0}"
 export ARAGORA_AUTOMATION_MIN_FREE_GIB="${ARAGORA_AUTOMATION_MIN_FREE_GIB:-50}"
 export ARAGORA_AUTOMATION_CODEX_RSS_MAX_GIB="${ARAGORA_AUTOMATION_CODEX_RSS_MAX_GIB:-25}"
 export ARAGORA_AUTOMATION_SPEND_DAILY_CAP_USD="${ARAGORA_AUTOMATION_SPEND_DAILY_CAP_USD:-200}"
@@ -100,6 +101,13 @@ if [[ "${HEALTH_READY}" != "true" ]]; then
   fi
   exit 0
 fi
+
+case "${CACHE_ONLY}" in
+  1|true|TRUE|yes|YES)
+    echo "$(STAMP) [codex-automation-publisher] cache-only mode: skipping value drain, branch publish, and handoff publish"
+    exit 0
+    ;;
+esac
 
 if ! git fetch --no-write-fetch-head --prune origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1; then
   echo "$(STAMP) [codex-automation-publisher] origin refresh failed; continuing with cached refs"

--- a/tests/scripts/test_run_codex_automation_publisher.py
+++ b/tests/scripts/test_run_codex_automation_publisher.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import plistlib
+import shutil
+import subprocess
 from pathlib import Path
 
 
@@ -64,3 +68,102 @@ def test_launchd_installer_prefers_canonical_git_worktree_root() -> None:
     assert 'git -C "${SCRIPT_REPO_ROOT}" worktree list --porcelain' in script
     assert 'REPO_ROOT="${CANONICAL_REPO_ROOT}"' in script
     assert 'LOG_PATH="${REPO_ROOT}/.aragora/overnight/codex-automation-publisher.log"' in script
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_publisher_wrapper_cache_only_skips_all_publish_paths(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    shutil.copy2(REPO_ROOT / "scripts" / "run_codex_automation_publisher.sh", scripts)
+    (repo / ".git").mkdir()
+    (repo / ".aragora" / "automation-outbox").mkdir(parents=True)
+    (repo / ".aragora" / "automation-receipts").mkdir(parents=True)
+
+    (scripts / "github_cli_health.py").write_text(
+        'print("{\\"ready\\": true}")\n', encoding="utf-8"
+    )
+    (scripts / "cache_codex_automation_github_status.py").write_text(
+        "import os, pathlib\npathlib.Path(os.environ['CACHE_CALL_LOG']).write_text('cache\\n')\n",
+        encoding="utf-8",
+    )
+    for name in (
+        "drain_codex_automation_value.py",
+        "publish_codex_automation_branches.py",
+        "publish_automation_handoffs.py",
+    ):
+        (scripts / name).write_text(
+            "raise SystemExit('forbidden publish path invoked')\n", encoding="utf-8"
+        )
+
+    cache_log = tmp_path / "cache.log"
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_AUTOMATION_CACHE_ONLY": "1",
+            "ARAGORA_AUTOMATION_STATE_ROOT": str(repo),
+            "CACHE_CALL_LOG": str(cache_log),
+            "TMPDIR": str(tmp_path),
+        }
+    )
+    proc = subprocess.run(
+        ["/bin/bash", str(scripts / "run_codex_automation_publisher.sh")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert cache_log.read_text(encoding="utf-8") == "cache\n"
+    assert (
+        "cache-only mode: skipping value drain, branch publish, and handoff publish" in proc.stdout
+    )
+    assert "starting branch publish pass" not in proc.stdout
+    assert "starting handoff publish pass" not in proc.stdout
+
+
+def test_launchd_installer_cache_only_dry_run_never_calls_launchctl(tmp_path: Path) -> None:
+    installer = REPO_ROOT / "scripts" / "install_codex_automation_publisher_launchd.sh"
+    plist_path = tmp_path / "publisher.plist"
+    launchctl_marker = tmp_path / "launchctl-called"
+    bindir = tmp_path / "bin"
+    _write_executable(
+        bindir / "launchctl",
+        f"#!/bin/bash\ntouch {launchctl_marker}\nexit 99\n",
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "ARAGORA_AUTOMATION_PUBLISHER_REPO_ROOT": str(REPO_ROOT),
+            "HOME": str(tmp_path / "home"),
+            "PATH": f"{bindir}:{env['PATH']}",
+        }
+    )
+    proc = subprocess.run(
+        [
+            "/bin/bash",
+            str(installer),
+            "--cache-only",
+            "--dry-run",
+            "--plist-path",
+            str(plist_path),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert plist_path.exists()
+    payload = plistlib.loads(plist_path.read_bytes())
+    assert "ARAGORA_AUTOMATION_CACHE_ONLY=1" in payload["ProgramArguments"][-1]
+    assert not launchctl_marker.exists()


### PR DESCRIPTION
## Summary

- add `ARAGORA_AUTOMATION_CACHE_ONLY` so the publisher refreshes GitHub health/cache and exits before value drain, branch publication, or handoff publication
- add installer `--cache-only`, `--dry-run`, and `--plist-path` support for a CI-safe no-publish LaunchAgent render
- preserve default publisher/install behavior when the new mode is not selected

## Motivation

Fleet health currently reports the publisher LaunchAgent unloaded. The existing installer has `RunAtLoad=true`, immediately kickstarts the full publisher, and can apply multiple branch/handoff publications, so it cannot safely restore cache freshness as one bounded operational unit. This repair is grounded in `.aragora/goal-cycle-context/20260711T1800Z-hard-progress-candidates.md`.

## Validation

- `bash -n scripts/run_codex_automation_publisher.sh`
- `bash -n scripts/install_codex_automation_publisher_launchd.sh`
- `python -m pytest tests/scripts/test_run_codex_automation_publisher.py tests/scripts/test_drain_codex_automation_value.py -q` (20 passed)
- `python -m ruff check tests/scripts/test_run_codex_automation_publisher.py`
- `python -m ruff format --check tests/scripts/test_run_codex_automation_publisher.py`
- `git diff --check origin/main...HEAD`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and pre-push hooks passed

## Safety boundary

This is the cycle's single bounded hard-progress unit. No live LaunchAgent or publisher process was started, no outbox or receipt was mutated, and no workflow, branch protection, active halt, issue #8845, evidence, settlement, or merge state was touched. The PR remains draft.