### PR TITLE
refactor(events): invert dispatcher server boundaries

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -507,6 +507,13 @@ async def _shutdown_cmd_ask_resources() -> None:
         logger.debug("Ask receipt store shutdown skipped: %s", exc)
 
     try:
+        from aragora.events.dispatcher import shutdown_dispatcher
+
+        shutdown_dispatcher(wait=True)
+    except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
+        logger.debug("Ask dispatcher shutdown skipped: %s", exc)
+
+    try:
         from aragora.storage.webhook_config_store import reset_webhook_config_store
 
         reset_webhook_config_store()
@@ -519,13 +526,6 @@ async def _shutdown_cmd_ask_resources() -> None:
         DatabaseManager.clear_instances()
     except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
         logger.debug("Ask SQLite manager shutdown skipped: %s", exc)
-
-    try:
-        from aragora.events.dispatcher import shutdown_dispatcher
-
-        shutdown_dispatcher(wait=True)
-    except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
-        logger.debug("Ask dispatcher shutdown skipped: %s", exc)
 
     # Give async transport/connector close callbacks one loop turn before
     # asyncio.run() tears the loop down. This avoids intermittent unclosed

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -472,6 +472,13 @@ async def _shutdown_cmd_ask_resources() -> None:
         logger.debug("Ask spam moderation shutdown skipped: %s", exc)
 
     try:
+        from aragora.events.dispatcher import shutdown_dispatcher
+
+        shutdown_dispatcher(wait=True)
+    except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
+        logger.debug("Ask dispatcher shutdown skipped: %s", exc)
+
+    try:
         from aragora.server.startup.database import close_postgres_pool
 
         await close_postgres_pool()
@@ -505,13 +512,6 @@ async def _shutdown_cmd_ask_resources() -> None:
         close_receipt_store()
     except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
         logger.debug("Ask receipt store shutdown skipped: %s", exc)
-
-    try:
-        from aragora.events.dispatcher import shutdown_dispatcher
-
-        shutdown_dispatcher(wait=True)
-    except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
-        logger.debug("Ask dispatcher shutdown skipped: %s", exc)
 
     try:
         from aragora.storage.webhook_config_store import reset_webhook_config_store

--- a/aragora/cli/main.py
+++ b/aragora/cli/main.py
@@ -185,6 +185,10 @@ def main() -> int:
     if fast_result is not None:
         return fast_result
 
+    from aragora.server.startup.event_subscribers import register_webhook_store
+
+    register_webhook_store()
+
     # Register built-in modes here (not at module level) to avoid import-time cost
     from aragora.modes import register_all_builtins
     from aragora.cli.parser import build_parser

--- a/aragora/events/dispatcher.py
+++ b/aragora/events/dispatcher.py
@@ -32,7 +32,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 from collections.abc import Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -40,9 +40,8 @@ from urllib.request import Request, urlopen
 from aragora.server.middleware.tracing import get_trace_id
 
 if TYPE_CHECKING:
+    from aragora.events.types import EventEmitter, StreamEvent
     from aragora.storage.webhook_config_store import WebhookConfig
-    from aragora.server.stream.emitter import SyncEventEmitter
-    from aragora.events.types import StreamEvent
 
 logger = logging.getLogger(__name__)
 
@@ -171,6 +170,44 @@ class DeliveryResult:
     error: str | None = None
     retry_count: int = 0
     duration_ms: float = 0.0
