### PR TITLE
fix(tests): recut #8277 self-healing agent registry + probed-branch smoke coverage

### DIFF
--- a/aragora/agents/registry.py
+++ b/aragora/agents/registry.py
@@ -156,6 +156,15 @@ class AgentFactory:
                 accepts_api_key=accepts_api_key,
             )
             cls._registry[type_name] = spec
+            # Record the spec on the class itself so register_all_agents()
+            # can self-heal a cleared/rebound registry without re-importing
+            # (decorators never re-run while the module is cached in
+            # sys.modules). vars() lookup avoids inheriting a parent's specs.
+            own_specs = vars(agent_cls).get("__registry_specs__")
+            if own_specs is None:
+                own_specs = []
+                setattr(agent_cls, "__registry_specs__", own_specs)
+            own_specs.append(spec)
             return agent_cls
 
         return decorator
@@ -463,6 +472,11 @@ def register_all_agents() -> None:
 
     This function should be called once at startup to ensure
     all agents are registered before create() is used.
+
+    Safe to call repeatedly: if the registry was cleared (or rebound) after
+    the agent modules were first imported, the registrations are re-applied
+    from specs recorded on the agent classes, since the cached modules'
+    @AgentRegistry.register decorators never re-run.
     """
     # Import modules to trigger @register decorators
     # These imports are intentionally side-effect only
@@ -480,3 +494,24 @@ def register_all_agents() -> None:
         from aragora.agents import api_agents  # noqa: F401
     except ImportError:
         logger.debug("api_agents module not available for registration")
+
+    _heal_registry()
+
+
+def _heal_registry() -> None:
+    """Re-apply registrations recorded on already-imported agent classes.
+
+    Only production modules (``aragora.agents.*``) are scanned, so agent
+    classes registered ad hoc by tests are never resurrected. Existing
+    entries are never overwritten, so deliberate overrides survive.
+    """
+    import sys
+
+    for module_name, module in list(sys.modules.items()):
+        if module is None or not module_name.startswith("aragora.agents"):
+            continue
+        for obj in list(vars(module).values()):
+            if not isinstance(obj, type):
+                continue
+            for spec in vars(obj).get("__registry_specs__", ()):
+                AgentFactory._registry.setdefault(spec.name, spec)

--- a/tests/agents/test_registry.py
+++ b/tests/agents/test_registry.py
@@ -771,6 +771,55 @@ class TestRegisterAllAgents:
             AgentRegistry._registry.clear()
             AgentRegistry._registry.update(original)
 
+    def test_register_all_agents_self_heals_cleared_registry(self):
+        """A cleared registry is repopulated even when agent modules are cached.
+
+        Regression test for #8277: under xdist a test that clears (or rebinds)
+        AgentFactory._registry used to permanently break agent lookup for the
+        rest of the worker, because aragora.agents.cli_agents stays cached in
+        sys.modules so its @AgentRegistry.register decorators never re-run.
+        """
+        from aragora.agents.registry import AgentRegistry, register_all_agents
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+
+        AgentRegistry.clear()
+        assert not AgentRegistry.is_registered("claude")
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+        assert AgentRegistry.is_registered("openai")
+
+    def test_register_all_agents_self_heals_rebound_registry(self):
+        """Healing also works when _registry was replaced with a new dict."""
+        from aragora.agents.registry import AgentRegistry, register_all_agents
+
+        register_all_agents()
+        AgentRegistry._registry = {}
+
+        register_all_agents()
+        assert AgentRegistry.is_registered("claude")
+
+    def test_register_all_agents_does_not_clobber_existing_entries(self):
+        """Healing only fills gaps; deliberate overrides are preserved."""
+        from aragora.agents.registry import AgentRegistry, RegistrySpec, register_all_agents
+
+        register_all_agents()
+        sentinel = RegistrySpec(
+            name="claude",
+            agent_class=object,
+            default_model=None,
+            default_name="claude",
+            agent_type="CLI",
+            requires=None,
+            env_vars=None,
+        )
+        AgentRegistry._registry["claude"] = sentinel
+
+        register_all_agents()
+        assert AgentRegistry.get_spec("claude") is sentinel
+
 
 # =============================================================================
 # Module Exports Tests

--- a/tests/debate/test_pr_review_protocol_smoke.py
+++ b/tests/debate/test_pr_review_protocol_smoke.py
@@ -5,11 +5,33 @@ import pytest
 from aragora.swarm.pr_review_protocol import (
     PROTOCOL_STATUS,
     RECOMMEND_ATTENTION,
+    PRReviewerExecutionFailure,
     default_pr_review_protocol,
 )
 
+_PACKET_KWARGS = dict(
+    repo="synaptent/aragora",
+    pr_number=6355,
+    title="Add PR review protocol scaffold",
+    base_sha="base123",
+    head_sha="head456",
+    mergeable="MERGEABLE",
+    review_decision="REVIEW_REQUIRED",
+    checks_summary="2 pending / 10 total",
+    has_failures=False,
+    has_pending=True,
+    additions=650,
+    deletions=20,
+    changed_files=5,
+    labels=["parked"],
+    high_risk_paths=["aragora/swarm/pr_review_protocol.py"],
+    validation_commands=["python -m pytest tests/debate/test_pr_review_protocol_smoke.py -q"],
+    machine_recommendation=RECOMMEND_ATTENTION,
+    machine_recommendation_reason="metadata-derived attention recommendation",
+)
 
-def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+
+def _mock_provider_availability(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     monkeypatch.setenv("MISTRAL_API_KEY", "test-key")
 
@@ -21,26 +43,10 @@ def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr("aragora.review.provider_slots.shutil.which", fake_which)
 
-    packet = default_pr_review_protocol().build_packet(
-        repo="synaptent/aragora",
-        pr_number=6355,
-        title="Add PR review protocol scaffold",
-        base_sha="base123",
-        head_sha="head456",
-        mergeable="MERGEABLE",
-        review_decision="REVIEW_REQUIRED",
-        checks_summary="2 pending / 10 total",
-        has_failures=False,
-        has_pending=True,
-        additions=650,
-        deletions=20,
-        changed_files=5,
-        labels=["parked"],
-        high_risk_paths=["aragora/swarm/pr_review_protocol.py"],
-        validation_commands=["python -m pytest tests/debate/test_pr_review_protocol_smoke.py -q"],
-        machine_recommendation=RECOMMEND_ATTENTION,
-        machine_recommendation_reason="metadata-derived attention recommendation",
-    )
+
+def test_pr_review_protocol_packet_smoke() -> None:
+    """Metadata-only packets must not probe provider availability (#8185)."""
+    packet = default_pr_review_protocol().build_packet(**_PACKET_KWARGS)
 
     assert packet.status == PROTOCOL_STATUS
     assert packet.binding.pr_number == 6355
@@ -48,8 +54,40 @@ def test_pr_review_protocol_packet_smoke(monkeypatch: pytest.MonkeyPatch) -> Non
     assert len(packet.provider_slots) == 5
     assert [slot.status for slot in packet.provider_slots] == ["not_probed"] * 5
     assert [slot.selected_provider for slot in packet.provider_slots] == [None] * 5
+    for slot in packet.provider_slots:
+        assert slot.candidate_checks == []
     assert packet.provider_slots[0].candidates == ["claude", "anthropic-api"]
     assert packet.top_findings
     assert packet.top_findings[0].source == PROTOCOL_STATUS
+    assert packet.validation_summary["has_pending"] is True
+    assert packet.to_dict()["binding"]["head_sha"] == "head456"
+
+
+def test_pr_review_protocol_packet_probes_providers_for_live_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Packets carrying live reviewer results resolve real provider slots."""
+    _mock_provider_availability(monkeypatch)
+
+    packet = default_pr_review_protocol().build_packet(
+        **_PACKET_KWARGS,
+        execution_failures=[
+            PRReviewerExecutionFailure(
+                slot_id="logic",
+                review_role="logic_reviewer",
+                provider="claude",
+                reason="reviewer timed out",
+            )
+        ],
+    )
+
+    assert packet.status == f"{PROTOCOL_STATUS}_fallback_execution_failed"
+    assert packet.binding.pr_number == 6355
+    assert len(packet.provider_slots) == 5
+    assert packet.provider_slots[0].selected_provider == "claude"
+    assert packet.provider_slots[1].selected_provider == "openai-api"
+    assert packet.provider_slots[2].selected_provider == "gemini-cli"
+    assert packet.provider_slots[4].selected_provider == "mistral-api"
+    assert packet.top_findings
     assert packet.validation_summary["has_pending"] is True
     assert packet.to_dict()["binding"]["head_sha"] == "head456"


### PR DESCRIPTION
## Summary

Recut of stranded commit `73e9b4b37d` from branch `worktree-fix-8277-registry-pollution` (authored Jun 12, never merged — surfaced by the Jul 15 believed-merged stranded-work audit alongside the rlm dotenv guard, which is being recovered separately in #9319).

**Supersession check performed:** the original commit had two halves.
- The metadata-only smoke-test fix was independently superseded on main by #8882 (Jul 5) — **not** re-applied; main's assertion style kept.
- The pieces below never reached main and are carried here.

## Changes

- **Self-healing agent registry** (defense-in-depth for issue #8277): `@AgentRegistry.register` records each spec on the agent class, and `register_all_agents()` re-applies specs from already-imported `aragora.agents.*` modules, so a cleared or rebound `AgentFactory._registry` recovers even though cached modules never re-run their decorators. Existing entries are never overwritten; test-defined agents (in `tests.*`) are never resurrected.
- **`test_pr_review_protocol_packet_probes_providers_for_live_results`**: passes `execution_failures` so the probed branch keeps the original provider-selection assertions (#8185 removed this coverage from the metadata-only path). Provider expectations verified unchanged on current main.
- 3 registry self-healing tests in `tests/agents/test_registry.py`.

## Conflict resolution

1-file cherry-pick conflict in `tests/debate/test_pr_review_protocol_smoke.py`: kept main's (#8882) assertions for the metadata-only test, grafted the probed-branch test on top, factored shared `_PACKET_KWARGS` / `_mock_provider_availability` helpers.

## Validation

- `pytest tests/debate/test_pr_review_protocol_smoke.py tests/agents/test_registry.py tests/agents/test_agent_registry.py` — 110 passed
- `ruff check` + `ruff format --check` clean on all three files

Closes #8277

🤖 Generated with [Claude Code](https://claude.com/claude-code)