### PR TITLE
feat(agents): secured-provider support + surface buried answers (#9304)

### DIFF
--- a/aragora/agents/api_agents/anthropic.py
+++ b/aragora/agents/api_agents/anthropic.py
@@ -66,6 +66,20 @@ WEB_SEARCH_INDICATORS = [
     env_vars="ANTHROPIC_API_KEY",
     accepts_api_key=True,
 )
+def _resolve_base_url(env_name: str, default: str) -> str:
+    """Resolve the API base URL from the environment (issue #9304).
+
+    Gateway values may omit the /v1 suffix the client paths expect; normalize
+    so both "https://gw.example" and "https://gw.example/v1" work.
+    """
+    import os
+
+    raw = os.environ.get(env_name, "").strip().rstrip("/")
+    if not raw:
+        return default
+    return raw if raw.endswith("/v1") else raw + "/v1"
+
+
 class AnthropicAPIAgent(QuotaFallbackMixin, APIAgent):
     """Agent that uses Anthropic API directly (without CLI).
 
@@ -109,7 +123,11 @@ class AnthropicAPIAgent(QuotaFallbackMixin, APIAgent):
             timeout=timeout,
             api_key=api_key
             or get_primary_api_key("ANTHROPIC_API_KEY", allow_openrouter_fallback=True),
-            base_url="https://api.anthropic.com/v1",
+            # ANTHROPIC_BASE_URL supports BYOK gateways/proxies (LiteLLM,
+            # enterprise API gateways, local proxies) — issue #9304: the
+            # hardcoded endpoint made secured providers architecturally
+            # unsupported. Accepts values with or without a trailing /v1.
+            base_url=_resolve_base_url("ANTHROPIC_BASE_URL", "https://api.anthropic.com/v1"),
         )
         self.agent_type = "anthropic"
         # Use config setting if not explicitly provided

--- a/aragora/agents/api_agents/anthropic.py
+++ b/aragora/agents/api_agents/anthropic.py
@@ -58,14 +58,6 @@ WEB_SEARCH_INDICATORS = [
 ]
 
 
-@AgentRegistry.register(
-    "anthropic-api",
-    default_model="claude-opus-4-8",
-    default_name="claude-api",
-    agent_type="API",
-    env_vars="ANTHROPIC_API_KEY",
-    accepts_api_key=True,
-)
 def _resolve_base_url(env_name: str, default: str) -> str:
     """Resolve the API base URL from the environment (issue #9304).
 
@@ -80,6 +72,14 @@ def _resolve_base_url(env_name: str, default: str) -> str:
     return raw if raw.endswith("/v1") else raw + "/v1"
 
 
+@AgentRegistry.register(
+    "anthropic-api",
+    default_model="claude-opus-4-8",
+    default_name="claude-api",
+    agent_type="API",
+    env_vars="ANTHROPIC_API_KEY",
+    accepts_api_key=True,
+)
 class AnthropicAPIAgent(QuotaFallbackMixin, APIAgent):
     """Agent that uses Anthropic API directly (without CLI).
 

--- a/aragora/agents/api_agents/openai.py
+++ b/aragora/agents/api_agents/openai.py
@@ -41,6 +41,16 @@ _WEB_SEARCH_PATTERNS = [
     env_vars="OPENAI_API_KEY",
     accepts_api_key=True,
 )
+def _resolve_openai_base_url() -> str:
+    """OPENAI_BASE_URL override for gateways/proxies (issue #9304)."""
+    import os
+
+    raw = os.environ.get("OPENAI_BASE_URL", "").strip().rstrip("/")
+    if not raw:
+        return "https://api.openai.com/v1"
+    return raw if raw.endswith("/v1") else raw + "/v1"
+
+
 class OpenAIAPIAgent(OpenAICompatibleMixin, APIAgent):
     """Agent that uses OpenAI API directly.
 
@@ -95,7 +105,8 @@ class OpenAIAPIAgent(OpenAICompatibleMixin, APIAgent):
             timeout=timeout,
             api_key=api_key
             or get_primary_api_key("OPENAI_API_KEY", allow_openrouter_fallback=True),
-            base_url="https://api.openai.com/v1",
+            # OPENAI_BASE_URL supports BYOK gateways/proxies (issue #9304).
+            base_url=_resolve_openai_base_url(),
         )
         self.agent_type = "openai"
         # Use config setting if not explicitly provided

--- a/aragora/agents/api_agents/openai.py
+++ b/aragora/agents/api_agents/openai.py
@@ -33,14 +33,6 @@ _WEB_SEARCH_PATTERNS = [
 ]
 
 
-@AgentRegistry.register(
-    "openai-api",
-    default_model="gpt-5.5",
-    default_name="openai-api",
-    agent_type="API",
-    env_vars="OPENAI_API_KEY",
-    accepts_api_key=True,
-)
 def _resolve_openai_base_url() -> str:
     """OPENAI_BASE_URL override for gateways/proxies (issue #9304)."""
     import os
@@ -51,6 +43,14 @@ def _resolve_openai_base_url() -> str:
     return raw if raw.endswith("/v1") else raw + "/v1"
 
 
+@AgentRegistry.register(
+    "openai-api",
+    default_model="gpt-5.5",
+    default_name="openai-api",
+    agent_type="API",
+    env_vars="OPENAI_API_KEY",
+    accepts_api_key=True,
+)
 class OpenAIAPIAgent(OpenAICompatibleMixin, APIAgent):
     """Agent that uses OpenAI API directly.
 

--- a/aragora/agents/cli_agents.py
+++ b/aragora/agents/cli_agents.py
@@ -194,20 +194,29 @@ def terminate_tracked_cli_processes(grace_seconds: float = 0.2) -> dict[str, int
     }
 
 
-#: Provider-wall / auth-error signatures that some CLIs print to STDOUT with
-#: exit 0 (issue #9304). Bounded to short outputs so a legitimate proposal
-#: QUOTING an error message is never misclassified.
-_EXIT0_PROVIDER_ERROR_MARKERS: tuple[str, ...] = (
+#: UNMISTAKABLE provider-wall signatures printed to STDOUT with exit 0
+#: (issue #9304): phrases that never occur as ordinary debate content.
+_EXIT0_STRONG_ERROR_MARKERS: tuple[str, ...] = (
     "do not have access to this model",
     "out of usage credits",
+    "run /usage-credits",
     "hit your usage limit",
-    "not logged in",
     "please run /login",
-    "quota exceeded",
-    "credit balance is too low",
     "invalid x-api-key",
+    "credit balance is too low",
+)
+
+#: Generic phrases ("quota exceeded", "not logged in") appear in legitimate
+#: answers ABOUT auth/quota topics — this repo's own debates discuss them.
+#: They only classify one-line outputs (#9315 round 1, both families).
+_EXIT0_WEAK_ERROR_MARKERS: tuple[str, ...] = (
+    "not logged in",
+    "quota exceeded",
     "authentication_error",
 )
+
+_EXIT0_STRONG_MAX_CHARS = 2000
+_EXIT0_WEAK_MAX_CHARS = 160
 
 
 class CLIAgent(CritiqueMixin, Agent):
@@ -475,11 +484,14 @@ class CLIAgent(CritiqueMixin, Agent):
                 # proposal. Without this, error text enters the debate as
                 # content ('Round 1: Low novelty 0.00') and rots memory.
                 lowered_stdout = stdout_text.lower()
-                if (
-                    stdout_text
-                    and any(marker in lowered_stdout for marker in _EXIT0_PROVIDER_ERROR_MARKERS)
-                    and len(stdout_text) < 2000
-                ):
+                is_wall = (
+                    len(stdout_text) < _EXIT0_STRONG_MAX_CHARS
+                    and any(m in lowered_stdout for m in _EXIT0_STRONG_ERROR_MARKERS)
+                ) or (
+                    len(stdout_text) < _EXIT0_WEAK_MAX_CHARS
+                    and any(m in lowered_stdout for m in _EXIT0_WEAK_ERROR_MARKERS)
+                )
+                if stdout_text and is_wall:
                     if self._circuit_breaker is not None:
                         self._circuit_breaker.record_failure()
                     raise CLISubprocessError(

--- a/aragora/agents/cli_agents.py
+++ b/aragora/agents/cli_agents.py
@@ -194,6 +194,22 @@ def terminate_tracked_cli_processes(grace_seconds: float = 0.2) -> dict[str, int
     }
 
 
+#: Provider-wall / auth-error signatures that some CLIs print to STDOUT with
+#: exit 0 (issue #9304). Bounded to short outputs so a legitimate proposal
+#: QUOTING an error message is never misclassified.
+_EXIT0_PROVIDER_ERROR_MARKERS: tuple[str, ...] = (
+    "do not have access to this model",
+    "out of usage credits",
+    "hit your usage limit",
+    "not logged in",
+    "please run /login",
+    "quota exceeded",
+    "credit balance is too low",
+    "invalid x-api-key",
+    "authentication_error",
+)
+
+
 class CLIAgent(CritiqueMixin, Agent):
     """Base class for CLI-based agents.
 
@@ -453,6 +469,25 @@ class CLIAgent(CritiqueMixin, Agent):
 
                 stdout_text = stdout.decode("utf-8", errors="replace").strip()
                 stderr_text = stderr.decode("utf-8", errors="replace").strip()
+
+                # Provider walls/errors printed to STDOUT with exit 0 (issue
+                # #9304): a proxy's 403 body or a subscription wall is not a
+                # proposal. Without this, error text enters the debate as
+                # content ('Round 1: Low novelty 0.00') and rots memory.
+                lowered_stdout = stdout_text.lower()
+                if (
+                    stdout_text
+                    and any(marker in lowered_stdout for marker in _EXIT0_PROVIDER_ERROR_MARKERS)
+                    and len(stdout_text) < 2000
+                ):
+                    if self._circuit_breaker is not None:
+                        self._circuit_breaker.record_failure()
+                    raise CLISubprocessError(
+                        message=f"CLI returned a provider error as output: {stdout_text[:200]}",
+                        agent_name=self.name,
+                        returncode=0,
+                        stderr=stderr_text or None,
+                    )
 
                 # Some CLIs (e.g., Kilo) emit errors on stderr but return code 0.
                 # Treat "no stdout + non-empty stderr" as a failure to enable fallback.

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -2998,6 +2998,15 @@ def cmd_ask(args: argparse.Namespace) -> None:
         raise SystemExit(1)
 
     if _result_has_only_agent_failure_outputs(result):
+        # Surface a substantive final answer if one exists (issue #9304): the
+        # engine can synthesize a real answer even when round messages were
+        # placeholders — hiding it behind a bare exit-1 buries user value.
+        final = str(getattr(result, "final_answer", "") or "")
+        if final and not _looks_like_agent_failure_response(final):
+            print("\n" + "=" * 60)
+            print("FINAL ANSWER (degraded run — agent rounds reported errors):")
+            print("=" * 60)
+            print(final)
         print(
             "Debate failed: all selected agents returned provider/error placeholders. "
             f"Run 'aragora validate-env --smoke --agents {agents} --verbose' and retry.",

--- a/aragora/debate/phases/context_init.py
+++ b/aragora/debate/phases/context_init.py
@@ -1346,6 +1346,20 @@ class ContextInitializer:
             if not relevant_context or len(relevant_context.strip()) < 50:
                 return
 
+            # Never inject error placeholders as institutional knowledge
+            # (issue #9304: a failed attempt's 'tripped over an edge case'
+            # placeholder was re-fed to the next debate as a learned insight).
+            from aragora.agents.failure_semantics import looks_like_agent_failure_response
+
+            filtered_lines = [
+                line
+                for line in relevant_context.splitlines()
+                if not (line.strip() and looks_like_agent_failure_response(line))
+            ]
+            relevant_context = "\n".join(filtered_lines)
+            if len(relevant_context.strip()) < 50:
+                return
+
             # Inject as institutional knowledge section
             institutional_section = "\n\n## INSTITUTIONAL KNOWLEDGE\n"
             institutional_section += (

--- a/tests/agents/test_provider_support_9304.py
+++ b/tests/agents/test_provider_support_9304.py
@@ -1,0 +1,55 @@
+"""Secured-provider support + failure-text classification (issue #9304)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestBaseUrlOverride:
+    def test_anthropic_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+        from aragora.agents.api_agents.anthropic import _resolve_base_url
+
+        assert (
+            _resolve_base_url("ANTHROPIC_BASE_URL", "https://api.anthropic.com/v1")
+            == "https://api.anthropic.com/v1"
+        )
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("http://127.0.0.1:8317", "http://127.0.0.1:8317/v1"),
+            ("http://127.0.0.1:8317/", "http://127.0.0.1:8317/v1"),
+            ("https://gw.example/v1", "https://gw.example/v1"),
+        ],
+    )
+    def test_anthropic_override_normalizes(
+        self, monkeypatch: pytest.MonkeyPatch, value: str, expected: str
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", value)
+        from aragora.agents.api_agents.anthropic import _resolve_base_url
+
+        assert _resolve_base_url("ANTHROPIC_BASE_URL", "https://api.anthropic.com/v1") == expected
+
+    def test_openai_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENAI_BASE_URL", "https://litellm.internal")
+        from aragora.agents.api_agents.openai import _resolve_openai_base_url
+
+        assert _resolve_openai_base_url() == "https://litellm.internal/v1"
+
+
+class TestExit0ProviderErrors:
+    def test_markers_match_live_wall_texts(self) -> None:
+        from aragora.agents.cli_agents import _EXIT0_PROVIDER_ERROR_MARKERS
+
+        live = [
+            "Free tier users do not have access to this model",
+            "You're out of usage credits. Run /usage-credits",
+            "Not logged in · Please run /login",
+        ]
+        for text in live:
+            assert any(m in text.lower() for m in _EXIT0_PROVIDER_ERROR_MARKERS), text
+
+    def test_length_guard_protects_long_content(self) -> None:
+        legit = ("Analysis of auth flows. " * 100) + "the api returned 'quota exceeded' once"
+        assert len(legit) >= 2000

--- a/tests/agents/test_provider_support_9304.py
+++ b/tests/agents/test_provider_support_9304.py
@@ -39,17 +39,27 @@ class TestBaseUrlOverride:
 
 
 class TestExit0ProviderErrors:
-    def test_markers_match_live_wall_texts(self) -> None:
-        from aragora.agents.cli_agents import _EXIT0_PROVIDER_ERROR_MARKERS
+    def test_strong_markers_match_live_wall_texts(self) -> None:
+        from aragora.agents.cli_agents import _EXIT0_STRONG_ERROR_MARKERS
 
         live = [
             "Free tier users do not have access to this model",
             "You're out of usage credits. Run /usage-credits",
-            "Not logged in · Please run /login",
         ]
         for text in live:
-            assert any(m in text.lower() for m in _EXIT0_PROVIDER_ERROR_MARKERS), text
+            assert any(m in text.lower() for m in _EXIT0_STRONG_ERROR_MARKERS), text
 
-    def test_length_guard_protects_long_content(self) -> None:
-        legit = ("Analysis of auth flows. " * 100) + "the api returned 'quota exceeded' once"
-        assert len(legit) >= 2000
+    def test_generic_phrases_only_classify_one_liners(self) -> None:
+        from aragora.agents.cli_agents import (
+            _EXIT0_WEAK_ERROR_MARKERS,
+            _EXIT0_WEAK_MAX_CHARS,
+        )
+
+        answer = (
+            "Recommendation: return 401 when the session is not logged in, and "
+            "surface 'quota exceeded' to callers with a retry-after header so "
+            "clients can back off correctly instead of hammering the API."
+        )
+        assert len(answer) >= _EXIT0_WEAK_MAX_CHARS  # substantive answers exceed the bound
+        assert any(m in answer.lower() for m in _EXIT0_WEAK_ERROR_MARKERS)
+        # the length bound is what protects it — pinned here


### PR DESCRIPTION
Closes #9304 (quality-program dim-8, ledger #9039).

## Defects fixed (all measured live in the dim-8 instrument run)
1. **BYOK gateways unsupported**: API agents hardcoded provider endpoints; `ANTHROPIC_BASE_URL`/`OPENAI_BASE_URL` now honored (with /v1 normalization)
2. **Buried answers**: a real synthesized answer sat in the store while the CLI printed 'Debate failed' — now printed (marked degraded) before the nonzero exit
3. **Error text as proposals**: exit-0 provider walls on stdout ('do not have access to this model', usage walls, 'invalid x-api-key') classify as agent failure — no more 'Round 1: Low novelty 0.00' debates over 403 bodies
4. **Memory rot**: placeholder errors filtered from institutional-knowledge injection

## Validation
+7 tests; zero-evidence suite + TestRunDebate green; ruff/mypy/ratchet PASS. Tier 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)