### PR TITLE
fix(memory): stamp continuum tiers in UTC to match julianday('now')

### DIFF
--- a/aragora/memory/continuum/coordinator.py
+++ b/aragora/memory/continuum/coordinator.py
@@ -19,7 +19,6 @@ import json
 import logging
 import sqlite3
 import threading
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,6 +31,7 @@ from aragora.persistence.db_config import DatabaseType, get_db_path
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
 from aragora.storage.base_store import SQLiteStore
 from aragora.storage.schema import SchemaManager
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 # Import base types and tier mixins
@@ -305,7 +305,7 @@ class ContinuumMemory(
         Returns:
             The created memory entry
         """
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()
@@ -504,7 +504,7 @@ class ContinuumMemory(
                 SET success_count = ?, failure_count = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (entry.success_count, entry.failure_count, datetime.now().isoformat(), entry.id),
+                (entry.success_count, entry.failure_count, utc_now_iso_naive(), entry.id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -559,7 +559,7 @@ class ContinuumMemory(
 
         # Always update timestamp
         updates.append("updated_at = ?")
-        params.append(datetime.now().isoformat())
+        params.append(utc_now_iso_naive())
 
         # Add memory_id as final parameter
         params.append(memory_id)

--- a/aragora/memory/continuum/coordinator_search.py
+++ b/aragora/memory/continuum/coordinator_search.py
@@ -13,11 +13,11 @@ import hashlib
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 from aragora.memory.continuum.base import (
@@ -533,8 +533,8 @@ class CoordinatorSearchMixin:
                 return 0
 
             # Batch update all entries in a single transaction using executemany
-            prewarm_time: str = datetime.now().isoformat()
-            current_time: str = datetime.now().isoformat()
+            prewarm_time: str = utc_now_iso_naive()
+            current_time: str = utc_now_iso_naive()
 
             # Prepare batch update data
             update_data: list[tuple[str, str, str]] = []

--- a/aragora/memory/continuum/coordinator_tier_ops.py
+++ b/aragora/memory/continuum/coordinator_tier_ops.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import logging
 import math
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier, TierConfig
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 from aragora.memory.continuum.base import (
@@ -53,7 +53,7 @@ class CoordinatorTierOpsMixin:
                 SET tier = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (new_tier.value, datetime.now().isoformat(), memory_id),
+                (new_tier.value, utc_now_iso_naive(), memory_id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -71,7 +71,7 @@ class CoordinatorTierOpsMixin:
                 SET tier = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (new_tier.value, datetime.now().isoformat(), memory_id),
+                (new_tier.value, utc_now_iso_naive(), memory_id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -97,7 +97,7 @@ class CoordinatorTierOpsMixin:
         Returns:
             True if the entry was marked, False if entry not found
         """
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()
@@ -270,7 +270,7 @@ class CoordinatorTierOpsMixin:
                             updated_at = ?
                         WHERE id = ?
                         """,
-                        (updated_surprise, consolidation, datetime.now().isoformat(), id),
+                        (updated_surprise, consolidation, utc_now_iso_naive(), id),
                     )
                 else:
                     cursor.execute(
@@ -283,7 +283,7 @@ class CoordinatorTierOpsMixin:
                             updated_at = ?
                         WHERE id = ?
                         """,
-                        (updated_surprise, consolidation, datetime.now().isoformat(), id),
+                        (updated_surprise, consolidation, utc_now_iso_naive(), id),
                     )
 
                 cursor.execute("COMMIT")
@@ -357,7 +357,7 @@ class CoordinatorTierOpsMixin:
                 return None
 
             new_tier: MemoryTier = MemoryTier(tm_new.value)
