### PR TITLE
docs: repair Arena and routing imports

### DIFF
--- a/aragora/events/README.md
+++ b/aragora/events/README.md
@@ -167,7 +167,7 @@ print(f"Events processed: {stats.events_processed}")
 Connect Arena debates to the event system:
 
 ```python
-from aragora.events import ArenaEventBridge, create_arena_bridge
+from aragora.debate.arena_bridge import ArenaEventBridge, create_arena_bridge
 
 # Create bridge for an arena
 bridge = create_arena_bridge(arena)

--- a/docs-site/docs/advanced/cross-pollination.md
+++ b/docs-site/docs/advanced/cross-pollination.md
@@ -108,7 +108,7 @@ manager.register("my_handler", StreamEventType.AGENT_ELO_UPDATED, my_handler_fn)
 Connects Arena's internal EventBus to the CrossSubscriberManager.
 
 ```python
-from aragora.events.arena_bridge import ArenaEventBridge, create_arena_bridge
+from aragora.debate.arena_bridge import ArenaEventBridge, create_arena_bridge
 
 # Automatic - enabled by default via ArenaBuilder
 arena = ArenaBuilder(env, agents).build()

--- a/docs/deployment/DISASTER_RECOVERY.md
+++ b/docs/deployment/DISASTER_RECOVERY.md
@@ -717,11 +717,9 @@ asyncio.run(check())
 
 # Recover specific job types
 python -c "
-from aragora.queue.workers import (
-    recover_interrupted_transcriptions,
-    recover_interrupted_routing,
-)
+from aragora.queue.workers import recover_interrupted_transcriptions
 from aragora.server.workers.gauntlet_worker import recover_interrupted_gauntlets
+from aragora.server.workers.routing_worker import recover_interrupted_routing
 import asyncio
 
 async def recover():
@@ -960,11 +958,9 @@ Add to your application startup sequence:
 
 async def run_recovery_hooks():
     """Run automated recovery on startup."""
-    from aragora.queue.workers import (
-        recover_interrupted_transcriptions,
-        recover_interrupted_routing,
-    )
+    from aragora.queue.workers import recover_interrupted_transcriptions
     from aragora.server.workers.gauntlet_worker import recover_interrupted_gauntlets
+    from aragora.server.workers.routing_worker import recover_interrupted_routing
     from aragora.workflow.nodes.human_checkpoint import HumanCheckpointNode
 
     # Recover interrupted jobs

--- a/docs/integrations/CROSS_POLLINATION.md
+++ b/docs/integrations/CROSS_POLLINATION.md
@@ -103,7 +103,7 @@ manager.register("my_handler", StreamEventType.AGENT_ELO_UPDATED, my_handler_fn)
 Connects Arena's internal EventBus to the CrossSubscriberManager.
 
 ```python
-from aragora.events.arena_bridge import ArenaEventBridge, create_arena_bridge
+from aragora.debate.arena_bridge import ArenaEventBridge, create_arena_bridge
 
 # Automatic - enabled by default via ArenaBuilder
 arena = ArenaBuilder(env, agents).build()


### PR DESCRIPTION
## Source

- Mission feature: `p4a-arena-routing-docs-cleanup`
- Validation contract: `VAL-P4A-022`

## Summary

- repoint live Arena bridge examples to `aragora.debate.arena_bridge`
- import routing recovery from the canonical `aragora.server.workers.routing_worker` module in both disaster-recovery snippets
- regenerate the cross-pollination docs-site mirror through `docs-site/scripts/sync-docs.js`

## Behavior

The disaster-recovery flow is unchanged: transcription, routing, gauntlet, approval, and consensus-healing recovery calls retain their documented order and symbols. Historical archive and changelog references are untouched.

## Validation

- exact `VAL-P4A-022` stale-import census, routing assertion, and import probe
- `make docs-check`
- `python3 scripts/ci/check_docs_links.py`
- docs-site sync idempotence
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q -k 'not test_docs_specs_directory_is_mirrored'` (22 passed, 1 deselected)
- `make lint`
- `ruff format --check aragora/ tests/ scripts/`
- mission differential typecheck
- docs-site production build
- `make test-smoke`
- `PYTEST_BIN='python3 -m pytest' bash scripts/test_tiers.sh smoke` (138 passed)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

The deselected mirror-completeness test fails identically on clean `origin/main` because `docs/specs/OPERATOR_ADVISORY_SETTLEMENT.md` lacks its separately owned `DOC_MAP` entry.

## Risk

Tier 1, docs-only. Four Markdown files, including one generated mirror; no runtime, API, workflow, or test behavior changes.