### PR TITLE
refactor(debate): use canonical event emitter protocol

### DIFF
--- a/aragora/debate/memory_manager.py
+++ b/aragora/debate/memory_manager.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 from collections.abc import Callable
 
-from aragora.types.protocols import EventEmitterProtocol
+from aragora.protocols import LegacyEventEmitterProtocol
 
 from aragora.agents.errors import _build_error_action
 
@@ -442,7 +442,7 @@ class MemoryManager:
         consensus_memory: Optional["ConsensusMemory"] = None,
         debate_embeddings: Optional["DebateEmbeddingsDatabase"] = None,
         domain_extractor: Callable[[], str] | None = None,
-        event_emitter: EventEmitterProtocol | None = None,
+        event_emitter: LegacyEventEmitterProtocol | None = None,
         spectator: Optional["SpectatorStream"] = None,
         loop_id: str = "",
         tier_analytics_tracker: TierAnalyticsTracker | None = None,

--- a/tests/debate/test_memory_manager_protocol_import.py
+++ b/tests/debate/test_memory_manager_protocol_import.py
@@ -1,0 +1,47 @@
+"""Focused import-contract coverage for the debate memory manager."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_memory_manager_uses_canonical_legacy_event_emitter_protocol() -> None:
+    """The memory manager should annotate emitters with the canonical legacy contract."""
+    from aragora.debate.memory_manager import MemoryManager
+    from aragora.protocols import LegacyEventEmitterProtocol
+
+    annotation = MemoryManager.__init__.__annotations__["event_emitter"]
+
+    assert annotation == LegacyEventEmitterProtocol | None
+
+
+def test_memory_manager_import_does_not_warn_for_types_protocols_shim() -> None:
+    """Importing the memory manager should not traverse the deprecated protocol shim."""
+    project_root = Path(__file__).resolve().parents[2]
+    script = """
+import importlib
+import warnings
+
+with warnings.catch_warnings(record=True) as caught:
+    warnings.simplefilter("always")
+    importlib.import_module("aragora.debate.memory_manager")
+
+shim_warnings = [
+    str(item.message)
+    for item in caught
+    if "aragora.types.protocols is deprecated" in str(item.message)
+]
+assert shim_warnings == [], shim_warnings
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Source

Structural Excellence epic #8257, feature `p4a-memory-manager-protocol-caller-migration`.

## Behavior

- Repoints `aragora/debate/memory_manager.py` from the deprecated `aragora.types.protocols` shim to canonical `aragora.protocols.LegacyEventEmitterProtocol`.
- Preserves the exact legacy emitter contract used by the memory-manager annotation.
- Adds focused identity and warning-free import smoke coverage.
- Leaves the compatibility shim and unrelated protocol callers unchanged.

## Validation

- `python3 -m pytest tests/debate/test_memory_manager_protocol_import.py tests/types/test_protocols.py -q`: 41 passed.
- `python3 -m pytest tests/debate/test_memory_manager.py tests/debate/test_memory_manager_extended.py -q -k "not test_handles_notification_failures_gracefully and not test_partial_update_failures_handled" --timeout=120`: 85 passed, 2 documented pre-existing failures deselected.
- changed-file mypy: success, no issues in `memory_manager.py`.
- differential typecheck: pass, ambient new=104 <= 108.
- `make lint`: pass.
- `ruff format --check aragora/ tests/ scripts/`: 10710 files formatted.
- `make test-smoke`: pass, Core/Server/Memory imports OK.
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke`: 138 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: pass.

## Risk

Tier 1, bounded import and type-annotation migration only. Runtime behavior is unchanged because the deprecated shim exported the same canonical protocol object.