-            now: str = datetime.now().isoformat()
+            now: str = utc_now_iso_naive()
 
             logger.info(
                 f"[memory] Promoting {id}: {current_tier.value} -> {new_tier.value} "
@@ -437,7 +437,7 @@ class CoordinatorTierOpsMixin:
                 return None
 
             new_tier: MemoryTier = MemoryTier(tm_new.value)
-            now: str = datetime.now().isoformat()
+            now: str = utc_now_iso_naive()
 
             logger.info(
                 f"[memory] Demoting {id}: {current_tier.value} -> {new_tier.value} "

--- a/aragora/memory/continuum/crud.py
+++ b/aragora/memory/continuum/crud.py
@@ -12,11 +12,11 @@ import asyncio
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 from .entry import ContinuumMemoryEntry
@@ -57,7 +57,7 @@ class CrudMixin:
         Returns:
             The created memory entry
         """
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         # Inject tenant_id into metadata for tenant isolation
         if tenant_id is not None:
@@ -241,7 +241,7 @@ class CrudMixin:
                 SET success_count = ?, failure_count = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (entry.success_count, entry.failure_count, datetime.now().isoformat(), entry.id),
+                (entry.success_count, entry.failure_count, utc_now_iso_naive(), entry.id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -319,7 +319,7 @@ class CrudMixin:
 
         # Always update timestamp
         updates.append("updated_at = ?")
-        params.append(datetime.now().isoformat())
+        params.append(utc_now_iso_naive())
 
         # Add memory_id as final parameter
         params.append(memory_id)
@@ -406,7 +406,7 @@ class CrudMixin:
                 SET tier = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (new_tier.value, datetime.now().isoformat(), memory_id),
+                (new_tier.value, utc_now_iso_naive(), memory_id),
             )
             conn.commit()
             return cursor.rowcount > 0
@@ -466,7 +466,7 @@ class CrudMixin:
                 SET tier = ?, updated_at = ?
                 WHERE id = ?
                 """,
-                (new_tier.value, datetime.now().isoformat(), memory_id),
+                (new_tier.value, utc_now_iso_naive(), memory_id),
             )
             conn.commit()
             return cursor.rowcount > 0

--- a/aragora/memory/continuum/fast_tier.py
+++ b/aragora/memory/continuum/fast_tier.py
@@ -16,11 +16,11 @@ import asyncio
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.memory.continuum.base import ContinuumMemoryEntry
@@ -86,7 +86,7 @@ class FastTierMixin:
         """
         from aragora.memory.continuum.base import ContinuumMemoryEntry
 
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()

--- a/aragora/memory/continuum/glacial_tier.py
+++ b/aragora/memory/continuum/glacial_tier.py
@@ -21,11 +21,12 @@ import json
 import logging
 import math
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.memory.continuum.base import ContinuumMemoryEntry
@@ -96,7 +97,7 @@ class GlacialTierMixin:
         """
         from aragora.memory.continuum.base import ContinuumMemoryEntry
 
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()
@@ -277,10 +278,10 @@ class GlacialTierMixin:
         else:
             updated_dt = updated_at
 
-        now = datetime.now()
-        if updated_dt.tzinfo is not None and now.tzinfo is None:
-            # Make both naive for comparison
-            updated_dt = updated_dt.replace(tzinfo=None)
+        # Rows are stamped with naive-UTC strings, so age against naive-UTC now
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        if updated_dt.tzinfo is not None:
+            updated_dt = updated_dt.astimezone(timezone.utc).replace(tzinfo=None)
 
         days_elapsed = (now - updated_dt).total_seconds() / 86400
         if days_elapsed <= 0:

--- a/aragora/memory/continuum/km_integration.py
+++ b/aragora/memory/continuum/km_integration.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.utils.cache import TTLCache
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 from .entry import ContinuumMemoryEntry
@@ -127,8 +127,8 @@ class KMIntegrationMixin:
                 return 0
 
             # Batch update all entries in a single transaction using executemany
-            prewarm_time: str = datetime.now().isoformat()
-            current_time: str = datetime.now().isoformat()
+            prewarm_time: str = utc_now_iso_naive()
+            current_time: str = utc_now_iso_naive()
 
             # Prepare batch update data
             update_data: list[tuple[str, str, str]] = []

--- a/aragora/memory/continuum/medium_tier.py
+++ b/aragora/memory/continuum/medium_tier.py
@@ -16,11 +16,11 @@ import asyncio
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.memory.continuum.base import ContinuumMemoryEntry
@@ -86,7 +86,7 @@ class MediumTierMixin:
         """
         from aragora.memory.continuum.base import ContinuumMemoryEntry
 
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()

--- a/aragora/memory/continuum/outcome.py
+++ b/aragora/memory/continuum/outcome.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier, TierConfig
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 from .types import TIER_CONFIGS
 
@@ -187,7 +188,7 @@ class OutcomeMixin:
                             updated_at = ?
                         WHERE id = ?
                         """,
-                        (updated_surprise, consolidation, datetime.now().isoformat(), id),
+                        (updated_surprise, consolidation, utc_now_iso_naive(), id),
                     )
                 else:
                     cursor.execute(
@@ -200,7 +201,7 @@ class OutcomeMixin:
                             updated_at = ?
                         WHERE id = ?
                         """,
-                        (updated_surprise, consolidation, datetime.now().isoformat(), id),
+                        (updated_surprise, consolidation, utc_now_iso_naive(), id),
                     )
 
                 cursor.execute("COMMIT")

--- a/aragora/memory/continuum/slow_tier.py
+++ b/aragora/memory/continuum/slow_tier.py
@@ -16,11 +16,11 @@ import asyncio
 import json
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
 from aragora.resilience.retry import PROVIDER_RETRY_POLICIES, with_retry
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.memory.continuum.base import ContinuumMemoryEntry
@@ -86,7 +86,7 @@ class SlowTierMixin:
         """
         from aragora.memory.continuum.base import ContinuumMemoryEntry
 
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()

--- a/aragora/memory/continuum/tier_ops.py
+++ b/aragora/memory/continuum/tier_ops.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from aragora.memory.tier_manager import MemoryTier
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 from aragora.utils.json_helpers import safe_json_loads
 
 from .entry import ContinuumMemoryEntry
@@ -52,7 +52,7 @@ class TierOpsMixin:
         Returns:
             True if the entry was marked, False if entry not found
         """
-        now: str = datetime.now().isoformat()
+        now: str = utc_now_iso_naive()
 
         with self.connection() as conn:
             cursor: sqlite3.Cursor = conn.cursor()
@@ -180,7 +180,7 @@ class TierOpsMixin:
                 return None
 
             new_tier: MemoryTier = MemoryTier(tm_new.value)
-            now: str = datetime.now().isoformat()
+            now: str = utc_now_iso_naive()
 
             logger.info(
                 f"[memory] Promoting {id}: {current_tier.value} -> {new_tier.value} "
@@ -262,7 +262,7 @@ class TierOpsMixin:
                 return None
 
             new_tier: MemoryTier = MemoryTier(tm_new.value)
-            now: str = datetime.now().isoformat()
+            now: str = utc_now_iso_naive()
 
             logger.info(
                 f"[memory] Demoting {id}: {current_tier.value} -> {new_tier.value} "

--- a/aragora/memory/continuum_consolidation.py
+++ b/aragora/memory/continuum_consolidation.py
@@ -8,11 +8,12 @@ All functions operate on ContinuumMemory instances passed as the first parameter
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import importlib.util
 from typing import TYPE_CHECKING
 
 from aragora.memory.tier_manager import DEFAULT_TIER_CONFIGS, MemoryTier
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.memory.continuum import ContinuumMemory
@@ -85,9 +86,11 @@ def promote_batch(
     if not ids:
         return 0
 
-    now = datetime.now().isoformat()
+    # Naive-UTC clock: rows are aged with UTC julianday('now') comparisons
+    now_dt = datetime.now(timezone.utc).replace(tzinfo=None)
+    now = now_dt.isoformat()
     cooldown_hours = cms.hyperparams["promotion_cooldown_hours"]
-    cutoff_time = (datetime.now() - timedelta(hours=cooldown_hours)).isoformat()
+    cutoff_time = (now_dt - timedelta(hours=cooldown_hours)).isoformat()
 
     with cms._tier_lock, cms.immediate_transaction() as conn:
         cursor = conn.cursor()
@@ -172,7 +175,7 @@ def demote_batch(
     if not ids:
         return 0
 
-    now = datetime.now().isoformat()
+    now = utc_now_iso_naive()
 
     with cms._tier_lock, cms.immediate_transaction() as conn:
         cursor = conn.cursor()

--- a/aragora/memory/continuum_glacial.py
+++ b/aragora/memory/continuum_glacial.py
@@ -18,7 +18,7 @@ import math
 import os
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from collections.abc import Generator
@@ -246,10 +246,10 @@ class ContinuumGlacialMixin:
         else:
             updated_dt = updated_at
 
-        now = datetime.now()
-        if updated_dt.tzinfo is not None and now.tzinfo is None:
-            # Make both naive for comparison
-            updated_dt = updated_dt.replace(tzinfo=None)
+        # Rows are stamped with naive-UTC strings, so age against naive-UTC now
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        if updated_dt.tzinfo is not None:
+            updated_dt = updated_dt.astimezone(timezone.utc).replace(tzinfo=None)
 
         days_elapsed = (now - updated_dt).total_seconds() / 86400
         if days_elapsed <= 0:

--- a/aragora/memory/continuum_stats.py
+++ b/aragora/memory/continuum_stats.py
@@ -8,7 +8,7 @@ All functions operate on ContinuumMemory instances passed as the first parameter
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 from aragora.memory.tier_manager import DEFAULT_TIER_CONFIGS, MemoryTier
@@ -161,7 +161,10 @@ def cleanup_expired_memories(
             else:
                 retention_hours = config.half_life_hours * retention_multiplier
 
-            cutoff = datetime.now() - timedelta(hours=retention_hours)
+            # Naive-UTC clock: rows are stamped with naive-UTC strings
+            cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(
+                hours=retention_hours
+            )
             cutoff_str = cutoff.isoformat()
 
             # Build tenant filter clause if needed

--- a/aragora/memory/outcome_bridge.py
+++ b/aragora/memory/outcome_bridge.py
@@ -26,8 +26,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.debate.outcome_tracker import ConsensusOutcome, OutcomeTracker
@@ -43,7 +44,7 @@ class MemoryUsageRecord:
 
     memory_id: str
     debate_id: str
-    used_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    used_at: str = field(default_factory=utc_now_iso_naive)
 
 
 @dataclass
@@ -280,7 +281,7 @@ class OutcomeMemoryBridge:
 
             # Update the entry
             entry.update_count += 1
-            entry.updated_at = datetime.now().isoformat()
+            entry.updated_at = utc_now_iso_naive()
 
             # Recalculate consolidation score based on success rate
             if entry.success_count + entry.failure_count > 0:

--- a/aragora/memory/tier_manager.py
+++ b/aragora/memory/tier_manager.py
@@ -30,7 +30,7 @@ import asyncio
 import logging
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
@@ -272,7 +272,11 @@ class TierManager:
         # Check cooldown
         if last_promotion_at:
             last_dt = datetime.fromisoformat(last_promotion_at)
-            hours_since = (datetime.now() - last_dt).total_seconds() / 3600
+            if last_dt.tzinfo is not None:
+                last_dt = last_dt.astimezone(timezone.utc).replace(tzinfo=None)
+            # Stamps are naive UTC, so measure the cooldown against naive-UTC now
+            now_dt = datetime.now(timezone.utc).replace(tzinfo=None)
+            hours_since = (now_dt - last_dt).total_seconds() / 3600
             if hours_since < self._promotion_cooldown_hours:
                 return False
 

--- a/aragora/utils/datetime_helpers.py
+++ b/aragora/utils/datetime_helpers.py
@@ -45,6 +45,19 @@ def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def utc_now_iso_naive() -> str:
+    """Current UTC time as a naive ISO-8601 string (no ``+00:00`` suffix).
+
+    For SQLite TEXT timestamp columns that are aged with UTC
+    ``julianday('now')`` comparisons (decay ranking, TTL pruning, cooldown
+    checks): SQLite treats naive strings as UTC, so Python-side stamps must
+    be UTC too. Kept naive to match the format of legacy local-time rows and
+    SQLite's own ``CURRENT_TIMESTAMP`` defaults, and so
+    ``datetime.fromisoformat`` consumers keep receiving naive datetimes.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
+
+
 def to_iso_timestamp(dt: datetime) -> str:
     """Convert a datetime to ISO8601 string format.
 
@@ -223,6 +236,7 @@ def timestamp_s() -> int:
 
 __all__ = [
     "utc_now",
+    "utc_now_iso_naive",
     "to_iso_timestamp",
     "from_iso_timestamp",
     "ensure_timezone_aware",

--- a/tests/memory/continuum/test_coordinator.py
+++ b/tests/memory/continuum/test_coordinator.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -41,6 +41,11 @@ from aragora.memory.tier_manager import (
     TierManager,
     reset_tier_manager,
 )
+
+
+def _utc_naive_now() -> datetime:
+    """Naive-UTC now, matching how continuum rows are stamped (see PR #9311)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 # =============================================================================
@@ -214,8 +219,8 @@ class TestMediumTierOperations:
             update_count=15,  # Sufficient updates
             success_count=10,
             failure_count=5,
-            created_at=datetime.now().isoformat(),
-            updated_at=datetime.now().isoformat(),
+            created_at=_utc_naive_now().isoformat(),
+            updated_at=_utc_naive_now().isoformat(),
         )
 
         # Stability (0.9) > demotion threshold (0.3)
@@ -316,8 +321,8 @@ class TestGlacialTierOperations:
             update_count=100,
             success_count=80,
             failure_count=20,
-            created_at=datetime.now().isoformat(),
-            updated_at=datetime.now().isoformat(),
+            created_at=_utc_naive_now().isoformat(),
+            updated_at=_utc_naive_now().isoformat(),
         )
 
         assert entry.should_demote() is False  # Already at slowest tier
