### PR TITLE
docs(trust): publish production ODR signing public key

### DIFF
--- a/docs/trust/README.md
+++ b/docs/trust/README.md
@@ -1,0 +1,31 @@
+# Trust anchors
+
+Public keys used to verify Aragora-issued artifacts offline. Only PUBLIC key
+material lives here; private keys are held in AWS Secrets Manager and never
+appear in the repository (see `aragora/gauntlet/odr_signing.py`).
+
+## Production ODR signing key
+
+- File: [`production-odr-signing-key.pem`](production-odr-signing-key.pem)
+- Key id: `ed25519-8f9014589b35ab85`
+- Algorithm: Ed25519 (detached ODR signatures, ODR-2 #8225)
+- Signs: Open Decision Receipts issued by `api.aragora.ai`
+- Provisioned: 2026-07-11 by the operator (AWS Secrets Manager
+  `aragora/odr-signing-key`, us-east-1)
+- Also served live at `https://api.aragora.ai/.well-known/aragora-odr-signing-key`
+  and `GET /api/v2/receipts/signing-key` (#8804/#8809)
+
+Verify a production receipt offline:
+
+```bash
+pip install 'aragora-verify>=0.1.1'
+aragora-verify receipt.json --public-key docs/trust/production-odr-signing-key.pem
+```
+
+Cross-check this repo copy against the live endpoint before trusting either in
+isolation — they must match:
+
+```bash
+curl -s https://api.aragora.ai/.well-known/aragora-odr-signing-key \
+  | diff - docs/trust/production-odr-signing-key.pem && echo MATCH
+```

--- a/docs/trust/README.md
+++ b/docs/trust/README.md
@@ -19,7 +19,7 @@ Verify a production receipt offline:
 
 ```bash
 pip install 'aragora-verify>=0.1.1'
-aragora-verify receipt.json --public-key docs/trust/production-odr-signing-key.pem
+aragora-verify receipt.json --pubkey docs/trust/production-odr-signing-key.pem
 ```
 
 Cross-check this repo copy against the live endpoint before trusting either in

--- a/docs/trust/production-odr-signing-key.pem
+++ b/docs/trust/production-odr-signing-key.pem
@@ -1,0 +1,3 @@
+-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAsCfIvjtOpZebI+hJ4kIL5ygkxbNKrgiMPIWZhCF4aL0=
+-----END PUBLIC KEY-----


### PR DESCRIPTION
## Summary
- add `docs/trust/` with the production ODR signing PUBLIC key and key id `ed25519-8f9014589b35ab85`
- private key provisioned by the operator 2026-07-11 in AWS Secrets Manager (`aragora/odr-signing-key`); only the public half is published
- gives the #8858 outsider a repo-side trust anchor to cross-check against the `.well-known` endpoint (#8809)

## Validation
- PEM parses and matches the provisioned secret's public half; key id recomputed via the verifier formula (SHA-256 of raw public key, first 16 hex)

Refs #8225, #8804, #8858.

🤖 Generated with [Claude Code](https://claude.com/claude-code)