### PR TITLE
refactor(debate): remove feedback protocol shim

### DIFF
--- a/aragora/debate/phases/feedback_phase.py
+++ b/aragora/debate/phases/feedback_phase.py
@@ -43,7 +43,7 @@ from aragora.debate.phases.feedback_knowledge import KnowledgeFeedback
 from aragora.debate.phases.feedback_memory import MemoryFeedback
 from aragora.debate.phases.feedback_persona import PersonaFeedback
 from aragora.debate.phases.training_emitter import TrainingEmitter
-from aragora.type_protocols import (
+from aragora.protocols import (
     BroadcastPipelineProtocol,
     CalibrationTrackerProtocol,
     ConsensusMemoryProtocol,
@@ -1240,6 +1240,10 @@ class FeedbackPhase:
         This is a fire-and-forget task so it doesn't block debate completion.
         Failures are logged but don't affect the debate result.
         """
+        pipeline = self.broadcast_pipeline
+        if pipeline is None:
+            return
+
         try:
             from aragora.broadcast.pipeline import BroadcastOptions
 
@@ -1248,7 +1252,7 @@ class FeedbackPhase:
                 generate_rss_episode=True,
             )
 
-            pipeline_result = await self.broadcast_pipeline.run(
+            pipeline_result = await pipeline.run(
                 ctx.debate_id,
                 options,
             )

--- a/tests/debate/phases/test_feedback_phase.py
+++ b/tests/debate/phases/test_feedback_phase.py
@@ -1481,6 +1481,18 @@ class TestMaybeTriggerBroadcast:
         await phase._maybe_trigger_broadcast(ctx)
 
     @pytest.mark.asyncio
+    async def test_broadcast_async_returns_when_pipeline_is_none(self):
+        """Direct async broadcast returns before building pipeline options."""
+        phase = FeedbackPhase()
+        ctx = MockDebateContext()
+
+        with patch(
+            "aragora.broadcast.pipeline.BroadcastOptions",
+            side_effect=AssertionError("broadcast options should not be built"),
+        ):
+            await phase._broadcast_async(ctx)
+
+    @pytest.mark.asyncio
     async def test_broadcast_disabled(self):
         """Returns early when broadcast disabled."""
         pipeline = MagicMock()


### PR DESCRIPTION
## Summary

- migrate `FeedbackPhase` protocol imports from the deprecated `aragora.type_protocols` shim to `aragora.protocols`
- guard direct `_broadcast_async` execution when no broadcast pipeline is configured
- add the focused `broadcast_async_returns_when_pipeline_is_none` regression

## Scope

- Fulfills `VAL-P4A-020` for Structural Excellence epic #8257.
- Intentionally leaves the P6-owned Redis, redis-cluster, and consensus-storage typing tails unchanged.

## Validation

- `python3 /tmp/p4val/t1.py aragora/debate/phases/feedback_phase.py aragora.type_protocols` -> PASS
- `python3 -m pytest tests/debate/phases/test_feedback_phase.py -q -k "broadcast_async_returns_when_pipeline_is_none"` -> 1 passed
- `python3 -m pytest tests/debate/phases/test_feedback_phase.py -x -q --timeout=120` -> 149 passed
- changed-file mypy -> Success: no issues found in 1 source file
- `make lint` -> All checks passed
- `ruff format --check aragora/ tests/ scripts/` -> 10710 files already formatted
- differential typecheck -> PASS, new=103 <= 108
- `make test-smoke` -> Core/Server/Memory imports OK
- smoke tier -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok

## Risk

Tier 1 bounded caller migration. No public protocol definitions, compatibility shims, Redis paths, consensus storage, generated metadata, or gate surfaces changed.
