### PR TITLE
fix(stream): fail closed on escalated alert brake

### DIFF
--- a/aragora/events/cross_subscribers/dispatch.py
+++ b/aragora/events/cross_subscribers/dispatch.py
@@ -306,7 +306,7 @@ class DispatchMixin:
         if filter_func is not None:
             try:
                 accepted = filter_func(event)
-            except Exception as exc:  # noqa: BLE001 - fail closed on any filter failure
+            except (RuntimeError, TypeError, AttributeError, ValueError, KeyError) as exc:
                 stats.events_failed += 1
                 raise RuntimeError(
                     f"Required cross-subscriber '{handler_name}' filter failed"

--- a/aragora/events/cross_subscribers/dispatch.py
+++ b/aragora/events/cross_subscribers/dispatch.py
@@ -86,6 +86,8 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+CrossSubscriberHandler = Callable[[StreamEvent], object]
+
 
 def _default_async_event_types() -> set:
     """Default event types for async dispatch."""
@@ -112,7 +114,7 @@ class DispatchMixin:
     """
 
     # Mixin attribute declarations (provided by the composed class)
-    _subscribers: dict[StreamEventType, list[tuple[str, Callable[[StreamEvent], None]]]]
+    _subscribers: dict[StreamEventType, list[tuple[str, CrossSubscriberHandler]]]
     _stats: dict[str, SubscriberStats]
     _filters: dict[str, Callable[[StreamEvent], bool]]
     _circuit_breaker: CircuitBreaker
@@ -159,11 +161,8 @@ class DispatchMixin:
                 continue
 
             # Get retry config
-            retry_config = (
-                self._stats[name].retry_config
-                if name in self._stats and self._stats[name].retry_config
-                else self._default_retry_config
-            )
+            configured_retry = self._stats[name].retry_config if name in self._stats else None
+            retry_config = configured_retry or self._default_retry_config
 
             # Execute handler with timing, retry, and metrics
             start_time = time.time()
@@ -261,6 +260,114 @@ class DispatchMixin:
             event: The event to dispatch
         """
         self._dispatch_event(event)
+
+    def dispatch_required(self, event: StreamEvent, handler_name: str) -> None:
+        """Synchronously deliver an event once to one required named handler.
+
+        Unlike ordinary cross-subscriber dispatch, this safety-critical path
+        never samples, retries, or suppresses failures. The named handler must
+        be registered exactly once, enabled, available, and explicitly confirm
+        delivery by returning ``True``.
+
+        Args:
+            event: The event to deliver.
+            handler_name: Exact registered handler name.
+
+        Raises:
+            RuntimeError: If the handler cannot confirm one successful delivery.
+        """
+        if METRICS_AVAILABLE:
+            record_event_dispatched(event.type.value)
+
+        matches = [
+            handler
+            for name, handler in self._subscribers.get(event.type, [])
+            if name == handler_name
+        ]
+        if len(matches) != 1:
+            raise RuntimeError(
+                f"Required cross-subscriber '{handler_name}' must be registered exactly once "
+                f"for {event.type.value}; found {len(matches)}"
+            )
+
+        stats = self._stats.get(handler_name)
+        if stats is None:
+            raise RuntimeError(f"Required cross-subscriber '{handler_name}' has no runtime state")
+        if not stats.enabled:
+            stats.events_skipped += 1
+            raise RuntimeError(f"Required cross-subscriber '{handler_name}' is disabled")
+        if not self._circuit_breaker.is_available(handler_name):
+            stats.events_skipped += 1
+            raise RuntimeError(
+                f"Required cross-subscriber '{handler_name}' circuit breaker is open"
+            )
+
+        filter_func = self._filters.get(handler_name)
+        if filter_func is not None:
+            try:
+                accepted = filter_func(event)
+            except Exception as exc:  # noqa: BLE001 - fail closed on any filter failure
+                stats.events_failed += 1
+                raise RuntimeError(
+                    f"Required cross-subscriber '{handler_name}' filter failed"
+                ) from exc
+            if not accepted:
+                stats.events_skipped += 1
+                raise RuntimeError(f"Required cross-subscriber '{handler_name}' rejected the event")
+
+        if stats.sample_rate != 1.0:
+            stats.events_skipped += 1
+            raise RuntimeError(
+                f"Required cross-subscriber '{handler_name}' cannot use sampled delivery"
+            )
+
+        handler = matches[0]
+        start_time = time.time()
+        delivery_error: Exception | None = None
+        try:
+            confirmed = handler(event)
+            if confirmed is not True:
+                delivery_error = RuntimeError("handler did not confirm delivery")
+        except Exception as exc:  # noqa: BLE001 - propagate all delivery failures
+            delivery_error = exc
+
+        elapsed_ms = (time.time() - start_time) * 1000
+        stats.last_event_time = datetime.now()
+        stats.total_latency_ms += elapsed_ms
+        stats.min_latency_ms = min(stats.min_latency_ms, elapsed_ms)
+        stats.max_latency_ms = max(stats.max_latency_ms, elapsed_ms)
+        stats.record_latency(elapsed_ms)
+
+        if delivery_error is None:
+            stats.events_processed += 1
+            self._circuit_breaker.record_success(handler_name)
+        else:
+            stats.events_failed += 1
+            self._circuit_breaker.record_failure(handler_name)
+            if METRICS_AVAILABLE:
+                set_circuit_breaker_state(
+                    handler_name,
+                    not self._circuit_breaker.is_available(handler_name),
+                )
+
+        if METRICS_AVAILABLE:
+            record_handler_call(
+                handler_name,
+                "success" if delivery_error is None else "failure",
+                elapsed_ms,
+            )
+
+        if SLO_METRICS_AVAILABLE:
+            check_and_record_slo(
+                f"cross_subscriber_{handler_name}",
+                elapsed_ms,
+                percentile="p99",
+            )
+
+        if delivery_error is not None:
+            raise RuntimeError(
+                f"Required cross-subscriber '{handler_name}' failed to confirm delivery"
+            ) from delivery_error
 
     def _add_to_batch(self, event: StreamEvent) -> None:
         """Add event to batch queue for later processing.

--- a/aragora/events/cross_subscribers/dispatch.py
+++ b/aragora/events/cross_subscribers/dispatch.py
@@ -265,9 +265,9 @@ class DispatchMixin:
         """Synchronously deliver an event once to one required named handler.
 
         Unlike ordinary cross-subscriber dispatch, this safety-critical path
-        never samples, retries, or suppresses failures. The named handler must
-        be registered exactly once, enabled, available, and explicitly confirm
-        delivery by returning ``True``.
+        never samples, retries, or suppresses attempts. The named handler must
+        be registered exactly once, enabled, and explicitly confirm delivery
+        by returning ``True``.
 
         Args:
             event: The event to deliver.
@@ -296,11 +296,6 @@ class DispatchMixin:
         if not stats.enabled:
             stats.events_skipped += 1
             raise RuntimeError(f"Required cross-subscriber '{handler_name}' is disabled")
-        if not self._circuit_breaker.is_available(handler_name):
-            stats.events_skipped += 1
-            raise RuntimeError(
-                f"Required cross-subscriber '{handler_name}' circuit breaker is open"
-            )
 
         filter_func = self._filters.get(handler_name)
         if filter_func is not None:

--- a/aragora/events/cross_subscribers/manager.py
+++ b/aragora/events/cross_subscribers/manager.py
@@ -28,7 +28,7 @@ from aragora.events.types import StreamEvent, StreamEventType
 from aragora.resilience import CircuitBreaker
 
 from .admin import AdminMixin
-from .dispatch import DispatchMixin
+from .dispatch import CrossSubscriberHandler, DispatchMixin
 from .registry import get_registered_subscribers
 
 if TYPE_CHECKING:
@@ -106,9 +106,7 @@ class CrossSubscriberManager(
             default_retry_config: Default retry configuration for handlers (default: 3 retries)
             async_config: Configuration for async/batched event dispatch
         """
-        self._subscribers: dict[
-            StreamEventType, list[tuple[str, Callable[[StreamEvent], None]]]
-        ] = {}
+        self._subscribers: dict[StreamEventType, list[tuple[str, CrossSubscriberHandler]]] = {}
         self._stats: dict[str, SubscriberStats] = {}
         self._filters: dict[str, Callable[[StreamEvent], bool]] = {}
         self._connected = False
@@ -611,7 +609,7 @@ class CrossSubscriberManager(
         self,
         name: str,
         event_type: StreamEventType,
-        handler: Callable[[StreamEvent], None],
+        handler: CrossSubscriberHandler,
     ) -> None:
         """
         Register a cross-subsystem subscriber.
@@ -632,7 +630,7 @@ class CrossSubscriberManager(
     def subscribe(
         self,
         event_type: StreamEventType,
-    ) -> Callable[[Callable[[StreamEvent], None]], Callable[[StreamEvent], None]]:
+    ) -> Callable[[CrossSubscriberHandler], CrossSubscriberHandler]:
         """
         Decorator for registering subscribers.
 
@@ -642,7 +640,7 @@ class CrossSubscriberManager(
                 pass
         """
 
-        def decorator(func: Callable[[StreamEvent], None]) -> Callable[[StreamEvent], None]:
+        def decorator(func: CrossSubscriberHandler) -> CrossSubscriberHandler:
             self.register(func.__name__, event_type, func)
             return func
 

--- a/aragora/server/stream/autonomous_stream.py
+++ b/aragora/server/stream/autonomous_stream.py
@@ -206,6 +206,13 @@ def emit_alert_event(
             **kwargs,
         },
     )
+    brake_severity = event.data.get("new_severity", severity)
+    if event_type == "escalated" and brake_severity in ("critical", "emergency", "fatal"):
+        from aragora.server.startup.event_subscribers import bootstrap_event_subscribers
+
+        manager = bootstrap_event_subscribers()
+        manager.dispatch_required(event, "alert_escalated_to_workflow_brake")
+
     emitter.emit_sync(event)
 
 

--- a/aragora/server/stream/autonomous_stream.py
+++ b/aragora/server/stream/autonomous_stream.py
@@ -187,7 +187,11 @@ def emit_alert_event(
     title: str,
     **kwargs: Any,
 ) -> None:
-    """Emit an alert event."""
+    """Emit an alert event.
+
+    Raises:
+        RuntimeError: If a critical escalation cannot confirm workflow-brake delivery.
+    """
     emitter = get_autonomous_emitter()
 
     type_map = {

--- a/aragora/workflow/engine.py
+++ b/aragora/workflow/engine.py
@@ -1129,6 +1129,10 @@ class WorkflowEngine:
         self._termination_reason = reason
         logger.info("Workflow termination requested: %s", reason)
 
+    def pause_all(self, reason: str = "Emergency brake") -> None:
+        """Stop active workflow execution through the emergency-brake API."""
+        self.request_termination(reason)
+
     def check_termination(self) -> tuple[bool, str | None]:
         """Check if termination has been requested."""
         return self._should_terminate, self._termination_reason

--- a/aragora/workflow/engine.py
+++ b/aragora/workflow/engine.py
@@ -19,7 +19,7 @@ import json
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, ClassVar
 from collections.abc import Callable
 
 from aragora.events.types import StreamEventType
@@ -79,6 +79,8 @@ class WorkflowEngine:
         result = await engine.resume(workflow_id, checkpoint)
     """
 
+    _emergency_brake_reason: ClassVar[str | None] = None
+
     def __init__(
         self,
         config: WorkflowConfig | None = None,
@@ -99,6 +101,7 @@ class WorkflowEngine:
         self._should_terminate: bool = False
         self._termination_reason: str | None = None
         self._results: list[StepResult] = []
+        self._apply_emergency_brake()
 
         # Checkpoint storage - use provided store or fall back to file-based
         self._checkpoint_store: CheckpointStore = checkpoint_store or get_checkpoint_store()
@@ -395,6 +398,7 @@ class WorkflowEngine:
         self._results = []
         self._should_terminate = False
         self._termination_reason = None
+        self._apply_emergency_brake()
 
         start_time = time.time()
         checkpoints_created = 0
@@ -413,8 +417,8 @@ class WorkflowEngine:
                     self._execute_workflow(definition, context),
                     timeout=self._config.total_timeout_seconds,
                 )
-                success = all(r.success for r in self._results)
-                error = None
+                success = not self._should_terminate and all(r.success for r in self._results)
+                error = self._termination_reason if self._should_terminate else None
 
             except asyncio.TimeoutError:
                 logger.error(
@@ -554,6 +558,8 @@ class WorkflowEngine:
         # Reset execution state
         self._results = []
         self._should_terminate = False
+        self._termination_reason = None
+        self._apply_emergency_brake()
 
         start_time = time.time()
 
@@ -568,8 +574,8 @@ class WorkflowEngine:
                 ),
                 timeout=self._config.total_timeout_seconds,
             )
-            success = all(r.success for r in self._results)
-            error = None
+            success = not self._should_terminate and all(r.success for r in self._results)
+            error = self._termination_reason if self._should_terminate else None
 
         except asyncio.TimeoutError:
             success = False
@@ -648,6 +654,10 @@ class WorkflowEngine:
         self._timeout_warnings_issued = set()
 
         while current_step_id and not self._should_terminate:
+            self._apply_emergency_brake()
+            if self._should_terminate:
+                break
+
             # Check for progressive timeout warnings
             self._check_timeout_progress(
                 workflow_start_time,
@@ -1129,12 +1139,29 @@ class WorkflowEngine:
         self._termination_reason = reason
         logger.info("Workflow termination requested: %s", reason)
 
-    def pause_all(self, reason: str = "Emergency brake") -> None:
-        """Stop active workflow execution through the emergency-brake API."""
-        self.request_termination(reason)
+    @classmethod
+    def pause_all(cls, reason: str = "Emergency brake") -> None:
+        """Latch the emergency brake for every workflow engine instance."""
+        WorkflowEngine._emergency_brake_reason = reason
+        logger.critical("workflow_emergency_brake_activated", reason=reason)
+
+    @classmethod
+    def reset_emergency_brake(cls) -> None:
+        """Clear the process-wide emergency brake."""
+        WorkflowEngine._emergency_brake_reason = None
+        logger.warning("Workflow emergency brake reset")
+
+    def _apply_emergency_brake(self) -> None:
+        """Apply the process-wide brake to this engine's execution state."""
+        reason = WorkflowEngine._emergency_brake_reason
+        if reason is not None and (
+            not self._should_terminate or self._termination_reason != reason
+        ):
+            self.request_termination(reason)
 
     def check_termination(self) -> tuple[bool, str | None]:
         """Check if termination has been requested."""
+        self._apply_emergency_brake()
         return self._should_terminate, self._termination_reason
 
     @property
@@ -1196,6 +1223,7 @@ def reset_workflow_engine() -> None:
     """Reset the global WorkflowEngine singleton (for testing)."""
     global _workflow_engine_instance
     _workflow_engine_instance = None
+    WorkflowEngine.reset_emergency_brake()
 
 
 # Backward-compatible alias

--- a/aragora/workflow/engine.py
+++ b/aragora/workflow/engine.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import threading
 import time
 import uuid
+import weakref
 from datetime import datetime, timezone
 from typing import Any, ClassVar
 from collections.abc import Callable
@@ -79,7 +81,8 @@ class WorkflowEngine:
         result = await engine.resume(workflow_id, checkpoint)
     """
 
-    _emergency_brake_reason: ClassVar[str | None] = None
+    _instances: ClassVar[weakref.WeakSet[WorkflowEngine]] = weakref.WeakSet()
+    _instances_lock: ClassVar[threading.RLock] = threading.RLock()
 
     def __init__(
         self,
@@ -101,7 +104,8 @@ class WorkflowEngine:
         self._should_terminate: bool = False
         self._termination_reason: str | None = None
         self._results: list[StepResult] = []
-        self._apply_emergency_brake()
+        with WorkflowEngine._instances_lock:
+            WorkflowEngine._instances.add(self)
 
         # Checkpoint storage - use provided store or fall back to file-based
         self._checkpoint_store: CheckpointStore = checkpoint_store or get_checkpoint_store()
@@ -398,7 +402,6 @@ class WorkflowEngine:
         self._results = []
         self._should_terminate = False
         self._termination_reason = None
-        self._apply_emergency_brake()
 
         start_time = time.time()
         checkpoints_created = 0
@@ -417,8 +420,8 @@ class WorkflowEngine:
                     self._execute_workflow(definition, context),
                     timeout=self._config.total_timeout_seconds,
                 )
-                success = not self._should_terminate and all(r.success for r in self._results)
-                error = self._termination_reason if self._should_terminate else None
+                success = all(r.success for r in self._results)
+                error = None
 
             except asyncio.TimeoutError:
                 logger.error(
@@ -559,7 +562,6 @@ class WorkflowEngine:
         self._results = []
         self._should_terminate = False
         self._termination_reason = None
-        self._apply_emergency_brake()
 
         start_time = time.time()
 
@@ -574,8 +576,8 @@ class WorkflowEngine:
                 ),
                 timeout=self._config.total_timeout_seconds,
             )
-            success = not self._should_terminate and all(r.success for r in self._results)
-            error = self._termination_reason if self._should_terminate else None
+            success = all(r.success for r in self._results)
+            error = None
 
         except asyncio.TimeoutError:
             success = False
@@ -654,10 +656,6 @@ class WorkflowEngine:
         self._timeout_warnings_issued = set()
 
         while current_step_id and not self._should_terminate:
-            self._apply_emergency_brake()
-            if self._should_terminate:
-                break
-
             # Check for progressive timeout warnings
             self._check_timeout_progress(
                 workflow_start_time,
@@ -1141,27 +1139,15 @@ class WorkflowEngine:
 
     @classmethod
     def pause_all(cls, reason: str = "Emergency brake") -> None:
-        """Latch the emergency brake for every workflow engine instance."""
-        WorkflowEngine._emergency_brake_reason = reason
-        logger.critical("workflow_emergency_brake_activated", reason=reason)
-
-    @classmethod
-    def reset_emergency_brake(cls) -> None:
-        """Clear the process-wide emergency brake."""
-        WorkflowEngine._emergency_brake_reason = None
-        logger.warning("Workflow emergency brake reset")
-
-    def _apply_emergency_brake(self) -> None:
-        """Apply the process-wide brake to this engine's execution state."""
-        reason = WorkflowEngine._emergency_brake_reason
-        if reason is not None and (
-            not self._should_terminate or self._termination_reason != reason
-        ):
-            self.request_termination(reason)
+        """Request termination on every live workflow engine instance."""
+        with WorkflowEngine._instances_lock:
+            engines = list(WorkflowEngine._instances)
+        for engine in engines:
+            engine.request_termination(reason)
+        logger.critical("Workflow emergency brake activated: " + reason)
 
     def check_termination(self) -> tuple[bool, str | None]:
         """Check if termination has been requested."""
-        self._apply_emergency_brake()
         return self._should_terminate, self._termination_reason
 
     @property
@@ -1223,7 +1209,6 @@ def reset_workflow_engine() -> None:
     """Reset the global WorkflowEngine singleton (for testing)."""
     global _workflow_engine_instance
     _workflow_engine_instance = None
-    WorkflowEngine.reset_emergency_brake()
 
 
 # Backward-compatible alias

--- a/aragora/workflow/engine_v2.py
+++ b/aragora/workflow/engine_v2.py
@@ -301,7 +301,6 @@ class EnhancedWorkflowEngine(WorkflowEngine):
         self._results = []
         self._should_terminate = False
         self._termination_reason = None
-        self._apply_emergency_brake()
 
         limits_exceeded = False
         limit_exceeded_type = None
@@ -312,8 +311,8 @@ class EnhancedWorkflowEngine(WorkflowEngine):
                 self._execute_workflow_enhanced(definition, context),
                 timeout=self._limits.timeout_seconds,
             )
-            success = not self._should_terminate and all(r.success for r in self._results)
-            error = self._termination_reason if self._should_terminate else None
+            success = all(r.success for r in self._results)
+            error = None
 
         except asyncio.TimeoutError:
             logger.error("Workflow timed out after %ss", self._limits.timeout_seconds)
@@ -410,10 +409,6 @@ class EnhancedWorkflowEngine(WorkflowEngine):
         step_count = 0
 
         while current_step_id and not self._should_terminate:
-            self._apply_emergency_brake()
-            if self._should_terminate:
-                break
-
             # Check resource limits before each step
             self._check_limits()
 

--- a/aragora/workflow/engine_v2.py
+++ b/aragora/workflow/engine_v2.py
@@ -301,6 +301,7 @@ class EnhancedWorkflowEngine(WorkflowEngine):
         self._results = []
         self._should_terminate = False
         self._termination_reason = None
+        self._apply_emergency_brake()
 
         limits_exceeded = False
         limit_exceeded_type = None
@@ -311,8 +312,8 @@ class EnhancedWorkflowEngine(WorkflowEngine):
                 self._execute_workflow_enhanced(definition, context),
                 timeout=self._limits.timeout_seconds,
             )