+
+
+class WebhookStore(Protocol):
+    """Lower-layer contract for webhook lookup and delivery recording."""
+
+    def get_for_event(self, event_type: str) -> list[WebhookConfig]:
+        """Return active webhooks interested in an event type."""
+        ...
+
+    def record_delivery(
+        self,
+        webhook_id: str,
+        status_code: int,
+        success: bool = True,
+    ) -> None:
+        """Record a webhook delivery result."""
+        ...
+
+
+WebhookStoreProvider = Callable[[], WebhookStore | None]
+_webhook_store_provider: WebhookStoreProvider | None = None
+
+
+def register_webhook_store_provider(provider: WebhookStoreProvider | None) -> None:
+    """Register the higher-layer provider used by the webhook dispatcher."""
+    global _webhook_store_provider
+    _webhook_store_provider = provider
+
+
+def _resolve_webhook_store() -> WebhookStore | None:
+    """Resolve webhook storage without importing a server composition surface."""
+    if _webhook_store_provider is None:
+        return None
+    try:
+        return _webhook_store_provider()
+    except (ImportError, OSError, ConnectionError, RuntimeError, TypeError, ValueError) as e:
+        logger.debug("Webhook store provider unavailable: %s", e)
+        return None
 
 
 def dispatch_webhook(
@@ -436,12 +473,12 @@ class WebhookDispatcher:
         self._rate_limited = 0
         self._lock = threading.Lock()
 
-    def subscribe_to_stream(self, event_emitter: SyncEventEmitter) -> None:
+    def subscribe_to_stream(self, event_emitter: EventEmitter) -> None:
         """
         Subscribe to an event emitter to receive events.
 
         Args:
-            event_emitter: SyncEventEmitter instance to subscribe to
+            event_emitter: Events-layer emitter interface to subscribe to
         """
 
         def on_event(event: StreamEvent):
@@ -471,10 +508,9 @@ class WebhookDispatcher:
                 self._rate_limited += 1
             return
 
-        # Import here to avoid circular dependency
-        from aragora.server.handlers.webhooks import get_webhook_store
-
-        store = get_webhook_store()
+        store = _resolve_webhook_store()
+        if store is None:
+            return
         webhooks = store.get_for_event(event_type)
 
         if not webhooks:
@@ -495,12 +531,16 @@ class WebhookDispatcher:
                 self._deliver_webhook,
                 webhook,
                 payload.copy(),
+                store,
             )
 
-    def _deliver_webhook(self, webhook: WebhookConfig, payload: dict) -> None:
+    def _deliver_webhook(
+        self,
+        webhook: WebhookConfig,
+        payload: dict,
+        store: WebhookStore,
+    ) -> None:
         """Deliver webhook in background thread."""
-        from aragora.server.handlers.webhooks import get_webhook_store
-
         # Import metrics (lazy to avoid circular imports)
         try:
             from aragora.observability.metrics.webhook import record_webhook_delivery
@@ -528,7 +568,6 @@ class WebhookDispatcher:
             )
 
         # Record delivery in store
