### PR TITLE
fix(tests): make pattern-prune tests deterministic across timezones

### DIFF
--- a/tests/storage/test_store_extended.py
+++ b/tests/storage/test_store_extended.py
@@ -571,6 +571,22 @@ class TestDebateStorageExtended:
 # =============================================================================
 
 
+def _backdate_patterns(store, days: int = 10) -> None:
+    """Age all stored patterns using SQLite's own UTC clock.
+
+    Patterns are stamped with local-time ``datetime.now()`` while
+    ``prune_stale_patterns`` compares against UTC ``julianday('now')``, so a
+    freshly written pattern can appear up to a millisecond (or, east of UTC,
+    hours) in the future and dodge ``max_age_days=0`` pruning.
+    """
+    with store.connection() as conn:
+        conn.execute(
+            "UPDATE patterns SET updated_at = datetime('now', ?)",
+            (f"-{days} days",),
+        )
+        conn.commit()
+
+
 class TestPatternPruningExtended:
     """Extended tests for pattern pruning."""
 
@@ -589,6 +605,8 @@ class TestPatternPruningExtended:
         # Store many times (100% success rate)
         for _ in range(10):
             store.store_pattern(critique, "fix")
+
+        _backdate_patterns(store)
 
         # Prune with high min_success_rate
         pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5)
@@ -615,8 +633,11 @@ class TestPatternPruningExtended:
         store.fail_pattern("archive test pattern")
         store.fail_pattern("archive test pattern")
 
+        _backdate_patterns(store)
+
         # Prune (success_rate = 1/4 = 0.25 < 0.5)
-        store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=True)
+        pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=True)
+        assert pruned == 1
 
         archive_stats = store.get_archive_stats()
         assert archive_stats["total_archived"] >= 1
@@ -637,9 +658,12 @@ class TestPatternPruningExtended:
         store.fail_pattern("no archive pattern")
         store.fail_pattern("no archive pattern")
 
+        _backdate_patterns(store)
+
         initial_archive = store.get_archive_stats()["total_archived"]
 
-        store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=False)
+        pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=False)
+        assert pruned == 1
 
         final_archive = store.get_archive_stats()["total_archived"]
         assert final_archive == initial_archive  # No new archives


### PR DESCRIPTION
## Summary
Fixes the CI flake in `tests/storage/test_store_extended.py::TestPatternPruningExtended::test_prune_patterns_archive_created` (PR #9307, run 29423578237, `assert 0 >= 1` on gw3).

## Root cause
Pattern rows are stamped with **local-time** `datetime.now().isoformat()` (µs precision), while `prune_stale_patterns` compares them against **UTC** `julianday('now')`, which SQLite rounds to milliseconds. With `max_age_days=0` the prune condition is `now − updated_at ≥ 0`:

- On UTC CI runners, if store→fail→prune all land within ~1 ms, the stored µs fraction rounds **up** past the ms-floored `'now'`, the diff goes negative, the prune matches zero rows, and the archive count asserts 0 ≥ 1. A tight-loop SQL repro hits this ~49% of the time under `TZ=UTC`.
- East of UTC the test fails **deterministically** (verified: pre-fix fails 100% under `TZ=Europe/Paris`, since `updated_at` appears hours in the future).
- It never fails on US-timezone dev machines because local time is hours *behind* UTC.

Not xdist shared state — the `store` fixture already uses a per-test temp DB; parallel load just perturbed timing.

## Fix
Add a `_backdate_patterns` helper that rewrites `updated_at` using SQLite's own UTC clock (`datetime('now', '-10 days')`) before pruning, removing both the timezone skew and the sub-ms rounding race. Applied to all three prune tests in the class, and the assertions were **strengthened** (exact `pruned == 1` counts), not weakened.

## Verification
- Pre-fix: fails 100% under `TZ=Europe/Paris`; post-fix: passes under `TZ=UTC`, `TZ=Europe/Paris`, and `TZ=Pacific/Kiritimati` (UTC+14)
- `TZ=UTC pytest tests/storage/test_store_extended.py -n auto --dist loadscope`: 41 passed
- 30 randomized-order loops of the class under `TZ=UTC`: 0 failures

Note: the underlying local-vs-UTC timestamp mixing in `aragora/memory/store.py` also skews real prune thresholds by up to the UTC offset; left out of scope here (test-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)