### PR TITLE
fix(types): narrow social notification request bodies (#9099)

### DIFF
--- a/aragora/server/handlers/social/notifications.py
+++ b/aragora/server/handlers/social/notifications.py
@@ -600,11 +600,13 @@ class NotificationsHandler(SecureHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
 
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, EMAIL_CONFIG_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid email configuration", 400)
 
         try:
             # Save to per-org store if org_id provided
@@ -704,11 +706,13 @@ class NotificationsHandler(SecureHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
 
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, TELEGRAM_CONFIG_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid Telegram configuration", 400)
 
         bot_token = body.get("bot_token", "")
         chat_id = body.get("chat_id", "")
@@ -790,6 +794,8 @@ class NotificationsHandler(SecureHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
 
         recipient_email = body.get("email", "")
         if not recipient_email or "@" not in recipient_email:
@@ -942,6 +948,8 @@ class NotificationsHandler(SecureHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
 
         notification_type = body.get("type", "all")
         results = {}
@@ -1042,11 +1050,13 @@ class NotificationsHandler(SecureHandler):
         body, err = self.read_json_body_validated(handler)
         if err:
             return err
+        if body is None:
+            return error_response("Request body must be a JSON object", 400)
 
         # Schema validation for input sanitization
         validation_result = validate_against_schema(body, NOTIFICATION_SEND_SCHEMA)
         if not validation_result.is_valid:
-            return error_response(validation_result.error, 400)
+            return error_response(validation_result.error or "Invalid notification payload", 400)
 
         notification_type = body.get("type", "all")
         subject = body.get("subject", "Aragora Notification")

--- a/tests/server/handlers/social/test_notifications_handler.py
+++ b/tests/server/handlers/social/test_notifications_handler.py
@@ -160,6 +160,29 @@ class TestRateLimiting:
         assert get_status_code(result) == 429
 
 
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "_configure_email",
+        "_configure_telegram",
+        "_add_email_recipient",
+        "_send_test_notification",
+        "_send_notification",
+    ],
+)
+def test_mutating_handlers_fail_closed_when_validated_body_is_absent(
+    handler, monkeypatch, method_name
+):
+    """A parser contract violation must not reach body-dependent handler logic."""
+    monkeypatch.setattr(handler, "read_json_body_validated", lambda _handler: (None, None))
+
+    result = getattr(handler, method_name)(MagicMock())
+
+    status_code, body = parse_result(result)
+    assert status_code == 400
+    assert body["error"] == "Request body must be a JSON object"
+
+
 # ===========================================================================
 # Status Endpoint Logic Tests
 # ===========================================================================


### PR DESCRIPTION
## Summary

- fail closed when validated notification request bodies are unexpectedly absent
- provide stable schema-validation fallback messages
- cover all five mutating notification paths with a focused regression

## Main-red proof

Exact base: `fd96da3cc00757dd7c6ed96d6413fd7067827e16`

- whole-repo mypy: `2564 -> 2499`
- removed identities: `65`
- added identities: `0`
- removed file: `aragora/server/handlers/social/notifications.py`

## Validation

- focused mypy: clean
- notification suites: `140 passed`
- Ruff: passed
- `git diff --check`: passed
- `python3 scripts/check_portability.py`: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed
- pre-push hooks: passed

## Risk

Low and fail-closed. The added branches guard a parser-contract violation before body-dependent logic; valid request behavior is unchanged.

Tracks #9099.