### PR TITLE
refactor(layers): repoint tracing shim callers

### DIFF
--- a/aragora/events/async_dispatcher.py
+++ b/aragora/events/async_dispatcher.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -152,7 +153,7 @@ class AsyncWebhookDispatcher:
             Tuple of (success, status_code, error_message)
         """
         from aragora.security.webhook_signing import generate_signature
-        from aragora.server.middleware.tracing import get_trace_id
+        from aragora.observability.middleware.tracing import get_trace_id
 
         client = await self._ensure_client()
 
@@ -227,15 +228,25 @@ class AsyncWebhookDispatcher:
             AsyncDeliveryResult with outcome
         """
         # Import metrics and tracing lazily
+        record_webhook_retry: Callable[[str, int], None] | None
         try:
-            from aragora.observability.metrics.webhook import record_webhook_retry
+            from aragora.observability.metrics.webhook import (
+                record_webhook_retry as _record_webhook_retry,
+            )
         except ImportError:
             record_webhook_retry = None
+        else:
+            record_webhook_retry = _record_webhook_retry
 
+        trace_webhook_delivery: Callable[..., Any] | None
         try:
-            from aragora.observability.tracing import trace_webhook_delivery
+            from aragora.observability.tracing import (
+                trace_webhook_delivery as _trace_webhook_delivery,
+            )
         except ImportError:
             trace_webhook_delivery = None
+        else:
+            trace_webhook_delivery = _trace_webhook_delivery
 
         event_type = payload.get("event", "unknown")
         correlation_id = payload.get("correlation_id") or payload.get("data", {}).get(

--- a/aragora/events/dispatcher.py
+++ b/aragora/events/dispatcher.py
@@ -38,7 +38,7 @@ from collections.abc import Callable
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from aragora.server.middleware.tracing import get_trace_id
+from aragora.observability.middleware.tracing import get_trace_id
 
 if TYPE_CHECKING:
     from aragora.events.types import EventEmitter, StreamEvent
@@ -347,15 +347,25 @@ def dispatch_webhook_with_retry(
         DeliveryResult with outcome
     """
     # Import metrics and tracing (lazy to avoid circular imports)
+    record_webhook_retry: Callable[[str, int], None] | None
     try:
-        from aragora.observability.metrics.webhook import record_webhook_retry
+        from aragora.observability.metrics.webhook import (
+            record_webhook_retry as _record_webhook_retry,
+        )
     except ImportError:
         record_webhook_retry = None
+    else:
+        record_webhook_retry = _record_webhook_retry
 
+    trace_webhook_delivery: Callable[..., Any] | None
     try:
-        from aragora.observability.tracing import trace_webhook_delivery
+        from aragora.observability.tracing import (
+            trace_webhook_delivery as _trace_webhook_delivery,
+        )
     except ImportError:
         trace_webhook_delivery = None
+    else:
+        trace_webhook_delivery = _trace_webhook_delivery
 
     event_type = payload.get("event", "unknown")
     correlation_id = (

--- a/aragora/logging_config.py
+++ b/aragora/logging_config.py
@@ -47,7 +47,7 @@ def _get_trace_context() -> dict[str, str | None]:
         Dict with trace_id and span_id (may be None if not in trace context)
     """
     try:
-        from aragora.server.middleware.tracing import get_span_id, get_trace_id
+        from aragora.observability.middleware.tracing import get_span_id, get_trace_id
 
         return {
             "trace_id": get_trace_id(),
@@ -491,7 +491,7 @@ def log_function(
     return decorator
 
 
-def log_request(logger: StructuredLogger = None):
+def log_request(logger: StructuredLogger | None = None):
     """
     Decorator to log HTTP request handling.
 

--- a/aragora/observability/tracing.py
+++ b/aragora/observability/tracing.py
@@ -743,13 +743,13 @@ def trace_decision(func: F) -> F:
 
         # Extract attributes from request
         request_id = getattr(request, "request_id", "unknown")
-        decision_type = getattr(request, "decision_type", None)
+        decision_type = cast(Any, getattr(request, "decision_type", None))
         decision_type_str = (
             decision_type.value if hasattr(decision_type, "value") else str(decision_type)
         )
-        source = getattr(request, "source", None)
+        source = cast(Any, getattr(request, "source", None))
         source_str = source.value if hasattr(source, "value") else str(source)
-        priority = getattr(request, "priority", None)
+        priority = cast(Any, getattr(request, "priority", None))
         priority_str = priority.value if hasattr(priority, "value") else str(priority)
 
         with tracer.start_as_current_span("decision.route") as span:
@@ -916,7 +916,7 @@ def build_trace_headers() -> dict[str, str]:
     headers: dict[str, str] = {}
 
     try:
-        from aragora.server.middleware.tracing import (
+        from aragora.observability.middleware.tracing import (
             get_trace_id,
             get_span_id,
             TRACE_ID_HEADER,


### PR DESCRIPTION
## Source

Mission feature `p4a-shim-caller-sweep`, the final P4a deferred foundation/infrastructure compatibility-shim caller sweep.

## Behavior

- repoints the four preserved tracing callers from `aragora.server.middleware.tracing` to `aragora.observability.middleware.tracing`
- preserves lazy optional metrics/tracing imports while making their callable types explicit
- fixes the six recorded changed-file mypy diagnostics without altering runtime behavior
- leaves all external compatibility shims and the events/observability aggregate import-contract baseline entries intact for `p4a-contracts-seal`

## Validation

- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/events/dispatcher.py aragora/events/async_dispatcher.py aragora/logging_config.py aragora/observability/tracing.py` - success, no issues in 4 files
- `python3 -m pytest tests/events/test_async_dispatcher.py tests/events/test_batch_dispatcher.py tests/events/test_dispatcher_server_boundary.py tests/events/test_security_dispatcher.py tests/observability/test_tracing.py tests/test_logging_config.py -q --timeout=120 -x` - 180 passed
- `make lint` - passed
- `ruff format --check aragora/ tests/ scripts/` - 10,706 files already formatted
- `make test-smoke` - Core, Server, and Memory import canaries passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` - 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - passed
- scoped Batch 1-6 shim scan - no foundation/infrastructure callers remain
- Grimp cut-set proof - every surviving events/observability/security route to server disappears when `aragora.exceptions -> aragora.server.handlers.exceptions` is removed
- import-contract analysis - exact expected pre-seal state: only authorized pending `aragora.utils -> aragora.caching`, with events/observability aggregate entries intentionally unshrunk
- repository-wide differential mypy A/B - clean `origin/main` and this branch have the identical 104 new diagnostics; this branch fixes 8 additional existing diagnostics and adds none
- `python3 scripts/regenerate_module_tiers.py --check` - no drift

## Risks

Low. The patch only changes internal import targets and type annotations/aliases. External compatibility paths remain available. Existing `docs/METRICS.md` drift is intentionally deferred to the coordinated regen and is not caused by this four-file patch.
