### PR TITLE
fix(docs): decouple protected metric pointers (#9273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,9 +191,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-<!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,286 tracked Python files | 144 top-level modules | 223,739 test functions | 5,469 test files | 3,299 API operations across 2,872 paths | canonical counts in `docs/METRICS.md`
-<!-- metrics:end -->
+**Codebase metrics:** See `docs/METRICS.md` for canonical generated counts.
 
 ## Architecture
 
@@ -441,9 +439,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-<!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,739 test functions across 5,469 test files (canonical counts in `docs/METRICS.md`)
-<!-- metrics:end -->
+**Test suite metrics:** See `docs/METRICS.md` for canonical generated counts.
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,8 +20,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,286 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,980,676 | `docs/METRICS.md` |
-| Automated tests | 223,739 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,980,901 | `docs/METRICS.md` |
+| Automated tests | 223,768 test functions | `docs/METRICS.md` |
 | Test files | 5,469 | `docs/METRICS.md` |
 | API operations | 3,299 across 2,872 paths | `docs/METRICS.md` |
 | API paths | 2,872 | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/claude.md
+++ b/docs-site/docs/contributing/claude.md
@@ -196,9 +196,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 46 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-<!-- metrics:begin claude-codebase-scale -->
-**Codebase Scale:** 4,286 tracked Python files | 144 top-level modules | 223,739 test functions | 5,469 test files | 3,299 API operations across 2,872 paths | canonical counts in `docs/METRICS.md`
-<!-- metrics:end -->
+**Codebase metrics:** See `docs/METRICS.md` for canonical generated counts.
 
 ## Architecture
 
@@ -446,9 +444,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-<!-- metrics:begin claude-test-suite -->
-**Test Suite:** 223,739 test functions across 5,469 test files (canonical counts in `docs/METRICS.md`)
-<!-- metrics:end -->
+**Test suite metrics:** See `docs/METRICS.md` for canonical generated counts.
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,739 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,768 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,286 Python files | 223,739 tests | 3,299 API operations across 2,872 paths
+**Total**: 230+ features | 4,286 Python files | 223,768 tests | 3,299 API operations across 2,872 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,286
-- **Tests**: 223,739 across 5,469 test files
+- **Tests**: 223,768 across 5,469 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,299 across 2,872 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,739 tests across 5,469 test files
+- **Test coverage**: 223,768 tests across 5,469 test files
 - **Source files**: 4,286 Python files under `aragora/`
 - **API surface**: 3,299 API operations across 2,872 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,8 +15,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,286 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,980,676 | `docs/METRICS.md` |
-| Automated tests | 223,739 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,980,901 | `docs/METRICS.md` |
+| Automated tests | 223,768 test functions | `docs/METRICS.md` |
 | Test files | 5,469 | `docs/METRICS.md` |
 | API operations | 3,299 across 2,872 paths | `docs/METRICS.md` |
 | API paths | 2,872 | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,739 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,768 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,286
-- **Tests**: 223,739 across 5,469 test files
+- **Tests**: 223,768 across 5,469 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,299 across 2,872 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,739 tests across 5,469 test files
+- **Test coverage**: 223,768 tests across 5,469 test files
 - **Source files**: 4,286 Python files under `aragora/`
 - **API surface**: 3,299 API operations across 2,872 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,286 Python files | 223,739 tests | 3,299 API operations across 2,872 paths
+**Total**: 230+ features | 4,286 Python files | 223,768 tests | 3,299 API operations across 2,872 paths
 <!-- metrics:end -->
 
 ---

--- a/scripts/doc_stats.py
+++ b/scripts/doc_stats.py
@@ -308,23 +308,6 @@ class RenderContext:
         return f"{(self.metrics[key].value // step) * step:,}"
 
 
-def _render_claude_codebase_scale(ctx: RenderContext) -> str:
-    return (
-        f"**Codebase Scale:** {ctx.exact('python_files')} tracked Python files | "
-        f"{ctx.exact('top_level_modules')} top-level modules | "
-        f"{ctx.exact('tests')} test functions | {ctx.exact('test_files')} test files | "
-        f"{ctx.exact('api_operations')} API operations across {ctx.exact('api_paths')} paths | "
-        "canonical counts in `docs/METRICS.md`"
-    )
-
-
-def _render_claude_test_suite(ctx: RenderContext) -> str:
-    return (
-        f"**Test Suite:** {ctx.exact('tests')} test functions across "
-        f"{ctx.exact('test_files')} test files (canonical counts in `docs/METRICS.md`)"
-    )
-
-
 def _render_readme_scale(ctx: RenderContext) -> str:
     loc_millions = (ctx.value("python_lines") // 100_000) / 10
     return (
@@ -422,8 +405,6 @@ def _render_km_adapter_specs(ctx: RenderContext) -> str:
 
 
 RENDERERS: dict[str, Callable[[RenderContext], str]] = {
-    "claude-codebase-scale": _render_claude_codebase_scale,
-    "claude-test-suite": _render_claude_test_suite,
     "readme-scale": _render_readme_scale,
     "extended-readme-scale": _render_extended_readme_scale,
     "extended-readme-api-surface": _render_extended_readme_api_surface,

--- a/tests/scripts/test_doc_stats.py
+++ b/tests/scripts/test_doc_stats.py
@@ -85,20 +85,14 @@ def test_rewrite_metric_blocks_rewrites_only_delimited_blocks(tmp_path, monkeypa
     mod = _load_module()
     root = _make_root(tmp_path)
 
-    prose_outside_blocks = (
-        "Aragora orchestrates 46 agent types. The old count 3,386 stays untouched."
+    claude_static = "\n".join(
+        [
+            "Aragora orchestrates 46 agent types.",
+            "**Codebase metrics:** See `docs/METRICS.md` for canonical generated counts.",
+            "**Test suite metrics:** See `docs/METRICS.md` for canonical generated counts.",
+        ]
     )
-    (root / "CLAUDE.md").write_text(
-        "\n".join(
-            [
-                prose_outside_blocks,
-                _block("claude-codebase-scale", "stale scale line"),
-                "middle prose with 9,999 tests that must not change",
-                _block("claude-test-suite", "stale test suite line"),
-            ]
-        ),
-        encoding="utf-8",
-    )
+    (root / "CLAUDE.md").write_text(claude_static, encoding="utf-8")
     (root / "docs" / "EXTENDED_README.md").write_text(
         _block("extended-readme-scale", "stale"),
         encoding="utf-8",
@@ -114,21 +108,10 @@ def test_rewrite_metric_blocks_rewrites_only_delimited_blocks(tmp_path, monkeypa
 
     monkeypatch.setattr(mod, "ROOT", root)
     updated = mod.rewrite_metric_blocks(write=True)
-    assert updated == 4
+    assert updated == 3
 
     claude = (root / "CLAUDE.md").read_text(encoding="utf-8")
-    assert prose_outside_blocks in claude
-    assert "middle prose with 9,999 tests that must not change" in claude
-    assert (
-        "**Codebase Scale:** 4,219 tracked Python files | 144 top-level modules | "
-        "222,659 test functions | 5,402 test files | 3,297 API operations across "
-        "2,870 paths | canonical counts in `docs/METRICS.md`"
-    ) in claude
-    assert (
-        "**Test Suite:** 222,659 test functions across 5,402 test files "
-        "(canonical counts in `docs/METRICS.md`)"
-    ) in claude
-    assert "stale" not in claude
+    assert claude == claude_static
 
     extended = (root / "docs" / "EXTENDED_README.md").read_text(encoding="utf-8")
     assert (
@@ -159,27 +142,28 @@ def test_rewrite_metric_blocks_rewrites_only_delimited_blocks(tmp_path, monkeypa
 def test_rewrite_metric_blocks_is_idempotent(tmp_path, monkeypatch):
     mod = _load_module()
     root = _make_root(tmp_path)
-    (root / "CLAUDE.md").write_text(
-        _block("claude-codebase-scale", "stale"),
+    (root / "docs" / "EXTENDED_README.md").write_text(
+        _block("extended-readme-scale", "stale"),
         encoding="utf-8",
     )
 
     monkeypatch.setattr(mod, "ROOT", root)
     assert mod.rewrite_metric_blocks(write=True) == 1
-    first = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    first = (root / "docs" / "EXTENDED_README.md").read_text(encoding="utf-8")
     assert mod.rewrite_metric_blocks(write=True) == 0
-    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == first
+    assert (root / "docs" / "EXTENDED_README.md").read_text(encoding="utf-8") == first
 
 
 def test_rewrite_metric_blocks_reports_without_writing_when_write_is_false(tmp_path, monkeypatch):
     mod = _load_module()
     root = _make_root(tmp_path)
-    original = _block("claude-test-suite", "stale")
-    (root / "CLAUDE.md").write_text(original, encoding="utf-8")
+    original = _block("extended-readme-scale", "stale")
+    target = root / "docs" / "EXTENDED_README.md"
+    target.write_text(original, encoding="utf-8")
 
     monkeypatch.setattr(mod, "ROOT", root)
     assert mod.rewrite_metric_blocks(write=False) == 1
-    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == original
+    assert target.read_text(encoding="utf-8") == original
 
 
 def test_rewrite_metric_blocks_fails_closed_when_metrics_doc_is_partial(tmp_path, monkeypatch):
@@ -193,33 +177,36 @@ def test_rewrite_metric_blocks_fails_closed_when_metrics_doc_is_partial(tmp_path
         ]
     )
     root = _make_root(tmp_path, metrics_table=partial)
-    original = _block("claude-codebase-scale", "stale but preserved")
-    (root / "CLAUDE.md").write_text(original, encoding="utf-8")
+    original = _block("extended-readme-scale", "stale but preserved")
+    target = root / "docs" / "EXTENDED_README.md"
+    target.write_text(original, encoding="utf-8")
 
     monkeypatch.setattr(mod, "ROOT", root)
     with pytest.raises(RuntimeError, match="docs/METRICS.md is missing rows"):
         mod.rewrite_metric_blocks(write=True)
-    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == original
+    assert target.read_text(encoding="utf-8") == original
 
 
 def test_rewrite_metric_blocks_fails_closed_on_missing_version(tmp_path, monkeypatch):
     mod = _load_module()
     root = _make_root(tmp_path)
     (root / "pyproject.toml").unlink()
-    original = _block("claude-codebase-scale", "stale but preserved")
-    (root / "CLAUDE.md").write_text(original, encoding="utf-8")
+    original = _block("extended-readme-scale", "stale but preserved")
+    target = root / "docs" / "EXTENDED_README.md"
+    target.write_text(original, encoding="utf-8")
 
     monkeypatch.setattr(mod, "ROOT", root)
     with pytest.raises(RuntimeError, match="version"):
         mod.rewrite_metric_blocks(write=True)
-    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == original
+    assert target.read_text(encoding="utf-8") == original
 
 
 def test_rewrite_metric_blocks_fails_closed_on_unknown_key(tmp_path, monkeypatch):
     mod = _load_module()
     root = _make_root(tmp_path)
-    known = _block("claude-test-suite", "stale but preserved")
-    (root / "CLAUDE.md").write_text(known, encoding="utf-8")
+    known = _block("extended-readme-scale", "stale but preserved")
+    target = root / "docs" / "EXTENDED_README.md"
+    target.write_text(known, encoding="utf-8")
     unknown = _block("no-such-renderer", "body")
     (root / "docs" / "OTHER.md").write_text(unknown, encoding="utf-8")
 
@@ -227,15 +214,15 @@ def test_rewrite_metric_blocks_fails_closed_on_unknown_key(tmp_path, monkeypatch
     with pytest.raises(RuntimeError, match="unknown metrics block key"):
         mod.rewrite_metric_blocks(write=True)
     # Fail-closed: nothing is written, not even valid blocks in other files.
-    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == known
+    assert target.read_text(encoding="utf-8") == known
     assert (root / "docs" / "OTHER.md").read_text(encoding="utf-8") == unknown
 
 
 def test_rewrite_metric_blocks_fails_closed_on_unterminated_block(tmp_path, monkeypatch):
     mod = _load_module()
     root = _make_root(tmp_path)
-    (root / "CLAUDE.md").write_text(
-        "<!-- metrics:begin claude-test-suite -->\nno end marker\n",
+    (root / "docs" / "EXTENDED_README.md").write_text(
+        "<!-- metrics:begin extended-readme-scale -->\nno end marker\n",
         encoding="utf-8",
     )
 
@@ -249,12 +236,25 @@ def test_rewrite_metric_blocks_excludes_docs_site_mirrors(tmp_path, monkeypatch)
     root = _make_root(tmp_path)
     mirror_dir = root / "docs-site" / "docs" / "contributing"
     mirror_dir.mkdir(parents=True)
-    mirror = _block("claude-test-suite", "mirror body owned by sync-docs.js")
+    mirror = _block("extended-readme-scale", "mirror body owned by sync-docs.js")
     (mirror_dir / "claude.md").write_text(mirror, encoding="utf-8")
 
     monkeypatch.setattr(mod, "ROOT", root)
     assert mod.rewrite_metric_blocks(write=True) == 0
     assert (mirror_dir / "claude.md").read_text(encoding="utf-8") == mirror
+
+
+@pytest.mark.parametrize("removed_key", ["claude-codebase-scale", "claude-test-suite"])
+def test_rewrite_metric_blocks_rejects_removed_claude_keys(tmp_path, monkeypatch, removed_key):
+    mod = _load_module()
+    root = _make_root(tmp_path)
+    original = _block(removed_key, "stale generated content")
+    (root / "CLAUDE.md").write_text(original, encoding="utf-8")
+
+    monkeypatch.setattr(mod, "ROOT", root)
+    with pytest.raises(RuntimeError, match="unknown metrics block key"):
+        mod.rewrite_metric_blocks(write=True)
+    assert (root / "CLAUDE.md").read_text(encoding="utf-8") == original
 
 
 def test_every_renderer_is_covered_by_required_metric_keys(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- replace the two volatile generated metric blocks in `CLAUDE.md` with static pointers to `docs/METRICS.md`
- remove only the corresponding Claude renderers and registry entries from `scripts/doc_stats.py`
- preserve generic malformed-block, unknown-key, missing-metric, and missing-version fail-closed behavior
- regenerate the affected source documents and docs-site mirrors

## Tier and authority

Tier 4 because this changes protected `CLAUDE.md`.

Implementation authorization is repo-visible at exact base main `a1cb413d7e4bba0a2944b8218d23587e3bede462`:
https://github.com/synaptent/aragora/issues/9273#issuecomment-4964537773

That authorization covers implementation only. This draft is not settlement or merge authority.

## Scope receipt

- exact branch head: `ec0619e6ac49404e145eb39be82df7d9d010d788`
- changed paths: 14/14 authorized maximum
- patch SHA-256: `0e49a0323cf72eb0058ac04d3742c149e7d43c6218a219d94a2a9cbafc65efc5`
- `docs/METRICS.md` unchanged; SHA-256 remains `1085ee51d0910200963197e09d9782a76a9a4a0fb27e2667ca474bb321ef5ea8`
- no workflow or required-check changes

## Validation

- `python3 -m pytest tests/scripts/test_doc_stats.py -q`: 12 passed
- repeated `python3 scripts/doc_stats.py --write`: `Updated 0 documentation files`
- repeated `node docs-site/scripts/sync-docs.js`: patch hash unchanged
- `python3 scripts/check_docs_consistency.py`: all applicable checks passed
- capability matrix, legacy entrypoint, and CLI reference checks: passed
- `ruff check scripts/doc_stats.py tests/scripts/test_doc_stats.py`: passed
- `ruff format --check scripts/doc_stats.py tests/scripts/test_doc_stats.py`: passed
- `git diff --check`: passed
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` in `docs-site`: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed
- commit and push hooks: passed

Fresh exact-head model review and separate Tier-4 human settlement are required before merge.

Closes #9273