### PR TITLE
chore(codeowners): remove stale types path [Tier-4]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,6 @@
 # Core package exports and types
 /aragora/__init__.py @an0mium
 /aragora/core.py @an0mium
-/aragora/types.py @an0mium
 /aragora/typing.py @an0mium
 
 # Nomic loop (self-improvement safety-critical)


### PR DESCRIPTION
## Source

- Structural-excellence feature `p4a-codeowners-stale-types-cleanup`
- Operator authorization: `library/operator-approvals.md` Decision dated 2026-07-13

## Behavior

- Removes exactly `/aragora/types.py @an0mium` from `.github/CODEOWNERS`
- Changes one file with one deleted line
- Adds no test file and makes no adjacent ownership or formatting changes

## Validation

- `git diff --numstat origin/main...HEAD` -> `0 1 .github/CODEOWNERS`
- Exact delta -> `-/aragora/types.py @an0mium`
- `make lint` -> passed
- `ruff format --check aragora/ tests/ scripts/` -> 10,710 files already formatted
- `bash /Users/armand/.factory/missions/4f616812-ddb9-4d30-ab59-9fa933be4103/scripts/typecheck_differential.sh` -> pass (`new=103 <= 108`)
- `AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` -> passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Risk and settlement boundary

This is an exact Tier-4 surgical cleanup. Authorization is void if the head moves or the diff expands. Settlement and merge must bind to commit `b2a46737d007d3ce2f4272550b1010c42256d99e`, use `--squash --match-head-commit`, and never use `--admin`.
