### PR TITLE
fix(observability): canonicalize active debate gauge

### DIFF
--- a/aragora/observability/alerting.py
+++ b/aragora/observability/alerting.py
@@ -629,11 +629,9 @@ class MetricsCollector:
     async def _collect_debate_metrics(self, snapshot: MetricsSnapshot) -> None:
         """Collect debate-related metrics."""
         try:
-            from aragora.observability.metrics.debate import ACTIVE_DEBATES
+            from aragora.observability.server_metrics import ACTIVE_DEBATES
 
-            if ACTIVE_DEBATES is not None:
-                # Prometheus Gauge value
-                snapshot.active_debates = int(ACTIVE_DEBATES._value.get())
+            snapshot.active_debates = int(ACTIVE_DEBATES.get())
         except (ImportError, AttributeError):
             pass
 

--- a/aragora/observability/metrics/debate.py
+++ b/aragora/observability/metrics/debate.py
@@ -8,6 +8,7 @@ performance monitoring, phases, and consensus outcomes.
 from __future__ import annotations
 
 import logging
+from threading import Lock
 import time
 from contextlib import contextmanager
 from typing import Any
@@ -34,6 +35,7 @@ DEBATE_EARLY_TERMINATION_TOTAL: Any = None
 DEBATE_STABILITY_SCORE: Any = None
 
 _initialized = False
+_active_debates_collector_lock = Lock()
 
 
 class _ActiveDebatesCollector:
@@ -54,12 +56,13 @@ class _ActiveDebatesCollector:
 
 def _ensure_active_debates_collector(registry: Any) -> None:
     """Register one read-only Prometheus view of the canonical gauge."""
-    existing = registry._names_to_collectors.get(_CANONICAL_ACTIVE_DEBATES.name)
-    if getattr(existing, "_canonical_gauge", None) is _CANONICAL_ACTIVE_DEBATES:
-        return
-    if existing is not None:
-        registry.unregister(existing)
-    registry.register(_ActiveDebatesCollector())
+    with _active_debates_collector_lock:
+        existing = registry._names_to_collectors.get(_CANONICAL_ACTIVE_DEBATES.name)
+        if getattr(existing, "_canonical_gauge", None) is _CANONICAL_ACTIVE_DEBATES:
+            return
+        if existing is not None:
+            registry.unregister(existing)
+        registry.register(_ActiveDebatesCollector())
 
 
 def init_debate_metrics() -> None:

--- a/aragora/observability/metrics/debate.py
+++ b/aragora/observability/metrics/debate.py
@@ -14,6 +14,9 @@ from typing import Any
 from collections.abc import Generator
 
 from aragora.observability.metrics.base import NoOpMetric, get_metrics_enabled
+from aragora.observability.server_metrics.api import (
+    ACTIVE_DEBATES as _CANONICAL_ACTIVE_DEBATES,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +28,38 @@ AGENT_PARTICIPATION: Any = None
 SLOW_DEBATES_TOTAL: Any = None
 SLOW_ROUNDS_TOTAL: Any = None
 DEBATE_ROUND_LATENCY: Any = None
-ACTIVE_DEBATES: Any = None
+ACTIVE_DEBATES: Any = _CANONICAL_ACTIVE_DEBATES
 CONSENSUS_RATE: Any = None
 DEBATE_EARLY_TERMINATION_TOTAL: Any = None
 DEBATE_STABILITY_SCORE: Any = None
 
 _initialized = False
+
+
+class _ActiveDebatesCollector:
+    """Prometheus adapter that reads the canonical active-debates gauge."""
+
+    _canonical_gauge = _CANONICAL_ACTIVE_DEBATES
+
+    def collect(self) -> Generator[Any, None, None]:
+        from prometheus_client.core import GaugeMetricFamily
+
+        metric = GaugeMetricFamily(
+            _CANONICAL_ACTIVE_DEBATES.name,
+            _CANONICAL_ACTIVE_DEBATES.help,
+        )
+        metric.add_metric([], _CANONICAL_ACTIVE_DEBATES.get())
+        yield metric
+
+
+def _ensure_active_debates_collector(registry: Any) -> None:
+    """Register one read-only Prometheus view of the canonical gauge."""
+    existing = registry._names_to_collectors.get(_CANONICAL_ACTIVE_DEBATES.name)
+    if getattr(existing, "_canonical_gauge", None) is _CANONICAL_ACTIVE_DEBATES:
+        return
+    if existing is not None:
+        registry.unregister(existing)
+    registry.register(_ActiveDebatesCollector())
 
 
 def init_debate_metrics() -> None:
@@ -130,10 +159,8 @@ def init_debate_metrics() -> None:
             [0.5, 1, 2, 5, 10, 20, 30, 60],
         )
 
