### PR TITLE
fix(observability): isolate all startup adapters

### DIFF
--- a/aragora/server/startup/observability.py
+++ b/aragora/server/startup/observability.py
@@ -19,29 +19,52 @@ def register_observability_sinks() -> bool:
         from aragora.connectors.devops.slo_alert_sink import (
             register_slo_alert_sink as register_pagerduty_sink,
         )
+
+        results.append(register_pagerduty_sink())
+    except ImportError as e:
+        logger.debug("PagerDuty observability adapter not available: %s", e)
+        results.append(False)
+    except (OSError, RuntimeError, ValueError) as e:
+        logger.warning("Failed to register PagerDuty observability adapter: %s", e)
+        results.append(False)
+
+    try:
         from aragora.control_plane.slo_alert_sink import (
             register_slo_alert_sink as register_channel_sink,
         )
+
+        results.append(register_channel_sink())
+    except ImportError as e:
+        logger.debug("Channel observability adapter not available: %s", e)
+        results.append(False)
+    except (OSError, RuntimeError, ValueError) as e:
+        logger.warning("Failed to register Channel observability adapter: %s", e)
+        results.append(False)
+
+    try:
         from aragora.integrations.webhooks import (
             register_slo_event_sink as register_webhook_sink,
         )
+
+        results.append(register_webhook_sink())
+    except ImportError as e:
+        logger.debug("Webhook observability adapter not available: %s", e)
+        results.append(False)
+    except (OSError, RuntimeError, ValueError) as e:
+        logger.warning("Failed to register Webhook observability adapter: %s", e)
+        results.append(False)
+
+    try:
         from aragora.knowledge.mound.metrics import (
             register_prometheus_health_provider as register_km_health_provider,
         )
 
-        results.extend(
-            (
-                register_pagerduty_sink(),
-                register_channel_sink(),
-                register_webhook_sink(),
-                register_km_health_provider(),
-            )
-        )
+        results.append(register_km_health_provider())
     except ImportError as e:
-        logger.debug("Observability adapters not available: %s", e)
+        logger.debug("Knowledge Mound observability adapter not available: %s", e)
         results.append(False)
     except (OSError, RuntimeError, ValueError) as e:
-        logger.warning("Failed to register observability adapters: %s", e)
+        logger.warning("Failed to register Knowledge Mound observability adapter: %s", e)
         results.append(False)
 
     try:

--- a/tests/server/startup/test_observability.py
+++ b/tests/server/startup/test_observability.py
@@ -12,6 +12,75 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+_NON_NOMIC_ADAPTERS = (
+    pytest.param(
+        "pagerduty",
+        "aragora.connectors.devops.slo_alert_sink",
+        "register_slo_alert_sink",
+        "PagerDuty",
+        id="pagerduty",
+    ),
+    pytest.param(
+        "channel",
+        "aragora.control_plane.slo_alert_sink",
+        "register_slo_alert_sink",
+        "Channel",
+        id="channel",
+    ),
+    pytest.param(
+        "webhook",
+        "aragora.integrations.webhooks",
+        "register_slo_event_sink",
+        "Webhook",
+        id="webhook",
+    ),
+    pytest.param(
+        "knowledge_mound",
+        "aragora.knowledge.mound.metrics",
+        "register_prometheus_health_provider",
+        "Knowledge Mound",
+        id="knowledge-mound",
+    ),
+)
+
+_ALL_ADAPTERS = (
+    (
+        "pagerduty",
+        "aragora.connectors.devops.slo_alert_sink",
+        "register_slo_alert_sink",
+    ),
+    (
+        "channel",
+        "aragora.control_plane.slo_alert_sink",
+        "register_slo_alert_sink",
+    ),
+    (
+        "webhook",
+        "aragora.integrations.webhooks",
+        "register_slo_event_sink",
+    ),
+    (
+        "knowledge_mound",
+        "aragora.knowledge.mound.metrics",
+        "register_prometheus_health_provider",
+    ),
+    (
+        "nomic",
+        "aragora.nomic.metrics",
+        "register_prometheus_metrics_provider",
+    ),
+)
+
+
+def _mock_observability_adapters() -> dict[str, MagicMock]:
+    modules: dict[str, MagicMock] = {}
+    for _name, module_path, register_name in _ALL_ADAPTERS:
+        adapter = MagicMock()
+        getattr(adapter, register_name).return_value = True
+        modules[module_path] = adapter
+    return modules
+
+
 class TestRegisterObservabilitySinks:
     """Tests for higher-layer sink composition."""
 
