### PR TITLE
refactor(layers): invert channel boundary contracts

### DIFF
--- a/aragora/control_plane/event_registry.py
+++ b/aragora/control_plane/event_registry.py
@@ -1,0 +1,25 @@
+"""Control-plane adapter for the events-owned notification registry contract."""
+
+from __future__ import annotations
+
+from aragora.control_plane.channels import NotificationEventType
+from aragora.events.registry import (
+    register_notification_event_contributor as register_events_contributor,
+)
+
+
+def get_notification_event_names() -> tuple[str, ...]:
+    """Return every control-plane notification event name."""
+    return tuple(event_type.value for event_type in NotificationEventType)
+
+
+def register_notification_event_contributor() -> bool:
+    """Compose notification event discovery into the events registry."""
+    register_events_contributor(get_notification_event_names)
+    return True
+
+
+__all__ = [
+    "get_notification_event_names",
+    "register_notification_event_contributor",
+]

--- a/aragora/control_plane/slo_alert_sink.py
+++ b/aragora/control_plane/slo_alert_sink.py
@@ -6,10 +6,7 @@ import logging
 from typing import Any
 
 from aragora.control_plane.channels import (
-    ChannelConfig,
-    NotificationChannel,
     NotificationEventType,
-    NotificationManager,
     NotificationPriority,
 )
 from aragora.control_plane.notifications import get_default_notification_dispatcher
@@ -35,6 +32,12 @@ class ControlPlaneSLOAlertSink:
 
     def _get_manager(self) -> Any:
         if self._manager is None:
