### PR TITLE
fix(workflow): dispatch post-debate exactly once

### DIFF
--- a/aragora/workflow/event_subscribers.py
+++ b/aragora/workflow/event_subscribers.py
@@ -11,9 +11,10 @@ self-registers via the domain-free registry
 infrastructure, downward = legal); the interface-superset bootstrap
 (``aragora.server.startup.event_subscribers.bootstrap_event_subscribers``)
 imports this module so ``CrossSubscriberManager.apply_registered_subscribers``
-wires ``alert_escalated_to_workflow_brake`` in. A pure-domain debate with no
-workflow engine simply has no such reaction: this module is NOT imported by
-the domain-subset bootstrap
+wires both ``debate_end_to_workflow`` and
+``alert_escalated_to_workflow_brake`` in. A pure-domain debate with no workflow
+engine simply has no such reactions: this module is NOT imported by the
+domain-subset bootstrap
 (``aragora.debate.event_subscribers.bootstrap_debate_event_subscribers``).
 
 Per the relocate-UP no-shim exemption (AGENTS.md "P4a Contracts-Thread Shared
@@ -23,33 +24,22 @@ re-export shim at the old paths; every consumer is repointed instead.
 The former ``cross_subscribers.handlers.basic._handle_debate_end_to_workflow``
 delegate (an unregistered, dead runtime path that instantiated a throwaway
 ``PostDebateWorkflowSubscriber`` on every call - see
-docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §5.3) is removed rather than
-relocated. ``PostDebateWorkflowSubscriber`` itself IS relocated here (verbatim)
-so the workflow-coupled code lives in its application home, but
-``WorkflowEventSubscriber.register`` deliberately does NOT wire its
-``_handle_debate_end_to_workflow`` wrapper into the manager: on origin/main
-this reaction had NO live invocation path at all (its only caller was the
-dead ``basic.py`` delegate above, which was itself never registered against
-any event type - confirmed by the absence of ``debate_end_to_workflow`` from
-the pre-inversion ``GOLDEN_SUBSCRIBER_NAMES`` baseline in
-``tests/events/test_cross_subscriber_registry.py``). ``_trigger_workflow``'s
-body is also a known no-op stub (it constructs and discards a
-``WorkflowDefinition``/``WorkflowEngine`` without executing or queuing
-anything). Wiring it now would activate that no-op, for the first time ever,
-on every production ``DEBATE_END`` - a behavior change with no test coverage
-of real execution, not a mechanical relocation. Per the batch's own
-open-product-question guidance, the dead edge is removed rather than
-resurrected; the handler and its backing subscriber stay relocated and
-directly callable/testable so a future batch can wire them once
-``_trigger_workflow`` does real work. Only the alert-escalation brake -
-already live via the manager's built-in registration on origin/main - is
-wired here, preserving its existing production behavior across the move.
+docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md §5.3) remains removed rather
+than relocated. The application home owns the single production route:
+``WorkflowEventSubscriber.register`` registers one keyed
+``debate_end_to_workflow`` reaction that delegates to the persistent
+``PostDebateWorkflowSubscriber`` instance. The interface-superset bootstrap is
+idempotent, so repeating it does not duplicate that reaction.
+
+``_trigger_workflow`` remains a construction-only seam: it builds the workflow
+definition and engine without executing or queuing them. Production dispatch
+still invokes ``handle_debate_end`` exactly once so outcome classification and
+the existing fail-soft behavior remain observable while workflow execution is
+implemented separately.
 
 Handles:
+- Debate end -> Post-debate workflow outcome classification
 - Alert escalated -> Workflow emergency brake (pause/stop active workflows)
