### PR TITLE
fix(observability): isolate optional Nomic startup adapter

### DIFF
--- a/aragora/server/startup/observability.py
+++ b/aragora/server/startup/observability.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 def register_observability_sinks() -> bool:
     """Register higher-layer adapters with observability contracts."""
+    results: list[bool] = []
+
     try:
         from aragora.connectors.devops.slo_alert_sink import (
             register_slo_alert_sink as register_pagerduty_sink,
@@ -26,23 +28,36 @@ def register_observability_sinks() -> bool:
         from aragora.knowledge.mound.metrics import (
             register_prometheus_health_provider as register_km_health_provider,
         )
+
+        results.extend(
+            (
+                register_pagerduty_sink(),
+                register_channel_sink(),
+                register_webhook_sink(),
+                register_km_health_provider(),
+            )
+        )
+    except ImportError as e:
+        logger.debug("Observability adapters not available: %s", e)
+        results.append(False)
+    except (OSError, RuntimeError, ValueError) as e:
+        logger.warning("Failed to register observability adapters: %s", e)
+        results.append(False)
+
+    try:
         from aragora.nomic.metrics import (
             register_prometheus_metrics_provider as register_nomic_metrics_provider,
         )
 
-        results = (
-            register_pagerduty_sink(),
-            register_channel_sink(),
-            register_webhook_sink(),
-            register_km_health_provider(),
-            register_nomic_metrics_provider(),
-        )
-        return all(results)
+        results.append(register_nomic_metrics_provider())
     except ImportError as e:
-        logger.debug("Observability adapters not available: %s", e)
+        logger.debug("Nomic observability adapter not available: %s", e)
+        results.append(False)
     except (OSError, RuntimeError, ValueError) as e:
-        logger.warning("Failed to register observability adapters: %s", e)
-    return False
+        logger.warning("Failed to register Nomic observability adapter: %s", e)
+        results.append(False)
+
+    return all(results)
 
 
 def init_structured_logging() -> bool:

--- a/tests/server/startup/test_observability.py
+++ b/tests/server/startup/test_observability.py
@@ -70,6 +70,44 @@ class TestRegisterObservabilitySinks:
             km_metrics.register_km_health_provider(None)
             server_metrics_export.register_nomic_metrics_provider(None)
 
+    def test_nomic_import_failure_does_not_skip_other_adapters(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Optional Nomic import failure cannot short-circuit other adapters."""
+        pagerduty_adapter = MagicMock()
+        pagerduty_adapter.register_slo_alert_sink.return_value = True
+        channel_adapter = MagicMock()
+        channel_adapter.register_slo_alert_sink.return_value = True
+        webhook_adapter = MagicMock()
+        webhook_adapter.register_slo_event_sink.return_value = True
+        km_adapter = MagicMock()
+        km_adapter.register_prometheus_health_provider.return_value = True
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {
+                    "aragora.connectors.devops.slo_alert_sink": pagerduty_adapter,
+                    "aragora.control_plane.slo_alert_sink": channel_adapter,
+                    "aragora.integrations.webhooks": webhook_adapter,
+                    "aragora.knowledge.mound.metrics": km_adapter,
+                    "aragora.nomic.metrics": None,
+                },
+            ),
+            caplog.at_level("DEBUG", logger="aragora.server.startup.observability"),
+        ):
+            from aragora.server.startup.observability import register_observability_sinks
+
+            result = register_observability_sinks()
+
+        assert result is False
+        pagerduty_adapter.register_slo_alert_sink.assert_called_once_with()
+        channel_adapter.register_slo_alert_sink.assert_called_once_with()
+        webhook_adapter.register_slo_event_sink.assert_called_once_with()
+        km_adapter.register_prometheus_health_provider.assert_called_once_with()
+        assert "Nomic observability adapter not available" in caplog.text
+
 
 # =============================================================================
 # init_structured_logging Tests


### PR DESCRIPTION
## Summary

- isolate the optional Nomic metrics adapter import and registration from the four existing startup observability adapters
- preserve fail-soft logging and return `false` when Nomic is unavailable or fails
- add a focused regression proving PagerDuty, channel, webhook, and Knowledge Mound registration still run on Nomic import failure

## Validation

- `python3 -m pytest tests/server/startup/test_observability.py tests/observability/test_layered_metrics_providers.py -q` (`30 passed`)
- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/server/startup/observability.py` (`Success: no issues found`)
- `make lint` and `ruff format --check aragora/ tests/ scripts/`
- `python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure`
- `make test-smoke`
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` (`138 passed`)

## Boundaries

- no changes to `init_prometheus_metrics()`, provider contracts, observability-layer imports, import-contract baselines, or the three ambient higher-layer edges
- 64 additions and 11 deletions across two focused files
