### PR TITLE
fix(receipts): never mint PASS/APPROVED from zero evidence (#9303)

### DIFF
--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -1,0 +1,68 @@
+"""Shared semantics for recognizing agent FAILURE placeholders (issue #9303).
+
+Several layers emit human-friendly placeholder text when an agent errors out
+(autonomic recovery notes, chaos-theater whimsy, timeout stubs). Those strings
+are *about* a failure — they are never evidence, never an answer, and must
+never support a verdict. This module is the single source of truth for
+recognizing them so the CLI failure gate, receipt minting, and memory
+injection all agree on what "the agent said nothing" means.
+
+Failure modes this guards against (measured live in the 2026-07-15 dim-8
+instrument run):
+- a debate where every agent errored minted a PASS receipt at 80% confidence
+  whose sole "response" was a chaos-theater placeholder;
+- placeholder text from a failed attempt was re-injected into the next
+  attempt as institutional knowledge.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+#: Substrings that mark a response as an error placeholder rather than
+#: content. Mirrors the autonomic/chaos-theater emitters; keep lowercase.
+AGENT_FAILURE_RESPONSE_MARKERS: tuple[str, ...] = (
+    "[system: agent ",
+    "[error generating proposal:",
+    "[no proposals available",
+    "agent timed out",
+    "connection failed",
+    "encountered an error",
+    "encountered an unexpected situation",
+    "something went wrong with",
+    "needs to restart their thought process",
+    "tripped over an edge case",
+    "experienced a minor cognitive hiccup",
+    "got confused and needs to recalibrate",
+    "a wild bug appeared",
+    "has achieved unexpected behavior",
+    "fatal exception in",
+    "error 418:",
+)
+
+
+def looks_like_agent_failure_response(text: Any) -> bool:
+    """True when ``text`` is empty or reads as an error placeholder."""
+    if text is None:
+        return True
+    lowered = str(text).strip().lower()
+    if not lowered:
+        return True
+    return any(marker in lowered for marker in AGENT_FAILURE_RESPONSE_MARKERS)
+
+
+def all_responses_are_failures(texts: Iterable[Any]) -> bool:
+    """True when there is at least one response and EVERY one is a failure
+    placeholder (or empty). An empty iterable returns True as well: zero
+    responses is zero evidence."""
+    for text in texts:
+        if not looks_like_agent_failure_response(text):
+            return False
+    return True
+
+
+__all__ = [
+    "AGENT_FAILURE_RESPONSE_MARKERS",
+    "looks_like_agent_failure_response",
+    "all_responses_are_failures",
+]

--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -83,7 +83,9 @@ def _chaos_theater_fragments() -> tuple[str, ...]:
     """
     try:
         from aragora.debate import chaos_theater as ct
-    except Exception:  # noqa: BLE001 - marker derivation must never break callers
+    except (ImportError, AttributeError, RuntimeError):
+        # Marker derivation must never break callers; these cover circular
+        # imports, moved/renamed classes, and partially initialized packages.
         return ()
     fragments: list[str] = []
     for attr in dir(ct.ChaosDirector):

--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -40,6 +40,34 @@ AGENT_FAILURE_RESPONSE_MARKERS: tuple[str, ...] = (
     "error 418:",
 )
 
+#: UNMISTAKABLE placeholder signatures — never appear in real answers.
+_STRONG_MARKERS: tuple[str, ...] = (
+    "[system: agent ",
+    "[error generating proposal:",
+    "[no proposals available",
+    "needs to restart their thought process",
+    "tripped over an edge case",
+    "experienced a minor cognitive hiccup",
+    "got confused and needs to recalibrate",
+    "a wild bug appeared",
+    "has achieved unexpected behavior",
+    "error 418:",
+)
+
+#: Generic phrases that also occur in real technical content ("the outage
+#: happened because connection failed"). These only classify as placeholders
+#: when the text is a one-liner (openai #9306 r2 [P2]).
+_WEAK_MARKERS: tuple[str, ...] = (
+    "agent timed out",
+    "connection failed",
+    "encountered an error",
+    "encountered an unexpected situation",
+    "something went wrong with",
+    "fatal exception in",
+)
+
+_WEAK_MARKER_MAX_CHARS = 120
+
 
 #: Placeholders are short, single-sentence stubs. A response longer than this
 #: is substantive content even when it QUOTES an error string (a review
@@ -61,7 +89,13 @@ def looks_like_agent_failure_response(text: Any) -> bool:
         return True
     if len(lowered) >= _MAX_PLACEHOLDER_CHARS:
         return False
-    return any(marker in lowered for marker in AGENT_FAILURE_RESPONSE_MARKERS)
+    if any(marker in lowered for marker in _STRONG_MARKERS):
+        return True
+    # Weak/generic phrases classify only one-liners: a concise real answer
+    # ABOUT an outage must never mint NO_EVIDENCE.
+    if len(lowered) <= _WEAK_MARKER_MAX_CHARS:
+        return any(marker in lowered for marker in _WEAK_MARKERS)
+    return False
 
 
 def all_responses_are_failures(texts: Iterable[Any]) -> bool:

--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -87,6 +87,13 @@ def looks_like_agent_failure_response(text: Any) -> bool:
     lowered = str(text).strip().lower()
     if not lowered:
         return True
+    # Bracket-prefixed placeholders embed arbitrarily long error bodies
+    # (e.g. proposal_phase emits "[Error generating proposal: <traceback>]"),
+    # so PREFIX matches classify regardless of length (claude #9306 r3 [P2]).
+    if lowered.startswith(
+        ("[system: agent ", "[error generating proposal:", "[no proposals available")
+    ):
+        return True
     if len(lowered) >= _MAX_PLACEHOLDER_CHARS:
         return False
     if any(marker in lowered for marker in _STRONG_MARKERS):

--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -17,6 +17,8 @@ instrument run):
 
 from __future__ import annotations
 
