### PR TITLE
fix(handlers): stabilize batch creation status

### DIFF
--- a/aragora/server/handlers/explainability.py
+++ b/aragora/server/handlers/explainability.py
@@ -707,19 +707,18 @@ class ExplainabilityHandler(BaseHandler):
         )
         _save_batch_job(job)
 
+        response = {
+            "batch_id": batch_id,
+            "status": job.status.value,
+            "total_debates": len(debate_ids),
+            "status_url": f"/api/v1/explainability/batch/{batch_id}/status",
+            "results_url": f"/api/v1/explainability/batch/{batch_id}/results",
+        }
+
         # Start processing in background
         self._start_batch_processing(job)
 
-        return json_response(
-            {
-                "batch_id": batch_id,
-                "status": job.status.value,
-                "total_debates": len(debate_ids),
-                "status_url": f"/api/v1/explainability/batch/{batch_id}/status",
-                "results_url": f"/api/v1/explainability/batch/{batch_id}/results",
-            },
-            status=202,
-        )
+        return json_response(response, status=202)
 
     def _start_batch_processing(self, job: BatchJob) -> None:
         """Start processing batch job asynchronously."""

--- a/tests/handlers/test_handlers_batch_explainability.py
+++ b/tests/handlers/test_handlers_batch_explainability.py
@@ -260,6 +260,28 @@ class TestCreateBatchJob:
         assert "status_url" in response_body
         assert "results_url" in response_body
 
+    def test_create_batch_snapshots_pending_before_worker_starts(
+        self, handler, mock_post_request, monkeypatch
+    ):
+        body = {"debate_ids": ["debate-1"]}
+        mock_post_request.rfile = Mock()
+        mock_post_request.rfile.read = Mock(return_value=json.dumps(body).encode())
+        mock_post_request.headers["Content-Length"] = len(json.dumps(body))
+        worker_observation = {}
+
+        def fail_immediately(job):
+            worker_observation["initial_status"] = job.status
+            job.status = BatchStatus.FAILED
+
+        monkeypatch.setattr(handler, "_start_batch_processing", fail_immediately)
+
+        result = handler._handle_batch_create(mock_post_request)
+        response_body, status = parse_handler_result(result)
+
+        assert worker_observation["initial_status"] is BatchStatus.PENDING
+        assert status == 202
+        assert response_body["status"] == "pending"
+
     def test_create_batch_empty_debate_ids(self, handler, mock_post_request):
         body = {"debate_ids": []}
         mock_post_request.rfile = Mock()


### PR DESCRIPTION
## Summary

- snapshot the batch-creation `202` payload while the persisted job is still `PENDING`
- start background processing only after that response payload is stable
- add a deterministic regression where the worker immediately marks the job `FAILED` while the creation response remains `pending`

## Context

PR #9144's Integration Smoke exposed this pre-existing race in `ExplainabilityHandler._handle_batch_create`. The failing handler and test are outside #9144's OpenClaw scope, so this repair is intentionally isolated and does not change #9144.

## Validation

- `python -m pytest -q tests/handlers/test_handlers_batch_explainability.py` -> 28 passed
- `ruff check aragora/server/handlers/explainability.py tests/handlers/test_handlers_batch_explainability.py` -> passed
- `ruff format --check aragora/server/handlers/explainability.py tests/handlers/test_handlers_batch_explainability.py` -> passed
- `git diff --check` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- commit and pre-push hooks, including changed-file mypy and RBAC checks -> passed

## Scope

This draft does not modify workflows, branch protection, merge policy, or #9144. It requires normal review and settlement before any later #9144 restack.
