### PR TITLE
fix(memory): stamp pattern/reputation rows in UTC to match julianday('now')

### DIFF
--- a/aragora/memory/store.py
+++ b/aragora/memory/store.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,18 @@ from aragora.utils.json_helpers import safe_json_loads
 
 # Schema version for CritiqueStore migrations
 CRITIQUE_STORE_SCHEMA_VERSION = 1
+
+
+def _utc_now_iso() -> str:
+    """Current UTC time as a naive ISO-8601 string.
+
+    Rows stamped here are aged with UTC ``julianday('now')`` comparisons
+    (decay ranking, prune_stale_patterns), so stamps must be UTC. Kept naive
+    (no ``+00:00`` suffix) to match the format of legacy local-time rows and
+    SQLite's own ``CURRENT_TIMESTAMP`` defaults.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
 
 CRITIQUE_INITIAL_SCHEMA = """
     -- Debates table
@@ -744,7 +756,7 @@ class CritiqueStore(SQLiteStore):
 
                 # Atomic upsert to avoid race condition in concurrent writes
                 # Uses INSERT ... ON CONFLICT to eliminate check-then-act race window
-                now = datetime.now().isoformat()
+                now = _utc_now_iso()
                 cursor.execute(
                     """
                     INSERT INTO patterns
@@ -820,7 +832,7 @@ class CritiqueStore(SQLiteStore):
                     updated_at = ?
                 WHERE id = ?
                 """,
-                (datetime.now().isoformat(), pattern_id),
+                (_utc_now_iso(), pattern_id),
             )
 
             # Update surprise score based on unexpected failure
@@ -914,7 +926,7 @@ class CritiqueStore(SQLiteStore):
                 updated_at = ?
             WHERE agent_name = ?
             """,
-            (prediction_error, prediction_error, datetime.now().isoformat(), agent_name),
+            (prediction_error, prediction_error, _utc_now_iso(), agent_name),
         )
 
     def _calculate_surprise(self, cursor, issue_type: str, is_success: bool) -> float:
@@ -1410,7 +1422,7 @@ class CritiqueStore(SQLiteStore):
                     SET {", ".join(updates)}
                     WHERE agent_name = ?
                 """  # noqa: S608 -- dynamic clause from internal state
-                cursor.execute(sql, [datetime.now().isoformat(), agent_name])
+                cursor.execute(sql, [_utc_now_iso(), agent_name])
 
                 # Log reputation changes at debug level
                 change_types = []

--- a/tests/memory/test_store.py
+++ b/tests/memory/test_store.py
@@ -394,3 +394,98 @@ class TestCritiqueStoreArchive:
 
         assert "total_archived" in stats
         assert "archived_by_type" in stats
+
+
+class TestTimestampUTCConsistency:
+    """Python-side timestamps must be UTC to match SQLite's julianday('now').
+
+    Pattern and reputation rows are aged/pruned/ranked with UTC
+    julianday('now') comparisons, so local-time stamps skew staleness math
+    by the machine's UTC offset (see PR #9311's CI flake).
+    """
+
+    @pytest.fixture
+    def temp_db(self):
+        """Create a temporary database."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir) / "test_tz.db"
+
+    @pytest.fixture
+    def non_utc_timezone(self):
+        """Force a far-from-UTC, DST-free local timezone for the process."""
+        import os
+        import time
+
+        if not hasattr(time, "tzset"):
+            pytest.skip("requires time.tzset (POSIX)")
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "Pacific/Kiritimati"  # UTC+14, no DST
+        time.tzset()
+        try:
+            yield
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()
+
+    @staticmethod
+    def _age_seconds(store, table: str, column: str = "updated_at") -> float:
+        """Age of the single row's timestamp as SQLite's UTC clock sees it."""
+        assert table in {"patterns", "agent_reputation"}
+        with store.connection() as conn:
+            row = conn.execute(
+                f"SELECT (julianday('now') - julianday({column})) * 86400.0 FROM {table}"  # noqa: S608 -- table from whitelist above
+            ).fetchone()
+        assert row is not None and row[0] is not None
+        return row[0]
+
+    def _make_critique(self) -> Critique:
+        return Critique(
+            agent="claude",
+            target_agent="gpt",
+            target_content="Some code",
+            issues=["Timestamp skew issue"],
+            suggestions=["Stamp in UTC"],
+            severity=0.5,
+            reasoning="Local-time stamps skew julianday comparisons",
+        )
+
+    def test_store_pattern_stamps_utc(self, temp_db, non_utc_timezone):
+        """A freshly stored pattern must not appear hours old/new to julianday."""
+        store = CritiqueStore(str(temp_db))
+        store.store_pattern(self._make_critique(), successful_fix="fix")
+
+        age = self._age_seconds(store, "patterns")
+        assert abs(age) < 300, f"pattern updated_at skewed by {age:.0f}s vs UTC"
+
+        created_age = self._age_seconds(store, "patterns", column="created_at")
+        assert abs(created_age) < 300, f"pattern created_at skewed by {created_age:.0f}s vs UTC"
+
+    def test_fail_pattern_stamps_utc(self, temp_db, non_utc_timezone):
+        """fail_pattern's updated_at stamp must be UTC as well."""
+        store = CritiqueStore(str(temp_db))
+        store.store_pattern(self._make_critique(), successful_fix="fix")
+        store.fail_pattern("Timestamp skew issue")
+
+        age = self._age_seconds(store, "patterns")
+        assert abs(age) < 300, f"pattern updated_at skewed by {age:.0f}s vs UTC"
+
+    def test_reputation_update_stamps_utc(self, temp_db, non_utc_timezone):
+        """Reputation updates must stamp updated_at in UTC."""
+        store = CritiqueStore(str(temp_db))
+        store.update_reputation(agent_name="claude", proposal_made=True)
+
+        age = self._age_seconds(store, "agent_reputation")
+        assert abs(age) < 300, f"reputation updated_at skewed by {age:.0f}s vs UTC"
+
+    def test_fresh_pattern_not_pruned_under_utc_clock(self, temp_db, non_utc_timezone):
+        """A just-written, low-success pattern is fresh, so age gating keeps it."""
+        store = CritiqueStore(str(temp_db))
+        store.store_pattern(self._make_critique(), successful_fix="fix")
+        store.fail_pattern("Timestamp skew issue")
+        store.fail_pattern("Timestamp skew issue")
+
+        pruned = store.prune_stale_patterns(max_age_days=1, min_success_rate=0.5)
+        assert pruned == 0

