### PR TITLE
refactor(protocols): finish compatibility collapse

### DIFF
--- a/aragora/protocols/__init__.py
+++ b/aragora/protocols/__init__.py
@@ -115,6 +115,16 @@ from aragora.protocols.event_protocols import (
     EventEmitterProtocol,
     HandlerProtocol,
 )
+from aragora.protocols.legacy_protocols import (
+    AgentProtocol as LegacyAgentProtocol,
+    CacheProtocol,
+    EventData,
+    EventEmitterProtocol as LegacyEventEmitterProtocol,
+    EventHandlerProtocol,
+    MemoryProtocol as LegacyMemoryProtocol,
+    StorageProtocol,
+    SyncEventHandlerProtocol,
+)
 from aragora.protocols.debate_protocols import (
     ConsensusDetectorProtocol,
     ConsensusMemoryProtocol,
@@ -215,6 +225,15 @@ __all__ = [
     # Domain protocols - Events
     "EventEmitterProtocol",
     "AsyncEventEmitterProtocol",
+    # Compatibility protocols from aragora.types.protocols
+    "LegacyAgentProtocol",
+    "LegacyMemoryProtocol",
+    "LegacyEventEmitterProtocol",
+    "CacheProtocol",
+    "StorageProtocol",
+    "EventData",
+    "EventHandlerProtocol",
+    "SyncEventHandlerProtocol",
     # Domain protocols - Handlers
     "HandlerProtocol",
     "BaseHandlerProtocol",

--- a/aragora/protocols/legacy_protocols.py
+++ b/aragora/protocols/legacy_protocols.py
@@ -1,0 +1,167 @@
+"""Canonical homes for protocols preserved from :mod:`aragora.types.protocols`.
+
+The agent, memory, and event-emitter contracts here intentionally differ from
+the newer protocols exported under the same unprefixed names by
+``aragora.protocols``. They remain distinct so compatibility imports preserve
+their original structural requirements without weakening either contract.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
+from typing import Any, Protocol, runtime_checkable
+
+EventData = dict[str, Any]
+EventHandlerProtocol = Callable[[Any], Coroutine[Any, Any, None]]
+SyncEventHandlerProtocol = Callable[[Any], None]
+
+
+@runtime_checkable
+class EventEmitterProtocol(Protocol):
+    """Compatibility contract for subscription-based event emitters."""
+
+    def subscribe(
+        self,
+        event_type: str,
+        handler: EventHandlerProtocol,
+    ) -> None:
+        """Subscribe an async handler to an event type."""
+        ...
+
+    def subscribe_sync(
+        self,
+        event_type: str,
+        handler: SyncEventHandlerProtocol,
+    ) -> None:
+        """Subscribe a sync handler to an event type."""
+        ...
+
+    def unsubscribe(
+        self,
+        event_type: str,
+        handler: EventHandlerProtocol,
+    ) -> bool:
+        """Unsubscribe a handler from an event type."""
+        ...
+
+    async def emit(
+        self,
+        event_type: str,
+        debate_id: str = "",
+        correlation_id: str | None = None,
+        **data: Any,
+    ) -> None:
+        """Emit an event asynchronously."""
+        ...
+
+    def emit_sync(
+        self,
+        event_type: str,
+        debate_id: str = "",
+        correlation_id: str | None = None,
+        **data: Any,
+    ) -> None:
+        """Emit an event synchronously."""
+        ...
+
+
+@runtime_checkable
+class StorageProtocol(Protocol):
+    """Compatibility contract for asynchronous key-value storage."""
+
+    async def get(self, key: str) -> Any | None:
+        """Get a value by key."""
+        ...
+
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        """Set a value with an optional TTL."""
+        ...
+
+    async def delete(self, key: str) -> bool:
+        """Delete a value by key."""
+        ...
+
+    async def exists(self, key: str) -> bool:
+        """Check whether a key exists."""
+        ...
+
+
+@runtime_checkable
+class CacheProtocol(Protocol):
+    """Compatibility contract for synchronous caches."""
+
+    def get(self, key: str) -> Any | None:
+        """Get a cached value."""
+        ...
+
+    def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        """Set a cached value with an optional TTL."""
+        ...
+
+    def delete(self, key: str) -> None:
+        """Delete a cached value."""
+        ...
+
+    def clear(self) -> None:
+        """Clear all cached values."""
+        ...
+
+
+@runtime_checkable
+class AgentProtocol(Protocol):
+    """Compatibility contract for agents exposing ``generate``."""
+
+    @property
+    def name(self) -> str:
+        """Return the agent's display name."""
+        ...
+
+    @property
+    def model(self) -> str:
+        """Return the model identifier."""
+        ...
+
+    async def generate(
+        self,
+        prompt: str,
+        context: dict[str, Any] | None = None,
+    ) -> str:
+        """Generate a response to a prompt."""
+        ...
+
+
+@runtime_checkable
+class MemoryProtocol(Protocol):
+    """Compatibility contract for asynchronous debate memory."""
+
+    async def store(
+        self,
+        content: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> str:
+        """Store content and return its memory identifier."""
+        ...
+
+    async def retrieve(
+        self,
+        query: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Retrieve memories relevant to a query."""
+        ...
+
+    async def forget(self, memory_id: str) -> bool:
+        """Remove a memory by identifier."""
+        ...
+
+
+__all__ = [
+    "AgentProtocol",
+    "CacheProtocol",
+    "EventData",
+    "EventEmitterProtocol",
+    "EventHandlerProtocol",
+    "MemoryProtocol",
+    "StorageProtocol",
+    "SyncEventHandlerProtocol",
+]

--- a/aragora/types/__init__.py
+++ b/aragora/types/__init__.py
@@ -5,9 +5,9 @@ Provides structural typing via protocols to enable
 duck typing while maintaining type safety.
 """
 
-from aragora.types.protocols import (
-    EventEmitterProtocol,
+from aragora.protocols import (
     EventHandlerProtocol,
+    LegacyEventEmitterProtocol as EventEmitterProtocol,
     SyncEventHandlerProtocol,
 )
 

--- a/aragora/types/protocols.py
+++ b/aragora/types/protocols.py
@@ -1,191 +1,39 @@
-"""
-Protocols for structural typing in Aragora.
+"""Deprecated compatibility exports for protocols moved to ``aragora.protocols``.
 
-These protocols define interfaces for key abstractions, enabling
-duck typing while maintaining type safety through structural subtyping.
-
-Usage:
-    from aragora.types.protocols import EventEmitterProtocol
-
-    def setup_listener(emitter: EventEmitterProtocol) -> None:
-        emitter.subscribe("debate_start", handler)
+Importing from ``aragora.types.protocols`` remains supported for one release,
+but new code should use the canonical ``aragora.protocols`` package.
 """
 
-from __future__ import annotations
+import warnings
 
-from typing import Any, Protocol, runtime_checkable
-from collections.abc import Callable, Coroutine
+from aragora.protocols import (
+    CacheProtocol,
+    EventData,
+    EventHandlerProtocol,
+    LegacyAgentProtocol,
+    LegacyEventEmitterProtocol,
+    LegacyMemoryProtocol,
+    StorageProtocol,
+    SyncEventHandlerProtocol,
+)
 
-# Type alias for event data
-EventData = dict[str, Any]
+AgentProtocol = LegacyAgentProtocol
+EventEmitterProtocol = LegacyEventEmitterProtocol
+MemoryProtocol = LegacyMemoryProtocol
 
-# Handler type aliases
-EventHandlerProtocol = Callable[[Any], Coroutine[Any, Any, None]]
-SyncEventHandlerProtocol = Callable[[Any], None]
+warnings.warn(
+    "aragora.types.protocols is deprecated; import protocols from aragora.protocols instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-
-@runtime_checkable
-class EventEmitterProtocol(Protocol):
-    """
-    Protocol for event emitters.
-
-    Defines the interface for event emission and subscription.
-    Both EventBus and external emitters can satisfy this protocol.
-
-    Example:
-        def process_events(emitter: EventEmitterProtocol) -> None:
-            async def handler(event):
-                print(f"Received: {event}")
-
-            emitter.subscribe("my_event", handler)
-    """
-
-    def subscribe(
-        self,
-        event_type: str,
-        handler: EventHandlerProtocol,
-    ) -> None:
-        """Subscribe an async handler to an event type."""
-        ...
-
-    def subscribe_sync(
-        self,
-        event_type: str,
-        handler: SyncEventHandlerProtocol,
-    ) -> None:
-        """Subscribe a sync handler to an event type."""
-        ...
-
-    def unsubscribe(
-        self,
-        event_type: str,
-        handler: EventHandlerProtocol,
-    ) -> bool:
-        """Unsubscribe a handler from an event type."""
-        ...
-
-    async def emit(
-        self,
-        event_type: str,
-        debate_id: str = "",
-        correlation_id: str | None = None,
-        **data: Any,
-    ) -> None:
-        """Emit an event asynchronously."""
-        ...
-
-    def emit_sync(
-        self,
-        event_type: str,
-        debate_id: str = "",
-        correlation_id: str | None = None,
-        **data: Any,
-    ) -> None:
-        """Emit an event synchronously."""
-        ...
-
-
-@runtime_checkable
-class StorageProtocol(Protocol):
-    """
-    Protocol for storage backends.
-
-    Defines the interface for persistent storage operations.
-    """
-
-    async def get(self, key: str) -> Any | None:
-        """Get a value by key."""
-        ...
-
-    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        """Set a value with optional TTL."""
-        ...
-
-    async def delete(self, key: str) -> bool:
-        """Delete a value by key."""
-        ...
-
-    async def exists(self, key: str) -> bool:
-        """Check if a key exists."""
-        ...
-
-
-@runtime_checkable
-class CacheProtocol(Protocol):
-    """
-    Protocol for caching backends.
-
-    Defines the interface for cache operations with TTL support.
-    """
-
-    def get(self, key: str) -> Any | None:
-        """Get a cached value."""
-        ...
-
-    def set(self, key: str, value: Any, ttl: int | None = None) -> None:
-        """Set a cached value with optional TTL."""
-        ...
-
-    def delete(self, key: str) -> None:
-        """Delete a cached value."""
-        ...
-
-    def clear(self) -> None:
-        """Clear all cached values."""
-        ...
-
-
-@runtime_checkable
-class AgentProtocol(Protocol):
-    """
-    Protocol for debate agents.
-
-    Defines the minimal interface that all agents must implement.
-    """
-
-    @property
-    def name(self) -> str:
-        """Agent's display name."""
-        ...
-
-    @property
-    def model(self) -> str:
-        """Model identifier."""
-        ...
-
-    async def generate(
-        self,
-        prompt: str,
-        context: dict[str, Any] | None = None,
-    ) -> str:
-        """Generate a response to a prompt."""
-        ...
-
-
-@runtime_checkable
-class MemoryProtocol(Protocol):
-    """
-    Protocol for memory systems.
-
-    Defines the interface for storing and retrieving debate memories.
-    """
-
-    async def store(
-        self,
-        content: str,
-        metadata: dict[str, Any] | None = None,
-    ) -> str:
-        """Store content in memory, returns memory ID."""
-        ...
-
-    async def retrieve(
-        self,
-        query: str,
-        limit: int = 10,
-    ) -> list[dict[str, Any]]:
-        """Retrieve relevant memories for a query."""
-        ...
-
-    async def forget(self, memory_id: str) -> bool:
-        """Remove a memory by ID."""
-        ...
+__all__ = [
+    "AgentProtocol",
+    "CacheProtocol",
+    "EventData",
+    "EventEmitterProtocol",
+    "EventHandlerProtocol",
+    "MemoryProtocol",
+    "StorageProtocol",
+    "SyncEventHandlerProtocol",
+]

--- a/tests/types/test_protocols.py
+++ b/tests/types/test_protocols.py
@@ -14,6 +14,8 @@ Tests cover:
 
 from __future__ import annotations
 
+import importlib
+import warnings
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -438,15 +440,75 @@ class TestTypeAliases:
 class TestModuleExports:
     """Tests for aragora.types module exports."""
 
+    def test_legacy_protocol_paths_preserve_canonical_identity(self):
+        """Existing protocol shims should return canonical objects unchanged."""
+        from aragora.core_protocols import StorageBackend as CoreStorageBackend
+        from aragora.protocols import AgentProtocol as CanonicalAgentProtocol
+        from aragora.protocols import StorageBackend as CanonicalStorageBackend
+        from aragora.type_protocols import AgentProtocol as TypeAgentProtocol
+
+        assert CoreStorageBackend is CanonicalStorageBackend
+        assert TypeAgentProtocol is CanonicalAgentProtocol
+
+    def test_types_protocols_warns_with_legacy_path(self):
+        """Reloading the legacy types module should emit its deprecation warning."""
+        legacy = importlib.import_module("aragora.types.protocols")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            importlib.reload(legacy)
+
+        assert any(
+            issubclass(item.category, DeprecationWarning) and "types.protocols" in str(item.message)
+            for item in caught
+        )
+
+    def test_types_protocols_shared_exports_preserve_identity(self):
+        """Non-conflicting legacy contracts should be canonical package exports."""
+        import aragora.protocols as canonical
+        import aragora.types.protocols as legacy
+
+        shared = (
+            "CacheProtocol",
+            "StorageProtocol",
+            "EventData",
+            "EventHandlerProtocol",
+            "SyncEventHandlerProtocol",
+        )
+
+        assert all(getattr(canonical, name) is getattr(legacy, name) for name in shared)
+
+    def test_types_protocols_incompatible_contracts_remain_distinct(self):
+        """Legacy contracts with incompatible methods must not replace newer ones."""
+        import aragora.protocols as canonical
+        import aragora.types.protocols as legacy
+
+        incompatible = ("AgentProtocol", "MemoryProtocol", "EventEmitterProtocol")
+        assert all(
+            getattr(legacy, name).__module__.startswith("aragora.protocols.")
+            for name in incompatible
+        )
+        assert all(getattr(canonical, name) is not getattr(legacy, name) for name in incompatible)
+        assert hasattr(legacy.AgentProtocol, "generate")
+        assert hasattr(legacy.MemoryProtocol, "retrieve")
+        assert hasattr(legacy.EventEmitterProtocol, "subscribe")
+        assert hasattr(canonical.AgentProtocol, "respond")
+        assert not hasattr(canonical.AgentProtocol, "generate")
+        assert hasattr(canonical.MemoryProtocol, "query")
+        assert not hasattr(canonical.MemoryProtocol, "retrieve")
+        assert hasattr(canonical.EventEmitterProtocol, "on")
+        assert not hasattr(canonical.EventEmitterProtocol, "subscribe")
+
     def test_import_from_package(self):
         """Test importing from aragora.types package."""
+        from aragora.protocols import LegacyEventEmitterProtocol
         from aragora.types import (
             EventEmitterProtocol,
             EventHandlerProtocol,
             SyncEventHandlerProtocol,
         )
 
-        assert EventEmitterProtocol is not None
+        assert EventEmitterProtocol is LegacyEventEmitterProtocol
         assert EventHandlerProtocol is not None
         assert SyncEventHandlerProtocol is not None
 


### PR DESCRIPTION
## Summary

Finish VAL-P4A-009 by moving the remaining physical definitions from `aragora.types.protocols` into the canonical `aragora.protocols` substrate.

- add canonical compatibility contracts under `aragora.protocols.legacy_protocols`
- export non-conflicting contracts and explicit legacy aliases from `aragora.protocols`
- convert `aragora.types.protocols` into a warning re-export shim while preserving object identity
- preserve the incompatible `generate` / `retrieve` / `subscribe` contracts separately from the canonical `respond` / `query` / `on` protocols
- keep `aragora.core_protocols` and `aragora.type_protocols` unchanged

## Source

Structural Excellence epic #8257, `p4a-protocol-compatibility-collapse`, assertion VAL-P4A-009.

## Validation

- complete nine-command VAL-P4A-009 shim probe: PASS
- canonical and legacy identity/physical-home probes: PASS
- `python3 -m pytest tests/types/test_protocols.py tests/test_core_protocols.py tests/test_type_protocols.py -q`: 158 passed
- changed-file mypy: success in 4 source files
- mission differential typecheck: PASS (`new=103 <= 108`)
- `make lint`: PASS
- `ruff format --check aragora/ tests/ scripts/`: PASS
- `make test-smoke`: Core/Server/Memory imports OK
- smoke tier: 138 passed
- automation preflight: PASS

## Risk

Tier 1 compatibility refactor. The three incompatible legacy contracts remain distinct physical definitions and are never substituted for the canonical unprefixed contracts. `feedback_phase.py` and other caller migration are intentionally out of scope.