-
-Relocated but NOT wired (see above):
-- Debate end -> Post-debate workflow automation (outcome-based template trigger)
 """
 
 from __future__ import annotations
@@ -69,6 +59,7 @@ logger = logging.getLogger(__name__)
 WORKFLOW_EVENT_SUBSCRIBER_HANDLER_NAMES = frozenset(
     {
         "alert_escalated_to_workflow_brake",
+        "debate_end_to_workflow",
     }
 )
 
@@ -168,8 +159,7 @@ class PostDebateWorkflowSubscriber:
         Stub: constructs ``WorkflowDefinition``/``WorkflowEngine`` but never
         submits either for execution (no queue/execute call is made).
         ``stats["workflows_triggered"]`` counts these construction attempts,
-        not completed workflow runs - do not wire a caller of this method
-        into production event dispatch until it actually queues or executes.
+        not completed workflow runs.
         """
         try:
             (
@@ -235,10 +225,7 @@ class WorkflowEventSubscriber:
 
         Delegates to the persistent ``PostDebateWorkflowSubscriber`` instance
         to classify the debate outcome and trigger the appropriate workflow
-        template. NOT wired by :meth:`register` (see the module docstring):
-        kept relocated and directly callable/testable for a future batch to
-        wire once ``_trigger_workflow`` does real work, without reintroducing
-        the dead no-op reaction into production dispatch in the meantime.
+        template.
         """
         self.post_debate_workflow.handle_debate_end(event)
 
@@ -289,10 +276,14 @@ class WorkflowEventSubscriber:
     def register(self, manager: "CrossSubscriberManager") -> None:
         """Wire the workflow-domain reactions into ``manager`` (keyed/idempotent).
 
-        Only ``alert_escalated_to_workflow_brake`` is wired here - see the
-        module docstring for why ``_handle_debate_end_to_workflow`` is
-        relocated but deliberately left unregistered.
+        Registry application is tracked per manager, so repeated production
+        bootstrap calls apply this subscriber only once.
         """
+        manager.register(
+            "debate_end_to_workflow",
+            StreamEventType.DEBATE_END,
+            self._handle_debate_end_to_workflow,
+        )
         manager.register(
             "alert_escalated_to_workflow_brake",
             StreamEventType.ALERT_ESCALATED,

--- a/aragora/workflow/event_subscribers.py
+++ b/aragora/workflow/event_subscribers.py
@@ -32,10 +32,10 @@ than relocated. The application home owns the single production route:
 idempotent, so repeating it does not duplicate that reaction.
 
 ``_trigger_workflow`` remains a construction-only seam: it builds the workflow
-definition and engine without executing or queuing them. Production dispatch
-still invokes ``handle_debate_end`` exactly once so outcome classification and
-the existing fail-soft behavior remain observable while workflow execution is
-implemented separately.
+definition without creating an engine or executing or queuing the definition.
+Production dispatch still invokes ``handle_debate_end`` exactly once so outcome
+classification and the existing fail-soft behavior remain observable while
+workflow execution is implemented separately.
 
 Handles:
 - Debate end -> Post-debate workflow outcome classification
@@ -90,16 +90,11 @@ class PostDebateWorkflowSubscriber:
             "errors": 0,
         }
 
-    def _get_workflow_runtime(self) -> tuple[Any, Any, Any, Any]:
-        """Load workflow runtime classes behind a unit-testable seam."""
-        from aragora.workflow.engine import WorkflowEngine
-        from aragora.workflow.types import (
-            StepDefinition,
-            WorkflowConfig,
-            WorkflowDefinition,
-        )
+    def _get_workflow_runtime(self) -> tuple[Any, Any]:
+        """Load workflow definition classes behind a unit-testable seam."""
+        from aragora.workflow.types import StepDefinition, WorkflowDefinition
 
-        return WorkflowEngine, StepDefinition, WorkflowConfig, WorkflowDefinition
+        return StepDefinition, WorkflowDefinition
 
     def handle_debate_end(self, event: Any) -> None:
         """Handle a DEBATE_END event and trigger appropriate workflow."""
@@ -162,12 +157,7 @@ class PostDebateWorkflowSubscriber:
         not completed workflow runs.
         """
         try:
-            (
-                WorkflowEngine,
-                StepDefinition,
-                WorkflowConfig,
-                WorkflowDefinition,
-            ) = self._get_workflow_runtime()
+            StepDefinition, WorkflowDefinition = self._get_workflow_runtime()
 
             # Create a minimal workflow definition
             debate_id_short = context.get("debate_id", "unknown")[:8]
@@ -187,7 +177,6 @@ class PostDebateWorkflowSubscriber:
                 ],
             )
 