--- a/tests/storage/test_store_extended.py
+++ b/tests/storage/test_store_extended.py
@@ -571,6 +571,22 @@ class TestDebateStorageExtended:
 # =============================================================================
 
 
+def _backdate_patterns(store, days: int = 10) -> None:
+    """Age all stored patterns using SQLite's own UTC clock.
+
+    Patterns are stamped with local-time ``datetime.now()`` while
+    ``prune_stale_patterns`` compares against UTC ``julianday('now')``, so a
+    freshly written pattern can appear up to a millisecond (or, east of UTC,
+    hours) in the future and dodge ``max_age_days=0`` pruning.
+    """
+    with store.connection() as conn:
+        conn.execute(
+            "UPDATE patterns SET updated_at = datetime('now', ?)",
+            (f"-{days} days",),
+        )
+        conn.commit()
+
+
 class TestPatternPruningExtended:
     """Extended tests for pattern pruning."""
 
@@ -589,6 +605,8 @@ class TestPatternPruningExtended:
         # Store many times (100% success rate)
         for _ in range(10):
             store.store_pattern(critique, "fix")
+
+        _backdate_patterns(store)
 
         # Prune with high min_success_rate
         pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5)
@@ -615,8 +633,11 @@ class TestPatternPruningExtended:
         store.fail_pattern("archive test pattern")
         store.fail_pattern("archive test pattern")
 
+        _backdate_patterns(store)
+
         # Prune (success_rate = 1/4 = 0.25 < 0.5)
-        store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=True)
+        pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=True)
+        assert pruned == 1
 
         archive_stats = store.get_archive_stats()
         assert archive_stats["total_archived"] >= 1
@@ -637,9 +658,12 @@ class TestPatternPruningExtended:
         store.fail_pattern("no archive pattern")
         store.fail_pattern("no archive pattern")
 
+        _backdate_patterns(store)
+
         initial_archive = store.get_archive_stats()["total_archived"]
 
-        store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=False)
+        pruned = store.prune_stale_patterns(max_age_days=0, min_success_rate=0.5, archive=False)
+        assert pruned == 1
 
         final_archive = store.get_archive_stats()["total_archived"]
         assert final_archive == initial_archive  # No new archives


### PR DESCRIPTION
## Summary

`aragora/memory/store.py` stamped pattern and reputation rows (`created_at`/`updated_at`) with local-time `datetime.now().isoformat()`, while every consumer of those columns — decay ranking in `retrieve_patterns`/`retrieve_patterns_with_embeddings` and both prune queries in `prune_stale_patterns` — compares them against UTC `julianday('now')`. SQLite treats naive strings as UTC, so staleness math was skewed by the machine's UTC offset: patterns appeared ~5h newer in US Central, and hours *older* east of UTC. This is the root cause behind the CI flake addressed in #9311. The `agent_reputation` table was doubly inconsistent: its INSERT default is `CURRENT_TIMESTAMP` (UTC) while updates wrote local time.

## Changes

- All four Python-side stamp sites (`store_pattern`, `fail_pattern`, `_update_calibration`, `update_reputation`) now route through a `_utc_now_iso()` helper.
- The helper writes **naive**-UTC ISO strings (no `+00:00` suffix): identical on-disk format to legacy rows and SQLite's own `CURRENT_TIMESTAMP` defaults, so `julianday()` and `datetime.fromisoformat` consumers (e.g. `critique_adapter`) parse unchanged and no aware/naive comparison hazards are introduced. No migration needed — legacy local-time rows keep a bounded skew (≤ machine UTC offset) that self-corrects on their next update.
- New `TestTimestampUTCConsistency` regression tests pin `TZ=Pacific/Kiritimati` (UTC+14, no DST) via `time.tzset()` so the failure is deterministic on any runner (including UTC CI), asserting fresh stamps sit within 5 minutes of SQLite's UTC clock. Before the fix they fail with an exact −50400s (14h) skew.

## Relationship to #9311

This branch **includes #9311's test-fix commit verbatim** (cherry-picked): with correct UTC stamps, the `max_age_days=0` millisecond-rounding race in `test_prune_patterns_archive_created` reproduces on any machine, so the backdate fix is required here. Identical content — whichever PR merges first, the other becomes a no-op.

## Testing

- `tests/memory/test_store.py` (incl. 4 new tests), `tests/memory/test_memory_store.py`, `tests/storage/test_store_extended.py`, `tests/memory/test_coordinator.py`, `tests/knowledge/mound/adapters/test_critique_adapter.py`, `tests/knowledge/mound/test_critique_adapter_bidirectional.py`: **263 passed**
- `ruff` clean, `mypy aragora/memory/store.py` clean
- TDD red/green verified: new tests fail with 14h skew pre-fix, pass post-fix

Follow-up (separate session already running): same local-vs-UTC bug family in the continuum memory tiers (`fast/medium/slow/glacial_tier.py`, `coordinator_search.py`, `continuum_glacial.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)