@@ -442,7 +447,7 @@ class TestTierPromotion:
             )
             conn.commit()
 
-        before = datetime.now()
+        before = _utc_naive_now()
         memory.promote("timestamp_test")
 
         entry = memory.get("timestamp_test")
@@ -620,7 +625,7 @@ class TestEntryExpiration:
     def test_cleanup_fast_tier_expired(self, memory):
         """Test cleaning up expired fast tier entries."""
         # Add old entry
-        old_time = (datetime.now() - timedelta(hours=5)).isoformat()  # Older than 1hr half-life
+        old_time = (_utc_naive_now() - timedelta(hours=5)).isoformat()  # Older than 1hr half-life
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -637,7 +642,7 @@ class TestEntryExpiration:
 
     def test_cleanup_medium_tier_expired(self, memory):
         """Test cleaning up expired medium tier entries."""
-        old_time = (datetime.now() - timedelta(hours=50)).isoformat()  # Older than 24hr half-life
+        old_time = (_utc_naive_now() - timedelta(hours=50)).isoformat()  # Older than 24hr half-life
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -654,7 +659,7 @@ class TestEntryExpiration:
 
     def test_cleanup_slow_tier_expired(self, memory):
         """Test cleaning up expired slow tier entries."""
-        old_time = (datetime.now() - timedelta(days=15)).isoformat()  # Older than 7 day half-life
+        old_time = (_utc_naive_now() - timedelta(days=15)).isoformat()  # Older than 7 day half-life
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -671,7 +676,9 @@ class TestEntryExpiration:
 
     def test_cleanup_glacial_tier_expired(self, memory):
         """Test cleaning up expired glacial tier entries."""