-            WorkflowEngine(config=WorkflowConfig())
             logger.debug(
                 "Built post-debate workflow definition (stub, not queued or "
                 "executed): template=%s debate=%s outcome=%s",

--- a/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
+++ b/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
@@ -231,7 +231,7 @@ created **no `module_tiers.yaml` drift** (§9).
 | `aragora/memory/event_subscribers.py` | domain | The three live memory reactions from `handlers.basic`: `knowledge_to_memory`, `evidence_to_insight`, and `mound_to_memory`. |
 | `aragora/debate/event_subscribers.py` | domain | The six live debate reactions from `handlers.{basic,strategic}`: ELO, calibration, consensus learning, rhetorical analysis, budget alert, and meta-learning. Security composition and `arena_bridge` moved to separate debate modules (§5.1). |
 | `aragora/reasoning/event_subscribers.py` | domain | `vote_to_belief` from `handlers.basic`. |
-| `aragora/workflow/event_subscribers.py` | application | The live alert-escalation workflow brake plus the relocated, directly callable `PostDebateWorkflowSubscriber`. The obsolete unregistered `basic._handle_debate_end_to_workflow` delegate was deleted rather than re-wired. |
+| `aragora/workflow/event_subscribers.py` | application | The live alert-escalation workflow brake plus one keyed `debate_end_to_workflow` reaction backed by the persistent `PostDebateWorkflowSubscriber`. The obsolete unregistered `basic._handle_debate_end_to_workflow` delegate was deleted rather than re-wired. |
 | `aragora/server/event_subscribers.py` | interface | Webhook delivery, knowledge-staleness-to-debate, and gauntlet-notification reactions. The deleted `execution_handlers` and `notification_handlers` modules are not final-main contributors. |
 
 No `aragora/ranking/event_subscribers.py` or
@@ -447,15 +447,19 @@ The design-time census found two lazy delegates to
 `subscribers.debate_handlers.py` before E5 landed. The sole remaining delegate,
 `handlers.basic._handle_debate_end_to_workflow`, was unregistered dead code. E5
 therefore removed that delegate and relocated `PostDebateWorkflowSubscriber` to
-`aragora.workflow.event_subscribers` without activating a new production path.
-Its `_trigger_workflow` implementation remains a no-op construction seam, so final
-main deliberately does not register it for `debate_end`.
+`aragora.workflow.event_subscribers`. The application home registers exactly one
+keyed `debate_end_to_workflow` reaction. The interface-superset
+`bootstrap_event_subscribers()` applies that home once per manager, so one
+`DEBATE_END` dispatch invokes `PostDebateWorkflowSubscriber.handle_debate_end`
+exactly once even after repeated bootstrap calls.
 
 This preserves the general rule: **handlers communicate through the domain-free
-event bus, never by importing each other across layers.** If post-debate workflow
-execution is activated in a future feature, it must be registered only in the
-application home and an invocation-count test must prove exactly one execution per
-event; registration-count parity alone cannot detect a double-fire.
+event bus, never by importing each other across layers.** The
+`PostDebateWorkflowSubscriber._trigger_workflow` method remains a
+construction-only seam, but outcome classification and fail-soft handling are now
+reached through the production composition root. Invocation-count tests patch the
+handler itself because registration-count parity alone cannot detect a
+double-fire.
 
 > Note: the design-time `handlers.strategic` control-plane import and
 > `notification_handlers` notification import were unlayered. Final main moved the
@@ -779,7 +783,7 @@ cap and carry a noted split point. **`events.dispatcher`/`async_dispatcher` ->
 | E2 | knowledge-domain home | Move KM reactions from `handlers.{knowledge_mound,validation}` (+ knowledge bits of `basic`/`culture`/`strategic`, `subscribers.mound_handlers`) -> `aragora/knowledge/event_subscribers.py`; self-register; NO shim; repoint `test_e2e_debate_km_flow`, `test_consensus_ingestion`. **Split E2a(knowledge_mound)/E2b(validation) if >800.** | contributes `events->{knowledge,memory}` | ~750 |
 | E3 | memory + reasoning homes; ranking cleanup | Move the three live `handlers.basic` memory reactions to `aragora/memory/event_subscribers.py` and `vote_to_belief` to `aragora/reasoning/event_subscribers.py`. Ranking was already a no-code stale edge after E2c, so no ranking home was created. | clears `events->{memory,reasoning,ranking}` | ~600 |
 | E4 | debate-domain home | Move the six live debate reactions from `handlers.{basic,strategic}` to `aragora/debate/event_subscribers.py`. `subscribers.debate_handlers` had already been deleted by E2c. | removes the handler share of `events->debate` | ~700 |
-| E5 | workflow application home + stale nomic cleanup | Move `subscribers.workflow_automation` and the live strategic workflow brake to `aragora/workflow/event_subscribers.py`; remove the unregistered `basic._handle_debate_end_to_workflow` delegate. Nomic was already a no-code stale edge after E2c, so no nomic event-subscriber home was created. | clears `events->{workflow,nomic}` | ~700 |
+| E5 | workflow application home + stale nomic cleanup | Move `subscribers.workflow_automation` and the live strategic workflow brake to `aragora/workflow/event_subscribers.py`; register one keyed `debate_end_to_workflow` reaction in that application home; remove the unregistered `basic._handle_debate_end_to_workflow` delegate. Nomic was already a no-code stale edge after E2c, so no nomic event-subscriber home was created. | clears `events->{workflow,nomic}` | ~700 |
 | E6 | interface home (server-coupled reactions) | Move the live basic webhook and culture state-manager reactions to `aragora/server/event_subscribers.py`; relocate gauntlet notification for interface cohesion. `execution_handlers` was already deleted, and later notification/channel plus dispatcher-boundary features removed the remaining real `events->server` contributors. | removes the subscriber-side share of `events->server` | ~700 |
 | E7a | security split (events + dispatcher) + emitter callback inversion | SPLIT `security_events`: move `trigger_security_debate` + `_get_security_debate_agents` + `build_security_debate_question` -> `aragora/debate/security_response.py`; add the domain-free `register_security_debate_runner`/`get_security_debate_runner` hook and INVERT `SecurityEventEmitter._trigger_security_debate` to the callback (§5.1); KEEP the domain-free results store in events. SPLIT `security_dispatcher` (move the single Arena-runner fn). DROP `trigger_security_debate` + `build_security_debate_question` from `events/__init__.py` (§6.3 table). Repoint `debate/security_debate.py`, `tests/debate/test_security_debate.py` (8 `@patch`), `tests/events/test_security_events.py`, `tests/events/test_security_dispatcher.py`. | `events->agents` + `security_events`/`security_dispatcher` share of `events->debate` | ~650 |
 | E7b | arena_bridge relocate + manager de-mixin | Relocate `arena_bridge` -> `aragora/debate/arena_bridge.py` (preferred option (a); or the drop-TYPE_CHECKING fallback (b), §5.1); DROP the `arena_bridge` trio from `events/__init__.py` (§6.3 table); finalize `manager.py` domain-free (remove the last mixin imports). Repoint `server/handlers/cross_pollination.py:156` (`EVENT_TYPE_MAP`), `debate/orchestrator_memory.py:306` (`ArenaEventBridge`), `tests/events/test_arena_bridge.py`. | `arena_bridge` share of `events->debate` | ~400 |
@@ -813,10 +817,10 @@ cross-layer import of an application/interface home, e.g. `debate -> workflow`, 
 guards that each worker's new home is at/above its highest import); (3) NO re-export
 shim at any moved path; (4) all repointed consumers/tests pass; (5)
 `get_cross_subscriber_manager()` import path unchanged; (6) **E5-specific:** both
-legacy delegates are absent, and the relocated `PostDebateWorkflowSubscriber`
-remains directly callable/testable but intentionally unwired while its trigger is
-a no-op. Any future activation must add an invocation-count test proving exactly
-one execution per `debate_end`; registration-count parity is insufficient.
+legacy delegates are absent, the application home registers one keyed
+`debate_end_to_workflow` reaction, and production invocation-count tests prove
+one `PostDebateWorkflowSubscriber.handle_debate_end` call per event before and
+after repeated idempotent bootstrap. Registration-count parity is insufficient.
 
 ## 11. References
 

--- a/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
+++ b/docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
@@ -456,9 +456,10 @@ exactly once even after repeated bootstrap calls.
 This preserves the general rule: **handlers communicate through the domain-free
 event bus, never by importing each other across layers.** The
 `PostDebateWorkflowSubscriber._trigger_workflow` method remains a
-construction-only seam, but outcome classification and fail-soft handling are now
-reached through the production composition root. Invocation-count tests patch the
-handler itself because registration-count parity alone cannot detect a
+definition-construction-only seam and deliberately avoids creating a workflow
+engine or probing checkpoint infrastructure. Outcome classification and fail-soft
+handling are now reached through the production composition root. Invocation-count
+tests patch the handler itself because registration-count parity alone cannot detect a
 double-fire.
 
 > Note: the design-time `handlers.strategic` control-plane import and

--- a/tests/events/test_cross_subscriber_registry.py
+++ b/tests/events/test_cross_subscriber_registry.py
@@ -110,8 +110,9 @@ GOLDEN_SUBSCRIBER_NAMES = frozenset(
 # contributed by E7a security_dispatcher and E7b arena_bridge); only the last of
 # the three batches to land hand-shrinks the frozen baseline string.
 # E5: the workflow-coupled alert-escalation reaction embedded in the strategic
-# mixin -> aragora/workflow/event_subscribers.py (application-tier home, see
-# APPLICATION_TIER_SUBSCRIBER_NAMES below - it is wired only via the
+# mixin and the post-debate workflow subscriber ->
+# aragora/workflow/event_subscribers.py (application-tier home, see
+# APPLICATION_TIER_SUBSCRIBER_NAMES below - both are wired only via the
 # interface-superset bootstrap, unlike E2-E4's domain-tier relocations).
 # E6: the server-coupled webhook-delivery reaction embedded in the basic mixin
 # and the staleness-to-debate reaction embedded in the culture mixin ->
@@ -162,6 +163,7 @@ RELOCATED_SUBSCRIBER_NAMES = frozenset(
         "budget_alert_to_team_selection",
         "meta_learning_to_team_selection",
         "alert_escalated_to_workflow_brake",
+        "debate_end_to_workflow",
         "staleness_to_debate",
         "webhook_agent_elo_updated",
         "webhook_calibration_update",
@@ -184,6 +186,7 @@ RELOCATED_SUBSCRIBER_NAMES = frozenset(
 APPLICATION_TIER_SUBSCRIBER_NAMES = frozenset(
     {
         "alert_escalated_to_workflow_brake",
+        "debate_end_to_workflow",
     }
 )
 
@@ -474,10 +477,11 @@ def test_relocated_reactions_registered_via_home_bootstrap():
     slice, so a silently dropped home import is caught here and not only in the
     superset test). APPLICATION_TIER_SUBSCRIBER_NAMES and
     INTERFACE_TIER_SUBSCRIBER_NAMES are excluded: those reactions (e.g.
-    alert_escalated_to_workflow_brake, P4a Batch E5; staleness_to_debate /
-    webhook_*, P4a Batch E6) wire only via the interface-superset bootstrap -
-    see ``test_application_tier_reactions_registered_via_superset_bootstrap``
-    and ``test_interface_tier_reactions_registered_via_superset_bootstrap``.
+    alert_escalated_to_workflow_brake / debate_end_to_workflow, P4a Batch E5;
+    staleness_to_debate / webhook_*, P4a Batch E6) wire only via the
+    interface-superset bootstrap - see
+    ``test_application_tier_reactions_registered_via_superset_bootstrap`` and
+    ``test_interface_tier_reactions_registered_via_superset_bootstrap``.
     """
     from aragora.debate.event_subscribers import bootstrap_debate_event_subscribers
 

--- a/tests/events/test_post_debate_workflow.py
+++ b/tests/events/test_post_debate_workflow.py
@@ -14,7 +14,7 @@ Tests cover:
 - Workflow template mapping and triggering
 - Custom workflow map overrides
 - Stats tracking (events_processed, workflows_triggered, errors)
-- Graceful degradation when WorkflowEngine import fails
+- Graceful degradation when workflow definition types are unavailable
 - Handling of malformed event data without crashing
 """
 
@@ -205,32 +205,18 @@ class TestPostDebateWorkflowSubscriber:
     def test_stats_workflows_triggered_increments(self):
         """workflows_triggered should increment when a workflow is triggered."""
         sub = PostDebateWorkflowSubscriber()
-        event = make_debate_end_event(
-            {
-                "debate_id": "d4",
-                "consensus_reached": True,
-                "confidence": 0.9,
-            }
-        )
+        sub._trigger_workflow("test_template", {"debate_id": "d4", "outcome": "test"})
 
-        # Patch the workflow engine import to succeed without side effects
-        with patch(
-            "aragora.workflow.event_subscribers.PostDebateWorkflowSubscriber._trigger_workflow",
-            wraps=sub._trigger_workflow,
-        ):
-            # We need to mock the actual import inside _trigger_workflow
-            pass
+        assert sub.stats["workflows_triggered"] == 1
 
-        # Call directly and patch the import chain
-        with patch.dict(
-            "sys.modules",
-            {
-                "aragora.workflow.engine": MagicMock(),
-                "aragora.workflow.types": MagicMock(),
-            },
-        ):
+    def test_construction_stub_does_not_create_workflow_engine(self):
+        """Production dispatch must not probe workflow infrastructure in the stub."""
+        sub = PostDebateWorkflowSubscriber()
+
+        with patch("aragora.workflow.engine.WorkflowEngine") as mock_engine:
             sub._trigger_workflow("test_template", {"debate_id": "d4", "outcome": "test"})
 
+        mock_engine.assert_not_called()
         assert sub.stats["workflows_triggered"] == 1
 
     def test_stats_errors_on_malformed_data(self):
@@ -260,11 +246,11 @@ class TestPostDebateWorkflowSubscriber:
         mock_trigger.assert_called_once()
         assert mock_trigger.call_args[0][1]["outcome"] == "no_consensus"
 
-    def test_graceful_degradation_workflow_engine_unavailable(self):
-        """Should not crash when WorkflowEngine is not importable."""
+    def test_graceful_degradation_workflow_types_unavailable(self):
+        """Should not crash when workflow definition types are not importable."""
         sub = PostDebateWorkflowSubscriber()
 
-        with patch.dict("sys.modules", {"aragora.workflow.engine": None}):
+        with patch.dict("sys.modules", {"aragora.workflow.types": None}):
             # This will cause ImportError inside _trigger_workflow
             sub._trigger_workflow("test_template", {"debate_id": "x", "outcome": "test"})
 

--- a/tests/workflow/test_event_subscribers.py
+++ b/tests/workflow/test_event_subscribers.py
@@ -202,6 +202,25 @@ class TestPostDebateWorkflowSubscriberInvocationCount:
         mock_handle.assert_called_once()
         assert manager.get_stats()["debate_end_to_workflow"]["events_processed"] == 1
 
+    def test_superset_dispatch_does_not_probe_workflow_infrastructure(self):
+        """The construction stub handles production events without creating an engine."""
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+        manager = bootstrap_event_subscribers()
+        subscriber = get_workflow_event_subscriber()
+        event = make_stream_event(
+            StreamEventType.DEBATE_END,
+            data={"debate_id": "d4", "consensus_reached": True, "confidence": 0.9},
+        )
+
+        with patch("aragora.workflow.engine.WorkflowEngine") as mock_engine:
+            manager._dispatch_event(event)
+
+        mock_engine.assert_not_called()
+        assert subscriber.post_debate_workflow.stats["events_processed"] == 1
+        assert subscriber.post_debate_workflow.stats["workflows_triggered"] == 1
+        assert manager.get_stats()["debate_end_to_workflow"]["events_processed"] == 1
+
 
 class TestLegacyDelegatingSitesRemoved:
     """Structural regression guard: both pre-inversion delegating call sites

--- a/tests/workflow/test_event_subscribers.py
+++ b/tests/workflow/test_event_subscribers.py
@@ -19,11 +19,10 @@ precedent as ``TestBudgetAlertToTeamSelection`` for the P4a Batch E4
 relocation). This module covers registration/dispatch integration plus the
 E5-specific invocation-count acceptance test.
 
-Only ``alert_escalated_to_workflow_brake`` is wired by
-``WorkflowEventSubscriber.register``: ``_handle_debate_end_to_workflow`` is
-relocated (and directly callable/testable) but intentionally NOT registered,
-since it had no live invocation path on origin/main either - see the module
-docstring on ``aragora.workflow.event_subscribers`` for the full rationale.
+``WorkflowEventSubscriber.register`` wires one keyed reaction for each handler.
+The production interface-superset bootstrap therefore dispatches
+``DEBATE_END`` to ``PostDebateWorkflowSubscriber.handle_debate_end`` exactly
+once, including after repeated bootstrap calls.
 """
 
 from __future__ import annotations
@@ -106,6 +105,7 @@ class TestWorkflowEventSubscriberRegistration:
         assert WORKFLOW_EVENT_SUBSCRIBER_HANDLER_NAMES == frozenset(
             {
                 "alert_escalated_to_workflow_brake",
+                "debate_end_to_workflow",
             }
         )
 
@@ -118,20 +118,14 @@ class TestWorkflowEventSubscriberRegistration:
         registered = set(manager.get_stats())
         assert WORKFLOW_EVENT_SUBSCRIBER_HANDLER_NAMES <= registered
 
-    def test_register_does_not_wire_debate_end_to_workflow(self):
-        """The relocated post-debate-workflow reaction stays unregistered.
-
-        ``debate_end_to_workflow`` had no live invocation path on
-        origin/main (its only caller was the dead, unregistered ``basic.py``
-        delegate); ``register`` must not resurrect it as a manager-dispatched
-        reaction merely because the backing code moved home.
-        """
+    def test_register_wires_debate_end_to_workflow(self):
+        """The workflow home owns one keyed DEBATE_END reaction."""
         manager = CrossSubscriberManager()
-        WorkflowEventSubscriber().register(manager)
+        subscriber = WorkflowEventSubscriber()
+        subscriber.register(manager)
 
-        assert "debate_end_to_workflow" not in manager.get_stats()
-
-        with patch.object(PostDebateWorkflowSubscriber, "handle_debate_end") as mock_handle:
+        assert "debate_end_to_workflow" in manager.get_stats()
+        with patch.object(subscriber.post_debate_workflow, "handle_debate_end") as mock_handle:
             manager._dispatch_event(
                 make_stream_event(
                     StreamEventType.DEBATE_END,
@@ -139,7 +133,7 @@ class TestWorkflowEventSubscriberRegistration:
                 )
             )
 
-        mock_handle.assert_not_called()
+        mock_handle.assert_called_once()
 
     def test_register_dispatches_alert_escalated_to_workflow_brake_through_manager(self):
         manager = CrossSubscriberManager()
@@ -170,36 +164,15 @@ class TestWorkflowEventSubscriberRegistration:
 
 
 class TestPostDebateWorkflowSubscriberInvocationCount:
-    """E5-specific acceptance test (docs/architecture/P4A_EVENTS_QUEUE_INVERSION.md
-    §10 row E5, acceptance criterion 6): an INVOCATION-COUNT test proving
-    ``PostDebateWorkflowSubscriber.handle_debate_end`` is invoked EXACTLY
-    ONCE per ``debate_end`` event wherever it IS wired, and not at all
-    through the default production composition root (see the module
-    docstring on ``aragora.workflow.event_subscribers`` for why the reaction
-    is relocated but deliberately left unregistered).
+    """Production composition-root exactly-once acceptance tests.
 
-    A registration-count parity check (e.g.
-    ``test_register_wires_all_handlers_into_manager`` above, or the
-    golden-name parity tests in
-    ``tests/events/test_cross_subscriber_registry.py``) is INSUFFICIENT: it
-    only proves subscriber *names* were (or weren't) registered, not how many
-    times the underlying ``PostDebateWorkflowSubscriber.handle_debate_end``
-    actually ran. Historically this reaction was reachable from TWO
-    independent delegating call sites - ``subscribers/debate_handlers.py:457``
-    (deleted by P4a Batch E4) and ``cross_subscribers/handlers/basic.py:577``
-    (deleted by this batch) - each of which instantiated its own throwaway
-    ``PostDebateWorkflowSubscriber`` and called ``.handle_debate_end()``. A
-    residual delegating site would go undetected by any PER-NAME
-    registration/dispatch-count check, so only a class-level invocation count
-    (patching ``PostDebateWorkflowSubscriber.handle_debate_end`` itself,
-    observed across the whole dispatch) can catch that regression.
+    Registration-name parity alone cannot detect duplicate delegates. These
+    tests patch ``PostDebateWorkflowSubscriber.handle_debate_end`` itself and
+    observe the complete production dispatch.
     """
 
-    def test_not_invoked_via_full_superset_bootstrap(self):
-        """Bootstrap the real interface-superset composition root (not a
-        hand-built manager) and dispatch ONE DEBATE_END event: neither of
-        the historical delegating sites nor the new home's ``register``
-        route it to ``handle_debate_end``, so the total call count is 0."""
+    def test_superset_bootstrap_dispatches_post_debate_exactly_once(self):
+        """One production DEBATE_END dispatch invokes the workflow handler once."""
         from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
 
         manager = bootstrap_event_subscribers()
@@ -211,44 +184,23 @@ class TestPostDebateWorkflowSubscriberInvocationCount:
         with patch.object(PostDebateWorkflowSubscriber, "handle_debate_end") as mock_handle:
             manager._dispatch_event(event)
 
-        mock_handle.assert_not_called()
-
-    def test_fires_exactly_once_when_wired_directly(self):
-        """Guarantee at the unit level for whoever wires this reaction back
-        in later: registering ``_handle_debate_end_to_workflow`` directly
-        onto a manager (bypassing ``WorkflowEventSubscriber.register``, which
-        deliberately omits it) still routes to ``handle_debate_end`` exactly
-        once per dispatched event, i.e. the relocated code itself carries no
-        residual double-dispatch from the historical two-site bug."""
-        manager = CrossSubscriberManager()
-        subscriber = WorkflowEventSubscriber()
-        manager.register(
-            "debate_end_to_workflow",
-            StreamEventType.DEBATE_END,
-            subscriber._handle_debate_end_to_workflow,
-        )
-        event = make_stream_event(StreamEventType.DEBATE_END, data={"debate_id": "d2"})
-
-        with patch.object(PostDebateWorkflowSubscriber, "handle_debate_end") as mock_handle:
-            manager._dispatch_event(event)
-
         mock_handle.assert_called_once()
+        assert manager.get_stats()["debate_end_to_workflow"]["events_processed"] == 1
 
-    def test_not_invoked_after_repeated_bootstrap_calls(self):
-        """Bootstrap is documented as idempotent (repeated calls only apply
-        newly-registered subscribers): calling it twice must not
-        retroactively wire the relocated reaction either, so DEBATE_END
-        still reaches ``handle_debate_end`` zero times."""
+    def test_repeated_superset_bootstrap_keeps_post_debate_exactly_once(self):
+        """Repeated production bootstrap does not duplicate the DEBATE_END reaction."""
         from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
 
-        bootstrap_event_subscribers()
-        manager = bootstrap_event_subscribers()  # simulate a second bootstrap call
+        first_manager = bootstrap_event_subscribers()
+        manager = bootstrap_event_subscribers()
+        assert manager is first_manager
         event = make_stream_event(StreamEventType.DEBATE_END, data={"debate_id": "d3"})
 
         with patch.object(PostDebateWorkflowSubscriber, "handle_debate_end") as mock_handle:
             manager._dispatch_event(event)
 
-        mock_handle.assert_not_called()
+        mock_handle.assert_called_once()
+        assert manager.get_stats()["debate_end_to_workflow"]["events_processed"] == 1
 
 
 class TestLegacyDelegatingSitesRemoved:


### PR DESCRIPTION
## Summary

- register one keyed `DEBATE_END` reaction in `WorkflowEventSubscriber.register()`
- prove the production superset bootstrap invokes `PostDebateWorkflowSubscriber.handle_debate_end` exactly once after one or repeated bootstrap calls
- keep the construction-only stub fail-soft by building only the workflow definition, without creating a workflow engine or probing checkpoint infrastructure
- remove superseded zero-invocation tests and reconcile the P4a architecture text with the operator-selected contract

## Contract

Implements mission feature `p4a-e5-post-debate-exactly-once` and `VAL-P4A-014`. The operator decision recorded on 2026-07-13 explicitly selects exactly-once production behavior over the stale zero-invocation wording.

## Verification

- `python3 -m pytest tests/workflow/test_event_subscribers.py -q`: 15 passed
- `python3 -m pytest tests/events/test_cross_subscriber_registry.py -q`: 26 passed
- `python3 -m pytest tests/events/test_post_debate_workflow.py -q`: 23 passed
- focused `VAL-P4A-014` selection: 2 passed
- stale contract guard: no matches, `stale_exit=1`
- changed-file mypy: success, 1 source file
- differential typecheck: accepted ambient drift, `new=104 <= 108`
- `make lint`: pass
- `ruff format --check aragora/ tests/ scripts/`: pass
- docs links and consistency: pass
- scoped foundation/infrastructure import contracts: pass
- `make test-smoke`: pass
- smoke tier: 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass

## Review repair

The first head-bound Claude review identified that the previously unwired construction stub instantiated `WorkflowEngine`, which could probe distributed checkpoint infrastructure during production dispatch. The follow-up commit removes that unused engine construction and adds direct plus composition-root regressions proving production `DEBATE_END` dispatch does not initialize it.

## Risk

Tier 1 bounded behavior repair. Existing registry application idempotency, handler order, workflow brake behavior, Nomic/domain reactions, and dispatch fail-soft machinery are unchanged. The non-required docs build still reports the mission-documented pre-existing generated-doc metric drift in protected/path-frozen files, which is outside this PR's scope.
