### PR TITLE
ci(test-shards): rebalance saturated debate-am shard [Tier-2]

### DIFF
--- a/scripts/ci_resolve_test_shard.py
+++ b/scripts/ci_resolve_test_shard.py
@@ -76,17 +76,28 @@ def _file_letter(name: str) -> str:
 # Per-shard resolvers
 # ---------------------------------------------------------------------------
 
+_DEBATE_PHASES_REBALANCED_FILES = frozenset(
+    {
+        "test_context_gatherer.py",
+        "test_context_gatherer_root.py",
+        "test_e2e_flow.py",
+    }
+)
+
 
 def _under(parent: Path, names: Iterable[str]) -> list[str]:
     return [str((parent / name).relative_to(REPO_ROOT)) for name in names]
 
 
 def shard_debate_am() -> list[str]:
-    """Top-level debate test files starting a-m, no subdir tests."""
+    """Top-level debate test files starting a-m, excluding rebalanced files."""
     parent = TESTS_ROOT / "debate"
     _, files = _entries(parent)
     in_am = _alpha_range("a", "m")
-    return _under(parent, [f for f in files if in_am(_file_letter(f))])
+    chosen = [
+        f for f in files if in_am(_file_letter(f)) and f not in _DEBATE_PHASES_REBALANCED_FILES
+    ]
+    return _under(parent, chosen)
 
 
 def shard_debate_nz() -> list[str]:
@@ -98,10 +109,17 @@ def shard_debate_nz() -> list[str]:
 
 
 def shard_debate_phases() -> list[str]:
-    """All subdirectories under tests/debate/."""
+    """Debate subdirectories plus measured heavy top-level files.
+
+    The selected top-level files repeatedly contributed about 82-93 seconds
+    of loadscope occupancy on the busiest debate-am worker. Moving them here
+    gives the saturated shard headroom while debate-phases remains far below
+    its 30-minute cap.
+    """
     parent = TESTS_ROOT / "debate"
-    subdirs, _ = _entries(parent)
-    return _under(parent, subdirs)
+    subdirs, files = _entries(parent)
+    rebalanced = [f for f in files if f in _DEBATE_PHASES_REBALANCED_FILES]
+    return _under(parent, [*subdirs, *rebalanced])
 
 
 def _server_handlers_root() -> Path:

