### PR TITLE
fix(observability): register layered metric providers

### DIFF
--- a/aragora/nomic/metrics.py
+++ b/aragora/nomic/metrics.py
@@ -27,9 +27,11 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from aragora.server.metrics import Counter, Gauge, Histogram
+from aragora.observability.server_metrics import Counter, Gauge, Histogram
 
 if TYPE_CHECKING:
+    from aragora.observability.server_metrics.export import NomicMetricCollection
+
     from .events import Event
     from .states import NomicState
 
@@ -355,6 +357,42 @@ def check_stuck_phases(
     return stuck_info
 
 
+def get_prometheus_metrics() -> NomicMetricCollection:
+    """Return the live Nomic metric objects through the observability contract."""
+    from aragora.observability.server_metrics.export import NomicMetricCollection
+
+    return NomicMetricCollection(
+        counters=(
+            NOMIC_PHASE_TRANSITIONS,
+            NOMIC_CYCLES_TOTAL,
+            NOMIC_ERRORS,
+            NOMIC_RECOVERY_DECISIONS,
+            NOMIC_RETRIES,
+        ),
+        gauges=(
+            NOMIC_CURRENT_PHASE,
+            NOMIC_CYCLES_IN_PROGRESS,
+            NOMIC_PHASE_LAST_TRANSITION,
+            NOMIC_CIRCUIT_BREAKERS_OPEN,
+        ),
+        histograms=(NOMIC_PHASE_DURATION,),
+    )
+
+
+def register_prometheus_metrics_provider() -> bool:
+    """Register Nomic metrics at an application composition root."""
+    try:
+        from aragora.observability.server_metrics.export import (
+            register_nomic_metrics_provider,
+        )
+    except ImportError as exc:
+        logger.debug("Nomic Prometheus metrics provider is unavailable: %s", exc)
+        return False
+
+    register_nomic_metrics_provider(get_prometheus_metrics)
+    return True
+
+
 __all__ = [
     # Metrics
     "NOMIC_PHASE_TRANSITIONS",
@@ -381,5 +419,7 @@ __all__ = [
     # Utilities
     "get_nomic_metrics_summary",
     "check_stuck_phases",
+    "get_prometheus_metrics",
+    "register_prometheus_metrics_provider",
     "PHASE_ENCODING",
 ]

--- a/aragora/observability/prometheus_recording.py
+++ b/aragora/observability/prometheus_recording.py
@@ -7,6 +7,7 @@ database, memory, cost, and V1 API deprecation metrics.
 """
 
 import logging
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,14 @@ if PROMETHEUS_AVAILABLE:
         WEBSOCKET_MESSAGES,
         ARAGORA_INFO,
     )
+
+_v1_sunset_days_provider: Callable[[], int] | None = None
+
+
+def register_v1_sunset_days_provider(provider: Callable[[], int] | None) -> None:
+    """Register the server-owned provider for the V1 sunset gauge value."""
+    global _v1_sunset_days_provider
+    _v1_sunset_days_provider = provider
 
 
 # ============================================================================
@@ -503,20 +512,19 @@ def record_v1_api_request(endpoint: str, method: str) -> None:
 
 def update_v1_days_until_sunset() -> None:
     """Update the gauge showing days until V1 API sunset."""
-    try:
-        # Resolved dynamically so this observability module does not statically
-        # import the interface-layer aragora.server.versioning package, which
-        # would invert the foundation/infra layer contract. Optional at runtime.
-        import importlib
+    if _v1_sunset_days_provider is None:
+        return
 
-        _versioning = importlib.import_module("aragora.server.versioning.constants")
-        days = _versioning.days_until_v1_sunset()
-        if PROMETHEUS_AVAILABLE:
-            V1_API_DAYS_UNTIL_SUNSET.set(days)
-        else:
-            _simple_metrics.set_gauge("aragora_v1_api_days_until_sunset", days)
-    except (ImportError, AttributeError):
-        pass
+    try:
+        days = _v1_sunset_days_provider()
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Failed to collect registered V1 sunset days: %s", exc)
+        return
+
+    if PROMETHEUS_AVAILABLE:
+        V1_API_DAYS_UNTIL_SUNSET.set(days)
+    else:
+        _simple_metrics.set_gauge("aragora_v1_api_days_until_sunset", days)
 
 
 def record_v1_api_sunset_blocked(endpoint: str, method: str) -> None:

--- a/aragora/observability/server_metrics/export.py
+++ b/aragora/observability/server_metrics/export.py
@@ -7,6 +7,8 @@ Generates Prometheus-format metrics output from all metric modules.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from dataclasses import dataclass
 
 from .agents import AGENT_LATENCY, AGENT_REQUESTS, AGENT_TOKENS
 from .api import ACTIVE_DEBATES, API_LATENCY, API_REQUESTS, WEBSOCKET_CONNECTIONS
@@ -49,8 +51,40 @@ from .knowledge_mound import (
     KNOWLEDGE_VISIBILITY_CHANGES,
 )
 from .security import AUTH_FAILURES, RATE_LIMIT_HITS, SECURITY_VIOLATIONS
+from .types import Counter, Gauge, Histogram
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class NomicMetricCollection:
+    """Nomic-owned metrics exposed through the lower observability contract."""
+
+    counters: tuple[Counter, ...] = ()
+    gauges: tuple[Gauge, ...] = ()
+    histograms: tuple[Histogram, ...] = ()
+
+
+NomicMetricsProvider = Callable[[], NomicMetricCollection]
+_nomic_metrics_provider: NomicMetricsProvider | None = None
+
+
+def register_nomic_metrics_provider(provider: NomicMetricsProvider | None) -> None:
+    """Register a higher-layer provider for optional Nomic export metrics."""
+    global _nomic_metrics_provider
+    _nomic_metrics_provider = provider
+
+
+def _get_nomic_metrics() -> NomicMetricCollection:
+    """Resolve optional Nomic metrics without importing the higher layer."""
+    if _nomic_metrics_provider is None:
+        return NomicMetricCollection()
+
+    try:
+        return _nomic_metrics_provider()
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.warning("Failed to collect registered Nomic metrics: %s", exc)
+        return NomicMetricCollection()
 
 
 def _format_labels(labels: dict) -> str:
@@ -130,35 +164,10 @@ def generate_metrics() -> str:
         KNOWLEDGE_FEDERATION_LATENCY,
     ]
 
-    # Add nomic loop metrics if available. Resolved dynamically so this
-    # observability-layer aggregator does not take a static import edge on the
-    # application-layer aragora.nomic package (would invert the layer contract).
-    try:
-        import importlib
-
-        _nomic = importlib.import_module("aragora.nomic.metrics")
-
-        counters.extend(
-            [
-                _nomic.NOMIC_PHASE_TRANSITIONS,
-                _nomic.NOMIC_CYCLES_TOTAL,
-                _nomic.NOMIC_ERRORS,
-                _nomic.NOMIC_RECOVERY_DECISIONS,
-                _nomic.NOMIC_RETRIES,
-            ]
-        )
-        gauges.extend(
-            [
-                _nomic.NOMIC_CURRENT_PHASE,
-                _nomic.NOMIC_CYCLES_IN_PROGRESS,
-                _nomic.NOMIC_PHASE_LAST_TRANSITION,
-                _nomic.NOMIC_CIRCUIT_BREAKERS_OPEN,
-            ]
-        )
-        histograms.append(_nomic.NOMIC_PHASE_DURATION)
-    except (ImportError, AttributeError):
-        # Nomic metrics not available
-        pass
+    nomic_metrics = _get_nomic_metrics()
+    counters.extend(nomic_metrics.counters)
+    gauges.extend(nomic_metrics.gauges)
+    histograms.extend(nomic_metrics.histograms)
 
     # Export counters
     for counter in counters:

--- a/aragora/server/middleware/deprecation_enforcer.py
+++ b/aragora/server/middleware/deprecation_enforcer.py
@@ -480,6 +480,7 @@ def register_default_deprecations() -> None:
     from aragora.server.versioning.constants import (
         MIGRATION_DOCS_URL,
         V1_SUNSET_DATE,
+        days_until_v1_sunset,
     )
 
     all_methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
@@ -624,8 +625,12 @@ def register_default_deprecations() -> None:
 
     # Update Prometheus gauge for days until sunset
     try:
-        from aragora.server.prometheus import update_v1_days_until_sunset
+        from aragora.observability.prometheus_recording import (
+            register_v1_sunset_days_provider,
+            update_v1_days_until_sunset,
+        )
 
+        register_v1_sunset_days_provider(days_until_v1_sunset)
         update_v1_days_until_sunset()
     except ImportError:
         pass

--- a/aragora/server/startup/observability.py
+++ b/aragora/server/startup/observability.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 def register_observability_sinks() -> bool:
-    """Register higher-layer alert adapters with observability contracts."""
+    """Register higher-layer adapters with observability contracts."""
     try:
         from aragora.connectors.devops.slo_alert_sink import (
             register_slo_alert_sink as register_pagerduty_sink,
@@ -26,18 +26,22 @@ def register_observability_sinks() -> bool:
         from aragora.knowledge.mound.metrics import (
             register_prometheus_health_provider as register_km_health_provider,
         )
+        from aragora.nomic.metrics import (
+            register_prometheus_metrics_provider as register_nomic_metrics_provider,
+        )
 
         results = (
             register_pagerduty_sink(),
             register_channel_sink(),
             register_webhook_sink(),
             register_km_health_provider(),
+            register_nomic_metrics_provider(),
         )
         return all(results)
     except ImportError as e:
-        logger.debug("Observability alert sinks not available: %s", e)
+        logger.debug("Observability adapters not available: %s", e)
     except (OSError, RuntimeError, ValueError) as e:
-        logger.warning("Failed to register observability alert sinks: %s", e)
+        logger.warning("Failed to register observability adapters: %s", e)
     return False
 
 

--- a/tests/observability/test_layered_metrics_providers.py
+++ b/tests/observability/test_layered_metrics_providers.py
@@ -1,0 +1,162 @@
+"""Tests for explicit higher-layer observability data providers."""
+
+from __future__ import annotations
+
+import builtins
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.observability import prometheus_recording
+from aragora.observability.prometheus_recording import (
+    register_v1_sunset_days_provider,
+    update_v1_days_until_sunset,
+)
+from aragora.observability.server_metrics.export import (
+    generate_metrics,
+    register_nomic_metrics_provider,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_layered_providers() -> Iterator[None]:
+    """Keep process-global provider state isolated between focused tests."""
+    register_nomic_metrics_provider(None)
+    register_v1_sunset_days_provider(None)
+    yield
+    register_nomic_metrics_provider(None)
+    register_v1_sunset_days_provider(None)
+
+
+def _sample_value(exposition: str, prefix: str) -> float:
+    """Return the first sample value for an exact Prometheus line prefix."""
+    line = next(line for line in exposition.splitlines() if line.startswith(prefix))
+    return float(line.rsplit(" ", 1)[1])
+
+
+def test_registered_nomic_data_is_exported() -> None:
+    """The Nomic composition adapter exposes the live metric objects."""
+    from aragora.nomic import metrics as nomic_metrics
+
+    before = nomic_metrics.NOMIC_PHASE_TRANSITIONS.get(
+        from_phase="provider_test",
+        to_phase="export",
+    )
+    nomic_metrics.NOMIC_PHASE_TRANSITIONS.inc(
+        from_phase="provider_test",
+        to_phase="export",
+    )
+    nomic_metrics.NOMIC_PHASE_DURATION.observe(2.5, phase="provider_test")
+
+    assert nomic_metrics.register_prometheus_metrics_provider() is True
+
+    exposition = generate_metrics()
+    assert (
+        _sample_value(
+            exposition,
+            'aragora_nomic_phase_transitions_total{from_phase="provider_test",to_phase="export"} ',
+        )
+        == before + 1
+    )
+    assert 'aragora_nomic_phase_duration_seconds_count{phase="provider_test"} 1' in exposition
+    for name in (
+        "aragora_nomic_phase_transitions_total",
+        "aragora_nomic_cycles_total",
+        "aragora_nomic_errors_total",
+        "aragora_nomic_recovery_decisions_total",
+        "aragora_nomic_retries_total",
+        "aragora_nomic_current_phase",
+        "aragora_nomic_cycles_in_progress",
+        "aragora_nomic_phase_last_transition_timestamp",
+        "aragora_nomic_circuit_breakers_open",
+        "aragora_nomic_phase_duration_seconds",
+    ):
+        assert f"# HELP {name} " in exposition
+
+
+def test_registered_versioning_data_updates_gauge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The registered server callback supplies the current sunset value."""
+    gauge = MagicMock()
+    monkeypatch.setattr(prometheus_recording, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(prometheus_recording, "V1_API_DAYS_UNTIL_SUNSET", gauge, raising=False)
+    register_v1_sunset_days_provider(lambda: 17)
+
+    update_v1_days_until_sunset()
+
+    gauge.set.assert_called_once_with(17)
+
+
+def test_absent_providers_fail_soft_without_upward_imports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Optional data disappears cleanly without importing higher layers."""
+    gauge = MagicMock()
+    monkeypatch.setattr(prometheus_recording, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(prometheus_recording, "V1_API_DAYS_UNTIL_SUNSET", gauge, raising=False)
+
+    original_import = builtins.__import__
+    forbidden = {
+        "aragora.nomic.metrics",
+        "aragora.server.versioning.constants",
+    }
+
+    def guarded_import(name: str, *args: object, **kwargs: object) -> object:
+        if name in forbidden:
+            raise AssertionError(f"unexpected upward import: {name}")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    exposition = generate_metrics()
+    update_v1_days_until_sunset()
+
+    assert "# HELP aragora_nomic_phase_transitions_total " not in exposition
+    gauge.set.assert_not_called()
+
+
+def test_registered_provider_failures_fail_soft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider failures cannot break metrics export or sunset startup."""
+    gauge = MagicMock()
+    monkeypatch.setattr(prometheus_recording, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(prometheus_recording, "V1_API_DAYS_UNTIL_SUNSET", gauge, raising=False)
+
+    def fail() -> object:
+        raise RuntimeError("provider unavailable")
+
+    register_nomic_metrics_provider(fail)
+    register_v1_sunset_days_provider(fail)
+
+    exposition = generate_metrics()
+    update_v1_days_until_sunset()
+
+    assert "# HELP aragora_api_requests_total " in exposition
+    assert "# HELP aragora_nomic_phase_transitions_total " not in exposition
+    gauge.set.assert_not_called()
+
+
+def test_higher_layer_roots_register_both_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nomic and server composition roots explicitly wire their callbacks."""
+    from aragora.nomic import metrics as nomic_metrics
+    from aragora.server.middleware import deprecation_enforcer
+    from aragora.server.versioning.constants import days_until_v1_sunset
+
+    monkeypatch.setattr(deprecation_enforcer, "register_deprecated_endpoint", MagicMock())
+
+    assert nomic_metrics.register_prometheus_metrics_provider() is True
+    deprecation_enforcer.register_default_deprecations()
+
+    nomic_exposition = generate_metrics()
+    assert "# HELP aragora_nomic_phase_transitions_total " in nomic_exposition
+
+    gauge = MagicMock()
+    monkeypatch.setattr(prometheus_recording, "PROMETHEUS_AVAILABLE", True)
+    monkeypatch.setattr(prometheus_recording, "V1_API_DAYS_UNTIL_SUNSET", gauge, raising=False)
+    update_v1_days_until_sunset()
+    gauge.set.assert_called_once_with(days_until_v1_sunset())

--- a/tests/server/startup/test_observability.py
+++ b/tests/server/startup/test_observability.py
@@ -45,6 +45,7 @@ class TestRegisterObservabilitySinks:
         from aragora.observability.metrics import slo as slo_metrics
         from aragora.observability import slo
         from aragora.observability import slo_alert_bridge
+        from aragora.observability.server_metrics import export as server_metrics_export
         from aragora.server.startup.observability import register_observability_sinks
 
         slo.register_slo_notification_sink_provider(None)
@@ -52,6 +53,7 @@ class TestRegisterObservabilitySinks:
         slo_alert_bridge.register_channel_alert_sink(None)
         slo_metrics.register_slo_event_sink_provider(None)
         km_metrics.register_km_health_provider(None)
+        server_metrics_export.register_nomic_metrics_provider(None)
         try:
             assert register_observability_sinks() is True
             assert slo._slo_notification_sink_provider is not None
@@ -59,12 +61,14 @@ class TestRegisterObservabilitySinks:
             assert slo_alert_bridge._channel_alert_sink_factory is not None
             assert slo_metrics._slo_event_sink_provider is not None
             assert km_metrics._km_health_provider is not None
+            assert server_metrics_export._nomic_metrics_provider is not None
         finally:
             slo.register_slo_notification_sink_provider(None)
             slo_alert_bridge.register_pagerduty_alert_sink(None)
             slo_alert_bridge.register_channel_alert_sink(None)
             slo_metrics.register_slo_event_sink_provider(None)
             km_metrics.register_km_health_provider(None)
+            server_metrics_export.register_nomic_metrics_provider(None)
 
 
 # =============================================================================


### PR DESCRIPTION
## Source

- Structural Excellence feature `p4a-observability-provider-inversion`
- Fulfills `VAL-P4A-019`

## Behavior

- Replaces hidden Nomic metric discovery in `aragora.observability.server_metrics.export` with an explicit lower-layer provider contract.
- Replaces hidden server versioning discovery in `aragora.observability.prometheus_recording` with an explicit sunset-days callback.
- Registers the Nomic metric collection from server observability startup and the V1 sunset callback from server deprecation composition.
- Preserves all ten existing Nomic metric exports and both Prometheus and simple-metric sunset gauge paths when providers are registered.
- Omits optional higher-layer data when providers are absent or raise expected runtime errors, without importing upward.
- Moves Nomic metric types off the deprecated server compatibility path onto canonical observability types.

## Validation

- Exact forbidden-reference scan under `aragora/observability` -> no matches, `rg_exit=1`
- `python3 -m pytest tests/observability/test_layered_metrics_providers.py -q` -> 5 passed
- Related observability, startup, Nomic, server metrics, middleware, and versioning suites -> 242 passed
- Changed-file mypy -> no issues in 5 source files
- `make lint` -> passed
- `ruff format --check aragora/ tests/` -> 10,254 files already formatted
- `python3 scripts/report_code_quality.py --check` -> ratchet passed
- `python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure` -> no new violations
- `make test-smoke` -> Core/Server/Memory imports passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Risk

Tier 2 bounded layering repair. The change keeps existing registered metric behavior, adds fail-soft optional-provider handling, and is covered at the lower contracts and both higher-layer registration roots.