-        old_time = (datetime.now() - timedelta(days=60)).isoformat()  # Older than 30 day half-life
+        old_time = (
+            _utc_naive_now() - timedelta(days=60)
+        ).isoformat()  # Older than 30 day half-life
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -698,7 +705,7 @@ class TestEntryExpiration:
 
     def test_cleanup_archives_by_default(self, memory):
         """Test that cleanup archives entries by default."""
-        old_time = (datetime.now() - timedelta(hours=10)).isoformat()
+        old_time = (_utc_naive_now() - timedelta(hours=10)).isoformat()
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -723,7 +730,7 @@ class TestEntryExpiration:
 
     def test_cleanup_skips_red_line_entries(self, memory):
         """Test that cleanup skips red-lined entries."""
-        old_time = (datetime.now() - timedelta(hours=10)).isoformat()
+        old_time = (_utc_naive_now() - timedelta(hours=10)).isoformat()
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -975,7 +982,7 @@ class TestPromotionCooldown:
         memory.add("cooldown_test", "Content", tier=MemoryTier.MEDIUM)
 
         # First promotion
-        now = datetime.now().isoformat()
+        now = _utc_naive_now().isoformat()
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -996,7 +1003,7 @@ class TestPromotionCooldown:
         memory.add("cooldown_passed", "Content", tier=MemoryTier.SLOW)
 
         # Set last promotion to 25 hours ago (beyond 24hr default cooldown)
-        old_time = (datetime.now() - timedelta(hours=25)).isoformat()
+        old_time = (_utc_naive_now() - timedelta(hours=25)).isoformat()
         with memory.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -1022,7 +1029,7 @@ class TestPromotionCooldown:
         cms.add("short_cooldown", "Content", tier=MemoryTier.SLOW)
 
         # Set last promotion to 2 hours ago
-        old_time = (datetime.now() - timedelta(hours=2)).isoformat()
+        old_time = (_utc_naive_now() - timedelta(hours=2)).isoformat()
         with cms.connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
@@ -1403,7 +1410,7 @@ class TestMemoryLeakPrevention:
             "tags": [f"tag_{i}" for i in range(100)],
             "cross_references": [f"ref_{i}" for i in range(100)],
             "history": [
-                {"action": f"action_{i}", "timestamp": datetime.now().isoformat()}
+                {"action": f"action_{i}", "timestamp": _utc_naive_now().isoformat()}
                 for i in range(50)
             ],
         }

--- a/tests/memory/test_continuum_consolidation.py
+++ b/tests/memory/test_continuum_consolidation.py
@@ -19,7 +19,7 @@ import sqlite3
 import tempfile
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -38,6 +38,13 @@ from aragora.memory.tier_manager import (
     TierManager,
     reset_tier_manager,
 )