-            success = all(r.success for r in self._results)
-            error = None
+            success = not self._should_terminate and all(r.success for r in self._results)
+            error = self._termination_reason if self._should_terminate else None
 
         except asyncio.TimeoutError:
             logger.error("Workflow timed out after %ss", self._limits.timeout_seconds)
@@ -409,6 +410,10 @@ class EnhancedWorkflowEngine(WorkflowEngine):
         step_count = 0
 
         while current_step_id and not self._should_terminate:
+            self._apply_emergency_brake()
+            if self._should_terminate:
+                break
+
             # Check resource limits before each step
             self._check_limits()
 

--- a/aragora/workflow/event_subscribers.py
+++ b/aragora/workflow/event_subscribers.py
@@ -218,22 +218,25 @@ class WorkflowEventSubscriber:
         """
         self.post_debate_workflow.handle_debate_end(event)
 
-    def _handle_alert_escalated_to_workflow_brake(self, event: "StreamEvent") -> None:
+    def _handle_alert_escalated_to_workflow_brake(self, event: "StreamEvent") -> bool:
         """Alert escalated → Workflow emergency brake.
 
         When an alert escalates to critical severity, pause all
         active workflows to prevent cascading failures. This is
         the safety valve that stops automated processes when
         something goes seriously wrong.
