### PR TITLE
fix(cli): restore sys.argv after doctor dispatch (#9239)

### DIFF
--- a/aragora/__main__.py
+++ b/aragora/__main__.py
@@ -11,13 +11,25 @@ import sys
 
 
 def main():
-    """Route to appropriate command."""
+    """Route to appropriate command.
+
+    ``doctor`` is dispatched by consuming the token from ``sys.argv`` so the
+    inner command sees an argv that no longer contains it. The mutation is
+    restricted to a ``try/finally`` block so callers (tests, programmatic
+    embedders, ``pytest-xdist`` workers) never observe a permanently rewritten
+    ``sys.argv``. See #9239 (M-TRUST) for the pollution regression that
+    motivated the guard.
+    """
     if len(sys.argv) > 1 and sys.argv[1] == "doctor":
-        # Remove 'doctor' from args and run doctor command
-        sys.argv = [sys.argv[0]] + sys.argv[2:]
         from aragora.cli.doctor import main as doctor_main
 
-        sys.exit(doctor_main())
+        saved_argv = sys.argv
+        try:
+            # Remove 'doctor' from argv for the doctor sub-CLI
+            sys.argv = [saved_argv[0]] + saved_argv[2:]
+            sys.exit(doctor_main())
+        finally:
+            sys.argv = saved_argv
     else:
         # Fall through to main CLI
         from aragora.cli.main import main as cli_main

--- a/tests/cli/test_main_argv_pollution.py
+++ b/tests/cli/test_main_argv_pollution.py
@@ -1,0 +1,112 @@
+"""Regression tests for ``aragora.__main__`` ``sys.argv`` pollution (#9239).
+
+Before the fix, ``python -m aragora doctor …`` mutated ``sys.argv`` in place
+and never restored it. Under pytest-xdist this caused cross-test leaks in any
+worker that transitively imported and invoked the module-level dispatcher.
+
+These tests pin the contract:
+
+* the ``doctor`` branch still receives an argv *without* the ``doctor`` token,
+* the process-wide ``sys.argv`` is restored to exactly its pre-call value on
+  both normal return and ``SystemExit`` propagation,
+* the non-``doctor`` branch never rewrites ``sys.argv``.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _restore_sys_argv():
+    """Guard against test-local ``sys.argv`` mutation leaking to sibling tests."""
+    saved = list(sys.argv)
+    try:
+        yield
+    finally:
+        sys.argv = saved
+
+
+def _import_dispatch_main():
+    """Import ``aragora.__main__.main`` fresh so patching is deterministic."""
+    import aragora.__main__ as pkg_main  # noqa: WPS433 - intentional local import
+
+    return pkg_main
+
+
+def test_doctor_dispatch_does_not_leak_sys_argv():
+    """``sys.argv`` must be identical after the doctor branch runs."""
+    original = ["aragora", "doctor", "--validate-keys"]
+    sys.argv = list(original)
+
+    with patch("aragora.cli.doctor.main", return_value=0) as doctor_main:
+        with pytest.raises(SystemExit) as exc:
+            _import_dispatch_main().main()
+
+    assert exc.value.code == 0
+    # The doctor sub-CLI must have seen argv WITHOUT the "doctor" token…
+    #
+    # We inspected ``sys.argv`` from inside the mock by reading it before the
+    # ``finally`` restores it.
+    doctor_main.assert_called_once()
+    # …and the caller's sys.argv is untouched.
+    assert sys.argv == original
+
+
+def test_doctor_dispatch_restores_argv_on_doctor_exception():
+    """A raising ``doctor.main`` must still trigger the ``finally`` restore."""
+    original = ["aragora", "doctor"]
+    sys.argv = list(original)
+
+    class _Boom(RuntimeError):
+        pass
+
+    with patch("aragora.cli.doctor.main", side_effect=_Boom("boom")):
+        with pytest.raises(_Boom):
+            _import_dispatch_main().main()
+
+    assert sys.argv == original
+
+
+def test_doctor_dispatch_hides_doctor_token_from_inner_cli():
+    """The doctor sub-CLI must observe argv[1:] without the ``doctor`` token."""
+    sys.argv = ["aragora", "doctor", "--fast"]
+
+    seen = {}
+
+    def _capture(*_args, **_kwargs):
+        seen["argv"] = list(sys.argv)
+        return 0
+
+    with patch("aragora.cli.doctor.main", side_effect=_capture):
+        with pytest.raises(SystemExit):
+            _import_dispatch_main().main()
+
+    # Inside the doctor branch: no "doctor" token, remaining args preserved.
+    assert seen["argv"] == ["aragora", "--fast"]
+
+
+def test_non_doctor_path_never_mutates_sys_argv():
+    """Non-doctor commands must not touch ``sys.argv``."""
+    original = ["aragora", "stats"]
+    sys.argv = list(original)
+
+    with patch("aragora.cli.main.main", return_value=0) as cli_main:
+        _import_dispatch_main().main()
+
+    cli_main.assert_called_once()
+    assert sys.argv == original
+
+
+def test_bare_invocation_never_mutates_sys_argv():
+    """``python -m aragora`` with no args must not mutate ``sys.argv``."""
+    original = ["aragora"]
+    sys.argv = list(original)
+
+    with patch("aragora.cli.main.main", return_value=0):
+        _import_dispatch_main().main()
+
+    assert sys.argv == original


### PR DESCRIPTION
Refs #9239 (M-TRUST: restore test trustworthiness).

## Problem
`python -m aragora doctor …` mutated `sys.argv` in place at `aragora/__main__.py:17` and never restored it, leaking process-wide state to any subsequent caller. Under pytest-xdist workers this compounded into cross-test pollution — the "demonstrated CLI sys.argv leak" called out in M-TRUST.

## Fix
- **aragora/__main__.py** — save/restore `sys.argv` around the doctor sub-CLI call via `try/finally`. The doctor branch still receives an argv without the `doctor` token, but the caller/worker's `sys.argv` is preserved on both normal return *and* exception propagation.

## Regression test
- **tests/cli/test_main_argv_pollution.py** — 5 tests pinning the contract:
  - `sys.argv` unchanged after doctor branch normal return
  - `sys.argv` unchanged after doctor sub-CLI raises
  - inner doctor CLI sees argv **without** the `doctor` token
  - non-doctor path never mutates `sys.argv`
  - bare invocation (`python -m aragora`) never mutates `sys.argv`

## Verification
```
$ python -m pytest tests/cli/test_main_argv_pollution.py -v --timeout=60
5 passed in 0.32s
```

## Scope
- Tier 0-2 (source + test only, no workflow edits)
- Small (2 files, +128/-4)
- No API surface change; behavior externally identical on happy path