+
+
+def _utc_naive_now() -> datetime:
+    """Naive-UTC now, matching how continuum rows are stamped (see PR #9311)."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 from aragora.memory import continuum_consolidation
 
 
@@ -234,7 +241,7 @@ class TestPromoteBatch:
 
     def test_promote_batch_respects_cooldown(self, memory: ContinuumMemory) -> None:
         """Test batch promote respects cooldown period."""
-        now = datetime.now().isoformat()
+        now = _utc_naive_now().isoformat()
 
         memory.add("no_cooldown", "Content", tier=MemoryTier.MEDIUM)
         memory.add("with_cooldown", "Content", tier=MemoryTier.MEDIUM)
@@ -258,7 +265,7 @@ class TestPromoteBatch:
 
     def test_promote_batch_old_cooldown_allowed(self, memory: ContinuumMemory) -> None:
         """Test batch promote allows entries with expired cooldown."""
-        old_time = (datetime.now() - timedelta(hours=48)).isoformat()
+        old_time = (_utc_naive_now() - timedelta(hours=48)).isoformat()
 
         memory.add("old_cooldown", "Content", tier=MemoryTier.MEDIUM)
 
@@ -296,7 +303,7 @@ class TestPromoteBatch:
         assert last_promotion is not None
         # Should be recent (within last second)
         promotion_dt = datetime.fromisoformat(last_promotion)
-        assert (datetime.now() - promotion_dt).total_seconds() < 2
+        assert (_utc_naive_now() - promotion_dt).total_seconds() < 2
 
     def test_promote_batch_records_transitions(self, memory: ContinuumMemory) -> None:
         """Test batch promote records transitions in database."""

--- a/tests/memory/test_continuum_glacial.py
+++ b/tests/memory/test_continuum_glacial.py
@@ -21,7 +21,7 @@ import sqlite3
 import tempfile
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -180,56 +180,60 @@ class TestConfidenceDecayCalculation:
 
     def test_decay_is_one_for_now(self, memory: ContinuumMemory) -> None:
         """Test decay factor is 1.0 for entries updated now."""
-        now = datetime.now()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         decay = memory.calculate_glacial_decay(now)
 
         assert abs(decay - 1.0) < 0.01
 
     def test_decay_is_half_at_30_days(self, memory: ContinuumMemory) -> None:
         """Test decay factor is 0.5 at exactly 30 days."""
-        thirty_days_ago = datetime.now() - timedelta(days=30)
+        thirty_days_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
         decay = memory.calculate_glacial_decay(thirty_days_ago)
 
         assert abs(decay - 0.5) < 0.01
 
     def test_decay_is_quarter_at_60_days(self, memory: ContinuumMemory) -> None:
         """Test decay factor is 0.25 at 60 days (two half-lives)."""
-        sixty_days_ago = datetime.now() - timedelta(days=60)
+        sixty_days_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=60)
         decay = memory.calculate_glacial_decay(sixty_days_ago)
 
         assert abs(decay - 0.25) < 0.01
 
     def test_decay_is_eighth_at_90_days(self, memory: ContinuumMemory) -> None:
         """Test decay factor is 0.125 at 90 days (three half-lives)."""
-        ninety_days_ago = datetime.now() - timedelta(days=90)
+        ninety_days_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=90)
         decay = memory.calculate_glacial_decay(ninety_days_ago)
 
         assert abs(decay - 0.125) < 0.02
 
     def test_decay_handles_iso_string(self, memory: ContinuumMemory) -> None:
         """Test decay calculation handles ISO string timestamps."""
-        thirty_days_ago = (datetime.now() - timedelta(days=30)).isoformat()
+        thirty_days_ago = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
+        ).isoformat()
         decay = memory.calculate_glacial_decay(thirty_days_ago)
 
         assert abs(decay - 0.5) < 0.01
 
     def test_decay_handles_timezone_aware_string(self, memory: ContinuumMemory) -> None:
         """Test decay handles timezone-aware ISO strings."""
-        thirty_days_ago = (datetime.now() - timedelta(days=30)).isoformat() + "Z"
+        thirty_days_ago = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
+        ).isoformat() + "Z"
         decay = memory.calculate_glacial_decay(thirty_days_ago)
 
         assert abs(decay - 0.5) < 0.02  # Slightly larger tolerance for TZ conversion
 
     def test_decay_clamps_to_one_for_future(self, memory: ContinuumMemory) -> None:
         """Test decay factor is clamped to 1.0 for future timestamps."""
-        future = datetime.now() + timedelta(days=1)
+        future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=1)
         decay = memory.calculate_glacial_decay(future)
 
         assert decay == 1.0
 
     def test_decay_approaches_zero_for_very_old(self, memory: ContinuumMemory) -> None:
         """Test decay approaches 0 for very old entries."""
-        one_year_ago = datetime.now() - timedelta(days=365)
+        one_year_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=365)
         decay = memory.calculate_glacial_decay(one_year_ago)
 
         # 365/30 = ~12 half-lives, so decay should be very small
@@ -641,7 +645,9 @@ class TestArchivalOperations:
 
     def test_glacial_cleanup_skips_red_line(self, memory: ContinuumMemory) -> None:
         """Test cleanup skips red-lined glacial entries."""
-        old_time = (datetime.now() - timedelta(days=365)).isoformat()
+        old_time = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=365)
+        ).isoformat()
 
         # Add old red-lined entry
         with memory.connection() as conn:

--- a/tests/memory/test_continuum_timestamp_utc.py
+++ b/tests/memory/test_continuum_timestamp_utc.py
@@ -1,0 +1,206 @@
+"""Timestamp UTC-consistency regression tests for continuum memory tiers.
+
+Python-side timestamps must be UTC to match SQLite's ``julianday('now')``.
+
+Continuum rows are decay-ranked, TTL-pruned, and cooldown-gated with UTC
+``julianday('now')`` / ``datetime('now')`` comparisons, so naive local-time
+stamps skew retention and retrieval math by the machine's UTC offset (the
+same bug family fixed for CritiqueStore patterns in
+tests/memory/test_store.py::TestTimestampUTCConsistency, see PR #9311).
+
+Tests pin far-from-UTC, DST-free timezones via time.tzset() so the skew is
+deterministic on any runner:
+- Pacific/Kiritimati (UTC+14): local stamps would look ~14h in the future
+- Etc/GMT+12 (UTC-12, POSIX inverted sign): local stamps would look ~12h old,
+  which under the old code made fresh fast-tier rows (2h TTL) expire on sight
+"""
+
+import os
+import time
+
+import pytest
+
+from aragora.memory.continuum import (
+    ContinuumMemory,
+    reset_continuum_memory,
+)
+from aragora.memory.continuum.coordinator import ContinuumMemory as CoordinatorContinuumMemory
+from aragora.memory.continuum_stats import cleanup_expired_memories
+from aragora.memory.tier_manager import (
+    MemoryTier,
+    TierManager,
+    reset_tier_manager,
+)
+from aragora.utils.datetime_helpers import utc_now_iso_naive
+
+# Freshly written stamps must agree with SQLite's UTC clock within this many
+# seconds. Any local-time stamp would be off by whole hours (>= 3600s).
+MAX_SKEW_SECONDS = 300
+
+
+def _pin_timezone(tz: str):
+    """Force a specific process-local timezone; restores the old one after."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("requires time.tzset (POSIX)")
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+
+@pytest.fixture
+def positive_offset_timezone():
+    """UTC+14, no DST: local stamps would lead julianday('now') by 14h."""
+    yield from _pin_timezone("Pacific/Kiritimati")
+
+
+@pytest.fixture
+def negative_offset_timezone():
+    """UTC-12, no DST: local stamps would trail julianday('now') by 12h."""
+    yield from _pin_timezone("Etc/GMT+12")
+
+
+@pytest.fixture
+def memory(tmp_path):
+    """Package (core) ContinuumMemory with an isolated database."""
+    reset_tier_manager()
+    reset_continuum_memory()
+    cms = ContinuumMemory(
+        db_path=str(tmp_path / "test_tz_core.db"),
+        tier_manager=TierManager(),
+    )
+    yield cms
+    reset_tier_manager()
+    reset_continuum_memory()
+
+
+@pytest.fixture
+def coordinator_memory(tmp_path):
+    """Coordinator ContinuumMemory (tier-mixin store_* API) with isolated db."""
+    reset_tier_manager()
+    reset_continuum_memory()
+    cms = CoordinatorContinuumMemory(
+        db_path=str(tmp_path / "test_tz_coordinator.db"),
+        tier_manager=TierManager(),
+    )
+    yield cms
+    reset_tier_manager()
+    reset_continuum_memory()
+
+
+def _age_seconds(cms, memory_id: str, column: str = "updated_at") -> float:
+    """Age of a row's timestamp as SQLite's UTC clock sees it."""
+    assert column in {"created_at", "updated_at", "last_promotion_at"}
+    with cms.connection() as conn:
+        row = conn.execute(
+            f"SELECT (julianday('now') - julianday({column})) * 86400.0 "
+            "FROM continuum_memory WHERE id = ?",  # noqa: S608 -- column from whitelist above
+            (memory_id,),
+        ).fetchone()
+    assert row is not None and row[0] is not None
+    return row[0]
+
+
+class TestContinuumTimestampUTCConsistency:
+    """Fresh continuum rows must not appear hours old/new to julianday."""
+
+    def test_add_stamps_utc_all_tiers(self, memory, positive_offset_timezone):
+        for tier in MemoryTier:
+            memory_id = f"add-{tier.value}"
+            memory.add(memory_id, f"{tier.value} entry", tier=tier, importance=0.5)
+            for column in ("created_at", "updated_at"):
+                age = _age_seconds(memory, memory_id, column)
+                assert abs(age) < MAX_SKEW_SECONDS, (
+                    f"{tier.value} {column} skewed by {age:.0f}s vs UTC"
+                )
+
+    def test_tier_store_methods_stamp_utc(self, coordinator_memory, positive_offset_timezone):
+        stores = {
+            "fast": coordinator_memory.store_fast,
+            "medium": coordinator_memory.store_medium,
+            "slow": coordinator_memory.store_slow,
+            "glacial": coordinator_memory.store_glacial,
+        }
+        for tier_name, store in stores.items():
+            memory_id = f"store-{tier_name}"
+            store(memory_id, f"{tier_name} entry", importance=0.5)
+            age = _age_seconds(coordinator_memory, memory_id)
+            assert abs(age) < MAX_SKEW_SECONDS, (
+                f"store_{tier_name} updated_at skewed by {age:.0f}s vs UTC"
+            )
+
+    def test_update_entry_stamps_utc(self, memory, positive_offset_timezone):
+        memory.add("upd-1", "entry", tier=MemoryTier.MEDIUM, importance=0.5)
+        entry = memory.get("upd-1")
+        assert entry is not None
+        entry.success_count += 1
+        assert memory.update_entry(entry)
+
+        age = _age_seconds(memory, "upd-1")
+        assert abs(age) < MAX_SKEW_SECONDS, f"updated_at skewed by {age:.0f}s vs UTC"
+
+    def test_fresh_fast_entry_survives_cleanup(self, memory, negative_offset_timezone):
+        """A just-written fast-tier row (2h TTL) must never expire on sight.
+
+        Under local-time stamping at UTC-12, the fresh row looked 12 hours
+        old to the UTC cutoff and was archived immediately.
+        """
+        memory.add("fresh-fast", "fast entry", tier=MemoryTier.FAST, importance=0.5)
+
+        result = cleanup_expired_memories(memory, tier=MemoryTier.FAST)
+
+        assert result["archived"] == 0
+        assert result["deleted"] == 0
+        assert memory.get("fresh-fast") is not None
+
+    def test_promotion_cooldown_respects_utc_stamp(self, positive_offset_timezone):
+        """A promotion stamped 'just now' in UTC must be inside the cooldown.
+
+        Under the old local-time comparison at UTC+14, a fresh UTC stamp
+        looked 14 hours old, so a 2h cooldown appeared long expired.
+        """
+        manager = TierManager(promotion_cooldown_hours=2.0)
+        allowed = manager.should_promote(
+            MemoryTier.MEDIUM,
+            surprise_score=0.9,  # above the medium promotion threshold
+            last_promotion_at=utc_now_iso_naive(),
+        )
+        assert allowed is False
+
+    def test_calculate_glacial_decay_fresh_entry(self, memory, negative_offset_timezone):
+        """A fresh naive-UTC stamp must show (almost) no glacial decay.
+
+        Under local-time 'now' at UTC-12, a fresh UTC stamp looked 12 hours
+        old and already decayed to ~0.989.
+        """
+        decay = memory.calculate_glacial_decay(utc_now_iso_naive())
+        assert decay >= 0.999
+
+    def test_legacy_current_timestamp_rows_compatible(self, memory, positive_offset_timezone):
+        """Rows stamped by SQLite's CURRENT_TIMESTAMP default stay compatible.
+
+        CURRENT_TIMESTAMP writes naive UTC 'YYYY-MM-DD HH:MM:SS' strings; both
+        julianday aging and datetime.fromisoformat consumers must handle them.
+        """
+        with memory.connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO continuum_memory (id, tier, content, importance)
+                VALUES ('legacy-1', 'glacial', 'legacy row', 0.5)
+                """
+            )
+            conn.commit()
+
+        age = _age_seconds(memory, "legacy-1")
+        assert abs(age) < MAX_SKEW_SECONDS, f"CURRENT_TIMESTAMP row skewed by {age:.0f}s"
+
+        entry = memory.get("legacy-1")
+        assert entry is not None
+        assert memory.calculate_glacial_decay(entry.updated_at) >= 0.999

--- a/tests/memory/test_glacial_tier.py
+++ b/tests/memory/test_glacial_tier.py
@@ -516,45 +516,47 @@ class TestGlacialConfidenceDecay:
 
     def test_decay_factor_is_one_for_just_updated(self, cms):
         """Test decay factor is 1.0 for entries updated now."""
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        now = datetime.now()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         decay = cms.calculate_glacial_decay(now)
 
         assert abs(decay - 1.0) < 0.01
 
     def test_decay_factor_is_half_at_30_days(self, cms):
         """Test decay factor is 0.5 at exactly 30 days old."""
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        thirty_days_ago = datetime.now() - timedelta(days=30)
+        thirty_days_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
         decay = cms.calculate_glacial_decay(thirty_days_ago)
 
         assert abs(decay - 0.5) < 0.01
 
     def test_decay_factor_is_quarter_at_60_days(self, cms):
         """Test decay factor is 0.25 at 60 days old (two half-lives)."""
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        sixty_days_ago = datetime.now() - timedelta(days=60)
+        sixty_days_ago = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=60)
         decay = cms.calculate_glacial_decay(sixty_days_ago)
 
         assert abs(decay - 0.25) < 0.01
 
     def test_decay_handles_string_timestamp(self, cms):
         """Test decay calculation handles ISO string timestamps."""
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        thirty_days_ago = (datetime.now() - timedelta(days=30)).isoformat()
+        thirty_days_ago = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=30)
+        ).isoformat()
         decay = cms.calculate_glacial_decay(thirty_days_ago)
 
         assert abs(decay - 0.5) < 0.01
 
     def test_decay_clamps_to_one_for_future_timestamps(self, cms):
         """Test decay factor is clamped to 1.0 for future timestamps."""
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
-        future = datetime.now() + timedelta(days=1)
+        future = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=1)
         decay = cms.calculate_glacial_decay(future)
 
         assert decay == 1.0

--- a/tests/memory/test_tier_ttl_expiration.py
+++ b/tests/memory/test_tier_ttl_expiration.py
@@ -1,6 +1,6 @@
 """Tests for ContinuumMemory tier TTL expiration with mocked time."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +17,11 @@ from aragora.memory.tier_manager import (
     TierManager,
     reset_tier_manager,
 )
