### PR TITLE
ci(test-shards): re-split debate into 4 balanced shards [Tier-4]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -683,6 +683,10 @@ jobs:
   # Sub-sharding history:
   #   2026-04-25: Heavy shards split to fit within 30-min runner cap.
   #     - debate (1 shard, 30+ min) -> debate-am, debate-nz, debate-phases
+  #   2026-07-15: debate-am re-saturated (28-30+ min, cancelled on main sched
+  #     run 29390230325 and PR #9245 run 29293412959 despite the #9280
+  #     rebalance). Re-split into 4 balanced shards: debate-phases + debate-1/2/3
+  #     (~11.5 min pytest each). Boundaries in scripts/ci_resolve_test_shard.py.
   #     - server (1 shard, 23 min)  -> server-handlers-am, server-handlers-nz, server-rest
   #     - handlers (1 shard, 26 min) -> handlers-features, handlers-amk-no-features, handlers-lz
   #   Path-filter (test-shard-scope) added: PRs touching only docs/CI/integration
@@ -723,23 +727,28 @@ jobs:
             scope: infra
             timeout: 30
 
-          # debate (was 1 shard hitting 30-min cap, now 3 sub-shards by alphabet)
-          # Top-level debate test files a-m (~5500 tests)
-          - name: debate-am
-            pytest_args: ""
-            resolver: debate-am
-            scope: debate
-            timeout: 30
-          # Top-level debate test files n-z (~5600 tests)
-          - name: debate-nz
-            pytest_args: ""
-            resolver: debate-nz
-            scope: debate
-            timeout: 30
-          # Subdirectories under tests/debate/ (~3000 tests)
+          # debate: 4 balanced sub-shards (~11.5 min pytest each, measured
+          # 2026-07-15). debate-phases = tests/debate/ subdirs + first range
+          # of top-level files; debate-1/2/3 = remaining contiguous ranges.
+          # Boundaries live in scripts/ci_resolve_test_shard.py.
           - name: debate-phases
             pytest_args: ""
             resolver: debate-phases
+            scope: debate
+            timeout: 30
+          - name: debate-1
+            pytest_args: ""
+            resolver: debate-1
+            scope: debate
+            timeout: 30
+          - name: debate-2
+            pytest_args: ""
+            resolver: debate-2
+            scope: debate
+            timeout: 30
+          - name: debate-3
+            pytest_args: ""
+            resolver: debate-3
             scope: debate
             timeout: 30
 

--- a/scripts/ci_resolve_test_shard.py
+++ b/scripts/ci_resolve_test_shard.py
@@ -8,13 +8,13 @@ express purely in YAML. Stacking many ``--ignore-glob`` patterns also
 leaves the resulting argv hard to audit at a glance.
 
 This helper translates a logical shard name (``handlers-amk-no-features``,
-``debate-am`` and friends) into a concrete list of test files / dirs that
+``debate-1`` and friends) into a concrete list of test files / dirs that
 pytest can be invoked with directly, leaving collection itself simple,
 deterministic, and easy to verify locally.
 
 Usage::
 
-    python3 scripts/ci_resolve_test_shard.py debate-am
+    python3 scripts/ci_resolve_test_shard.py debate-1
     python3 scripts/ci_resolve_test_shard.py handlers-lz --check
 
 Each shard prints a single line with the test paths to stdout. The
@@ -76,15 +76,18 @@ def _file_letter(name: str) -> str:
 # Per-shard resolvers
 # ---------------------------------------------------------------------------
 
