### PR TITLE
ci(pollution-guard): slice randomized guard + persist failing seed/nodes [Tier-4] (#9239)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1169,18 +1169,36 @@ jobs:
         run: echo "No high-risk path changes detected, skipping integration smoke tests."
 
   test-pollution-randomized:
-    # This is a stress guard, not a PR admission gate. It currently runs a
-    # broad randomized suite three times and regularly hits the 20-minute
-    # wall-clock cap even after the fast PR shards have passed.
+    # Stress guard for test-order pollution, not a PR admission gate.
+    #
+    # Design (M-TRUST #9239):
+    #   * Decoupled from `test-fast` so a slow/red PR shard cannot mask the guard
+    #     and vice versa. Runs on push/schedule only (not PRs).
+    #   * Split into BOUNDED DOMAIN SLICES to keep any single shard well under
+    #     the 20-minute wall-clock cap and to localize a polluted domain to its
+    #     slice.
+    #   * Each slice runs TWO seeds: a fixed per-slice seed (stable regression
+    #     signal) and a rotating seed derived from the CI run number
+    #     (broader search of the order space over time).
+    #   * On failure, the failing seed + node IDs are persisted as an artifact
+    #     so downstream lanes can bisect without rerunning the whole guard.
     if: github.event_name != 'pull_request'
     name: Randomized Order Pollution Guard
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: test-fast
     strategy:
       fail-fast: false
       matrix:
-        seed: [12345, 54321, 99999]
+        include:
+          - slice: core
+            paths: "tests/debate tests/knowledge tests/agents tests/memory"
+            fixed_seed: 12345
+          - slice: server
+            paths: "tests/server/handlers tests/control_plane tests/rbac tests/events tests/observability"
+            fixed_seed: 54321
+          - slice: workflow
+            paths: "tests/workflow tests/compliance tests/gauntlet tests/cli"
+            fixed_seed: 99999
 
     steps:
       - name: Checkout
@@ -1221,37 +1239,124 @@ jobs:
           bash scripts/ci_install_project.sh --extras test
           python -m pip install pytest-timeout pytest-xdist pytest-randomly
 
-      - name: Compute dynamic seed
-        id: dynamic-seed
+      - name: Compute rotating seed
+        id: rotating-seed
         run: echo "seed=$(( ${{ github.run_number }} % 100000 ))" >> $GITHUB_OUTPUT
 
-      - name: Run randomized-order guard (seed=${{ matrix.seed }})
+      - name: Prepare artifact directory
+        run: mkdir -p artifacts/pollution-guard
+
+      - name: Run randomized-order guard (${{ matrix.slice }}, fixed seed=${{ matrix.fixed_seed }})
+        id: fixed-seed-run
+        continue-on-error: true
         run: |
-          pytest tests/debate tests/knowledge tests/server/handlers tests/control_plane tests/agents tests/memory \
-            tests/rbac tests/events tests/observability tests/workflow tests/compliance tests/gauntlet tests/cli \
+          set +e
+          pytest ${{ matrix.paths }} \
             -m "not slow and not load and not e2e and not integration and not integration_minimal and not benchmark and not performance" \
             --timeout=60 \
-            -x \
             -p randomly \
-            --randomly-seed=${{ matrix.seed }} \
-            -v \
-            --tb=short
+            --randomly-seed=${{ matrix.fixed_seed }} \
+            --tb=short \
+            -q \
+            --junitxml=artifacts/pollution-guard/${{ matrix.slice }}-fixed-${{ matrix.fixed_seed }}.xml
+          rc=$?
+          echo "rc=$rc" >> $GITHUB_OUTPUT
+          echo "seed=${{ matrix.fixed_seed }}" >> $GITHUB_OUTPUT
+          exit 0
         env:
           PYTHONPATH: .:aragora-debate/src
 
-      - name: Run randomized-order guard (dynamic seed=${{ steps.dynamic-seed.outputs.seed }})
+      - name: Run randomized-order guard (${{ matrix.slice }}, rotating seed=${{ steps.rotating-seed.outputs.seed }})
+        id: rotating-seed-run
+        continue-on-error: true
         run: |
-          pytest tests/debate tests/knowledge tests/server/handlers tests/control_plane tests/agents tests/memory \
-            tests/rbac tests/events tests/observability tests/workflow tests/compliance tests/gauntlet tests/cli \
+          set +e
+          pytest ${{ matrix.paths }} \
             -m "not slow and not load and not e2e and not integration and not integration_minimal and not benchmark and not performance" \
             --timeout=60 \
-            -x \
             -p randomly \
-            --randomly-seed=${{ steps.dynamic-seed.outputs.seed }} \
-            -v \
-            --tb=short
+            --randomly-seed=${{ steps.rotating-seed.outputs.seed }} \
+            --tb=short \
+            -q \
+            --junitxml=artifacts/pollution-guard/${{ matrix.slice }}-rotating-${{ steps.rotating-seed.outputs.seed }}.xml
+          rc=$?
+          echo "rc=$rc" >> $GITHUB_OUTPUT
+          echo "seed=${{ steps.rotating-seed.outputs.seed }}" >> $GITHUB_OUTPUT
+          exit 0
         env:
           PYTHONPATH: .:aragora-debate/src
+
+      - name: Extract failing node IDs from JUnit XML
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import glob
+          import json
+          import os
+          from pathlib import Path
+          from xml.etree import ElementTree as ET
+
+          out_dir = Path("artifacts/pollution-guard")
+          out_dir.mkdir(parents=True, exist_ok=True)
+
+          failing = []
+          for xml_path in sorted(glob.glob(str(out_dir / "*.xml"))):
+              name = os.path.basename(xml_path)
+              # File name pattern: <slice>-<kind>-<seed>.xml
+              try:
+                  slice_, kind, seed_ext = name.rsplit(".", 1)[0].split("-", 2)
+              except ValueError:
+                  slice_, kind, seed_ext = name, "unknown", "unknown"
+              try:
+                  root = ET.parse(xml_path).getroot()
+              except ET.ParseError:
+                  continue
+              for tc in root.iter("testcase"):
+                  if tc.find("failure") is None and tc.find("error") is None:
+                      continue
+                  classname = tc.get("classname", "")
+                  testname = tc.get("name", "")
+                  # pytest JUnit encodes node id as <classname>::<testname>,
+                  # where classname already contains file path with dots.
+                  node_id = (
+                      f"{classname.replace('.', '/')}.py::{testname}"
+                      if classname else testname
+                  )
+                  failing.append(
+                      {
+                          "slice": slice_,
+                          "kind": kind,
+                          "seed": seed_ext,
+                          "node_id": node_id,
+                      }
+                  )
+
+          summary_path = out_dir / "failing_nodes.json"
+          summary_path.write_text(json.dumps(failing, indent=2))
+          print(f"failing_nodes count={len(failing)} -> {summary_path}")
+          PY
+
+      - name: Upload pollution-guard artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pollution-guard-${{ matrix.slice }}-${{ github.run_number }}
+          path: artifacts/pollution-guard/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Fail job if any seed failed
+        shell: bash
+        run: |
+          fixed_rc="${{ steps.fixed-seed-run.outputs.rc }}"
+          rotating_rc="${{ steps.rotating-seed-run.outputs.rc }}"
+          echo "fixed seed=${{ matrix.fixed_seed }} rc=$fixed_rc"
+          echo "rotating seed=${{ steps.rotating-seed.outputs.seed }} rc=$rotating_rc"
+          if [[ "$fixed_rc" != "0" || "$rotating_rc" != "0" ]]; then
+            echo "::error::Randomized pollution guard slice ${{ matrix.slice }} failed. Failing node IDs uploaded to pollution-guard-${{ matrix.slice }}-${{ github.run_number }}."
+            exit 1
+          fi
 
   golden-paths:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1243,12 +1243,16 @@ jobs:
         id: rotating-seed
         run: echo "seed=$(( ${{ github.run_number }} % 100000 ))" >> $GITHUB_OUTPUT
 
+      # SCOPE NOTE: slices run in separate pytest processes, so CROSS-SLICE
+      # pollution (e.g. tests/debate state leaking into tests/workflow) is
+      # structurally out of this guard's scope — a green guard certifies
+      # within-slice order-independence only. Cross-domain leaks are the full
+      # matrix / nightly lanes' concern.
       - name: Prepare artifact directory
         run: mkdir -p artifacts/pollution-guard
 
       - name: Run randomized-order guard (${{ matrix.slice }}, fixed seed=${{ matrix.fixed_seed }})
         id: fixed-seed-run
-        continue-on-error: true
         run: |
           set +e
           pytest ${{ matrix.paths }} \
@@ -1268,7 +1272,6 @@ jobs:
 
       - name: Run randomized-order guard (${{ matrix.slice }}, rotating seed=${{ steps.rotating-seed.outputs.seed }})
         id: rotating-seed-run
-        continue-on-error: true
         run: |
           set +e
           pytest ${{ matrix.paths }} \
@@ -1317,12 +1320,20 @@ jobs:
                       continue
                   classname = tc.get("classname", "")
                   testname = tc.get("name", "")
-                  # pytest JUnit encodes node id as <classname>::<testname>,
-                  # where classname already contains file path with dots.
-                  node_id = (
-                      f"{classname.replace('.', '/')}.py::{testname}"
-                      if classname else testname
-                  )
+                  # JUnit classname is the dotted MODULE path plus optional
+                  # CLASS segments (tests.foo.test_mod.TestBar): a blind
+                  # dot->slash replace yields invalid IDs for class-based
+                  # tests. Find the longest prefix that is a real module file;
+                  # remaining segments are class names.
+                  node_id = testname
+                  if classname:
+                      parts = classname.split(".")
+                      node_id = f"{classname.replace('.', '/')}.py::{testname}"
+                      for i in range(len(parts), 0, -1):
+                          candidate = "/".join(parts[:i]) + ".py"
+                          if Path(candidate).exists():
+                              node_id = "::".join([candidate, *parts[i:], testname])
+                              break
                   failing.append(
                       {
                           "slice": slice_,
@@ -1341,7 +1352,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pollution-guard-${{ matrix.slice }}-${{ github.run_number }}
+          name: pollution-guard-${{ matrix.slice }}-${{ github.run_number }}-${{ github.run_attempt }}
           path: artifacts/pollution-guard/
           if-no-files-found: warn
           retention-days: 14
@@ -1354,7 +1365,7 @@ jobs:
           echo "fixed seed=${{ matrix.fixed_seed }} rc=$fixed_rc"
           echo "rotating seed=${{ steps.rotating-seed.outputs.seed }} rc=$rotating_rc"
           if [[ "$fixed_rc" != "0" || "$rotating_rc" != "0" ]]; then
-            echo "::error::Randomized pollution guard slice ${{ matrix.slice }} failed. Failing node IDs uploaded to pollution-guard-${{ matrix.slice }}-${{ github.run_number }}."
+            echo "::error::Randomized pollution guard slice ${{ matrix.slice }} failed. Failing node IDs uploaded to pollution-guard-${{ matrix.slice }}-${{ github.run_number }}-${{ github.run_attempt }}."
             exit 1
           fi
 


### PR DESCRIPTION
Refs #9239 (M-TRUST: restore test trustworthiness) — **Tier-4 workflow change**, human approval required.

## Problem
The `test-pollution-randomized` job (\`.github/workflows/test.yml\` ~L1171) has three defects called out by #9239:

1. \`needs: test-fast\` couples the guard to the fast PR lane — a red fast lane silently skips the guard.
2. One giant \`pytest\` command over 13 test directories, run twice with different seeds, regularly hits the 20-minute cap.
3. Failing seed + node IDs live only in the raw log — nothing persistable for bisection or trend tracking.

## Change
Split the job into **bounded domain slices** with **one fixed + one rotating seed** per slice, and **persist failing node IDs as artifacts**:

- Slices:
  - \`core\` → \`tests/debate tests/knowledge tests/agents tests/memory\` (fixed seed 12345)
  - \`server\` → \`tests/server/handlers tests/control_plane tests/rbac tests/events tests/observability\` (fixed seed 54321)
  - \`workflow\` → \`tests/workflow tests/compliance tests/gauntlet tests/cli\` (fixed seed 99999)
- Rotating seed: \`github.run_number % 100000\` (same across slices per run for cross-slice correlation).
- Both runs write \`--junitxml\` → an inline Python step distills failing testcases into \`artifacts/pollution-guard/failing_nodes.json\` (fields: \`slice\`, \`kind\`, \`seed\`, \`node_id\`).
- Artifact \`pollution-guard-<slice>-<run>\` uploaded on \`if: always()\` with 14-day retention.
- Removed \`needs: test-fast\` — the guard now runs on push/schedule regardless of PR shard state.
- Still \`if: github.event_name != 'pull_request'\`; **not** a PR admission gate.
- Aggregation step fails the slice job iff either seed run failed, but only after the artifact is uploaded — so operators can bisect from the JSON without rerunning CI.

## Constraints preserved
- Same test-marker exclusions (\`not slow and not load and not e2e ...\`).
- Same 60s per-test timeout.
- Same 20-minute job wall-clock cap (per slice, not per giant command).
- No new required checks.

## Diff size
- 1 file (\`.github/workflows/test.yml\`), +126/-21.

## Follow-up (separate Tier-4 PRs)
- Nightly-core signal (acceptance criterion 3 of #9239).
- Bisection tooling on \`failing_nodes.json\` — tracks with #9122.

## Tier
- **Tier 4** — CI workflow change. Human approval required; draft until reviewed.