### PR TITLE
chore(governance): re-baseline contract drift ratchet to hold-the-line mode [Tier-3]

### DIFF
--- a/scripts/baselines/README.md
+++ b/scripts/baselines/README.md
@@ -1,0 +1,45 @@
+# CI Baselines — Governance Contract
+
+Files in this directory are **enforcement baselines**: committed snapshots of
+accepted debt that CI gates compare against. Growing a baseline is a
+governance event, not a routine edit.
+
+## Rules
+
+1. **Never grow a baseline to silence a failing gate.** Fix the drift, or get
+   explicit human sign-off for accepting the new debt in the PR that grows it.
+2. **Shrinking a baseline is always welcome** — when drift items are actually
+   fixed, refresh the corresponding baseline downward in the same PR.
+3. **Baseline changes are Tier 3+** under `docs/AGENT_OPERATING_CONTRACT.md`:
+   they change what CI enforces on main, so they require operator
+   human-settlement before merge. Use a `chore(governance): ...` commit title
+   (precedent: #1669, #2270, #6054).
+
+## Contract drift ratchet (`contract_drift_program.json`)
+
+`scripts/check_contract_drift_ratchet.py` (workflow: `contract-drift-governance.yml`)
+sums item counts from three sibling baselines —
+`verify_sdk_contracts.json` (py + ts SDK drift),
+`validate_openapi_routes.json` (missing + orphaned routes), and
+`check_sdk_parity.json` (missing from both SDKs) —
+and fails `--strict` when the total exceeds the program target.
+
+- `weekly_reduction: 0.0` — **hold-the-line mode** (current): target stays at
+  `start_total_items`; the gate fails only if the aggregate grows. This is a
+  no-regression gate and stays green without dedicated burn-down staffing.
+- `weekly_reduction > 0` — **burn-down mode**: the target decays
+  compounding per week from `start_date`. Only set this when drift-reduction
+  work is actually staffed at the implied weekly rate (10%/week from ~500
+  items requires closing ~35–50 items *every week*). History: four programs
+  (Feb 13 / Mar 29 / Apr 5+9 / Apr 17 2026) all went red within ~3 weeks of
+  their reset because the decay outpaced actual work, and the permanently red
+  check then masked real regressions.
+
+### Re-baselining the program
+
+Allowed when (a) drift items were genuinely fixed (lower the
+`start_total_items` to the new aggregate), or (b) a deliberate, human-approved
+debt acceptance occurred (raise it, documenting why in the PR). When
+re-baselining, set `start_total_items` to the current sum reported by
+`python scripts/check_contract_drift_ratchet.py` ("Current total") and
+`start_date` to the merge date.

--- a/scripts/baselines/contract_drift_program.json
+++ b/scripts/baselines/contract_drift_program.json
@@ -1,6 +1,6 @@
 {
-  "start_date": "2026-04-17",
-  "start_total_items": 655,
-  "weekly_reduction": 0.10,
+  "start_date": "2026-07-15",
+  "start_total_items": 518,
+  "weekly_reduction": 0.0,
   "grace_weeks": 0
 }

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Enforce week-over-week contract drift ratchet targets."""
+"""Enforce week-over-week contract drift ratchet targets.
+
+With ``weekly_reduction: 0.0`` the program runs in hold-the-line mode: the
+target stays at ``start_total_items`` and the check fails only when the
+aggregate baseline count grows (no-regression gate). Re-baselining rules
+live in scripts/baselines/README.md.
+"""
 
 from __future__ import annotations
 
@@ -68,8 +74,8 @@ def build_ratchet_result(
         raise ValueError("Program baseline must include 'start_date'")
     if start_total < 0:
         raise ValueError("Program baseline has invalid 'start_total_items'")
-    if not (0.0 < weekly_reduction < 1.0):
-        raise ValueError("Program baseline 'weekly_reduction' must be between 0 and 1")
+    if not (0.0 <= weekly_reduction < 1.0):
+        raise ValueError("Program baseline 'weekly_reduction' must be in [0, 1)")
 
     start_date = date.fromisoformat(start_date_raw)
     days_elapsed = max(0, (as_of - start_date).days)

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -76,6 +76,79 @@ def test_strict_passes_on_program_start(monkeypatch, tmp_path: Path):
     assert ratchet.main() == 0
 
 
+def test_zero_reduction_holds_line_indefinitely(monkeypatch, tmp_path: Path):
+    verify, routes, parity, program = _seed_files(tmp_path)
+    today = date.today()
+    as_of = (today + timedelta(days=365)).isoformat()
+
+    _write_json(
+        program,
+        {
+            "start_date": today.isoformat(),
+            "start_total_items": 10,
+            "weekly_reduction": 0.0,
+            "grace_weeks": 0,
+        },
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_contract_drift_ratchet.py",
+            "--strict",
+            "--program-baseline",
+            str(program),
+            "--verify-baseline",
+            str(verify),
+            "--routes-baseline",
+            str(routes),
+            "--parity-baseline",
+            str(parity),
+            "--as-of",
+            as_of,
+        ],
+    )
+
+    assert ratchet.main() == 0
+
+
+def test_zero_reduction_fails_when_baselines_grow(monkeypatch, tmp_path: Path):
+    verify, routes, parity, program = _seed_files(tmp_path)
+    today = date.today()
+
+    _write_json(
+        program,
+        {
+            "start_date": today.isoformat(),
+            "start_total_items": 9,
+            "weekly_reduction": 0.0,
+            "grace_weeks": 0,
+        },
+    )
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_contract_drift_ratchet.py",
+            "--strict",
+            "--program-baseline",
+            str(program),
+            "--verify-baseline",
+            str(verify),
+            "--routes-baseline",
+            str(routes),
+            "--parity-baseline",
+            str(parity),
+            "--as-of",
+            today.isoformat(),
+        ],
+    )
+
+    assert ratchet.main() == 1
+
+
 def test_strict_fails_when_above_target(monkeypatch, tmp_path: Path):
     verify, routes, parity, program = _seed_files(tmp_path)
     today = date.today()


### PR DESCRIPTION
## Problem

The `governance` check (Enforce weekly ratchet, `check_contract_drift_ratchet.py --strict`) fails on pristine `origin/main` (e1b8705c0e) with `Delta to target: +333` and has been red since **~May 8, 2026** — on every PR touching handlers/SDK/baselines, masking real governance regressions.

## Root cause

- The ratchet sums item counts **from the committed baseline files** (`verify_sdk_contracts.json` + `validate_openapi_routes.json` + `check_sdk_parity.json`) and requires the total to decay **10%/week compounding** from `start_total_items`.
- Drift did **not** jump. The aggregate has been static at **518** since #6268 (Apr 18). The target decayed 655 → 185 over 12 weeks; +333 is pure decay under a stalled backlog.
- The big TS number (420) entered via the Mar 27 baseline refresh (#1482: ts 32 → 524) — a mass TS SDK endpoint addition baselined without spec/Python parity — then partially burned down to 420 in #6268.
- This is the **fourth consecutive program** to go permanently red within ~3 weeks of its reset (precedent resets: #1669, #2270, #6054). 10%/week from ~500 items demands closing ~35–50 items *every week*; that work is not staffed. A fifth plain reset from 518 would go red again on **Jul 22** (week-1 target 466).

## What the red check masked (real regression, filed separately)

Route drift grew unpoliced while governance was noise: live `missing_in_spec` is **70 vs 11 baselined**, `orphaned_in_spec` **39 vs 17**. The `Validate handler route coverage` step in `openapi.yml` exits 1 on this today (69 new missing routes).

## Change

1. **Hold-the-line mode**: allow `weekly_reduction: 0.0` — target stays at `start_total_items`; the gate fails only when the aggregate **grows**. This matches the documented intent in `docs/internal/CI_WORKFLOWS.md` ("no new regressions vs baseline") and keeps the check green-and-meaningful without unfunded burn-down. Burn-down decay can be re-armed when staffed.
2. **Re-baseline** `contract_drift_program.json` → `{2026-07-15, 518, 0.0, 0}` per the reset precedent.
3. **Governance contract**: new `scripts/baselines/README.md` — baselines never grow to silence a gate; shrink freely when drift is fixed; changes are Tier 3+ with human sign-off.
4. Tests for zero-reduction mode (pass on hold, fail on growth).

## Verification

- `python scripts/check_contract_drift_ratchet.py --strict` → PASS (518/518, +0)
- `pytest tests/scripts/test_check_contract_drift_ratchet.py` → 4 passed

## Settlement

**Tier 3** — changes what CI enforces on main (baseline + gate semantics). Requires operator human-settlement per `docs/AGENT_OPERATING_CONTRACT.md`. Alternative if you prefer to keep forced burn-down: same reset with `weekly_reduction: 0.01` (~5 items/week) — but any nonzero rate goes red again the first week the work stalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)