### PR TITLE
docs(metrics): refresh repository counts after nightly workflow

### DIFF
--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,8 +20,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,286 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,980,901 | `docs/METRICS.md` |
-| Automated tests | 223,768 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,980,942 | `docs/METRICS.md` |
+| Automated tests | 223,783 test functions | `docs/METRICS.md` |
 | Test files | 5,469 | `docs/METRICS.md` |
 | API operations | 3,299 across 2,872 paths | `docs/METRICS.md` |
 | API paths | 2,872 | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,768 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,783 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,286 Python files | 223,768 tests | 3,299 API operations across 2,872 paths
+**Total**: 230+ features | 4,286 Python files | 223,783 tests | 3,299 API operations across 2,872 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,286
-- **Tests**: 223,768 across 5,469 test files
+- **Tests**: 223,783 across 5,469 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,299 across 2,872 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,768 tests across 5,469 test files
+- **Test coverage**: 223,783 tests across 5,469 test files
 - **Source files**: 4,286 Python files under `aragora/`
 - **API surface**: 3,299 API operations across 2,872 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,8 +15,8 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,286 | `docs/METRICS.md` |
 | Python modules | 144 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,980,901 | `docs/METRICS.md` |
-| Automated tests | 223,768 test functions | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,980,942 | `docs/METRICS.md` |
+| Automated tests | 223,783 test functions | `docs/METRICS.md` |
 | Test files | 5,469 | `docs/METRICS.md` |
 | API operations | 3,299 across 2,872 paths | `docs/METRICS.md` |
 | API paths | 2,872 | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,768 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,286 tracked Python files | 144 top-level modules | 223,783 test functions across 5,469 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -16,8 +16,8 @@
 | Python lines of code under aragora/ | `1980942` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5469` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223782` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `847` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test functions (class + module level) | `223783` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `848` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2872` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3299` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4286` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1980901` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1980962` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5469` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223768` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223780` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `847` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2872` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
@@ -29,7 +29,7 @@
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
 | Markdown files under docs/ | `1072` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
-| GitHub Actions workflows | `90` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
+| GitHub Actions workflows | `91` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 
 ## Notes on counting methodology

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,10 +13,10 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4286` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1980962` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1980942` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `144` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
 | Test files (test_*.py under tests/) | `5469` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `223780` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| Test functions (class + module level) | `223782` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
 | @pytest.mark.parametrize decorators | `847` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2872` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,286
-- **Tests**: 223,768 across 5,469 test files
+- **Tests**: 223,783 across 5,469 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,299 across 2,872 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 223,768 tests across 5,469 test files
+- **Test coverage**: 223,783 tests across 5,469 test files
 - **Source files**: 4,286 Python files under `aragora/`
 - **API surface**: 3,299 API operations across 2,872 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,286 Python files | 223,768 tests | 3,299 API operations across 2,872 paths
+**Total**: 230+ features | 4,286 Python files | 223,783 tests | 3,299 API operations across 2,872 paths
 <!-- metrics:end -->
 
 ---


### PR DESCRIPTION
## Summary

- refresh the generated repository metrics after `.github/workflows` increased from 90 to 91
- update the corresponding Python LOC and test-function counts emitted by the same generator run
- keep the repair limited to `docs/METRICS.md`

## Live failure receipt

The current shared `Metrics Drift` failure was reproduced on current `origin/main` with:

```text
DRIFT: GitHub Actions workflows 90 -> 91 (1.1%)
```

GitHub run: https://github.com/synaptent/aragora/actions/runs/29298930972

- workflow: `Metrics Drift`
- job: `check`
- failing step: `Verify drift`

## Queue blast radius

The latest exact-head check-run classification across 77 open, non-draft, non-Dependabot PRs found:

| Context | Latest failed/cancelled | Under 60s | Classification |
|---|---:|---:|---|
| portability | 51 | 51 | cancelled during checkout; no source error |
| build | 37 | 26 | representative run cancelled during checkout; no source error |
| check | 27 | 26 | only concrete fresh source error was the metrics drift above |
| Docs Consistency | 18 | 18 | cancelled during checkout; no source error |

This PR repairs the only reproduced shared source defect. It does not edit or rerun workflows. PR #9276 does not overlap: its live diff leaves `docs/METRICS.md` unchanged.

## Validation

- `python scripts/regenerate_metrics.py --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/scripts/test_regenerate_metrics.py` (`22 passed`)
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