+
+        Returns:
+            True only when the workflow engine confirms a brake method ran.
         """
         data = event.data
-        severity = data.get("severity", data.get("new_severity", ""))
+        severity = data.get("new_severity", data.get("severity", ""))
         alert_id = data.get("alert_id", "")
         reason = data.get("reason", data.get("message", ""))[:200]
 
         # Only brake on critical/emergency escalations
         if severity not in ("critical", "emergency", "fatal"):
-            return
+            return False
 
         logger.warning(
             "Alert escalated → workflow brake: alert=%s severity=%s reason=%s",
@@ -247,20 +250,25 @@ class WorkflowEventSubscriber:
 
             engine = get_workflow_engine()
             if engine is None:
-                return
+                return False
 
             if hasattr(engine, "pause_all"):
                 engine.pause_all(
                     reason=f"Emergency brake: {reason}",
                 )
                 logger.warning("Paused all workflows due to critical alert %s", alert_id)
+                return True
             elif hasattr(engine, "emergency_stop"):
                 engine.emergency_stop(reason=f"Alert escalation: {reason}")
                 logger.warning("Emergency stopped workflows due to critical alert %s", alert_id)
+                return True
         except ImportError:
-            pass  # Workflow engine not available
+            return False
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
             logger.debug("Workflow emergency brake failed: %s", e)
+            return False
+
+        return False
 
     def register(self, manager: "CrossSubscriberManager") -> None:
         """Wire the workflow-domain reactions into ``manager`` (keyed/idempotent).