-        store = get_webhook_store()
         store.record_delivery(
             webhook_id=webhook.id,
             status_code=result.status_code,
@@ -700,6 +739,7 @@ __all__ = [
     "dispatch_event",
     "dispatch_webhook",
     "dispatch_webhook_with_retry",
+    "register_webhook_store_provider",
     "shutdown_dispatcher",
     "DeliveryResult",
     # Receipt delivery helpers

--- a/aragora/events/dispatcher.py
+++ b/aragora/events/dispatcher.py
@@ -191,22 +191,46 @@ class WebhookStore(Protocol):
 
 WebhookStoreProvider = Callable[[], WebhookStore | None]
 _webhook_store_provider: WebhookStoreProvider | None = None
+_webhook_store_provider_lock = threading.Lock()
+_webhook_store_provider_last_warning: float | None = None
+WEBHOOK_STORE_PROVIDER_WARNING_INTERVAL = 60.0
 
 
 def register_webhook_store_provider(provider: WebhookStoreProvider | None) -> None:
     """Register the higher-layer provider used by the webhook dispatcher."""
-    global _webhook_store_provider
-    _webhook_store_provider = provider
+    global _webhook_store_provider, _webhook_store_provider_last_warning
+    with _webhook_store_provider_lock:
+        _webhook_store_provider = provider
+        _webhook_store_provider_last_warning = None
+
+
+def _warn_webhook_store_provider_failure(error: Exception) -> None:
+    """Emit a throttled warning when a registered provider cannot resolve."""
+    global _webhook_store_provider_last_warning
+
+    now = time.monotonic()
+    with _webhook_store_provider_lock:
+        last_warning = _webhook_store_provider_last_warning
+        if (
+            last_warning is not None
+            and now - last_warning < WEBHOOK_STORE_PROVIDER_WARNING_INTERVAL
+        ):
+            return
+        _webhook_store_provider_last_warning = now
+
+    logger.warning("Webhook store provider failed: %s", error)
 
 
 def _resolve_webhook_store() -> WebhookStore | None:
     """Resolve webhook storage without importing a server composition surface."""
-    if _webhook_store_provider is None:
+    with _webhook_store_provider_lock:
+        provider = _webhook_store_provider
+    if provider is None:
         return None
     try:
-        return _webhook_store_provider()
-    except (ImportError, OSError, ConnectionError, RuntimeError, TypeError, ValueError) as e:
-        logger.debug("Webhook store provider unavailable: %s", e)
+        return provider()
+    except Exception as e:  # noqa: BLE001 - isolate arbitrary registered backend failures
+        _warn_webhook_store_provider_failure(e)
         return None
 
 

--- a/aragora/events/dispatcher.py
+++ b/aragora/events/dispatcher.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -229,7 +230,7 @@ def _resolve_webhook_store() -> WebhookStore | None:
         return None
     try:
         return provider()
-    except Exception as e:  # noqa: BLE001 - isolate arbitrary registered backend failures
+    except (ImportError, OSError, RuntimeError, ValueError, sqlite3.Error) as e:
         _warn_webhook_store_provider_failure(e)
         return None
 

--- a/aragora/events/types.py
+++ b/aragora/events/types.py
@@ -10,12 +10,10 @@ This module is part of the shared events layer, accessible to all packages
 
 import json
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
-
-if TYPE_CHECKING:
-    pass
+from typing import Protocol, runtime_checkable
 
 
 class StreamEventType(Enum):
@@ -523,6 +521,10 @@ class EventEmitter(Protocol):
 
     def set_loop_id(self, loop_id: str) -> None:
         """Set the current loop ID for emitted events."""
+        ...
+
+    def subscribe(self, callback: Callable[[StreamEvent], None]) -> None:
+        """Subscribe a callback for synchronously emitted events."""
         ...
 
 

--- a/aragora/server/fastapi/factory.py
+++ b/aragora/server/fastapi/factory.py
@@ -228,6 +228,10 @@ async def lifespan(app: FastAPI):
     """
     logger.info("FastAPI server starting up...")
 
+    from aragora.server.startup.event_subscribers import register_webhook_store
+
+    register_webhook_store()
+
     # Initialize shared PostgreSQL pool on the running event loop before
     # any stores attempt backend selection.
     try:

--- a/aragora/server/fastapi/factory.py
+++ b/aragora/server/fastapi/factory.py
@@ -169,8 +169,10 @@ def _build_server_context(nomic_dir: Path | None = None) -> dict[str, Any]:
     try:
         from aragora.memory.continuum import get_continuum_memory
 
-        db_path = nomic_dir / "continuum_memory.db" if nomic_dir else None
-        ctx["continuum_memory"] = get_continuum_memory(db_path=str(db_path) if db_path else None)
+        continuum_db_path = nomic_dir / "continuum_memory.db" if nomic_dir else None
+        ctx["continuum_memory"] = get_continuum_memory(
+            db_path=str(continuum_db_path) if continuum_db_path else None
+        )
     except (ImportError, OSError, RuntimeError, ValueError) as e:
         logger.debug("ContinuumMemory not available: %s", e)
         ctx["continuum_memory"] = None

--- a/aragora/server/startup/__init__.py
+++ b/aragora/server/startup/__init__.py
@@ -429,6 +429,10 @@ async def _init_all_components(
     stream_emitter: Any | None,
 ) -> None:
     """Phase 3: Initialize all server components sequentially."""
+    from aragora.server.startup.event_subscribers import register_webhook_store
+
+    register_webhook_store()
+
     # PostgreSQL connection pool FIRST (event-loop bound, needed by subsystems)
     status["postgres_pool"] = await init_postgres_pool()
 

--- a/aragora/server/startup/event_subscribers.py
+++ b/aragora/server/startup/event_subscribers.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
     from aragora.events.cross_subscribers import CrossSubscriberManager
 
 
+def register_webhook_store() -> None:
+    """Register durable webhook storage without loading server subscribers."""
+    from aragora.events.dispatcher import register_webhook_store_provider
+    from aragora.storage.webhook_config_store import get_webhook_config_store
+
+    register_webhook_store_provider(get_webhook_config_store)
+
+
 def bootstrap_event_subscribers() -> CrossSubscriberManager:
     """Import all event-subscriber home modules and wire them into the manager.
 
@@ -34,12 +42,10 @@ def bootstrap_event_subscribers() -> CrossSubscriberManager:
         The registry-backed cross-subscriber manager singleton.
     """
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
-    from aragora.events.dispatcher import register_webhook_store_provider
     from aragora.server import event_subscribers as server_home
-    from aragora.storage.webhook_config_store import get_webhook_config_store
     from aragora.workflow import event_subscribers as workflow_home
 
-    register_webhook_store_provider(get_webhook_config_store)
+    register_webhook_store()
     bootstrap_debate_event_subscribers()
     workflow_home.register()
     server_home.register()

--- a/aragora/server/startup/event_subscribers.py
+++ b/aragora/server/startup/event_subscribers.py
@@ -34,9 +34,12 @@ def bootstrap_event_subscribers() -> CrossSubscriberManager:
         The registry-backed cross-subscriber manager singleton.
     """
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
+    from aragora.events.dispatcher import register_webhook_store_provider
     from aragora.server import event_subscribers as server_home
+    from aragora.storage.webhook_config_store import get_webhook_config_store
     from aragora.workflow import event_subscribers as workflow_home
 
+    register_webhook_store_provider(get_webhook_config_store)
     bootstrap_debate_event_subscribers()
     workflow_home.register()
     server_home.register()

--- a/aragora/server/startup/parallel.py
+++ b/aragora/server/startup/parallel.py
@@ -834,6 +834,10 @@ async def parallel_init(
         if not status.get("_parallel_init_success"):
             logger.error("Initialization failed")
     """
+    from aragora.server.startup.event_subscribers import register_webhook_store
+
+    register_webhook_store()
+
     strict_startup = os.environ.get("ARAGORA_STRICT_STARTUP", "").lower() in (
         "1",
         "true",

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -21,6 +21,26 @@ from aragora.cli.main import (
 )
 
 
+def test_ask_cleanup_drains_dispatcher_before_closing_webhook_store():
+    """In-flight webhook workers must finish before their lookup store closes."""
+    from aragora.cli.commands import debate as debate_cmd
+
+    order: list[str] = []
+    with (
+        patch(
+            "aragora.events.dispatcher.shutdown_dispatcher",
+            side_effect=lambda *, wait: order.append(f"dispatcher:{wait}"),
+        ),
+        patch(
+            "aragora.storage.webhook_config_store.reset_webhook_config_store",
+            side_effect=lambda: order.append("store"),
+        ),
+    ):
+        asyncio.run(debate_cmd._shutdown_cmd_ask_resources())
+
+    assert order == ["dispatcher:True", "store"]
+
+
 # =============================================================================
 # Parse Agents Tests
 # =============================================================================

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -548,6 +548,44 @@ class TestDemoTasks:
 class TestMain:
     """Tests for main entry point."""
 
+    def test_main_registers_webhook_store_before_normal_cli_initialization(self, monkeypatch):
+        """Normal CLI startup should register durable webhook storage first."""
+        order: list[str] = []
+        fake_args = argparse.Namespace(
+            command="status",
+            verbose=False,
+            func=lambda _args: order.append("command"),
+        )
+        fake_parser = Mock()
+        fake_parser.parse_args.return_value = fake_args
+
+        monkeypatch.setattr("aragora.cli.main._try_review_queue_fast_path", lambda _argv: None)
+        monkeypatch.setattr(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            lambda: order.append("webhook_store"),
+        )
+        monkeypatch.setattr(
+            "aragora.modes.register_all_builtins",
+            lambda: order.append("modes"),
+        )
+        monkeypatch.setattr("aragora.cli.parser.build_parser", lambda: fake_parser)
+        monkeypatch.setattr("aragora.cli.main._hydrate_startup_secrets", lambda: None)
+
+        assert main() == 0
+        assert order == ["webhook_store", "modes", "command"]
+
+    def test_main_review_queue_fast_path_skips_webhook_store_registration(self, monkeypatch):
+        """The lightweight review-queue path should remain registration-free."""
+        register_webhook_store = Mock()
+        monkeypatch.setattr(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            register_webhook_store,
+        )
+        monkeypatch.setattr("aragora.cli.main._try_review_queue_fast_path", lambda _argv: 17)
+
+        assert main() == 17
+        register_webhook_store.assert_not_called()
+
     def test_review_queue_build_accepts_repo_override(self):
         parser = cli_parser.build_parser()
         args = parser.parse_args(
@@ -599,7 +637,12 @@ class TestMain:
         def _unexpected_hydration(*_args, **_kwargs):
             raise AssertionError("record-settlement should not hydrate startup secrets")
 
-        monkeypatch.setattr("aragora.cli.main.build_parser", lambda: fake_parser)
+        monkeypatch.setattr("aragora.cli.main._try_review_queue_fast_path", lambda _argv: None)
+        monkeypatch.setattr(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            lambda: None,
+        )
+        monkeypatch.setattr("aragora.cli.parser.build_parser", lambda: fake_parser)
         monkeypatch.setattr("aragora.modes.register_all_builtins", lambda: None)
         monkeypatch.setattr(
             "aragora.config.secrets.hydrate_env_from_secrets",

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -21,8 +21,8 @@ from aragora.cli.main import (
 )
 
 
-def test_ask_cleanup_drains_dispatcher_before_closing_webhook_store():
-    """In-flight webhook workers must finish before their lookup store closes."""
+def test_ask_cleanup_drains_dispatcher_before_closing_webhook_store_dependencies():
+    """In-flight webhook workers finish before their store dependencies close."""
     from aragora.cli.commands import debate as debate_cmd
 
     order: list[str] = []
@@ -32,13 +32,21 @@ def test_ask_cleanup_drains_dispatcher_before_closing_webhook_store():
             side_effect=lambda *, wait: order.append(f"dispatcher:{wait}"),
         ),
         patch(
+            "aragora.server.startup.database.close_postgres_pool",
+            new=AsyncMock(side_effect=lambda: order.append("postgres")),
+        ),
+        patch(
+            "aragora.storage.connection_factory.close_all_pools",
+            new=AsyncMock(side_effect=lambda: order.append("connection-pools")),
+        ),
+        patch(
             "aragora.storage.webhook_config_store.reset_webhook_config_store",
             side_effect=lambda: order.append("store"),
         ),
     ):
         asyncio.run(debate_cmd._shutdown_cmd_ask_resources())
 
-    assert order == ["dispatcher:True", "store"]
+    assert order == ["dispatcher:True", "postgres", "connection-pools", "store"]
 
 
 # =============================================================================

--- a/tests/events/test_dispatcher_server_boundary.py
+++ b/tests/events/test_dispatcher_server_boundary.py
@@ -75,6 +75,23 @@ def test_registered_provider_failure_emits_rate_limited_warning(caplog):
     assert len(warnings) == 1
 
 
+def test_registered_provider_programming_error_propagates():
+    """Unexpected provider bugs must not be hidden as storage outages."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    register_webhook_store_provider(
+        MagicMock(side_effect=AssertionError("provider invariant failed"))
+    )
+
+    try:
+        with (
+            patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
+            pytest.raises(AssertionError, match="provider invariant failed"),
+        ):
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
+    finally:
+        dispatcher.shutdown(wait=False)
+
+
 def test_dispatch_event_looks_up_webhooks_through_registered_provider():
     """Dispatch lookup resolves the store exclusively through the events registry."""
     dispatcher = WebhookDispatcher(max_workers=1)

--- a/tests/events/test_dispatcher_server_boundary.py
+++ b/tests/events/test_dispatcher_server_boundary.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import ast
+import logging
+import sqlite3
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -24,19 +26,53 @@ def _reset_webhook_store_provider():
     register_webhook_store_provider(None)
 
 
-def test_dispatch_event_without_registered_provider_is_noop():
+def test_dispatch_event_without_registered_provider_is_noop(caplog):
     """Library-only events usage must not require the server composition root."""
     dispatcher = WebhookDispatcher(max_workers=1)
     submit = MagicMock()
     dispatcher._executor.submit = submit
 
     try:
-        with patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None):
+        with (
+            patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
+            caplog.at_level(logging.WARNING, logger="aragora.events.dispatcher"),
+        ):
             dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
     finally:
         dispatcher.shutdown(wait=False)
 
     submit.assert_not_called()
+    assert not [
+        record
+        for record in caplog.records
+        if "webhook store provider" in record.getMessage().lower()
+    ]
+
+
+def test_registered_provider_failure_emits_rate_limited_warning(caplog):
+    """A broken registered provider warns once per throttle window."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    provider = MagicMock(side_effect=sqlite3.OperationalError("store unavailable"))
+    register_webhook_store_provider(provider)
+
+    try:
+        with (
+            patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
+            patch("aragora.events.dispatcher.time.monotonic", side_effect=[100.0, 101.0]),
+            caplog.at_level(logging.WARNING, logger="aragora.events.dispatcher"),
+        ):
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-2"})
+    finally:
+        dispatcher.shutdown(wait=False)
+
+    assert provider.call_count == 2
+    warnings = [
+        record
+        for record in caplog.records
+        if "webhook store provider failed" in record.getMessage().lower()
+    ]
+    assert len(warnings) == 1
 
 
 def test_dispatch_event_looks_up_webhooks_through_registered_provider():

--- a/tests/events/test_dispatcher_server_boundary.py
+++ b/tests/events/test_dispatcher_server_boundary.py
@@ -1,0 +1,128 @@
+"""Regression tests for the events dispatcher server-boundary inversion."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.events.dispatcher import (
+    DeliveryResult,
+    WebhookDispatcher,
+    register_webhook_store_provider,
+)
+from aragora.events.types import StreamEvent, StreamEventType
+
+
+@pytest.fixture(autouse=True)
+def _reset_webhook_store_provider():
+    """Keep the process-wide provider registry isolated across tests."""
+    register_webhook_store_provider(None)
+    yield
+    register_webhook_store_provider(None)
+
+
+def test_dispatch_event_without_registered_provider_is_noop():
+    """Library-only events usage must not require the server composition root."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    submit = MagicMock()
+    dispatcher._executor.submit = submit
+
+    try:
+        with patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None):
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
+    finally:
+        dispatcher.shutdown(wait=False)
+
+    submit.assert_not_called()
+
+
+def test_dispatch_event_looks_up_webhooks_through_registered_provider():
+    """Dispatch lookup resolves the store exclusively through the events registry."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    store = MagicMock()
+    store.get_for_event.return_value = []
+    provider = MagicMock(return_value=store)
+    register_webhook_store_provider(provider)
+
+    try:
+        with patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None):
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
+    finally:
+        dispatcher.shutdown(wait=False)
+
+    provider.assert_called_once_with()
+    store.get_for_event.assert_called_once_with("debates.created")
+
+
+def test_delivery_result_is_recorded_on_lookup_store():
+    """The store used for lookup must receive the matching delivery result."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    webhook = MagicMock(id="wh-1", url="https://example.com/hook")
+    store = MagicMock()
+    store.get_for_event.return_value = [webhook]
+    register_webhook_store_provider(lambda: store)
+    dispatcher._executor.submit = MagicMock(side_effect=lambda callback, *args: callback(*args))
+
+    result = DeliveryResult(
+        success=False,
+        status_code=503,
+        error="unavailable",
+        retry_count=2,
+        duration_ms=25.0,
+    )
+
+    try:
+        with (
+            patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
+            patch(
+                "aragora.events.dispatcher.dispatch_webhook_with_retry",
+                return_value=result,
+            ),
+        ):
+            dispatcher.dispatch_event("debates.created", {"debate_id": "d-1"})
+    finally:
+        dispatcher.shutdown(wait=False)
+
+    store.record_delivery.assert_called_once_with(
+        webhook_id="wh-1",
+        status_code=503,
+        success=False,
+    )
+
+
+def test_subscribe_to_stream_uses_events_side_emitter_contract():
+    """Emitter subscription dispatches events and remains inert after shutdown."""
+    dispatcher = WebhookDispatcher(max_workers=1)
+    emitter = MagicMock()
+    dispatcher.dispatch_event = MagicMock()
+
+    dispatcher.subscribe_to_stream(emitter)
+
+    callback = emitter.subscribe.call_args.args[0]
+    event = StreamEvent(
+        type=StreamEventType.DEBATE_END,
+        data={"debate_id": "d-1"},
+    )
+    callback(event)
+    dispatcher.dispatch_event.assert_called_once_with("debate_end", event.to_dict())
+
+    dispatcher.shutdown(wait=False)
+    callback(event)
+    dispatcher.dispatch_event.assert_called_once()
+
+
+def test_dispatcher_has_no_server_emitter_or_webhook_handler_imports():
+    """The lower-layer dispatcher must not import either server-owned surface."""
+    dispatcher_path = Path(__file__).parents[2] / "aragora" / "events" / "dispatcher.py"
+    tree = ast.parse(dispatcher_path.read_text(encoding="utf-8"))
+    imported_modules = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+
+    assert "aragora.server.stream.emitter" not in imported_modules
+    assert "aragora.server.handlers.webhooks" not in imported_modules

--- a/tests/integration/test_event_pipeline_e2e.py
+++ b/tests/integration/test_event_pipeline_e2e.py
@@ -29,10 +29,14 @@ from aragora.events.types import StreamEvent, StreamEventType
 
 @pytest.fixture(autouse=True)
 def _reset_dispatcher_cache():
-    """Reset the lazy-loaded dispatcher availability flag between tests."""
+    """Reset dispatcher availability and provider state between tests."""
+    from aragora.events.dispatcher import register_webhook_store_provider
+
     original = handler_events._dispatcher_available
+    register_webhook_store_provider(None)
     yield
     handler_events._dispatcher_available = original
+    register_webhook_store_provider(None)
 
 
 # ---------------------------------------------------------------------------
@@ -187,10 +191,10 @@ class TestDispatcherDelivery:
         mock_store = MagicMock()
         mock_store.get_for_event.return_value = []  # No webhooks registered
 
-        with (
-            patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
-            patch("aragora.server.handlers.webhooks.get_webhook_store", return_value=mock_store),
-        ):
+        from aragora.events.dispatcher import register_webhook_store_provider
+
+        register_webhook_store_provider(lambda: mock_store)
+        with patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None):
             dispatcher.dispatch_event("debates.created", {"handler": "debates"})
 
         mock_store.get_for_event.assert_called_once_with("debates.created")
@@ -356,13 +360,9 @@ class TestEndToEndPipeline:
             dispatcher_mod.get_dispatcher = lambda: test_dispatcher
             # Reset the lazy flag so dispatch_event import succeeds
             handler_events._dispatcher_available = None
+            dispatcher_mod.register_webhook_store_provider(lambda: mock_store)
 
-            with (
-                patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None),
-                patch(
-                    "aragora.server.handlers.webhooks.get_webhook_store", return_value=mock_store
-                ),
-            ):
+            with patch("aragora.events.dispatcher.get_event_rate_limiter", return_value=None):
                 emit_handler_event("devops", "started", {"pipeline": "deploy-prod"})
 
             # The dispatcher should have queried the store for this event type

--- a/tests/server/fastapi/test_factory.py
+++ b/tests/server/fastapi/test_factory.py
@@ -27,7 +27,7 @@ def _patched_startup_dependencies():
             patch("aragora.server.startup.database.close_postgres_pool", new_callable=AsyncMock)
         )
         stack.enter_context(patch("aragora.ranking.elo.EloSystem", return_value=MagicMock()))
-        stack.enter_context(
+        mocked["get_continuum_memory"] = stack.enter_context(
             patch("aragora.memory.continuum.get_continuum_memory", return_value=MagicMock())
         )
         mock_cross_config = stack.enter_context(
@@ -57,6 +57,9 @@ def test_build_server_context_initializes_debate_storage_in_nomic_dir(tmp_path: 
         ctx = factory._build_server_context(tmp_path)
 
     mocked["storage"].assert_called_once_with(str(tmp_path / "debates.db"))
+    mocked["get_continuum_memory"].assert_called_once_with(
+        db_path=str(tmp_path / "continuum_memory.db")
+    )
     assert ctx["storage"] is mocked["storage"].return_value
 
 

--- a/tests/server/fastapi/test_factory.py
+++ b/tests/server/fastapi/test_factory.py
@@ -75,6 +75,36 @@ def test_create_app_lifespan_starts_with_fastapi_context(tmp_path: Path, monkeyp
     mocked["close_postgres_pool"].assert_awaited_once()
 
 
+def test_lifespan_registers_webhook_store_before_context_construction():
+    """FastAPI startup wires durable webhooks before optional context work."""
+    order: list[str] = []
+    app = MagicMock()
+
+    def build_context(_nomic_dir):
+        order.append("context")
+        return {}
+
+    with (
+        patch(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            side_effect=lambda: order.append("webhook_store"),
+        ),
+        patch(
+            "aragora.server.startup.database.init_postgres_pool",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "aragora.server.startup.database.close_postgres_pool",
+            new_callable=AsyncMock,
+        ),
+        patch.object(factory, "_build_server_context", side_effect=build_context),
+        patch("aragora.server.middleware.deprecation_enforcer.register_default_deprecations"),
+    ):
+        asyncio.run(_exercise_lifespan(app))
+
+    assert order == ["webhook_store", "context"]
+
+
 def test_build_server_context_defers_postgres_user_store_in_async_context(tmp_path: Path):
     config = DatabaseConfig(
         backend_type=StorageBackendType.POSTGRES,
@@ -101,3 +131,8 @@ def test_build_server_context_defers_postgres_user_store_in_async_context(tmp_pa
 
 async def _async_build_server_context(tmp_path: Path):
     return factory._build_server_context(tmp_path)
+
+
+async def _exercise_lifespan(app):
+    async with factory.lifespan(app):
+        pass

--- a/tests/server/startup/test_parallel.py
+++ b/tests/server/startup/test_parallel.py
@@ -556,3 +556,34 @@ class TestParallelInitializerPhases:
         assert "agent_registry" in task_names
         assert "control_plane" in task_names
         assert "background_tasks" in task_names
+
+
+async def test_parallel_entrypoint_registers_webhook_store_before_initializer_run():
+    """Durable webhook wiring must precede scheduling optional KM work."""
+    from aragora.server.startup.parallel import parallel_init
+
+    order: list[str] = []
+
+    async def run_stub(_self):
+        order.append("initializer_run")
+        return ParallelInitResult(
+            phases=[],
+            total_duration_ms=1.0,
+            success=True,
+            results={},
+        )
+
+    with (
+        patch(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            side_effect=lambda: order.append("webhook_store"),
+        ),
+        patch(
+            "aragora.server.startup.parallel.init_security_edge_adapters",
+            return_value={},
+        ),
+        patch.object(ParallelInitializer, "run", run_stub),
+    ):
+        await parallel_init()
+
+    assert order == ["webhook_store", "initializer_run"]

--- a/tests/server/test_event_subscribers.py
+++ b/tests/server/test_event_subscribers.py
@@ -176,6 +176,31 @@ class TestServerEventSubscriberRegistration:
         second = get_registered_subscribers()["server"]
         assert first is second
 
+    def test_lightweight_bootstrap_registers_webhook_store_provider(self):
+        """Durable webhook storage can be wired without subscriber imports."""
+        from aragora.server.startup.event_subscribers import register_webhook_store
+
+        with (
+            patch("aragora.events.dispatcher.register_webhook_store_provider") as register_provider,
+            patch(
+                "aragora.storage.webhook_config_store.get_webhook_config_store"
+            ) as get_webhook_config_store,
+        ):
+            register_webhook_store()
+
+        register_provider.assert_called_once_with(get_webhook_config_store)
+
+    def test_superset_bootstrap_uses_lightweight_webhook_store_registration(self):
+        """Direct subscriber bootstrap must include durable store wiring."""
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+        with patch(
+            "aragora.server.startup.event_subscribers.register_webhook_store"
+        ) as register_store:
+            bootstrap_event_subscribers()
+
+        register_store.assert_called_once_with()
+
     def test_superset_bootstrap_registers_webhook_store_provider(self):
         """Server composition wires durable webhook storage into events."""
         from aragora.server.startup.event_subscribers import bootstrap_event_subscribers

--- a/tests/server/test_event_subscribers.py
+++ b/tests/server/test_event_subscribers.py
@@ -176,6 +176,20 @@ class TestServerEventSubscriberRegistration:
         second = get_registered_subscribers()["server"]
         assert first is second
 
+    def test_superset_bootstrap_registers_webhook_store_provider(self):
+        """Server composition wires durable webhook storage into events."""
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+        with (
+            patch("aragora.events.dispatcher.register_webhook_store_provider") as register_provider,
+            patch(
+                "aragora.storage.webhook_config_store.get_webhook_config_store"
+            ) as get_webhook_config_store,
+        ):
+            bootstrap_event_subscribers()
+
+        register_provider.assert_called_once_with(get_webhook_config_store)
+
 
 class TestLegacyDelegatingSitesRemoved:
     """Structural regression guard: both pre-inversion handler methods are