@@ -107,6 +176,71 @@ class TestRegisterObservabilitySinks:
         webhook_adapter.register_slo_event_sink.assert_called_once_with()
         km_adapter.register_prometheus_health_provider.assert_called_once_with()
         assert "Nomic observability adapter not available" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("failed_adapter", "failed_module", "register_name", "log_name"),
+        _NON_NOMIC_ADAPTERS,
+    )
+    def test_non_nomic_import_failure_does_not_skip_sibling_adapters(
+        self,
+        failed_adapter: str,
+        failed_module: str,
+        register_name: str,
+        log_name: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Every adapter import has its own fail-soft boundary."""
+        adapters = _mock_observability_adapters()
+        adapters_with_failure: dict[str, MagicMock | None] = dict(adapters)
+        adapters_with_failure[failed_module] = None
+
+        with (
+            patch.dict("sys.modules", adapters_with_failure),
+            caplog.at_level("DEBUG", logger="aragora.server.startup.observability"),
+        ):
+            from aragora.server.startup.observability import register_observability_sinks
+
+            result = register_observability_sinks()
+
+        assert result is False
+        for adapter_name, module_path, sibling_register_name in _ALL_ADAPTERS:
+            if adapter_name == failed_adapter:
+                continue
+            getattr(adapters[module_path], sibling_register_name).assert_called_once_with()
+        getattr(adapters[failed_module], register_name).assert_not_called()
+        assert f"{log_name} observability adapter not available" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("failed_adapter", "failed_module", "register_name", "log_name"),
+        _NON_NOMIC_ADAPTERS,
+    )
+    def test_non_nomic_registration_failure_does_not_skip_sibling_adapters(
+        self,
+        failed_adapter: str,
+        failed_module: str,
+        register_name: str,
+        log_name: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Every adapter registration has its own fail-soft boundary."""
+        adapters = _mock_observability_adapters()
+        getattr(adapters[failed_module], register_name).side_effect = RuntimeError("boom")
+
+        with (
+            patch.dict("sys.modules", adapters),
+            caplog.at_level("WARNING", logger="aragora.server.startup.observability"),
+        ):
+            from aragora.server.startup.observability import register_observability_sinks
+
+            result = register_observability_sinks()
+
+        assert result is False
+        for adapter_name, module_path, sibling_register_name in _ALL_ADAPTERS:
+            if adapter_name == failed_adapter:
+                continue
+            getattr(adapters[module_path], sibling_register_name).assert_called_once_with()
+        getattr(adapters[failed_module], register_name).assert_called_once_with()
+        assert f"Failed to register {log_name} observability adapter" in caplog.text
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- give PagerDuty, channel, webhook, and Knowledge Mound imports and registrations independent fail-soft boundaries
- keep attempting later adapters after an earlier import or runtime failure while returning false for any failed adapter
- preserve the merged Nomic isolation, all-success behavior, provider inversion, and Prometheus startup behavior
- add parameterized ordering regressions for import and registration failures across all four non-Nomic adapters

Follow-up to #9298 under structural-excellence epic #8257.

## Validation

- `python3 -m pytest tests/server/startup/test_observability.py tests/observability/test_layered_metrics_providers.py -q` -> 38 passed
- focused randomized seeds 1, 42, 100, 2024, 12345 -> 33 passed per seed
- `mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/server/startup/observability.py` -> success
- mission differential typecheck -> PASS, new=103 <= ambient ceiling 108
- `make lint` -> passed
- `ruff format --check aragora/ tests/ scripts/` -> 10708 files formatted
- `python3 scripts/ci/check_import_contracts.py --layers foundation,infrastructure` -> no new violations
- VAL-P4A-019 provider inversion scan and tests -> no upward imports, 5 passed
- `make test-smoke` -> Core, Server, and Memory imports passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Risk

Bounded to the server startup composition root and its focused tests. Adapter implementations, provider contracts, import baselines, layer boundaries, and `init_prometheus_metrics()` are unchanged.