+import re
+from functools import lru_cache as _lru_cache
 from typing import Any, Iterable
 
 #: Substrings that mark a response as an error placeholder rather than
@@ -69,6 +71,49 @@ _WEAK_MARKERS: tuple[str, ...] = (
 _WEAK_MARKER_MAX_CHARS = 120
 
 
+def _chaos_theater_fragments() -> tuple[str, ...]:
+    """Derive placeholder fragments from chaos_theater's OWN templates.
+
+    claude #9306 terminal-round [P2]: the static marker list covered only one
+    of chaos_theater's message families, so an all-timeouts debate ("X is
+    wrestling with the complexity...") still minted PASS. Deriving fragments
+    from the source templates closes the family by construction — new
+    templates are recognized automatically. Soft import: on any failure the
+    static lists still apply.
+    """
+    try:
+        from aragora.debate import chaos_theater as ct
+    except Exception:  # noqa: BLE001 - marker derivation must never break callers
+        return ()
+    fragments: list[str] = []
+    for attr in dir(ct.ChaosDirector):
+        if not attr.endswith("_MESSAGES"):
+            continue
+        families = getattr(ct.ChaosDirector, attr, None)
+        templates = []
+        if isinstance(families, dict):
+            for family in families.values():
+                templates.extend(family)
+        elif isinstance(families, (list, tuple)):
+            templates.extend(families)
+        for template in templates:
+            if not isinstance(template, str):
+                continue
+            # Longest static run without format fields, lowercased.
+            parts = [part for part in re.split(r"\{[^}]*\}", template) if part]
+            best = max(parts, key=len, default="").strip(" .!?[]⚡🌀🔌⚠️️")
+            if len(best) >= 12:
+                fragments.append(best.lower())
+    return tuple(dict.fromkeys(fragments))
+
+
+@_lru_cache(maxsize=1)
+def _chaos_fragments_cached() -> tuple[str, ...]:
+    # Lazy: import-time derivation hits circular imports (agents <-> debate);
+    # by first classification call the debate package is loaded.
+    return _chaos_theater_fragments()
+
+
 #: Placeholders are short, single-sentence stubs. A response longer than this
 #: is substantive content even when it QUOTES an error string (a review
 #: discussing "connection failed" is an answer, not a failure).
@@ -97,6 +142,10 @@ def looks_like_agent_failure_response(text: Any) -> bool:
     if len(lowered) >= _MAX_PLACEHOLDER_CHARS:
         return False
     if any(marker in lowered for marker in _STRONG_MARKERS):
+        return True
+    # Chaos-theater templates (all families, derived from source) are
+    # unmistakable placeholders regardless of which family emitted them.
+    if any(fragment in lowered for fragment in _chaos_fragments_cached()):
         return True
     # Weak/generic phrases classify only one-liners: a concise real answer
     # ABOUT an outage must never mint NO_EVIDENCE.

--- a/aragora/agents/failure_semantics.py
+++ b/aragora/agents/failure_semantics.py
@@ -41,13 +41,26 @@ AGENT_FAILURE_RESPONSE_MARKERS: tuple[str, ...] = (
 )
 
 
+#: Placeholders are short, single-sentence stubs. A response longer than this
+#: is substantive content even when it QUOTES an error string (a review
+#: discussing "connection failed" is an answer, not a failure).
+_MAX_PLACEHOLDER_CHARS = 500
+
+
 def looks_like_agent_failure_response(text: Any) -> bool:
-    """True when ``text`` is empty or reads as an error placeholder."""
+    """True when ``text`` is empty or reads as an error placeholder.
+
+    Marker matching applies only to short texts (< _MAX_PLACEHOLDER_CHARS):
+    real placeholders are one-liners, and the length bound prevents
+    misclassifying substantive answers that merely mention an error.
+    """
     if text is None:
         return True
     lowered = str(text).strip().lower()
     if not lowered:
         return True
+    if len(lowered) >= _MAX_PLACEHOLDER_CHARS:
+        return False
     return any(marker in lowered for marker in AGENT_FAILURE_RESPONSE_MARKERS)
 
 

--- a/aragora/cli/commands/verify.py
+++ b/aragora/cli/commands/verify.py
@@ -88,6 +88,9 @@ _VALID_VERDICTS = frozenset(
         "pass",
         "fail",
         "conditional",
+        # Zero-evidence receipts (issue #9303): a valid receipt that truthfully
+        # asserts no deliberation occurred. Integrity-valid, never supportive.
+        "no_evidence",
     }
 )
 