--- a/tests/server/test_startup.py
+++ b/tests/server/test_startup.py
@@ -330,3 +330,30 @@ class TestGauntletRecovery:
         result = init_gauntlet_run_recovery()
         assert isinstance(result, int)
         assert result >= 0
+
+
+@pytest.mark.asyncio
+async def test_sequential_startup_registers_webhook_store_before_components():
+    """Durable webhook wiring must precede optional component initialization."""
+    from aragora.server.startup import _init_all_components
+
+    order: list[str] = []
+
+    async def fail_first_component():
+        order.append("first_component")
+        raise RuntimeError("stop after ordering assertion")
+
+    with (
+        patch(
+            "aragora.server.startup.event_subscribers.register_webhook_store",
+            side_effect=lambda: order.append("webhook_store"),
+        ),
+        patch(
+            "aragora.server.startup.init_postgres_pool",
+            side_effect=fail_first_component,
+        ),
+        pytest.raises(RuntimeError, match="stop after ordering assertion"),
+    ):
+        await _init_all_components({}, None, None)
+
+    assert order == ["webhook_store", "first_component"]


### PR DESCRIPTION
## Summary
- add an events-owned webhook-store provider contract
- remove dispatcher imports of server emitter and webhook handler modules
- register durable webhook storage from the server startup composition root
- preserve event delivery recording, emitter subscription, and shutdown behavior

## Validation
- 211 focused events/webhook/storage/security tests passed
- five randomized focused runs passed
- changed-file mypy, Ruff lint/format, smoke imports, and 138-test smoke tier passed
- no server/handlers, baseline, metrics, or module-tier files changed

## Reviewer context: chartered scope
- Provider absence is intentionally a quiet library-only no-op. Product composition roots register the provider before event-capable startup; changing absence semantics is outside this feature.
- `aragora.events.dispatcher` deliberately retains the tracing shim import and the `events -> server` baseline string for `p4a-shim-caller-sweep`, which owns all remaining old-shim caller repoints.
- Normal CLI registration is an explicit requirement and registers only a callable. The tracing shim is the current source of transitive import weight and remains sweep-owned.
- This final additive repair only drains `shutdown_dispatcher(wait=True)` before PostgreSQL and connection-factory pools close, preserving same-store delivery-result recording for in-flight workers.