--- a/aragora/workflow/event_subscribers.py
+++ b/aragora/workflow/event_subscribers.py
@@ -232,7 +232,7 @@ class WorkflowEventSubscriber:
         data = event.data
         severity = data.get("new_severity", data.get("severity", ""))
         alert_id = data.get("alert_id", "")
-        reason = data.get("reason", data.get("message", ""))[:200]
+        reason = str(data.get("reason", data.get("message", "")) or "")[:200]
 
         # Only brake on critical/emergency escalations
         if severity not in ("critical", "emergency", "fatal"):
@@ -256,10 +256,8 @@ class WorkflowEventSubscriber:
         except ImportError:
             return False
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:
-            logger.debug("Workflow emergency brake failed: %s", e)
+            logger.error("Workflow emergency brake failed: %s", e, exc_info=True)
             return False
-
-        return False
 
     def register(self, manager: "CrossSubscriberManager") -> None:
         """Wire the workflow-domain reactions into ``manager`` (keyed/idempotent).

--- a/aragora/workflow/event_subscribers.py
+++ b/aragora/workflow/event_subscribers.py
@@ -246,22 +246,13 @@ class WorkflowEventSubscriber:
         )
 
         try:
-            from aragora.workflow.engine import get_workflow_engine
+            from aragora.workflow.engine import WorkflowEngine
 
-            engine = get_workflow_engine()
-            if engine is None:
-                return False
-
-            if hasattr(engine, "pause_all"):
-                engine.pause_all(
-                    reason=f"Emergency brake: {reason}",
-                )
-                logger.warning("Paused all workflows due to critical alert %s", alert_id)
-                return True
-            elif hasattr(engine, "emergency_stop"):
-                engine.emergency_stop(reason=f"Alert escalation: {reason}")
-                logger.warning("Emergency stopped workflows due to critical alert %s", alert_id)
-                return True
+            WorkflowEngine.pause_all(
+                reason=f"Emergency brake: {reason}",
+            )
+            logger.warning("Paused all workflows due to critical alert %s", alert_id)
+            return True
         except ImportError:
             return False
         except (RuntimeError, TypeError, AttributeError, ValueError) as e:

--- a/tests/events/test_cross_subscribers.py
+++ b/tests/events/test_cross_subscribers.py
@@ -123,6 +123,20 @@ class TestCrossSubscriberManager:
 
         handler.assert_not_called()
 
+    def test_required_dispatch_attempts_handler_with_open_circuit(self):
+        """Safety-critical dispatch must not suppress an attempt after prior failures."""
+        manager = CrossSubscriberManager(failure_threshold=1)
+        handler = MagicMock(return_value=True)
+        manager.register("required", StreamEventType.ALERT_ESCALATED, handler)
+        manager._circuit_breaker.record_failure("required")
+        assert manager._circuit_breaker.is_available("required") is False
+
+        event = make_stream_event(StreamEventType.ALERT_ESCALATED)
+        manager.dispatch_required(event, "required")
+
+        handler.assert_called_once_with(event)
+        assert manager._stats["required"].events_processed == 1
+
 
 class TestBuiltinHandlers:
     """Test built-in cross-subsystem handlers.