+
+
+def _utc_naive_now() -> datetime:
+    """Naive-UTC now, matching how rows are stamped and cutoffs computed."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 @pytest.fixture
@@ -46,7 +51,7 @@ class TestFastTierExpiration:
 
     def test_not_expired_before_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=1, minutes=59)
+        future = _utc_naive_now() + timedelta(hours=1, minutes=59)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -55,7 +60,7 @@ class TestFastTierExpiration:
 
     def test_expired_after_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=3)
+        future = _utc_naive_now() + timedelta(hours=3)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -68,7 +73,7 @@ class TestMediumTierExpiration:
 
     def test_not_expired_before_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=47)
+        future = _utc_naive_now() + timedelta(hours=47)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -77,7 +82,7 @@ class TestMediumTierExpiration:
 
     def test_expired_after_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=49)
+        future = _utc_naive_now() + timedelta(hours=49)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -90,7 +95,7 @@ class TestSlowTierExpiration:
 
     def test_not_expired_before_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(days=13)
+        future = _utc_naive_now() + timedelta(days=13)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -99,7 +104,7 @@ class TestSlowTierExpiration:
 
     def test_expired_after_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(days=15)
+        future = _utc_naive_now() + timedelta(days=15)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -112,7 +117,7 @@ class TestGlacialTierExpiration:
 
     def test_not_expired_before_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(days=59)
+        future = _utc_naive_now() + timedelta(days=59)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -121,7 +126,7 @@ class TestGlacialTierExpiration:
 
     def test_expired_after_ttl(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(days=61)
+        future = _utc_naive_now() + timedelta(days=61)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -134,7 +139,7 @@ class TestCrosssTierExpiration:
 
     def test_only_fast_expires_at_3h(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=3)
+        future = _utc_naive_now() + timedelta(hours=3)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -146,7 +151,7 @@ class TestCrosssTierExpiration:
 
     def test_fast_and_medium_expire_at_49h(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(hours=49)
+        future = _utc_naive_now() + timedelta(hours=49)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -157,7 +162,7 @@ class TestCrosssTierExpiration:
 
     def test_all_tiers_expire_at_61d(self, memory):
         _add_entries(memory)
-        future = datetime.now() + timedelta(days=61)
+        future = _utc_naive_now() + timedelta(days=61)
         with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
             mock_dt.now.return_value = future
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
@@ -176,7 +181,7 @@ class TestCrosssTierExpiration:
 def test_delete_mode_reports_expected_cutoff_hours(memory, tier, future):
     _add_entries(memory)
     with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
-        mock_dt.now.return_value = datetime.now() + future
+        mock_dt.now.return_value = _utc_naive_now() + future
         mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
         result = cleanup_expired_memories(memory, tier=tier, archive=False)
 


### PR DESCRIPTION
## Summary

Extends the CritiqueStore UTC fix (#9311 flake root cause, `_utc_now_iso()` in `aragora/memory/store.py`) to the continuum memory subsystem, which had the identical local-vs-UTC clock mix.

**Bug:** every `continuum_memory` writer stamped `created_at` / `updated_at` / `last_promotion_at` with local-time `datetime.now().isoformat()`, while the readers age those columns with UTC clocks — `julianday('now')` decay ranking in all four tier retrievals + `retrieval.py` + `coordinator_search.py`, `datetime('now')`-style TTL cutoffs in `continuum_stats.cleanup_expired_memories`, cooldown gating in `TierManager.should_promote` / `continuum_consolidation`, and `calculate_glacial_decay`. SQLite treats naive strings as UTC, so TTL/decay/retrieval math skewed by the machine's UTC offset. Worst case at negative offsets: a fresh fast-tier row (2h TTL) looks hours old and is archived on sight.

**Fix:** a shared `utc_now_iso_naive()` helper in `aragora/utils/datetime_helpers.py` writes naive-UTC ISO strings — same on-disk format as legacy rows and SQLite's `CURRENT_TIMESTAMP` defaults, so `julianday` and `datetime.fromisoformat` consumers parse unchanged and **no migration is needed** (legacy local-time rows keep a bounded skew that self-corrects on next update). All writers route through it: fast/medium/slow/glacial `store_*` mixins, crud + coordinator add/update/promote/demote, outcome surprise updates, KM/search prewarm, batch promotion, `outcome_bridge`. Python-side readers that compared stamps against local `datetime.now()` now use the same naive-UTC clock and convert aware inputs to UTC before stripping tzinfo.

**Audited as already consistent (unchanged):** `continuum/retrieval.py` (read-only julianday scoring; its writers are fixed here), `aragora/learning/meta.py` (inserts rely on SQLite `CURRENT_TIMESTAMP`, already UTC), `memory/streams.py` (self-contained local-clock system, no julianday reads).

## Tests

- New `tests/memory/test_continuum_timestamp_utc.py` following the `TestTimestampUTCConsistency` pattern: pins `TZ=Pacific/Kiritimati` (UTC+14) and `Etc/GMT+12` (UTC-12) via `time.tzset()`, asserts julianday age of fresh rows < 5 min across write paths (core `add`, coordinator `store_*`, `update_entry`), fresh fast-tier rows survive cleanup, fresh promotions stay inside the cooldown, fresh glacial stamps show ~no decay, and `CURRENT_TIMESTAMP`-format legacy rows stay compatible.
- Existing tests that backdated rows with local `datetime.now()` (`test_tier_ttl_expiration.py`, `continuum/test_coordinator.py`, `test_continuum_consolidation.py`, glacial decay tests) switched to the naive-UTC clock.
- Continuum suites (756 tests) pass under `UTC`, `UTC+14`, `UTC-12`, and `America/Chicago`; full `tests/memory/` passes (2,263) excluding pre-existing env-dep failures (`numpy` / `pytest-benchmark` missing locally).
- `ruff check` / `ruff format` clean; scoped mypy shows only the 3 pre-existing errors also present on pristine `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)