### PR TITLE
fix(security): count key rotation list failures

### DIFF
--- a/aragora/security/migration.py
+++ b/aragora/security/migration.py
@@ -635,7 +635,7 @@ def rotate_and_reencrypt_store(
 
     except (TypeError, RuntimeError, OSError, ValueError) as e:
         result.errors.append("Re-encryption failed due to an internal error")
-        result.failed_records = result.total_records
+        result.failed_records = max(1, result.total_records)
         logger.error("Key rotation re-encryption failed for %s: %s", store_name, e)
 
     return result

--- a/tests/security/test_migration.py
+++ b/tests/security/test_migration.py
@@ -549,9 +549,7 @@ class TestMigrationAuditProvider:
             {"api_key": "decrypted-secret"},
         )
 
-    def test_default_rotation_resolves_unregistered_storage_store(
-        self, encryption_service, monkeypatch
-    ):
+    def test_optional_store_absence_remains_best_effort(self, encryption_service, monkeypatch):
         old_key = MagicMock(version=1)
         new_key = MagicMock(key_id="default", version=2)
         encryption_service._keys = {"default": old_key}
@@ -577,6 +575,8 @@ class TestMigrationAuditProvider:
 
         assert result.success is True
         assert result.stores_processed == 1
+        assert result.failed_records == 0
+        assert result.errors == []
         get_sync_store.assert_awaited_once_with()
         store.list_connectors.assert_awaited_once_with()
 
@@ -604,6 +604,35 @@ class TestMigrationAuditProvider:
         assert result.failed_records == 1
         assert result.errors == ["Store sync re-encryption failed"]
         get_sync_store.assert_awaited_once_with()
+
+    def test_live_sync_rotation_fails_closed_when_connector_list_fails(
+        self, encryption_service, monkeypatch
+    ):
+        old_key = MagicMock(version=1)
+        new_key = MagicMock(key_id="default", version=2)
+        encryption_service._keys = {"default": old_key}
+        encryption_service._active_key_id = "default"
+        encryption_service.rotate_key.return_value = new_key
+        store = MagicMock()
+        store.list_connectors = AsyncMock(side_effect=RuntimeError("credential=secret-value"))
+        get_sync_store = AsyncMock(return_value=store)
+        sync_store_module = ModuleType("aragora.storage.sync_store")
+        sync_store_module.get_sync_store = get_sync_store
+        monkeypatch.setitem(sys.modules, "aragora.storage.sync_store", sync_store_module)
+
+        with patch(
+            "aragora.security.encryption.get_encryption_service",
+            return_value=encryption_service,
+        ):
+            result = rotate_encryption_key(dry_run=False, stores=["sync"])
+
+        assert result.success is False
+        assert result.stores_processed == 1
+        assert result.failed_records >= 1
+        assert result.errors == ["Re-encryption failed due to an internal error"]
+        assert "secret-value" not in " ".join(result.errors)
+        get_sync_store.assert_awaited_once_with()
+        store.list_connectors.assert_awaited_once_with()
 
     def test_live_sync_rotation_fails_closed_when_connector_save_fails(
         self, encryption_service, monkeypatch


### PR DESCRIPTION
## Source

Mission feature `misc-security-key-rotation-failure-accounting`, fulfilling `VAL-P4A-017`.

## Behavior

- Count configured record-list failures as at least one failed record, even before the list function can report a record count.
- Keep required sync-store setup failures fail-closed.
- Preserve intentionally absent integration and Gmail stores as best-effort optional absence.
- Preserve sanitized result errors while leaving exception details only in logs.

## Reviewer context

`VAL-P4A-017` explicitly distinguishes required sync setup/list failures from optional integration and Gmail absence. The bounded implementation changes only the outer record-list failure accounting in `rotate_and_reencrypt_store`; it does not make optional `None` store configurations fail.

## Validation

- `python3 -m pytest tests/security/test_migration.py::TestMigrationAuditProvider::test_live_sync_rotation_fails_closed_when_storage_resolution_fails tests/security/test_migration.py::TestMigrationAuditProvider::test_live_sync_rotation_fails_closed_when_connector_list_fails tests/security/test_migration.py::TestMigrationAuditProvider::test_optional_store_absence_remains_best_effort -q` -> 3 passed
- `python3 -m pytest tests/security/test_migration.py -q --timeout=120` -> 47 passed
- `make lint` -> passed
- `ruff format --check aragora/ tests/ scripts/` -> 10712 files formatted
- changed-file mypy on `aragora/security/migration.py` -> no issues
- mission differential typecheck -> PASS, new=103 <= 108
- `make test-smoke` -> passed
- smoke tier -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed

## Risk

Tier 3 security surface. Prepare-only after exact-head two-family evidence; human risk settlement is required before merge.