--- a/scripts/ci_resolve_test_shard.py
+++ b/scripts/ci_resolve_test_shard.py
@@ -78,6 +78,9 @@ def _file_letter(name: str) -> str:
 
 _DEBATE_PHASES_REBALANCED_FILES = frozenset(
     {
+        "test_autonomic_executor.py",
+        "test_convergence_comprehensive.py",
+        "test_counterfactual_root.py",
         "test_context_gatherer.py",
         "test_context_gatherer_root.py",
         "test_e2e_flow.py",
@@ -111,10 +114,9 @@ def shard_debate_nz() -> list[str]:
 def shard_debate_phases() -> list[str]:
     """Debate subdirectories plus measured heavy top-level files.
 
-    The selected top-level files repeatedly contributed about 82-93 seconds
-    of loadscope occupancy on the busiest debate-am worker. Moving them here
-    gives the saturated shard headroom while debate-phases remains far below
-    its 30-minute cap.
+    The selected files contributed about 604 aggregate worker-seconds in the
+    measured saturated run. Moving them here gives debate-am bounded headroom
+    while debate-phases remains far below its 30-minute cap.
     """
     parent = TESTS_ROOT / "debate"
     subdirs, files = _entries(parent)

--- a/tests/scripts/test_ci_resolve_test_shard.py
+++ b/tests/scripts/test_ci_resolve_test_shard.py
@@ -105,6 +105,22 @@ def test_debate_partition_is_complete_and_disjoint() -> None:
     )
 
 
+def test_debate_runtime_balanced_files_are_in_phases_shard() -> None:
+    """Measured heavy top-level files run in the debate shard with ample headroom."""
+    rebalanced = {
+        "tests/debate/test_context_gatherer.py",
+        "tests/debate/test_context_gatherer_root.py",
+        "tests/debate/test_e2e_flow.py",
+    }
+    debate_am = _expand_to_files(shard_mod.shard_debate_am())
+    debate_nz = _expand_to_files(shard_mod.shard_debate_nz())
+    debate_phases = _expand_to_files(shard_mod.shard_debate_phases())
+
+    assert rebalanced <= debate_phases
+    assert rebalanced.isdisjoint(debate_am)
+    assert rebalanced.isdisjoint(debate_nz)
+
+
 def test_resolver_emits_relative_paths() -> None:
     """All resolver outputs are repo-relative paths that exist or are pytest options."""
     for name, fn in shard_mod.SHARDS.items():

--- a/tests/scripts/test_ci_resolve_test_shard.py
+++ b/tests/scripts/test_ci_resolve_test_shard.py
@@ -108,6 +108,9 @@ def test_debate_partition_is_complete_and_disjoint() -> None:
 def test_debate_runtime_balanced_files_are_in_phases_shard() -> None:
     """Measured heavy top-level files run in the debate shard with ample headroom."""
     rebalanced = {
+        "tests/debate/test_autonomic_executor.py",
+        "tests/debate/test_convergence_comprehensive.py",
+        "tests/debate/test_counterfactual_root.py",
         "tests/debate/test_context_gatherer.py",
         "tests/debate/test_context_gatherer_root.py",
         "tests/debate/test_e2e_flow.py",


### PR DESCRIPTION
## Summary

- Move six measured loadscope-heavy top-level debate files from `debate-am` to the low-utilization `debate-phases` resolver selection.
- Preserve complete, pairwise-disjoint coverage across `debate-am`, `debate-nz`, and `debate-phases`.
- Add an exact-boundary regression test for the rebalanced files.

## Measured diagnosis

Current-main run `29307264024` completed the debate-am pytest body in 27:36 and the whole job in 29:56. Four of seven recent main runs reached the 30-minute cap. PR #9279 run `29309377942` was cancelled at roughly 86% and 98% in its two attempts without an observed test failure.

Timestamped loadscope logs attributed about 604 aggregate worker-seconds to these files in the measured saturated run:

- `tests/debate/test_autonomic_executor.py` (103.0s)
- `tests/debate/test_context_gatherer.py` (167.7s)
- `tests/debate/test_context_gatherer_root.py` (38.1s)
- `tests/debate/test_convergence_comprehensive.py` (87.2s)
- `tests/debate/test_counterfactual_root.py` (82.9s)
- `tests/debate/test_e2e_flow.py` (125.4s)

A fresh exact-head workflow run (`29320265990`) proved the initial three-file move was too narrow: debate-am still used 27:05 for pytest and 29:35 for the job. The follow-up therefore adds the three largest remaining measured files (284 aggregate worker-seconds) rather than accepting 25 seconds of job headroom.

## Final runtime proof

Fresh workflow-dispatch run `29324760752` exercised the final exact head `6e501d018fabf5c52486f075acc8d1da20ebc1a9`:

| Shard | Pytest | Whole job | Result |
| --- | ---: | ---: | --- |
| debate-am | 25:17 | 27:46 | 8,307 passed, 2 skipped |
| debate-nz | 12:18 | 15:02 | 6,732 passed, 4 skipped |
| debate-phases | 5:27 | 8:07 | 3,686 passed |

Debate-am now has 2:14 of whole-job headroom below the unchanged 30-minute cap. A second four-worker loadscope execution of the final debate-am selection passed locally in 7:56 pytest / 7:59 wall, confirming the resolver selection is repeatable outside the hosted run.

## Coverage proof

The final resolver moves 605 marker-selected tests:

| Shard | Before | Final |
| --- | ---: | ---: |
| debate-am | 8,914 | 8,309 |
| debate-nz | 6,736 | 6,736 |
| debate-phases | 3,081 | 3,686 |
| **Total** | **18,731** | **18,731** |

The existing exhaustive partition test remains green and verifies complete, pairwise-disjoint file coverage. The new regression verifies all six measured files belong only to `debate-phases`.

## Constraints preserved

- No edit to path-frozen `.github/workflows/test.yml`.
- No workflow timeout increase.
- No skip, xfail, assertion weakening, serialization, or removed PR coverage.
- No physical test-file moves.

## Validation

- `python3 -m pytest tests/scripts/test_ci_resolve_test_shard.py -q` (5 passed)
- collect-only final debate shards: 8,309 + 6,736 + 3,686 = 18,731 selected
- final `debate-am` under four-worker CI loadscope options (8,307 passed, 2 skipped)
- `mypy --pretty scripts/ci_resolve_test_shard.py tests/scripts/test_ci_resolve_test_shard.py`
- `bash scripts/preflight_mypy.sh --diff-base origin/main`
- `make lint`
- `ruff format --check aragora/ tests/ scripts/`
- AWS-neutralized `make test-smoke`
- AWS-neutralized `PYTEST_BIN=\"python3 -m pytest\" bash scripts/test_tiers.sh smoke` (138 passed)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Risk

Tier 2. This changes only test-shard selection, with exhaustive resolver coverage and no production runtime behavior change.

After merge, PR #9279 needs a fresh merge-ref workflow against repaired `main`; its old pre-fix attempt must not be rerun.