-        ACTIVE_DEBATES = _get_or_create_gauge(
-            "aragora_active_debates",
-            "Number of currently active debates",
-        )
+        ACTIVE_DEBATES = _CANONICAL_ACTIVE_DEBATES
+        _ensure_active_debates_collector(REGISTRY)
 
         CONSENSUS_RATE = _get_or_create_gauge(
             "aragora_consensus_rate",
@@ -175,7 +202,7 @@ def _init_noop_metrics() -> None:
     SLOW_DEBATES_TOTAL = NoOpMetric()
     SLOW_ROUNDS_TOTAL = NoOpMetric()
     DEBATE_ROUND_LATENCY = NoOpMetric()
-    ACTIVE_DEBATES = NoOpMetric()
+    ACTIVE_DEBATES = _CANONICAL_ACTIVE_DEBATES
     CONSENSUS_RATE = NoOpMetric()
     DEBATE_EARLY_TERMINATION_TOTAL = NoOpMetric()
     DEBATE_STABILITY_SCORE = NoOpMetric()

--- a/aragora/observability/server_metrics/api.py
+++ b/aragora/observability/server_metrics/api.py
@@ -38,6 +38,7 @@ ACTIVE_DEBATES = Gauge(
     help="Currently running debates",
     label_names=[],
 )
+ACTIVE_DEBATES.set(0)
 
 WEBSOCKET_CONNECTIONS = Gauge(
     name="aragora_websocket_connections",

--- a/aragora/observability/server_metrics/export.py
+++ b/aragora/observability/server_metrics/export.py
@@ -195,6 +195,15 @@ def generate_metrics() -> str:
         from prometheus_client import REGISTRY, generate_latest
 
         observability_metrics = generate_latest(REGISTRY).decode("utf-8")
+        observability_metrics = "\n".join(
+            line
+            for line in observability_metrics.splitlines()
+            if not (
+                line.startswith("# HELP aragora_active_debates ")
+                or line == "# TYPE aragora_active_debates gauge"
+                or line.startswith("aragora_active_debates ")
+            )
+        )
         if observability_metrics.strip():
             lines.append("# Observability metrics (from prometheus_client)")
             lines.append(observability_metrics)

--- a/aragora/observability/server_metrics/export.py
+++ b/aragora/observability/server_metrics/export.py
@@ -195,13 +195,14 @@ def generate_metrics() -> str:
         from prometheus_client import REGISTRY, generate_latest
 
         observability_metrics = generate_latest(REGISTRY).decode("utf-8")
-        observability_metrics = "\n".join(
+        observability_metrics = "".join(
             line
-            for line in observability_metrics.splitlines()
+            for line in observability_metrics.splitlines(keepends=True)
             if not (
                 line.startswith("# HELP aragora_active_debates ")
-                or line == "# TYPE aragora_active_debates gauge"
+                or line.startswith("# TYPE aragora_active_debates ")
                 or line.startswith("aragora_active_debates ")
+                or line.startswith("aragora_active_debates{")
             )
         )
         if observability_metrics.strip():

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -93,3 +93,10 @@ def _cleanup() -> None:
         mod = sys.modules.get(mod_name)
         if mod and hasattr(mod, "_initialized"):
             mod._initialized = False
+
+    try:
+        from aragora.observability.server_metrics import ACTIVE_DEBATES
+
+        ACTIVE_DEBATES.set(0)
+    except ImportError:
+        pass

--- a/tests/observability/test_active_debates_canonical.py
+++ b/tests/observability/test_active_debates_canonical.py
@@ -1,0 +1,97 @@
+"""Regression tests for the canonical active-debates metric state."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import aragora.observability.metrics as public_metrics
+from aragora.observability.alerting import MetricsCollector, MetricsSnapshot
+from aragora.observability.metrics import debate as debate_metrics
+from aragora.observability.server_metrics import (
+    ACTIVE_DEBATES as CANONICAL_ACTIVE_DEBATES,
+    generate_metrics,
+    track_debate_execution,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_active_debates() -> None:
+    """Keep the process-global gauge isolated between focused tests."""
+    CANONICAL_ACTIVE_DEBATES.set(0)
+    yield
+    CANONICAL_ACTIVE_DEBATES.set(0)
+
+
+def _exported_active_debate_values() -> list[float]:
+    return [
+        float(line.split()[-1])
+        for line in generate_metrics().splitlines()
+        if line.startswith("aragora_active_debates ")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_alerting_and_export_share_canonical_state() -> None:
+    """Lifecycle, alert collection, and public exports observe one count."""
+    debate_metrics.init_debate_metrics()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from aragora.server.metrics import ACTIVE_DEBATES as legacy_active_debates
+
+    assert debate_metrics.ACTIVE_DEBATES is CANONICAL_ACTIVE_DEBATES
+    assert public_metrics.ACTIVE_DEBATES is CANONICAL_ACTIVE_DEBATES
+    assert legacy_active_debates is CANONICAL_ACTIVE_DEBATES
+
+    collector = MetricsCollector()
+    before = MetricsSnapshot()
+    await collector._collect_debate_metrics(before)
+    assert before.active_debates == 0
+    assert _exported_active_debate_values() == [0.0]
+
+    with track_debate_execution():
+        assert CANONICAL_ACTIVE_DEBATES.get() == 1
+        assert public_metrics.ACTIVE_DEBATES.get() == 1
+
+        active = MetricsSnapshot()
+        await collector._collect_debate_metrics(active)
+        assert active.active_debates == 1
+        assert _exported_active_debate_values() == [1.0]
+
+    after = MetricsSnapshot()
+    await collector._collect_debate_metrics(after)
+    assert after.active_debates == 0
+    assert _exported_active_debate_values() == [0.0]
+
+
+def test_observability_initialization_registers_single_collector() -> None:
+    """Initializing compatibility namespaces never duplicates the collector."""
+    from prometheus_client import Gauge as PrometheusGauge
+    from prometheus_client import REGISTRY, generate_latest
+
+    stale_collector = PrometheusGauge(
+        "aragora_active_debates",
+        "Stale active debate storage",
+    )
+    stale_collector.set(11)
+    debate_metrics.init_debate_metrics()
+    public_metrics._refresh_exports()
+    debate_metrics.init_debate_metrics()
+
+    active_collectors = {
+        collector
+        for name, collector in REGISTRY._names_to_collectors.items()
+        if name == "aragora_active_debates"
+    }
+    assert len(active_collectors) == 1
+    assert stale_collector not in active_collectors
+
+    CANONICAL_ACTIVE_DEBATES.set(3)
+    samples = [
+        float(line.split()[-1])
+        for line in generate_latest(REGISTRY).decode("utf-8").splitlines()
+        if line.startswith("aragora_active_debates ")
+    ]
+    assert samples == [3.0]

--- a/tests/observability/test_active_debates_canonical.py
+++ b/tests/observability/test_active_debates_canonical.py
@@ -72,6 +72,7 @@ def test_observability_initialization_registers_single_collector(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Initializing compatibility namespaces never duplicates the collector."""
+    pytest.importorskip("prometheus_client")
     from prometheus_client import Gauge as PrometheusGauge
     from prometheus_client import REGISTRY, generate_latest
 

--- a/tests/observability/test_active_debates_canonical.py
+++ b/tests/observability/test_active_debates_canonical.py
@@ -25,9 +25,11 @@ def reset_active_debates() -> None:
 
 
 def _exported_active_debate_values() -> list[float]:
+    exposition = generate_metrics()
+    assert exposition.endswith("\n")
     return [
         float(line.split()[-1])
-        for line in generate_metrics().splitlines()
+        for line in exposition.splitlines()
         if line.startswith("aragora_active_debates ")
     ]
 
@@ -66,11 +68,14 @@ async def test_lifecycle_alerting_and_export_share_canonical_state() -> None:
     assert _exported_active_debate_values() == [0.0]
 
 
-def test_observability_initialization_registers_single_collector() -> None:
+def test_observability_initialization_registers_single_collector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Initializing compatibility namespaces never duplicates the collector."""
     from prometheus_client import Gauge as PrometheusGauge
     from prometheus_client import REGISTRY, generate_latest
 
+    monkeypatch.setattr(debate_metrics, "get_metrics_enabled", lambda: True)
     stale_collector = PrometheusGauge(
         "aragora_active_debates",
         "Stale active debate storage",


### PR DESCRIPTION
## Source

- Structural Excellence feature `p4a-active-debates-canonical-state`
- Fulfills `VAL-P4A-018`

## Behavior

- Uses `aragora.observability.server_metrics.ACTIVE_DEBATES` as the only stored active-debate count.
- Keeps `aragora.observability.metrics`, `aragora.observability.metrics.debate`, and deprecated `aragora.server.metrics` compatibility shapes on the same gauge object.
- Exposes one read-only Prometheus collector backed by that canonical gauge and reconciles a stale same-name collector without creating duplicate storage.
- Makes `MetricsCollector._collect_debate_metrics` read the canonical gauge through its public `get()` method.
- Preserves one `aragora_active_debates` family and a valid terminal newline in the combined server metrics export.
- Serializes canonical collector reconciliation and resets canonical state in observability test cleanup.
- Intentionally excludes the separate observability provider inversion.

## Validation

- Focused canonical tests, normal and `ARAGORA_OFFLINE=1` -> 2 passed in each mode
- No-op cleanup ordering regression -> 3 passed
- Expanded related suite under seeds 1, 42, 100, 2024, 12345 -> 309 passed per seed
- `make lint` -> passed
- Changed-file Ruff and formatting -> passed
- Changed-file mypy -> no issues in 4 source files
- Differential typecheck -> PASS, new=104 <= 108 ambient threshold
- `make test-smoke` -> Core/Server/Memory imports passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- `python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure` -> no new violations
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk

Tier 2 observability-internal change. The compatibility import paths and metric name remain stable; the Prometheus adapter is read-only, mirrors the canonical lifecycle state, and has exact lifecycle/export/alerting coverage.