--- a/tests/events/test_strategic_handlers.py
+++ b/tests/events/test_strategic_handlers.py
@@ -400,9 +400,9 @@ class TestAlertEscalatedToWorkflowBrake:
                 "alert_id": "alert_1",
             },
         )
-        with patch("aragora.workflow.engine.get_workflow_engine") as mock_get:
+        with patch("aragora.workflow.engine.WorkflowEngine.pause_all") as pause_all:
             handler._handle_alert_escalated_to_workflow_brake(event)
-            mock_get.assert_not_called()
+            pause_all.assert_not_called()
 
     def test_pauses_workflows_on_critical(self, make_event):
         handler = self._get_handler()
@@ -415,14 +415,13 @@ class TestAlertEscalatedToWorkflowBrake:
             },
         )
 
-        mock_engine = MagicMock()
-        with patch("aragora.workflow.engine.get_workflow_engine", return_value=mock_engine):
+        with patch("aragora.workflow.engine.WorkflowEngine.pause_all") as pause_all:
             handler._handle_alert_escalated_to_workflow_brake(event)
-            mock_engine.pause_all.assert_called_once()
-            call_kwargs = mock_engine.pause_all.call_args[1]
+            pause_all.assert_called_once()
+            call_kwargs = pause_all.call_args[1]
             assert "Database connection pool" in call_kwargs["reason"]
 
