### PR TITLE
fix(caching): correct legacy decorator replacement guidance

### DIFF
--- a/aragora/cache.py
+++ b/aragora/cache.py
@@ -2,10 +2,11 @@
 
 The unified caching implementation now lives under :mod:`aragora.caching`.
 Importing from ``aragora.cache`` still works but is deprecated. Migrate to the
-matching ``aragora.caching`` submodules: ``aragora.caching.ttl`` (``cached``,
-``TTLCache``, ``clear_all_caches`` and the TTL primitives),
-``aragora.caching.registry`` (``get_cache``, ``CacheStats``, ``register_cache``),
-and ``aragora.caching.redis`` (``RedisTTLCache``, ``HybridTTLCache``).
+matching ``aragora.caching`` submodules. In particular, replace ``cached`` with
+``aragora.caching.ttl.ttl_cache`` and ``async_cached`` with
+``aragora.caching.ttl.async_ttl_cache``. Other legacy names retain their names
+under ``aragora.caching.ttl`` (TTL primitives), ``aragora.caching.registry``
+(cache registry APIs), or ``aragora.caching.redis`` (Redis-backed caches).
 
 Note: the top-level ``aragora.caching`` names ``cached`` / ``CacheStats`` /
 ``clear_all_caches`` are the decorator-layer API and are *not* drop-in
@@ -43,12 +44,15 @@ from aragora.caching.ttl import (
 )
 
 warnings.warn(
-    "aragora.cache is deprecated; import from the matching aragora.caching "
-    "submodules instead (aragora.caching.ttl for cached/TTLCache/clear_all_caches, "
-    "aragora.caching.registry for get_cache/CacheStats, aragora.caching.redis for "
-    "RedisTTLCache/HybridTTLCache). The aragora.caching top-level "
-    "cached/CacheStats/clear_all_caches are the decorator-layer API and are not "
-    "drop-in replacements for these names.",
+    "aragora.cache is deprecated; replace cached with "
+    "aragora.caching.ttl.ttl_cache and async_cached with "
+    "aragora.caching.ttl.async_ttl_cache. Import other legacy names from their "
+    "matching submodules: aragora.caching.ttl.TTLCache and "
+    "aragora.caching.ttl.clear_all_caches, aragora.caching.registry.get_cache and "
+    "aragora.caching.registry.CacheStats, or aragora.caching.redis.RedisTTLCache "
+    "and aragora.caching.redis.HybridTTLCache. The aragora.caching top-level "
+    "cached, CacheStats, and clear_all_caches names are the decorator-layer API "
+    "and are not drop-in replacements for these legacy names.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/tests/caching/test_consolidation_shims.py
+++ b/tests/caching/test_consolidation_shims.py
@@ -23,6 +23,15 @@ SHIMS = [
 MODS = [mod for mod, _ in SHIMS]
 
 
+def _import_legacy_cache():
+    sys.modules.pop("aragora.cache", None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        module = importlib.import_module("aragora.cache")
+    deprecations = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    return module, deprecations
+
+
 @pytest.fixture(autouse=True)
 def _restore_cache_modules():
     saved = {name: sys.modules.get(name) for name in MODS}
@@ -89,3 +98,68 @@ def test_distinct_cachestats_apis_preserved():
     assert DecoratorStats is not RegistryStats
     assert DecoratorStats is not AdaptiveStats
     assert RegistryStats is not AdaptiveStats
+
+
+def test_cache_warning_names_valid_cached_replacement():
+    legacy_cache, deprecations = _import_legacy_cache()
+    from aragora.caching.ttl import ttl_cache
+
+    message = "\n".join(deprecations)
+    assert "aragora.caching.ttl.ttl_cache" in message
+    assert "aragora.caching.ttl.cached" not in message
+    assert legacy_cache.cached is ttl_cache
+
+
+def test_cache_warning_names_valid_async_cached_replacement():
+    legacy_cache, deprecations = _import_legacy_cache()
+    from aragora.caching.ttl import async_ttl_cache
+
+    message = "\n".join(deprecations)
+    assert "aragora.caching.ttl.async_ttl_cache" in message
+    assert "aragora.caching.ttl.async_cached" not in message
+    assert legacy_cache.async_cached is async_ttl_cache
+
+
+@pytest.mark.asyncio
+async def test_cache_decorator_replacements_preserve_identity_and_behavior():
+    legacy_cache, _ = _import_legacy_cache()
+    from aragora.caching.ttl import async_ttl_cache, get_handler_cache, ttl_cache
+
+    assert legacy_cache.cached is ttl_cache
+    assert legacy_cache.async_cached is async_ttl_cache
+
+    handler_cache = get_handler_cache()
+    handler_cache.clear()
+    sync_calls = 0
+    async_calls = 0
+
+    @legacy_cache.cached(
+        ttl_seconds=60,
+        key_prefix="val_p4a_021_sync",
+        skip_first=False,
+    )
+    def sync_value(value: int) -> int:
+        nonlocal sync_calls
+        sync_calls += 1
+        return value * 2
+
+    @legacy_cache.async_cached(
+        ttl_seconds=60,
+        key_prefix="val_p4a_021_async",
+        skip_first=False,
+    )
+    async def async_value(value: int) -> int:
+        nonlocal async_calls
+        async_calls += 1
+        return value * 3
+
+    try:
+        assert sync_value(7) == 14
+        assert sync_value(7) == 14
+        assert sync_calls == 1
+
+        assert await async_value(7) == 21
+        assert await async_value(7) == 21
+        assert async_calls == 1
+    finally:
+        handler_cache.clear()


### PR DESCRIPTION
## Summary

- correct `aragora.cache` deprecation guidance so `cached` names `aragora.caching.ttl.ttl_cache`
- name `aragora.caching.ttl.async_ttl_cache` as the behavior-preserving `async_cached` replacement
- retain the existing top-level `aragora.caching` namespace clarification and distinct `CacheStats` contracts
- add the three focused VAL-P4A-021 warning, identity, and behavior regressions

## Validation

- `python3 -c "from aragora.caching.ttl import ttl_cache, async_ttl_cache; from aragora.cache import cached, async_cached; assert cached is ttl_cache; assert async_cached is async_ttl_cache; print('PASS')"`: PASS
- `python3 -m pytest tests/caching/test_consolidation_shims.py -q -k 'test_cache_warning_names_valid_cached_replacement or test_cache_warning_names_valid_async_cached_replacement or test_cache_decorator_replacements_preserve_identity_and_behavior'`: 3 passed
- `python3 -m pytest tests/caching -x -q --timeout=120`: 161 passed
- `make lint`: passed
- `ruff format --check aragora/ tests/ scripts/`: 10,710 files formatted
- targeted changed-file mypy for `aragora/cache.py`: no issues
- mission differential typecheck: PASS (`new=103 <= recorded env drift=108`)
- `make test-smoke`: Core, Server, and Memory imports passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke`: 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed

## Risk

Low, Tier 1 compatibility-guidance repair. The legacy decorator aliases already preserve canonical object identity; this PR makes the warning text accurate and locks existing sync and async cache semantics with regressions.