-_DEBATE_PHASES_REBALANCED_FILES = frozenset(
-    {
-        "test_autonomic_executor.py",
-        "test_convergence_comprehensive.py",
-        "test_counterfactual_root.py",
-        "test_context_gatherer.py",
-        "test_context_gatherer_root.py",
-        "test_e2e_flow.py",
-    }
+# Debate shards: four contiguous ranges over the sorted top-level test files
+# of tests/debate/, plus all subdirectories (which ride with the first range
+# in ``debate-phases``). Boundaries were sized from the 2026-07-15 saturated
+# run (debate-am 25:16 pytest / 28:15 job, cancelled at 30:00 on main): each
+# range estimates ~11.5 min of pytest wall clock on ubuntu-latest ``-n auto``,
+# ~15 min per job including setup. When a debate shard saturates again, re-run
+# the sizing (test count per file x measured s/test) and move these boundaries
+# rather than adding per-file exception sets.
+_DEBATE_FILE_BOUNDARIES = (
+    "test_checkpoint_memory.py",  # debate-phases | debate-1
+    "test_event_emission.py",  # debate-1 | debate-2
+    "test_outcome_context.py",  # debate-2 | debate-3
 )
 
 
@@ -92,36 +95,42 @@ def _under(parent: Path, names: Iterable[str]) -> list[str]:
     return [str((parent / name).relative_to(REPO_ROOT)) for name in names]
 
 
-def shard_debate_am() -> list[str]:
-    """Top-level debate test files starting a-m, excluding rebalanced files."""
+def _debate_file_range(index: int) -> list[str]:
+    """Top-level tests/debate files in half-open boundary range ``index``.
+
+    Range 0 is everything before the first boundary; range 3 is everything
+    from the last boundary onward. Boundary files belong to the range they
+    open (half-open intervals), so every file lands in exactly one range.
+    """
     parent = TESTS_ROOT / "debate"
     _, files = _entries(parent)
-    in_am = _alpha_range("a", "m")
-    chosen = [
-        f for f in files if in_am(_file_letter(f)) and f not in _DEBATE_PHASES_REBALANCED_FILES
-    ]
+    bounds = _DEBATE_FILE_BOUNDARIES
+    low = bounds[index - 1] if index > 0 else None
+    high = bounds[index] if index < len(bounds) else None
+    chosen = [f for f in files if (low is None or f >= low) and (high is None or f < high)]
     return _under(parent, chosen)
 
 
-def shard_debate_nz() -> list[str]:
-    """Top-level debate test files starting n-z, no subdir tests."""
-    parent = TESTS_ROOT / "debate"
-    _, files = _entries(parent)
-    in_nz = _alpha_range("n", "z")
-    return _under(parent, [f for f in files if in_nz(_file_letter(f))])
-
-
 def shard_debate_phases() -> list[str]:
-    """Debate subdirectories plus measured heavy top-level files.
-
-    The selected files contributed about 604 aggregate worker-seconds in the
-    measured saturated run. Moving them here gives debate-am bounded headroom
-    while debate-phases remains far below its 30-minute cap.
-    """
+    """All tests/debate subdirectories plus the first top-level file range."""
     parent = TESTS_ROOT / "debate"
-    subdirs, files = _entries(parent)
-    rebalanced = [f for f in files if f in _DEBATE_PHASES_REBALANCED_FILES]
-    return _under(parent, [*subdirs, *rebalanced])
+    subdirs, _ = _entries(parent)
+    return _under(parent, subdirs) + _debate_file_range(0)
+
+
+def shard_debate_1() -> list[str]:
+    """Second range of top-level tests/debate files."""
+    return _debate_file_range(1)
+
+
+def shard_debate_2() -> list[str]:
+    """Third range of top-level tests/debate files."""
+    return _debate_file_range(2)
+
+
+def shard_debate_3() -> list[str]:
+    """Fourth range of top-level tests/debate files."""
+    return _debate_file_range(3)
 
 
 def _server_handlers_root() -> Path:
@@ -187,9 +196,10 @@ def shard_handlers_lz() -> list[str]:
 
 
 SHARDS: dict[str, Callable[[], list[str]]] = {
-    "debate-am": shard_debate_am,
-    "debate-nz": shard_debate_nz,
     "debate-phases": shard_debate_phases,
+    "debate-1": shard_debate_1,
+    "debate-2": shard_debate_2,
+    "debate-3": shard_debate_3,
     "server-handlers-am": shard_server_handlers_am,
     "server-handlers-nz": shard_server_handlers_nz,
     "server-rest": shard_server_rest,

--- a/tests/scripts/test_ci_resolve_test_shard.py
+++ b/tests/scripts/test_ci_resolve_test_shard.py
@@ -101,27 +101,24 @@ def test_server_handlers_partition_is_complete_and_disjoint() -> None:
 def test_debate_partition_is_complete_and_disjoint() -> None:
     _assert_partition(
         "tests/debate",
-        ["debate-am", "debate-nz", "debate-phases"],
+        ["debate-phases", "debate-1", "debate-2", "debate-3"],
     )
 
 
-def test_debate_runtime_balanced_files_are_in_phases_shard() -> None:
-    """Measured heavy top-level files run in the debate shard with ample headroom."""
-    rebalanced = {
-        "tests/debate/test_autonomic_executor.py",
-        "tests/debate/test_convergence_comprehensive.py",
-        "tests/debate/test_counterfactual_root.py",
-        "tests/debate/test_context_gatherer.py",
-        "tests/debate/test_context_gatherer_root.py",
-        "tests/debate/test_e2e_flow.py",
-    }
-    debate_am = _expand_to_files(shard_mod.shard_debate_am())
-    debate_nz = _expand_to_files(shard_mod.shard_debate_nz())
-    debate_phases = _expand_to_files(shard_mod.shard_debate_phases())
+def test_debate_boundaries_are_sorted_and_each_range_nonempty() -> None:
+    """Boundary tuple stays sorted, and no debate shard silently degenerates."""
+    bounds = shard_mod._DEBATE_FILE_BOUNDARIES
+    assert list(bounds) == sorted(bounds)
+    for name in ["debate-phases", "debate-1", "debate-2", "debate-3"]:
+        assert shard_mod.SHARDS[name](), f"shard {name} resolved to no paths"
 
-    assert rebalanced <= debate_phases
-    assert rebalanced.isdisjoint(debate_am)
-    assert rebalanced.isdisjoint(debate_nz)
+
+def test_debate_subdirs_run_only_in_phases_shard() -> None:
+    """Subdirectory tests belong to debate-phases; ranges cover only top-level files."""
+    subdir_tests = {f for f in _all_tests_under("tests/debate") if len(Path(f).parts) > 3}
+    assert subdir_tests <= _expand_to_files(shard_mod.shard_debate_phases())
+    for fn in (shard_mod.shard_debate_1, shard_mod.shard_debate_2, shard_mod.shard_debate_3):
+        assert subdir_tests.isdisjoint(_expand_to_files(fn()))
 
 
 def test_resolver_emits_relative_paths() -> None:


### PR DESCRIPTION
## Problem

`test-fast (debate-am)` is exceeding the 30-minute GitHub-hosted runner cap again:

- PR #9245: run [29293412959](https://github.com/synaptent/aragora/actions/runs/29293412959) job [87346063906](https://github.com/synaptent/aragora/actions/runs/29293412959/job/87346063906) — "The job has exceeded the maximum execution time of 30m0s", all steps green, pytest ran out of wall clock.
- main scheduled run [29390230325](https://github.com/synaptent/aragora/actions/runs/29390230325) — debate-am cancelled at 30m18s.

The prior rebalance #9280 (move 6 heavy files into debate-phases) held for only a few days before re-saturating.

## Evidence (measured 2026-07-15, run [29410884808](https://github.com/synaptent/aragora/actions/runs/29410884808))

| Shard | Tests | pytest wall | Job time |
|---|---|---|---|
| debate-am | 8,311 | 25:16 | 28:15 |
| debate-nz | 6,732 | 15:24 | 18:27 |
| debate-phases | 3,686 | 5:38 | 8:04 |

~46 min of aggregate pytest across 3 shards; the slowest-20 report shows no dominant test (worst single test 4.6s) — this is volume, not outliers, so per-file exception sets can't hold under the current growth rate of `tests/debate/`.

## Change

Replace the a-m/n-z alphabet split + `_DEBATE_PHASES_REBALANCED_FILES` exception set with **four contiguous filename ranges** over the sorted top-level `tests/debate/` files, boundaries in `scripts/ci_resolve_test_shard.py`:

- `debate-phases` — all subdirectories + files before `test_checkpoint_memory.py`
- `debate-1` — `test_checkpoint_memory.py` … before `test_event_emission.py`
- `debate-2` — `test_event_emission.py` … before `test_outcome_context.py`
- `debate-3` — `test_outcome_context.py` … end

Boundaries were sized from collected per-file test counts × measured s/test rates per shard:

| New shard | Tests | Est. pytest | Est. job |
|---|---|---|---|
| debate-phases | 5,261 | 11.3 min | ~14 min |
| debate-1 | 3,965 | 11.4 min | ~14 min |
| debate-2 | 4,112 | 11.4 min | ~14 min |
| debate-3 | 5,023 | 11.5 min | ~14 min |

All well under the 22-min p95 target with ~50% growth headroom. The next saturation is fixed by moving a boundary, not stacking exceptions.

## Guard rails

- `tests/scripts/test_ci_resolve_test_shard.py` updated: partition completeness/disjointness over the new shard names, sorted-boundary + non-empty-range invariants, subdirs pinned to debate-phases. **6/6 passing locally.**
- `ci_resolve_test_shard.py --check` verified for all four shards; YAML validated; ruff + mypy clean on changed files.
- One extra matrix job, but total debate runner-minutes stay roughly flat (4×~14 ≈ 3×~18).

## Tier

Workflow change ⇒ **Tier-4**, opened as draft for founder settlement per the operating contract. The `test-fast` matrix names are not in the 5 required checks, so renaming `debate-am`/`debate-nz` → `debate-1/2/3` does not touch branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)