--- a/aragora/gauntlet/api/schema.py
+++ b/aragora/gauntlet/api/schema.py
@@ -281,7 +281,7 @@ DECISION_RECEIPT_SCHEMA: dict[str, Any] = {
         # Verdict
         "verdict": {
             "type": "string",
-            "enum": ["PASS", "CONDITIONAL", "FAIL"],
+            "enum": ["PASS", "CONDITIONAL", "FAIL", "NO_EVIDENCE"],
             "description": "Final validation verdict",
         },
         "confidence": {
@@ -564,8 +564,8 @@ def validate_receipt(data: dict[str, Any]) -> tuple[bool, list[str]]:
                 errors.append("confidence must be a number between 0 and 1")
 
         if "verdict" in data:
-            if data["verdict"] not in ["PASS", "CONDITIONAL", "FAIL"]:
-                errors.append("verdict must be PASS, CONDITIONAL, or FAIL")
+            if data["verdict"] not in ["PASS", "CONDITIONAL", "FAIL", "NO_EVIDENCE"]:
+                errors.append("verdict must be PASS, CONDITIONAL, FAIL, or NO_EVIDENCE")
 
         return len(errors) == 0, errors
 

--- a/aragora/gauntlet/orchestrator.py
+++ b/aragora/gauntlet/orchestrator.py
@@ -975,10 +975,27 @@ class GauntletOrchestrator:
             f"Scores: risk={risk_score:.0%}, robustness={robustness_score:.0%}",
         )
 
-        # Determine verdict
-        verdict, confidence = self._determine_verdict(
-            critical, high, medium, risk_score, robustness_score, dissenting_views
+        # Zero-adversarial-work gate (issue #9303): APPROVED means "survived
+        # adversarial scrutiny". If NO attacks ran, NO probes ran, NO audit ran,
+        # and nothing was verified or found, there was no scrutiny to survive —
+        # measured live 2026-07-15: a quick-profile run with 0 attacks / 0%
+        # coverage minted APPROVED at 95%. Fail closed to NEEDS_REVIEW @ 0.
+        zero_evidence = _no_adversarial_work(
+            redteam_result,
+            probe_report,
+            audit_verdict,
+            verified_claims,
+            unverified_claims,
+            all_findings,
         )
+
+        # Determine verdict
+        if zero_evidence:
+            verdict, confidence = Verdict.NEEDS_REVIEW, 0.0
+        else:
+            verdict, confidence = self._determine_verdict(
+                critical, high, medium, risk_score, robustness_score, dissenting_views
+            )
         self._emit_progress(
             "Aggregation",
             3,
@@ -1636,3 +1653,24 @@ HIPAA_GAUNTLET = get_compliance_gauntlet("hipaa") if PERSONAS_AVAILABLE else Non
 AI_ACT_GAUNTLET = get_compliance_gauntlet("ai_act") if PERSONAS_AVAILABLE else None
 SECURITY_GAUNTLET = get_compliance_gauntlet("security") if PERSONAS_AVAILABLE else None
 SOX_GAUNTLET = get_compliance_gauntlet("sox") if PERSONAS_AVAILABLE else None
+
+
+def _no_adversarial_work(
+    redteam: Any,
+    probe: Any,
+    audit: Any,
+    verified_claims: Any,
+    unverified_claims: Any,
+    findings: Any,
+) -> bool:
+    """True when the run produced ZERO adversarial evidence (issue #9303).
+
+    APPROVED means "survived adversarial scrutiny"; with no attacks, no
+    probes, no audit, no claims examined, and no findings there was no
+    scrutiny to survive, and the verdict must fail closed to NEEDS_REVIEW.
+    """
+    attacks_ran = bool(redteam and getattr(redteam, "total_attacks", 0) > 0)
+    probes_ran = bool(probe and getattr(probe, "probes_run", 0) > 0)
+    audit_ran = audit is not None
+    claims_examined = bool(verified_claims or unverified_claims)
+    return not (attacks_ran or probes_ran or audit_ran or claims_examined or bool(findings))

--- a/aragora/gauntlet/orchestrator.py
+++ b/aragora/gauntlet/orchestrator.py
@@ -992,6 +992,11 @@ class GauntletOrchestrator:
         # Determine verdict
         if zero_evidence:
             verdict, confidence = Verdict.NEEDS_REVIEW, 0.0
+            # No redteam ran, so robustness defaulted to a perfect 1.0 —
+            # 100% robustness on a path where nothing executed is the same
+            # hollow-receipt lie in a different field (claude #9306 r4 [P2]).
+            robustness_score = 0.0
+            coverage_score = 0.0
         else:
             verdict, confidence = self._determine_verdict(
                 critical, high, medium, risk_score, robustness_score, dissenting_views

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+
+from aragora.agents.failure_semantics import all_responses_are_failures
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from html import escape
@@ -1460,8 +1462,21 @@ class DecisionReceipt:
         if live_explainability is not None:
             explainability = {"live_explainability": live_explainability}
 
+        # Zero-evidence gate (issue #9303): if every agent response is an error
+        # placeholder (autonomic/chaos-theater text) — or there are none — no
+        # deliberation happened. A decision-integrity receipt must say so
+        # instead of asserting PASS on top of provider failures.
+        response_texts = [
+            getattr(msg, "content", "") for msg in getattr(result, "messages", []) or []
+        ]
+        zero_evidence = all_responses_are_failures(response_texts) and all_responses_are_failures(
+            [result.final_answer]
+        )
+
         # Determine verdict from consensus
-        if result.consensus_reached and result.confidence >= 0.7:
+        if zero_evidence:
+            verdict = "NO_EVIDENCE"
+        elif result.consensus_reached and result.confidence >= 0.7:
             verdict = "PASS"
         elif result.consensus_reached:
             verdict = "CONDITIONAL"
@@ -1472,6 +1487,8 @@ class DecisionReceipt:
         robustness_score = result.confidence * (0.8 if result.consensus_reached else 0.5)
         if hasattr(result, "convergence_similarity"):
             robustness_score = (robustness_score + result.convergence_similarity) / 2
+        if zero_evidence:
+            robustness_score = 0.0
 
         # Build verdict reasoning
         reasoning_parts = []
@@ -1487,6 +1504,11 @@ class DecisionReceipt:
             reasoning_parts.append(f"Winner: {result.winner}")
 
         verdict_reasoning = ". ".join(reasoning_parts)
+        if zero_evidence:
+            verdict_reasoning = (
+                "NO EVIDENCE: every agent response was a provider/error placeholder; "
+                "no substantive deliberation occurred. " + verdict_reasoning
+            )
 
         agent_responses = cls._build_agent_responses(result, cost_summary=cost_summary)
 
@@ -1505,7 +1527,7 @@ class DecisionReceipt:
             probes_run=result.rounds_used,  # Map rounds to probes
             vulnerabilities_found=len(dissenting_views),
             verdict=verdict,
-            confidence=result.confidence,
+            confidence=0.0 if zero_evidence else result.confidence,
             robustness_score=robustness_score,
             vulnerability_details=[],  # No vulnerability details for debates
             verdict_reasoning=verdict_reasoning,

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -1433,9 +1433,17 @@ class DecisionReceipt:
         # empty messages but substantive proposals is NOT zero-evidence.
         proposals = getattr(result, "proposals", None) or {}
         proposal_texts = list(proposals.values()) if isinstance(proposals, dict) else []
+        # agent_responses is the third evidence source _build_agent_responses
+        # reads (openai #9306 r6 [P2]) — detection now mirrors that method's
+        # sources exactly: messages, proposals, agent_responses, final_answer.
+        agent_response_texts = [
+            getattr(r, "response", "") or str(getattr(r, "content", "") or "")
+            for r in getattr(result, "agent_responses", []) or []
+        ]
         zero_evidence = (
             all_responses_are_failures(response_texts)
             and all_responses_are_failures(proposal_texts)
+            and all_responses_are_failures(agent_response_texts)
             and all_responses_are_failures([result.final_answer])
         )
 

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -1422,13 +1422,26 @@ class DecisionReceipt:
                 if agent_name:
                     dissenting_agents.append(agent_name)
 
+        # Zero-evidence gate (issue #9303): if every agent response is an error
+        # placeholder (autonomic/chaos-theater text) — or there are none — no
+        # deliberation happened. A decision-integrity receipt must say so
+        # instead of asserting PASS on top of provider failures.
+        response_texts = [
+            getattr(msg, "content", "") for msg in getattr(result, "messages", []) or []
+        ]
+        zero_evidence = all_responses_are_failures(response_texts) and all_responses_are_failures(
+            [result.final_answer]
+        )
+
         # Supporting agents = participants minus dissenters
         supporting_agents = [p for p in participants if p not in dissenting_agents]
 
+        # A zero-evidence run cannot claim consensus: the 'agreement' is between
+        # error placeholders (openai #9306 r3 [P2]).
         consensus = ConsensusProof(
-            reached=result.consensus_reached,
-            confidence=result.confidence,
-            supporting_agents=supporting_agents,
+            reached=False if zero_evidence else result.consensus_reached,
+            confidence=0.0 if zero_evidence else result.confidence,
+            supporting_agents=[] if zero_evidence else supporting_agents,
             dissenting_agents=dissenting_agents,
             method=getattr(result, "consensus_strength", "majority") or "majority",
             evidence_hash=(
@@ -1461,17 +1474,6 @@ class DecisionReceipt:
         live_explainability = normalize_live_explainability(metadata.get("live_explainability"))
         if live_explainability is not None:
             explainability = {"live_explainability": live_explainability}
-
-        # Zero-evidence gate (issue #9303): if every agent response is an error
-        # placeholder (autonomic/chaos-theater text) — or there are none — no
-        # deliberation happened. A decision-integrity receipt must say so
-        # instead of asserting PASS on top of provider failures.
-        response_texts = [
-            getattr(msg, "content", "") for msg in getattr(result, "messages", []) or []
-        ]
-        zero_evidence = all_responses_are_failures(response_texts) and all_responses_are_failures(
-            [result.final_answer]
-        )
 
         # Determine verdict from consensus
         if zero_evidence:
@@ -1507,7 +1509,7 @@ class DecisionReceipt:
         if zero_evidence:
             verdict_reasoning = (
                 "NO EVIDENCE: every agent response was a provider/error placeholder; "
-                "no substantive deliberation occurred. " + verdict_reasoning
+                "no substantive deliberation occurred."
             )
 
         agent_responses = cls._build_agent_responses(result, cost_summary=cost_summary)

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -1437,7 +1437,11 @@ class DecisionReceipt:
         # reads (openai #9306 r6 [P2]) — detection now mirrors that method's
         # sources exactly: messages, proposals, agent_responses, final_answer.
         agent_response_texts = [
-            getattr(r, "response", "") or str(getattr(r, "content", "") or "")
+            (
+                r.get("response") or r.get("content") or ""
+                if isinstance(r, dict)
+                else getattr(r, "response", "") or str(getattr(r, "content", "") or "")
+            )
             for r in getattr(result, "agent_responses", []) or []
         ]
         zero_evidence = (

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -1429,8 +1429,14 @@ class DecisionReceipt:
         response_texts = [
             getattr(msg, "content", "") for msg in getattr(result, "messages", []) or []
         ]
-        zero_evidence = all_responses_are_failures(response_texts) and all_responses_are_failures(
-            [result.final_answer]
+        # Proposals are evidence too (openai #9306 r5 [P2]): a result with
+        # empty messages but substantive proposals is NOT zero-evidence.
+        proposals = getattr(result, "proposals", None) or {}
+        proposal_texts = list(proposals.values()) if isinstance(proposals, dict) else []
+        zero_evidence = (
+            all_responses_are_failures(response_texts)
+            and all_responses_are_failures(proposal_texts)
+            and all_responses_are_failures([result.final_answer])
         )
 
         # Supporting agents = participants minus dissenters

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -1,0 +1,83 @@
+"""Zero-evidence receipts must never assert PASS/APPROVED (issue #9303).
+
+Measured live 2026-07-15 (dim-8 instrument): a debate where every agent
+returned provider/error placeholders minted verdict=PASS at 80% confidence,
+and a gauntlet run with 0 attacks / 0 probes / 0 findings minted APPROVED at
+95%. These tests pin the fail-closed behavior.
+"""
+
+from __future__ import annotations
+
+from aragora.agents.failure_semantics import (
+    all_responses_are_failures,
+    looks_like_agent_failure_response,
+)
+from aragora.core_types import DebateResult, Message
+from aragora.gauntlet.orchestrator import _no_adversarial_work
+from aragora.gauntlet.receipt_models import DecisionReceipt
+
+
+def _placeholder_result() -> DebateResult:
+    return DebateResult(
+        debate_id="d-zero",
+        task="Should we adopt a monorepo?",
+        final_answer="anthropic-api got confused and needs to recalibrate.",
+        confidence=0.8,
+        consensus_reached=True,
+        rounds_used=1,
+        participants=["anthropic-api"],
+        messages=[
+            Message(
+                role="proposal",
+                agent="anthropic-api",
+                content="anthropic-api got confused and needs to recalibrate.",
+            )
+        ],
+        winner="anthropic-api",
+    )
+
+
+class TestFailureSemantics:
+    def test_placeholders_recognized(self) -> None:
+        assert looks_like_agent_failure_response(
+            "anthropic-api got confused and needs to recalibrate."
+        )
+        assert looks_like_agent_failure_response("")
+        assert looks_like_agent_failure_response(None)
+        assert not looks_like_agent_failure_response("Use a monorepo because ...")
+
+    def test_all_responses(self) -> None:
+        assert all_responses_are_failures([])  # zero responses = zero evidence
+        assert all_responses_are_failures(["agent timed out", ""])
+        assert not all_responses_are_failures(["agent timed out", "real answer"])
+
+
+class TestDebateZeroEvidenceReceipt:
+    def test_placeholder_only_debate_mints_no_evidence(self) -> None:
+        receipt = DecisionReceipt.from_debate_result(_placeholder_result())
+        assert receipt.verdict == "NO_EVIDENCE"
+        assert receipt.confidence == 0.0
+        assert receipt.robustness_score == 0.0
+        assert "NO EVIDENCE" in receipt.verdict_reasoning
+
+    def test_real_answer_still_passes(self) -> None:
+        result = _placeholder_result()
+        result.final_answer = "Adopt a monorepo: single CI surface, atomic refactors."
+        result.messages = [Message(role="proposal", agent="claude", content=result.final_answer)]
+        receipt = DecisionReceipt.from_debate_result(result)
+        assert receipt.verdict == "PASS"
+        assert receipt.confidence == 0.8
+
+
+class TestGauntletZeroWork:
+    def test_no_work_is_zero_evidence(self) -> None:
+        assert _no_adversarial_work(None, None, None, [], [], []) is True
+
+    class _Redteam:
+        total_attacks = 3
+
+    def test_any_real_work_counts(self) -> None:
+        assert _no_adversarial_work(self._Redteam(), None, None, [], [], []) is False
+        assert _no_adversarial_work(None, None, object(), [], [], []) is False
+        assert _no_adversarial_work(None, None, None, ["claim"], [], []) is False
+        assert _no_adversarial_work(None, None, None, [], [], ["finding"]) is False

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -81,3 +81,19 @@ class TestGauntletZeroWork:
         assert _no_adversarial_work(None, None, object(), [], [], []) is False
         assert _no_adversarial_work(None, None, None, ["claim"], [], []) is False
         assert _no_adversarial_work(None, None, None, [], [], ["finding"]) is False
+
+
+class TestRoundTwoHardening:
+    def test_no_evidence_verdict_is_verify_valid(self) -> None:
+        from aragora.cli.commands.verify import _is_valid_verdict
+
+        assert _is_valid_verdict("NO_EVIDENCE")
+        assert _is_valid_verdict("no_evidence")
+
+    def test_long_answer_quoting_error_is_not_a_placeholder(self) -> None:
+        text = (
+            "The root cause is that the retry loop swallows 'connection failed' "
+            "errors from the pool. " + "Detailed analysis follows. " * 30
+        )
+        assert len(text) >= 500
+        assert not looks_like_agent_failure_response(text)

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -149,3 +149,13 @@ class TestRoundTwoHardening:
         }
         receipt = DecisionReceipt.from_debate_result(result)
         assert receipt.verdict != "NO_EVIDENCE"
+
+    def test_substantive_agent_responses_prevent_zero_evidence(self) -> None:
+        from types import SimpleNamespace
+
+        result = _placeholder_result()
+        result.agent_responses = [
+            SimpleNamespace(response="Real analysis: adopt the monorepo for atomic refactors.")
+        ]
+        receipt = DecisionReceipt.from_debate_result(result)
+        assert receipt.verdict != "NO_EVIDENCE"

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -97,3 +97,22 @@ class TestRoundTwoHardening:
         )
         assert len(text) >= 500
         assert not looks_like_agent_failure_response(text)
+
+    def test_short_real_outage_answer_not_a_placeholder(self) -> None:
+        text = (
+            "Root cause: the LB health check failed after the pool's connection "
+            "failed during cert rotation; fix is to pin the CA bundle and retry."
+        )
+        assert 120 < len(text) < 500
+        assert not looks_like_agent_failure_response(text)
+
+    def test_strong_placeholder_still_classified(self) -> None:
+        assert looks_like_agent_failure_response(
+            "claude tripped over an edge case and is recovering"
+        )
+
+    def test_schema_accepts_no_evidence(self) -> None:
+        from aragora.gauntlet.api.schema import validate_receipt
+
+        _ok, errors = validate_receipt({"verdict": "NO_EVIDENCE", "confidence": 0.0})
+        assert not any("verdict must be" in e for e in errors)

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -141,3 +141,11 @@ class TestRoundTwoHardening:
         gate = src[src.index("if zero_evidence:") :]
         assert "robustness_score = 0.0" in gate[:600]
         assert "coverage_score = 0.0" in gate[:600]
+
+    def test_substantive_proposals_prevent_zero_evidence(self) -> None:
+        result = _placeholder_result()
+        result.proposals = {
+            "claude": "Monorepo: one CI surface, atomic refactors, single review gate."
+        }
+        receipt = DecisionReceipt.from_debate_result(result)
+        assert receipt.verdict != "NO_EVIDENCE"

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -116,3 +116,16 @@ class TestRoundTwoHardening:
 
         _ok, errors = validate_receipt({"verdict": "NO_EVIDENCE", "confidence": 0.0})
         assert not any("verdict must be" in e for e in errors)
+
+    def test_long_bracketed_error_body_is_still_a_placeholder(self) -> None:
+        text = "[Error generating proposal: " + "traceback line\n" * 100 + "]"
+        assert len(text) > 500
+        assert looks_like_agent_failure_response(text)
+
+    def test_zero_evidence_receipt_has_no_supportive_consensus(self) -> None:
+        receipt = DecisionReceipt.from_debate_result(_placeholder_result())
+        assert receipt.consensus_proof.reached is False
+        assert receipt.consensus_proof.confidence == 0.0
+        assert receipt.consensus_proof.supporting_agents == []
+        assert "Winner" not in receipt.verdict_reasoning
+        assert "Consensus reached" not in receipt.verdict_reasoning

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -159,3 +159,9 @@ class TestRoundTwoHardening:
         ]
         receipt = DecisionReceipt.from_debate_result(result)
         assert receipt.verdict != "NO_EVIDENCE"
+
+    def test_dict_backed_agent_responses_prevent_zero_evidence(self) -> None:
+        result = _placeholder_result()
+        result.agent_responses = [{"agent": "claude", "response": "Real monorepo analysis."}]
+        receipt = DecisionReceipt.from_debate_result(result)
+        assert receipt.verdict != "NO_EVIDENCE"

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -165,3 +165,21 @@ class TestRoundTwoHardening:
         result.agent_responses = [{"agent": "claude", "response": "Real monorepo analysis."}]
         receipt = DecisionReceipt.from_debate_result(result)
         assert receipt.verdict != "NO_EVIDENCE"
+
+    def test_all_chaos_theater_families_classified(self) -> None:
+        # claude #9306 terminal [P2]: TIMEOUT and CONNECTION families were
+        # unrecognized. Fragments now derive from chaos_theater's own
+        # templates — every family, current and future.
+        samples = [
+            "claude is wrestling with the complexity of your question.",
+            "gpt's signal has faded into the digital ether.",
+            "codex is taking longer than expected to respond...",
+            "[claude stares into the abyss of computation for 90 seconds...]",
+        ]
+        for text in samples:
+            assert looks_like_agent_failure_response(text), text
+
+    def test_real_answer_mentioning_wrestling_is_not_classified(self) -> None:
+        assert not looks_like_agent_failure_response(
+            "Our analysis: the wrestling industry monorepo should be split."
+        )

--- a/tests/gauntlet/test_zero_evidence_receipts.py
+++ b/tests/gauntlet/test_zero_evidence_receipts.py
@@ -129,3 +129,15 @@ class TestRoundTwoHardening:
         assert receipt.consensus_proof.supporting_agents == []
         assert "Winner" not in receipt.verdict_reasoning
         assert "Consensus reached" not in receipt.verdict_reasoning
+
+    def test_zero_work_result_reports_zero_robustness(self) -> None:
+        # Pin the orchestrator constants: the zero-evidence branch must zero
+        # robustness/coverage (defaults are 1.0/derived when redteam is None).
+        import inspect
+
+        from aragora.gauntlet import orchestrator as go
+
+        src = inspect.getsource(go)
+        gate = src[src.index("if zero_evidence:") :]
+        assert "robustness_score = 0.0" in gate[:600]
+        assert "coverage_score = 0.0" in gate[:600]

--- a/tests/integration/test_chaos_scenarios.py
+++ b/tests/integration/test_chaos_scenarios.py
@@ -529,9 +529,12 @@ class TestReceiptGenerationFailure:
 
         assert receipt is not None
         assert receipt.receipt_id is not None
-        assert receipt.verdict in ("PASS", "CONDITIONAL", "FAIL")
-        # With no consensus and 0 confidence, should be FAIL
-        assert receipt.verdict == "FAIL"
+        assert receipt.verdict in ("PASS", "CONDITIONAL", "FAIL", "NO_EVIDENCE")
+        # Intentional semantics change (#9303): a malformed result with no
+        # agent output is NO_EVIDENCE (nothing ran), not FAIL (adversarially
+        # rejected). Graceful handling now also means truthful labeling.
+        assert receipt.verdict == "NO_EVIDENCE"
+        assert receipt.confidence == 0.0
 
     def test_receipt_hash_verification_catches_tampering(self):
         """Tampered receipts fail integrity verification, proving


### PR DESCRIPTION
Closes #9303 (quality-program dim-8, ledger #9039).

## The defect (measured live, 2026-07-15)
A decision-integrity platform minted **PASS @ 80%** from a debate where every agent errored, and **APPROVED @ 95%** from a gauntlet with zero attacks and 0% coverage — and both verifiers validated the hollow receipts.

## Changes
- `aragora/agents/failure_semantics.py` (new): shared error-placeholder recognition
- `from_debate_result`: placeholder-only debates → **NO_EVIDENCE / 0.0 / 0.0** with explicit reasoning (ODR verdict is a free string — schema-safe)
- gauntlet orchestrator: zero adversarial work → **NEEDS_REVIEW @ 0.0** via `_no_adversarial_work` (was clean-approval fallthrough + robustness defaulting to 1.0)

## Validation
+6 regression tests pinning both live repros; 100 pass across receipt/orchestrator suites; ruff + mypy clean. Tier 2-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)