-    def test_falls_back_to_emergency_stop(self, make_event):
+    def test_pauses_workflows_on_emergency(self, make_event):
         handler = self._get_handler()
         event = make_event(
             StreamEventType.ALERT_ESCALATED,
@@ -433,12 +432,9 @@ class TestAlertEscalatedToWorkflowBrake:
             },
         )
 
-        mock_engine = MagicMock(spec=[])
-        mock_engine.emergency_stop = MagicMock()
-        # Remove pause_all so fallback triggers
-        with patch("aragora.workflow.engine.get_workflow_engine", return_value=mock_engine):
+        with patch("aragora.workflow.engine.WorkflowEngine.pause_all") as pause_all:
             handler._handle_alert_escalated_to_workflow_brake(event)
-            mock_engine.emergency_stop.assert_called_once()
+            pause_all.assert_called_once()
 
     def test_graceful_on_import_error(self, make_event):
         handler = self._get_handler()

--- a/tests/server/stream/test_autonomous_stream.py
+++ b/tests/server/stream/test_autonomous_stream.py
@@ -621,13 +621,14 @@ class TestEmitAlertEvent:
         set_autonomous_emitter(emitter)
 
         async def check():
-            emit_alert_event(
-                event_type="escalated",
-                alert_id="alert-004",
-                severity="critical",
-                title="Escalated",
-                new_severity="critical",
-            )
+            with patch("aragora.workflow.engine.WorkflowEngine.pause_all"):
+                emit_alert_event(
+                    event_type="escalated",
+                    alert_id="alert-004",
+                    severity="critical",
+                    title="Escalated",
+                    new_severity="critical",
+                )
             await asyncio.sleep(0.1)
             event = emitter._event_history[0]
             assert event.type == StreamEventType.ALERT_ESCALATED
@@ -640,13 +641,14 @@ class TestEmitAlertEvent:
     ):
         """Critical production escalations brake once before broadcast."""
         delivery_order = []
-        engine = MagicMock(spec=["pause_all"])
-        engine.pause_all.side_effect = lambda **kwargs: delivery_order.append("brake")
         emitter = MagicMock(spec=AutonomousStreamEmitter)
         emitter.emit_sync.side_effect = lambda event: delivery_order.append("broadcast")
         set_autonomous_emitter(emitter)
 
-        with patch("aragora.workflow.engine.get_workflow_engine", return_value=engine):
+        with patch(
+            "aragora.workflow.engine.WorkflowEngine.pause_all",
+            side_effect=lambda **kwargs: delivery_order.append("brake"),
+        ) as pause_all:
             emit_alert_event(
                 event_type="escalated",
                 alert_id="alert-critical",
@@ -656,7 +658,7 @@ class TestEmitAlertEvent:
                 reason="Database connection pool exhausted",
             )
 