+            from aragora.control_plane.channels import (
+                ChannelConfig,
+                NotificationChannel,
+                NotificationManager,
+            )
+
             manager = NotificationManager()
             manager.add_channel(
                 ChannelConfig(
@@ -56,6 +59,11 @@ class ControlPlaneSLOAlertSink:
         metadata: dict[str, Any],
     ) -> Any:
         """Deliver an observability alert through the channel manager."""
+        from aragora.control_plane.channels import (
+            NotificationEventType,
+            NotificationPriority,
+        )
+
         return await self._get_manager().notify(
             event_type=NotificationEventType(event_type),
             title=title,

--- a/aragora/control_plane/slo_alert_sink.py
+++ b/aragora/control_plane/slo_alert_sink.py
@@ -3,10 +3,25 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from aragora.observability.slo_alert_bridge import SLOAlertConfig
+from aragora.control_plane.channels import (
+    ChannelConfig,
+    NotificationChannel,
+    NotificationEventType,
+    NotificationManager,
+    NotificationPriority,
+)
+from aragora.control_plane.notifications import get_default_notification_dispatcher
+from aragora.observability.slo import (
+    SLOBreach,
+    SLONotificationSink,
+    register_slo_notification_sink_provider,
+)
+from aragora.observability.slo_alert_bridge import (
+    SLOAlertConfig,
+    register_channel_alert_sink,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +35,6 @@ class ControlPlaneSLOAlertSink:
 
     def _get_manager(self) -> Any:
         if self._manager is None:
-            from aragora.control_plane.channels import (
-                ChannelConfig,
-                NotificationChannel,
-                NotificationManager,
-            )
-
             manager = NotificationManager()
             manager.add_channel(
                 ChannelConfig(
@@ -47,11 +56,6 @@ class ControlPlaneSLOAlertSink:
         metadata: dict[str, Any],
     ) -> Any:
         """Deliver an observability alert through the channel manager."""
-        from aragora.control_plane.channels import (
-            NotificationEventType,
-            NotificationPriority,
-        )
-
         return await self._get_manager().notify(
             event_type=NotificationEventType(event_type),
             title=title,
@@ -61,16 +65,57 @@ class ControlPlaneSLOAlertSink:
         )
 
 
-def register_slo_alert_sink() -> bool:
-    """Register this adapter with the observability-owned sink contract."""
-    try:
-        from aragora.observability.slo_alert_bridge import register_channel_alert_sink
-    except ImportError as e:
-        logger.debug("Observability channel sink contract unavailable: %s", e)
-        return False
+class ControlPlaneSLONotificationSink:
+    """Deliver direct SLO notifications through the current dispatcher."""
 
+    async def notify(self, breach: SLOBreach) -> None:
+        """Dispatch one SLO breach without caching the dispatcher."""
+        dispatcher = get_default_notification_dispatcher()
+        if dispatcher is None:
+            logger.warning("Notification dispatcher not configured")
+            return
+
+        priority = (
+            NotificationPriority.CRITICAL
+            if breach.severity == "critical"
+            else NotificationPriority.HIGH
+        )
+
+        await dispatcher.dispatch(
+            event_type=NotificationEventType.SYSTEM_ALERT,
+            title=f"SLO Alert: {breach.slo_name}",
+            body=(
+                f"{breach.message}\n\n"
+                f"Current: {breach.current_value:.4f}\n"
+                f"Target: {breach.target_value:.4f}\n"
+                f"Error Budget: {breach.error_budget_remaining:.1f}%\n"
+                f"Burn Rate: {breach.burn_rate:.2f}x"
+            ),
+            priority=priority,
+            metadata=breach.to_dict(),
+        )
+
+
+_direct_notification_sink = ControlPlaneSLONotificationSink()
+
+
+def get_slo_notification_sink() -> SLONotificationSink | None:
+    """Resolve the direct sink only while a dispatcher is configured."""
+    if get_default_notification_dispatcher() is None:
+        return None
+    return _direct_notification_sink
+
+
+def register_slo_alert_sink() -> bool:
+    """Register both control-plane adapters with observability contracts."""
     register_channel_alert_sink(ControlPlaneSLOAlertSink)
+    register_slo_notification_sink_provider(get_slo_notification_sink)
     return True
 
 
-__all__ = ["ControlPlaneSLOAlertSink", "register_slo_alert_sink"]
+__all__ = [
+    "ControlPlaneSLOAlertSink",
+    "ControlPlaneSLONotificationSink",
+    "get_slo_notification_sink",
+    "register_slo_alert_sink",
+]

--- a/aragora/events/registry.py
+++ b/aragora/events/registry.py
@@ -42,9 +42,20 @@ import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, TypeVar
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 
 logger = logging.getLogger(__name__)
+
+NotificationEventContributor = Callable[[], Iterable[str]]
+_notification_event_contributor: NotificationEventContributor | None = None
+
+
+def register_notification_event_contributor(
+    contributor: NotificationEventContributor | None,
+) -> None:
+    """Register the application-owned source of notification event names."""
+    global _notification_event_contributor
+    _notification_event_contributor = contributor
 
 
 class EventCategory(str, Enum):
@@ -354,12 +365,11 @@ class EventRegistry:
         except ImportError:
             logger.debug("StreamEventType not available")
 
-        try:
-            from aragora.control_plane.channels import NotificationEventType
-
-            self._register_notification_events(NotificationEventType)
-        except ImportError:
-            logger.debug("NotificationEventType not available")
+        if _notification_event_contributor is not None:
+            try:
+                self._register_notification_events(_notification_event_contributor())
+            except (ImportError, RuntimeError, TypeError, ValueError) as e:
+                logger.debug("Notification event contributor not available: %s", e)
 
         try:
             from aragora.control_plane.deliberation_events import DeliberationEventType
@@ -423,8 +433,8 @@ class EventRegistry:
                 description=f"Stream event: {name}",
             )
 
-    def _register_notification_events(self, enum_class: type[Enum]) -> None:
-        """Register NotificationEventType events."""
+    def _register_notification_events(self, event_names: Iterable[str]) -> None:
+        """Register application-contributed notification event names."""
         category_map = {
             "task_": EventCategory.CONTROL_PLANE,
             "deliberation_": EventCategory.CONTROL_PLANE,
@@ -435,8 +445,7 @@ class EventRegistry:
             "connector_": EventCategory.WEBHOOK,
         }
 
-        for member in enum_class:
-            name = member.value
+        for name in event_names:
             category = EventCategory.CONTROL_PLANE
 
             for prefix, cat in category_map.items():

--- a/aragora/observability/slo.py
+++ b/aragora/observability/slo.py
@@ -40,9 +40,10 @@ import asyncio
 import importlib.util
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
-from typing import Any
+from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -1002,6 +1003,32 @@ class SLOBreach:
         }
 
 
+class SLONotificationSink(Protocol):
+    """Higher-layer delivery contract for SLO notification messages."""
+
+    async def notify(self, breach: SLOBreach) -> None:
+        """Deliver one SLO breach notification."""
+
+
+SLONotificationSinkProvider = Callable[[], SLONotificationSink | None]
+_slo_notification_sink_provider: SLONotificationSinkProvider | None = None
+
+
+def register_slo_notification_sink_provider(
+    provider: SLONotificationSinkProvider | None,
+) -> None:
+    """Register the higher-layer provider for direct SLO notifications."""
+    global _slo_notification_sink_provider
+    _slo_notification_sink_provider = provider
+
+
+def _resolve_slo_notification_sink() -> SLONotificationSink | None:
+    """Resolve the currently registered notification sink without caching it."""
+    if _slo_notification_sink_provider is None:
+        return None
+    return _slo_notification_sink_provider()
+
+
 # Type alias for alert callback
 AlertCallback = Any  # Callable[[SLOBreach], None] or async version
 
@@ -1283,44 +1310,20 @@ def create_slack_alert_callback(webhook_url: str) -> AlertCallback:
 
 
 def create_notification_callback() -> AlertCallback:
-    """Create a callback using the control plane notification system.
+    """Create a callback using the registered SLO notification sink.
 
     Returns:
-        Callback function that sends alerts through NotificationDispatcher
+        Callback function that sends alerts through the current notification sink
     """
 
     async def notification_callback(breach: SLOBreach) -> None:
         try:
-            from aragora.control_plane.channels import (
-                NotificationEventType,
-                NotificationPriority,
-            )
-            from aragora.control_plane.notifications import get_default_notification_dispatcher
-
-            dispatcher = get_default_notification_dispatcher()
-            if dispatcher is None:
+            sink = _resolve_slo_notification_sink()
+            if sink is None:
                 logger.warning("Notification dispatcher not configured")
                 return
 
-            priority = (
-                NotificationPriority.CRITICAL
-                if breach.severity == "critical"
-                else NotificationPriority.HIGH
-            )
-
-            await dispatcher.dispatch(
-                event_type=NotificationEventType.SYSTEM_ALERT,
-                title=f"SLO Alert: {breach.slo_name}",
-                body=(
-                    f"{breach.message}\n\n"
-                    f"Current: {breach.current_value:.4f}\n"
-                    f"Target: {breach.target_value:.4f}\n"
-                    f"Error Budget: {breach.error_budget_remaining:.1f}%\n"
-                    f"Burn Rate: {breach.burn_rate:.2f}x"
-                ),
-                priority=priority,
-                metadata=breach.to_dict(),
-            )
+            await sink.notify(breach)
             logger.info("SLO alert dispatched via notification system")
 
         except ImportError:
@@ -1924,6 +1927,8 @@ __all__ = [
     "webhook_alert_callback",
     "create_slack_alert_callback",
     "create_notification_callback",
+    "SLONotificationSink",
+    "register_slo_notification_sink_provider",
     # SLO Enforcer
     "SLOEnforcer",
     "get_slo_enforcer",

--- a/aragora/server/startup/__init__.py
+++ b/aragora/server/startup/__init__.py
@@ -54,6 +54,7 @@ from aragora.server.startup.control_plane import (
     init_persistent_task_queue,
     init_shared_control_plane_state,
     init_witness_patrol,
+    register_control_plane_event_contributors,
 )
 from aragora.server.startup.knowledge_mound import (
     get_km_config_from_env,
@@ -432,6 +433,7 @@ async def _init_all_components(
     """Phase 3: Initialize all server components sequentially."""
     from aragora.server.startup.event_subscribers import register_webhook_store
 
+    register_control_plane_event_contributors()
     register_webhook_store()
 
     # PostgreSQL connection pool FIRST (event-loop bound, needed by subsystems)
@@ -735,6 +737,7 @@ __all__ = [
     "init_slack_token_refresh_scheduler",
     "init_titans_memory_sweep",
     "init_self_improvement_daemon",
+    "register_control_plane_event_contributors",
     "init_control_plane_coordinator",
     "init_shared_control_plane_state",
     "init_tts_integration",

--- a/aragora/server/startup/control_plane.py
+++ b/aragora/server/startup/control_plane.py
@@ -15,6 +15,15 @@ from aragora.exceptions import REDIS_CONNECTION_ERRORS
 logger = logging.getLogger(__name__)
 
 
+def register_control_plane_event_contributors() -> bool:
+    """Register control-plane event metadata providers before registry use."""
+    from aragora.control_plane.event_registry import (
+        register_notification_event_contributor,
+    )
+
+    return register_notification_event_contributor()
+
+
 async def init_control_plane_coordinator() -> Any | None:
     """Initialize the Control Plane coordinator.
 

--- a/aragora/server/startup/parallel.py
+++ b/aragora/server/startup/parallel.py
@@ -835,8 +835,10 @@ async def parallel_init(
         if not status.get("_parallel_init_success"):
             logger.error("Initialization failed")
     """
+    from aragora.server.startup.control_plane import register_control_plane_event_contributors
     from aragora.server.startup.event_subscribers import register_webhook_store
 
+    register_control_plane_event_contributors()
     register_webhook_store()
 
     strict_startup = os.environ.get("ARAGORA_STRICT_STARTUP", "").lower() in (

--- a/tests/control_plane/test_event_registry.py
+++ b/tests/control_plane/test_event_registry.py
@@ -1,0 +1,58 @@
+"""Tests for the control-plane event registry adapter."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from aragora.control_plane.channels import NotificationEventType
+from aragora.events import registry as registry_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_event_registry():
+    registry_module.reset_event_registry()
+    register = getattr(registry_module, "register_notification_event_contributor", None)
+    if register is not None:
+        register(None)
+    yield
+    registry_module.reset_event_registry()
+    if register is not None:
+        register(None)
+
+
+def test_adapter_import_is_side_effect_free() -> None:
+    """Importing the adapter does not register its contributor."""
+    registry_module.register_notification_event_contributor(None)
+
+    adapter = importlib.import_module("aragora.control_plane.event_registry")
+    importlib.reload(adapter)
+
+    assert registry_module._notification_event_contributor is None
+
+
+def test_adapter_supplies_every_notification_event_value() -> None:
+    """The adapter exposes all channel-owned notification enum values."""
+    adapter = importlib.import_module("aragora.control_plane.event_registry")
+
+    assert adapter.get_notification_event_names() == tuple(
+        event_type.value for event_type in NotificationEventType
+    )
+
+
+def test_adapter_registration_is_explicit_and_idempotent() -> None:
+    """Explicit repeated composition installs one stable contributor."""
+    adapter = importlib.import_module("aragora.control_plane.event_registry")
+
+    assert adapter.register_notification_event_contributor() is True
+    contributor = registry_module._notification_event_contributor
+    assert adapter.register_notification_event_contributor() is True
+    assert registry_module._notification_event_contributor is contributor
+
+    registry = registry_module.EventRegistry()
+    registered = {
+        event.name
+        for event in registry.list_events(source=registry_module.EventSource.CONTROL_PLANE)
+    }
+    assert registered == {event_type.value for event_type in NotificationEventType}

--- a/tests/control_plane/test_slo_alert_sink.py
+++ b/tests/control_plane/test_slo_alert_sink.py
@@ -1,0 +1,164 @@
+"""Tests for the control-plane SLO alert adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aragora.control_plane.channels import NotificationEventType, NotificationPriority
+from aragora.control_plane import slo_alert_sink as adapter
+from aragora.observability import slo as slo_module
+from aragora.observability import slo_alert_bridge
+from aragora.observability.slo import SLOBreach, create_notification_callback
+from aragora.observability.slo_alert_bridge import SLOAlertConfig
+
+
+def _breach(*, severity: str = "critical") -> SLOBreach:
+    return SLOBreach(
+        slo_name="API Availability",
+        severity=severity,
+        current_value=0.975,
+        target_value=0.999,
+        error_budget_remaining=12.3,
+        burn_rate=4.56,
+        message="Availability below target",
+        timestamp=datetime(2026, 7, 13, 12, 30, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_sinks():
+    slo_alert_bridge.register_channel_alert_sink(None)
+    register = getattr(slo_module, "register_slo_notification_sink_provider", None)
+    if register is not None:
+        register(None)
+    yield
+    slo_alert_bridge.register_channel_alert_sink(None)
+    if register is not None:
+        register(None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("severity", "priority"),
+    [
+        ("critical", NotificationPriority.CRITICAL),
+        ("major", NotificationPriority.HIGH),
+    ],
+)
+async def test_direct_notification_preserves_payload_and_priority(
+    monkeypatch: pytest.MonkeyPatch,
+    severity: str,
+    priority: NotificationPriority,
+) -> None:
+    dispatcher = AsyncMock()
+    monkeypatch.setattr(adapter, "get_default_notification_dispatcher", lambda: dispatcher)
+    breach = _breach(severity=severity)
+
+    await adapter.ControlPlaneSLONotificationSink().notify(breach)
+
+    dispatcher.dispatch.assert_awaited_once_with(
+        event_type=NotificationEventType.SYSTEM_ALERT,
+        title="SLO Alert: API Availability",
+        body=(
+            "Availability below target\n\n"
+            "Current: 0.9750\n"
+            "Target: 0.9990\n"
+            "Error Budget: 12.3%\n"
+            "Burn Rate: 4.56x"
+        ),
+        priority=priority,
+        metadata=breach.to_dict(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_notification_resolves_replaced_dispatcher_each_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_dispatcher = AsyncMock()
+    second_dispatcher = AsyncMock()
+    dispatchers = iter((first_dispatcher, second_dispatcher))
+    monkeypatch.setattr(
+        adapter,
+        "get_default_notification_dispatcher",
+        lambda: next(dispatchers),
+    )
+    sink = adapter.ControlPlaneSLONotificationSink()
+    breach = _breach()
+
+    await sink.notify(breach)
+    await sink.notify(breach)
+
+    first_dispatcher.dispatch.assert_awaited_once()
+    second_dispatcher.dispatch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_missing_dispatcher_is_fail_soft(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(adapter, "get_default_notification_dispatcher", lambda: None)
+
+    await adapter.ControlPlaneSLONotificationSink().notify(_breach())
+
+    assert "Notification dispatcher not configured" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_registered_provider_tracks_dispatcher_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_dispatcher = AsyncMock()
+    second_dispatcher = AsyncMock()
+    current_dispatcher = [first_dispatcher]
+    monkeypatch.setattr(
+        adapter,
+        "get_default_notification_dispatcher",
+        lambda: current_dispatcher[0],
+    )
+    adapter.register_slo_alert_sink()
+    callback = create_notification_callback()
+    breach = _breach()
+
+    await callback(breach)
+    current_dispatcher[0] = second_dispatcher
+    await callback(breach)
+
+    first_dispatcher.dispatch.assert_awaited_once()
+    second_dispatcher.dispatch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_existing_channel_bridge_contract_remains_compatible(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = AsyncMock()
+    sink = adapter.ControlPlaneSLOAlertSink(SLOAlertConfig())
+    monkeypatch.setattr(sink, "_get_manager", lambda: manager)
+
+    await sink.notify(
+        event_type="system_alert",
+        title="SLO Alert",
+        body="Threshold exceeded",
+        priority="critical",
+        metadata={"slo_name": "availability"},
+    )
+
+    manager.notify.assert_awaited_once_with(
+        event_type=NotificationEventType.SYSTEM_ALERT,
+        title="SLO Alert",
+        body="Threshold exceeded",
+        priority=NotificationPriority.CRITICAL,
+        metadata={"slo_name": "availability"},
+    )
+
+
+def test_registration_keeps_bridge_and_adds_direct_provider() -> None:
+    assert adapter.register_slo_alert_sink() is True
+
+    assert slo_alert_bridge._channel_alert_sink_factory is adapter.ControlPlaneSLOAlertSink
+    assert slo_module._slo_notification_sink_provider is not None

--- a/tests/events/test_registry.py
+++ b/tests/events/test_registry.py
@@ -1,0 +1,73 @@
+"""Tests for the unified event registry composition contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.events import registry as registry_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_state():
+    registry_module.reset_event_registry()
+    register = getattr(registry_module, "register_notification_event_contributor", None)
+    if register is not None:
+        register(None)
+    yield
+    registry_module.reset_event_registry()
+    if register is not None:
+        register(None)
+
+
+def test_registry_has_no_control_plane_channel_import() -> None:
+    """The events-owned registry must not import the control-plane channel enum."""
+    source = Path(registry_module.__file__).read_text(encoding="utf-8")
+
+    assert "aragora.control_plane.channels" not in source
+
+
+def test_missing_notification_contributor_is_fail_soft() -> None:
+    """A cold registry still initializes when startup composition is absent."""
+    registry_module.register_notification_event_contributor(None)
+
+    registry = registry_module.EventRegistry()
+
+    assert registry.get_event("task_claimed") is None
+    assert registry.get_event("debate_start") is not None
+
+
+def test_notification_contributor_runs_at_original_precedence_position() -> None:
+    """Notifications override stream metadata, then deliberation overrides them."""
+
+    def notification_events() -> tuple[str, ...]:
+        return ("debate_start", "deliberation_started")
+
+    registry_module.register_notification_event_contributor(notification_events)
+
+    registry = registry_module.EventRegistry()
+
+    assert registry.get_event("debate_start").source is registry_module.EventSource.CONTROL_PLANE
+    assert (
+        registry.get_event("deliberation_started").source
+        is registry_module.EventSource.DELIBERATION
+    )
+
+
+def test_repeated_contributor_registration_is_idempotent() -> None:
+    """Registering the same contributor twice does not duplicate event entries."""
+    calls = 0
+
+    def notification_events() -> tuple[str, ...]:
+        nonlocal calls
+        calls += 1
+        return ("task_claimed",)
+
+    registry_module.register_notification_event_contributor(notification_events)
+    registry_module.register_notification_event_contributor(notification_events)
+
+    registry = registry_module.EventRegistry()
+
+    assert calls == 1
+    assert [event.name for event in registry.list_events()].count("task_claimed") == 1

--- a/tests/observability/test_slo.py
+++ b/tests/observability/test_slo.py
@@ -7,18 +7,22 @@ Tests SLO definitions, compliance calculations, and alerting.
 from __future__ import annotations
 
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 import os
 
 import pytest
 
+from aragora.observability import slo as slo_module
 from aragora.observability.slo import (
     DEFAULT_AVAILABILITY_TARGET,
     DEFAULT_DEBATE_SUCCESS_TARGET,
     DEFAULT_LATENCY_P99_MS,
+    SLOBreach,
     SLOResult,
     SLOStatus,
     SLOTarget,
+    create_notification_callback,
     get_slo_targets,
     _calculate_error_budget,
 )
@@ -297,3 +301,84 @@ class TestCalculateErrorBudget:
 
         # Budget is exhausted (clamped to 0, never negative)
         assert remaining == 0
+
+
+class _RecordingNotificationSink:
+    def __init__(self) -> None:
+        self.breaches: list[SLOBreach] = []
+
+    async def notify(self, breach: SLOBreach) -> None:
+        self.breaches.append(breach)
+
+
+def _make_breach() -> SLOBreach:
+    return SLOBreach(
+        slo_name="API Availability",
+        severity="critical",
+        current_value=0.975,
+        target_value=0.999,
+        error_budget_remaining=12.3,
+        burn_rate=4.56,
+        message="Availability below target",
+    )
+
+
+class TestNotificationCallback:
+    """Tests for the observability-owned SLO notification contract."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_notification_provider(self):
+        register = getattr(slo_module, "register_slo_notification_sink_provider", None)
+        if register is not None:
+            register(None)
+        yield
+        if register is not None:
+            register(None)
+
+    def test_slo_module_has_no_control_plane_imports(self) -> None:
+        source = Path(slo_module.__file__).read_text(encoding="utf-8")
+
+        assert "aragora.control_plane.channels" not in source
+        assert "aragora.control_plane.notifications" not in source
+
+    @pytest.mark.asyncio
+    async def test_resolves_registered_provider_on_every_invocation(self) -> None:
+        first_sink = _RecordingNotificationSink()
+        second_sink = _RecordingNotificationSink()
+        sinks = iter((first_sink, second_sink))
+        provider_calls = 0
+
+        def provider():
+            nonlocal provider_calls
+            provider_calls += 1
+            return next(sinks)
+
+        slo_module.register_slo_notification_sink_provider(provider)
+        callback = create_notification_callback()
+        breach = _make_breach()
+
+        await callback(breach)
+        await callback(breach)
+
+        assert provider_calls == 2
+        assert first_sink.breaches == [breach]
+        assert second_sink.breaches == [breach]
+
+    @pytest.mark.asyncio
+    async def test_missing_provider_is_fail_soft(self, caplog: pytest.LogCaptureFixture) -> None:
+        slo_module.register_slo_notification_sink_provider(None)
+
+        await create_notification_callback()(_make_breach())
+
+        assert "Notification dispatcher not configured" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_is_fail_soft(self, caplog: pytest.LogCaptureFixture) -> None:
+        def failing_provider():
+            raise RuntimeError("dispatcher unavailable")
+
+        slo_module.register_slo_notification_sink_provider(failing_provider)
+
+        await create_notification_callback()(_make_breach())
+
+        assert "Failed to dispatch notification" in caplog.text

--- a/tests/server/startup/test_control_plane.py
+++ b/tests/server/startup/test_control_plane.py
@@ -8,9 +8,48 @@ mayor coordinator, and persistent task queue initialization.
 from __future__ import annotations
 
 import asyncio
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+# =============================================================================
+# Event Registry Composition Tests
+# =============================================================================
+
+
+class TestControlPlaneEventRegistryComposition:
+    """Tests for explicit control-plane event contributor composition."""
+
+    def test_registers_notification_event_contributor(self) -> None:
+        from aragora.control_plane.channels import NotificationEventType
+        from aragora.events import registry as registry_module
+        from aragora.server.startup.control_plane import register_control_plane_event_contributors
+
+        registry_module.register_notification_event_contributor(None)
+        registry_module.reset_event_registry()
+        try:
+            assert register_control_plane_event_contributors() is True
+
+            registry = registry_module.get_event_registry()
+            registered = {
+                event.name
+                for event in registry.list_events(source=registry_module.EventSource.CONTROL_PLANE)
+            }
+            assert registered == {event_type.value for event_type in NotificationEventType}
+        finally:
+            registry_module.register_notification_event_contributor(None)
+            registry_module.reset_event_registry()
+
+    def test_composes_events_before_control_plane_startup(self) -> None:
+        from aragora.server.startup import _init_all_components
+
+        source = inspect.getsource(_init_all_components)
+
+        assert source.index("register_control_plane_event_contributors()") < source.index(
+            "init_control_plane_coordinator()"
+        )
 
 
 # =============================================================================

--- a/tests/server/startup/test_observability.py
+++ b/tests/server/startup/test_observability.py
@@ -22,9 +22,11 @@ class TestRegisterObservabilitySinks:
         from aragora.connectors.devops import slo_alert_sink as pagerduty_adapter
         from aragora.control_plane import slo_alert_sink as channel_adapter
         from aragora.integrations import webhooks as webhook_adapter
+        from aragora.observability import slo
         from aragora.observability import slo_alert_bridge
         from aragora.observability.metrics import slo as slo_metrics
 
+        slo.register_slo_notification_sink_provider(None)
         slo_alert_bridge.register_pagerduty_alert_sink(None)
         slo_alert_bridge.register_channel_alert_sink(None)
         slo_metrics.register_slo_event_sink_provider(None)
@@ -33,6 +35,7 @@ class TestRegisterObservabilitySinks:
         importlib.reload(channel_adapter)
         importlib.reload(webhook_adapter)
 
+        assert slo._slo_notification_sink_provider is None
         assert slo_alert_bridge._pagerduty_alert_sink_factory is None
         assert slo_alert_bridge._channel_alert_sink_factory is None
         assert slo_metrics._slo_event_sink_provider is None
@@ -40,20 +43,24 @@ class TestRegisterObservabilitySinks:
     def test_registers_all_external_sink_providers(self) -> None:
         from aragora.observability.metrics import km as km_metrics
         from aragora.observability.metrics import slo as slo_metrics
+        from aragora.observability import slo
         from aragora.observability import slo_alert_bridge
         from aragora.server.startup.observability import register_observability_sinks
 
+        slo.register_slo_notification_sink_provider(None)
         slo_alert_bridge.register_pagerduty_alert_sink(None)
         slo_alert_bridge.register_channel_alert_sink(None)
         slo_metrics.register_slo_event_sink_provider(None)
         km_metrics.register_km_health_provider(None)
         try:
             assert register_observability_sinks() is True
+            assert slo._slo_notification_sink_provider is not None
             assert slo_alert_bridge._pagerduty_alert_sink_factory is not None
             assert slo_alert_bridge._channel_alert_sink_factory is not None
             assert slo_metrics._slo_event_sink_provider is not None
             assert km_metrics._km_health_provider is not None
         finally:
+            slo.register_slo_notification_sink_provider(None)
             slo_alert_bridge.register_pagerduty_alert_sink(None)
             slo_alert_bridge.register_channel_alert_sink(None)
             slo_metrics.register_slo_event_sink_provider(None)

--- a/tests/server/startup/test_parallel.py
+++ b/tests/server/startup/test_parallel.py
@@ -559,7 +559,7 @@ class TestParallelInitializerPhases:
 
 
 async def test_parallel_entrypoint_registers_webhook_store_before_initializer_run():
-    """Durable webhook wiring must precede scheduling optional KM work."""
+    """Event and webhook wiring must precede scheduling subsystem work."""
     from aragora.server.startup.parallel import parallel_init
 
     order: list[str] = []
@@ -574,6 +574,10 @@ async def test_parallel_entrypoint_registers_webhook_store_before_initializer_ru
         )
 
     with (
+        patch(
+            "aragora.server.startup.control_plane.register_control_plane_event_contributors",
+            side_effect=lambda: order.append("control_plane_events"),
+        ),
         patch(
             "aragora.server.startup.event_subscribers.register_webhook_store",
             side_effect=lambda: order.append("webhook_store"),
@@ -590,4 +594,4 @@ async def test_parallel_entrypoint_registers_webhook_store_before_initializer_ru
     ):
         await parallel_init()
 
-    assert order == ["webhook_store", "initializer_run"]
+    assert order == ["control_plane_events", "webhook_store", "initializer_run"]


### PR DESCRIPTION
## Source issue
P4a corrective inversion for the remaining channel-boundary routes found by the final shim sweep. This does not edit the path-frozen `aragora/control_plane/channels.py`, adopt PR #9166, or shrink aggregate import baselines.

## Behavior
- Adds an events-owned notification contributor hook and a side-effect-free control-plane adapter, composed before sequential and parallel control-plane startup.
- Adds an observability-owned SLO notification sink provider and extends `ControlPlaneSLOAlertSink` composition with a direct dispatcher adapter.
- Preserves notification event precedence, every `NotificationEventType` value, SLO formatting, priority mapping, metadata, dynamic dispatcher replacement, and fail-soft delivery.
- Removes the targeted Grimp chains from `events.registry` and `observability.slo`.

## Validation
- `make lint` (pass)
- `python3 -m ruff format --check aragora/ tests/ scripts/` (10,706 files formatted)
- changed-file mypy (7 source files, pass)
- targeted pytest (125 passed)
- 5-seed randomized targeted sweep (all passes)
- `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` (pass)
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` (138 passed)
- targeted Grimp chains (all `None`)
- `python3 scripts/ci/check_import_contracts.py --layers infrastructure` (pass)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` (pass)

The full import-contract and differential-typecheck wrappers are currently red on clean `origin/main` for unrelated pre-existing violations. This branch adds no changed-file mypy errors and the affected infrastructure import-contract layer passes.

## Risks
Startup composition is explicit and adapter imports remain side-effect free. The generated module metrics files are intentionally unchanged because `docs/METRICS.md` and `aragora/module_tiers.yaml` are path-frozen by open PRs.