### PR TITLE
fix(sentinel): normalize legacy lane status before liveness timestamp checks

### DIFF
--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -709,13 +709,16 @@ def check_lane_liveness(
         try:
             entry = json.loads(Path(ledger_file).read_text())
             lane = str(entry["lane"])
-            raw_status = entry.get("status", entry.get("state"))
+            raw_status = entry.get("status") or entry.get("state")
             if raw_status is None:
                 raise KeyError("status")
             status = str(raw_status)
             if status != "in_progress":
                 continue
-            launched_at = parse_iso(str(entry["launched_at"]))
+            raw_launched_at = entry.get("launched_at") or entry.get("started_at")
+            if raw_launched_at is None:
+                raise KeyError("launched_at")
+            launched_at = parse_iso(str(raw_launched_at))
         except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
             unreadable.append(f"{ledger_file} ({exc.__class__.__name__})")
             continue

--- a/scripts/fleet_sentinel.py
+++ b/scripts/fleet_sentinel.py
@@ -709,12 +709,15 @@ def check_lane_liveness(
         try:
             entry = json.loads(Path(ledger_file).read_text())
             lane = str(entry["lane"])
-            status = str(entry.get("status", ""))
+            raw_status = entry.get("status", entry.get("state"))
+            if raw_status is None:
+                raise KeyError("status")
+            status = str(raw_status)
+            if status != "in_progress":
+                continue
             launched_at = parse_iso(str(entry["launched_at"]))
         except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
             unreadable.append(f"{ledger_file} ({exc.__class__.__name__})")
-            continue
-        if status != "in_progress":
             continue
         in_progress += 1
         age_hours = (now - launched_at).total_seconds() / 3600.0

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -907,6 +907,36 @@ def test_lane_liveness_legacy_done_state_without_launched_at_ignored(tmp_path: P
     assert result["status"] == "ok"
 
 
+def test_lane_liveness_null_status_falls_back_to_legacy_state(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "laneOUTBOX.json").write_text(
+        json.dumps({"lane": "laneOUTBOX", "status": None, "state": "done"})
+    )
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_legacy_in_progress_uses_started_at(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "legacy-active.json").write_text(
+        json.dumps(
+            {
+                "lane": "q2",
+                "state": "in_progress",
+                "started_at": "2026-06-10T07:00:00Z",
+                "branch": "elves/run-x-q2",
+            }
+        )
+    )
+
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": 0})
+
+    assert result["status"] == "breach"
+    assert "zero commits ahead" in result["detail"]
+
+
 def test_lane_liveness_legacy_parked_state_without_launched_at_ignored(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
     (tmp_path / "lanePARITY.json").write_text(
@@ -916,6 +946,24 @@ def test_lane_liveness_legacy_parked_state_without_launched_at_ignored(tmp_path:
     result = _liveness(tmp_path, heads={}, ahead={})
 
     assert result["status"] == "ok"
+
+
+def test_lane_liveness_missing_status_and_state_is_unknown(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "missing-status.json").write_text(
+        json.dumps(
+            {
+                "lane": "q2",
+                "launched_at": "2026-06-10T11:00:00Z",
+                "branch": "elves/run-x-q2",
+            }
+        )
+    )
+
+    result = _liveness(tmp_path, heads={"elves/run-x-q2": "aaa"}, ahead={"aaa": 0})
+
+    assert result["status"] == "unknown"
+    assert "missing-status.json" in result["detail"]
 
 
 def test_lane_liveness_pr_open_status_without_launched_at_ignored(tmp_path: Path) -> None:

--- a/tests/scripts/test_fleet_sentinel.py
+++ b/tests/scripts/test_fleet_sentinel.py
@@ -896,6 +896,61 @@ def test_lane_liveness_non_in_progress_ignored(tmp_path: Path) -> None:
     assert result["status"] == "ok"
 
 
+def test_lane_liveness_legacy_done_state_without_launched_at_ignored(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "laneOUTBOX.json").write_text(
+        json.dumps({"lane": "laneOUTBOX", "state": "done", "started_at": "2026-06-10T07:00:00Z"})
+    )
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_legacy_parked_state_without_launched_at_ignored(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "lanePARITY.json").write_text(
+        json.dumps({"lane": "PARITY", "state": "parked_awaiting_human_settlement"})
+    )
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_pr_open_status_without_launched_at_ignored(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "lanePROD.json").write_text(json.dumps({"lane": "PROD", "status": "pr_open"}))
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "ok"
+
+
+def test_lane_liveness_in_progress_missing_launched_at_is_unknown(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "missing-timestamp.json").write_text(
+        json.dumps({"lane": "q2", "status": "in_progress"})
+    )
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "unknown"
+    assert "missing-timestamp.json" in result["detail"]
+
+
+def test_lane_liveness_in_progress_invalid_launched_at_is_unknown(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    (tmp_path / "invalid-timestamp.json").write_text(
+        json.dumps({"lane": "q2", "status": "in_progress", "launched_at": "not-a-time"})
+    )
+
+    result = _liveness(tmp_path, heads={}, ahead={})
+
+    assert result["status"] == "unknown"
+    assert "invalid-timestamp.json" in result["detail"]
+
+
 def test_lane_liveness_orphan_branch_breaches(tmp_path: Path) -> None:
     result = _liveness(
         tmp_path,


### PR DESCRIPTION
## Summary
- normalize lane liveness status from current `status` or legacy `state`
- skip terminal/non-`in_progress` ledgers before requiring `launched_at`
- preserve fail-closed behavior for missing status and active ledgers with missing/invalid timestamps

## Live defect
`fleet_sentinel.py` reported `lane_liveness=unknown` because three terminal legacy ledgers lacked `launched_at`. With this branch, the same live read-only probe becomes determinate and exposes two real stale lanes (`q2-8101` and `s2-b1`) instead of hiding the check.

## Validation
- `python -m pytest tests/scripts/test_fleet_sentinel.py -q` (148 passed)
- `python -m ruff check scripts/fleet_sentinel.py tests/scripts/test_fleet_sentinel.py`
- `python -m ruff format --check scripts/fleet_sentinel.py tests/scripts/test_fleet_sentinel.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- push hooks, including changed-file mypy, passed

## Scope
No live sentinel state, outbox, halt file, workflows, branch protection, or protected merge/quorum scripts were mutated. This PR remains draft for normal review gates.