-        engine.pause_all.assert_called_once_with(
+        pause_all.assert_called_once_with(
             reason="Emergency brake: Database connection pool exhausted"
         )
         emitter.emit_sync.assert_called_once()

--- a/tests/server/stream/test_autonomous_stream.py
+++ b/tests/server/stream/test_autonomous_stream.py
@@ -90,6 +90,16 @@ def reset_global_emitter():
     module._autonomous_emitter = original
 
 
+@pytest.fixture
+def clean_cross_subscriber_manager():
+    """Provide isolated production cross-subscriber wiring."""
+    from aragora.events.cross_subscribers import reset_cross_subscriber_manager
+
+    reset_cross_subscriber_manager()
+    yield
+    reset_cross_subscriber_manager()
+
+
 # ===========================================================================
 # Test AutonomousStreamClient
 # ===========================================================================
@@ -623,6 +633,88 @@ class TestEmitAlertEvent:
             assert event.type == StreamEventType.ALERT_ESCALATED
 
         asyncio.run(check())
+
+    def test_emit_alert_escalated_reaches_workflow_brake_exactly_once(
+        self,
+        clean_cross_subscriber_manager,
+    ):
+        """Critical production escalations brake once before broadcast."""
+        delivery_order = []
+        engine = MagicMock(spec=["pause_all"])
+        engine.pause_all.side_effect = lambda **kwargs: delivery_order.append("brake")
+        emitter = MagicMock(spec=AutonomousStreamEmitter)
+        emitter.emit_sync.side_effect = lambda event: delivery_order.append("broadcast")
+        set_autonomous_emitter(emitter)
+
+        with patch("aragora.workflow.engine.get_workflow_engine", return_value=engine):
+            emit_alert_event(
+                event_type="escalated",
+                alert_id="alert-critical",
+                severity="high",
+                title="Critical production alert",
+                new_severity="critical",
+                reason="Database connection pool exhausted",
+            )
+
+        engine.pause_all.assert_called_once_with(
+            reason="Emergency brake: Database connection pool exhausted"
+        )
+        emitter.emit_sync.assert_called_once()
+        event = emitter.emit_sync.call_args.args[0]
+        assert event.type == StreamEventType.ALERT_ESCALATED
+        assert event.data == {
+            "alert_id": "alert-critical",
+            "severity": "high",
+            "title": "Critical production alert",
+            "new_severity": "critical",
+            "reason": "Database connection pool exhausted",
+        }
+        assert delivery_order == ["brake", "broadcast"]
+
+    def test_emit_alert_escalated_noncritical_preserves_broadcast_behavior(self):
+        """Noncritical escalation remains a broadcast-only alert event."""
+        emitter = MagicMock(spec=AutonomousStreamEmitter)
+        set_autonomous_emitter(emitter)
+
+        with patch(
+            "aragora.server.startup.event_subscribers.bootstrap_event_subscribers"
+        ) as bootstrap:
+            emit_alert_event(
+                event_type="escalated",
+                alert_id="alert-warning",
+                severity="warning",
+                title="Warning escalation",
+            )
+
+        bootstrap.assert_not_called()
+        emitter.emit_sync.assert_called_once()
+        assert emitter.emit_sync.call_args.args[0].type == StreamEventType.ALERT_ESCALATED
+
+    def test_emit_alert_escalated_fails_closed_without_production_wiring(
+        self,
+        clean_cross_subscriber_manager,
+    ):
+        """Critical escalation cannot broadcast without its production brake wiring."""
+        from aragora.events.cross_subscribers import CrossSubscriberManager
+
+        emitter = MagicMock(spec=AutonomousStreamEmitter)
+        set_autonomous_emitter(emitter)
+
+        with (
+            patch(
+                "aragora.server.startup.event_subscribers.bootstrap_event_subscribers",
+                return_value=CrossSubscriberManager(),
+            ),
+            pytest.raises(RuntimeError, match="alert_escalated_to_workflow_brake"),
+        ):
+            emit_alert_event(
+                event_type="escalated",
+                alert_id="alert-unwired",
+                severity="critical",
+                title="Unwired production alert",
+            )
+
+        emitter.emit_sync.assert_not_called()
 
 
 class TestEmitTriggerEvent:

--- a/tests/workflow/test_engine_v3.py
+++ b/tests/workflow/test_engine_v3.py
@@ -632,29 +632,46 @@ class TestTerminationControl:
         assert reason == "done"
 
     @pytest.mark.asyncio
-    async def test_pause_all_latches_across_engine_instances(
+    async def test_pause_all_stops_all_live_engine_instances(
         self,
         engine: WorkflowEngine,
-        simple_def: WorkflowDefinition,
     ):
-        """The emergency brake should stop existing and future engine instances."""
+        """The emergency brake should stop every currently executing engine."""
         reset_workflow_engine()
-        other_engine = WorkflowEngine(checkpoint_store=MagicMock())
+        other_engine = WorkflowEngine(
+            config=WorkflowConfig(enable_checkpointing=False),
+            step_registry={"slow": SlowStep, "echo": EchoStep},
+            checkpoint_store=MagicMock(),
+        )
+        workflow = WorkflowDefinition(
+            id="wf-brake",
+            name="Brake",
+            steps=[
+                StepDefinition(
+                    id="s1",
+                    name="Slow",
+                    step_type="slow",
+                    config={"delay": 0.05},
+                    next_steps=["s2"],
+                ),
+                StepDefinition(id="s2", name="Should Not Run", step_type="echo"),
+            ],
+            entry_step="s1",
+        )
 
         try:
+            tasks = [
+                asyncio.create_task(engine.execute(workflow)),
+                asyncio.create_task(other_engine.execute(workflow)),
+            ]
+            await asyncio.sleep(0.01)
             WorkflowEngine.pause_all("Critical alert")
+            results = await asyncio.gather(*tasks)
 
             assert engine.check_termination() == (True, "Critical alert")
             assert other_engine.check_termination() == (True, "Critical alert")
-            assert WorkflowEngine(checkpoint_store=MagicMock()).check_termination() == (
-                True,
-                "Critical alert",
-            )
-
-            result = await engine.execute(simple_def)
-            assert result.success is False
-            assert result.steps == []
-            assert result.error == "Critical alert"
+            assert all([step.step_id for step in result.steps] == ["s1"] for result in results)
+            assert WorkflowEngine(checkpoint_store=MagicMock()).check_termination() == (False, None)
         finally:
             reset_workflow_engine()
 

--- a/tests/workflow/test_engine_v3.py
+++ b/tests/workflow/test_engine_v3.py
@@ -631,6 +631,33 @@ class TestTerminationControl:
         assert terminated is True
         assert reason == "done"
 
+    @pytest.mark.asyncio
+    async def test_pause_all_latches_across_engine_instances(
+        self,
+        engine: WorkflowEngine,
+        simple_def: WorkflowDefinition,
+    ):
+        """The emergency brake should stop existing and future engine instances."""
+        reset_workflow_engine()
+        other_engine = WorkflowEngine(checkpoint_store=MagicMock())
+
+        try:
+            WorkflowEngine.pause_all("Critical alert")
+
+            assert engine.check_termination() == (True, "Critical alert")
+            assert other_engine.check_termination() == (True, "Critical alert")
+            assert WorkflowEngine(checkpoint_store=MagicMock()).check_termination() == (
+                True,
+                "Critical alert",
+            )
+
+            result = await engine.execute(simple_def)
+            assert result.success is False
+            assert result.steps == []
+            assert result.error == "Critical alert"
+        finally:
+            reset_workflow_engine()
+
 
 # ---------------------------------------------------------------------------
 # Metrics

--- a/tests/workflow/test_event_subscribers.py
+++ b/tests/workflow/test_event_subscribers.py
@@ -92,10 +92,9 @@ class TestWorkflowEventSubscriberHandlers:
             StreamEventType.ALERT_ESCALATED,
             data={"severity": "critical", "alert_id": "alert_2", "reason": "test reason"},
         )
-        mock_engine = MagicMock()
-        with patch("aragora.workflow.engine.get_workflow_engine", return_value=mock_engine):
+        with patch("aragora.workflow.engine.WorkflowEngine.pause_all") as pause_all:
             subscriber._handle_alert_escalated_to_workflow_brake(event)
-        mock_engine.pause_all.assert_called_once()
+        pause_all.assert_called_once()
 
 
 class TestWorkflowEventSubscriberRegistration:

--- a/tests/workflow/test_event_subscribers.py
+++ b/tests/workflow/test_event_subscribers.py
@@ -96,6 +96,18 @@ class TestWorkflowEventSubscriberHandlers:
             subscriber._handle_alert_escalated_to_workflow_brake(event)
         pause_all.assert_called_once()
 
+    def test_alert_escalated_to_workflow_brake_handles_none_reason(self):
+        subscriber = WorkflowEventSubscriber()
+        event = make_stream_event(
+            StreamEventType.ALERT_ESCALATED,
+            data={"severity": "critical", "alert_id": "alert_3", "reason": None},
+        )
+        with patch("aragora.workflow.engine.WorkflowEngine.pause_all") as pause_all:
+            delivered = subscriber._handle_alert_escalated_to_workflow_brake(event)
+
+        assert delivered is True
+        pause_all.assert_called_once_with(reason="Emergency brake: ")
+
 
 class TestWorkflowEventSubscriberRegistration:
     """Registration + self-registration surface tests."""


### PR DESCRIPTION
## Summary

- route critical `emit_alert_event(event_type=\"escalated\")` calls through the production superset subscriber bootstrap before WebSocket broadcast
- add strict named cross-subscriber delivery that invokes one registered brake handler once, without sampling, retries, or circuit-breaker suppression, and requires explicit success confirmation
- track live base and enhanced workflow engines process-wide so `WorkflowEngine.pause_all()` requests termination exactly once on every live instance without latching future executions
- preserve broadcast-only behavior for noncritical escalations and all non-escalated alert helpers

## Contract

Implements mission feature `p4a-alert-escalated-workflow-brake` and `VAL-P4A-016`.

The production helper now fails closed when the workflow-brake wiring is missing, duplicated, disabled, filtered, sampled, throwing, or unable to confirm delivery. Broadcast occurs only after confirmed brake delivery. Prior circuit state never suppresses the required attempt, while outcomes and metrics remain recorded.

## Verification

- exact `VAL-P4A-016` production-helper regressions: 2 passed
- focused production alert/wiring suites: 168 passed
- workflow engine regression suites: 255 passed
- open-circuit required-delivery regression: passed
- concurrent live base/enhanced engine brake regression: passed
- changed-file mypy: success
- changed-file `ruff check`: pass
- changed-file `ruff format --check`: pass
- code-quality ratchet: pass (900/900 `except Exception`)
- alert brake import and multi-instance runtime canaries: pass
- `make test-smoke`: pass
- pre-commit and pre-push hooks: pass
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass
- exact-head Claude and OpenAI model quorum on `9643f5e`: pass

## Invariants preserved

- alert event payload shape and `StreamEventType.ALERT_ESCALATED` WebSocket delivery
- non-escalated alert behavior
- noncritical escalation broadcast behavior
- ordinary cross-subscriber sampling, retry, filtering, circuit-breaker, and fail-soft semantics
- existing dispatch metrics, latency statistics, circuit-breaker metrics, and SLO recording
- E5 post-debate registration and dispatch behavior
- future workflow executions after a point-in-time emergency brake

## Risk and non-goals

Tier 1 bounded behavior repair. This PR does not change E5 registration, live merge-gate logic, scheduler admission control, or general workflow concurrency semantics.