### PR TITLE
fix(routing): drop undeclared numpy dependency from lara_router

### DIFF
--- a/aragora/routing/lara_router.py
+++ b/aragora/routing/lara_router.py
@@ -15,13 +15,12 @@ Factual lookups -> RAG, Complex reasoning -> RLM, Connected concepts -> Graph.
 """
 
 from dataclasses import dataclass, field
+from statistics import fmean
 from typing import Any
 from enum import Enum
 import logging
 import re
 import time
-
-import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -551,8 +550,8 @@ class LaRARouter:
             "total_decisions": total,
             "mode_distribution": {mode: count / total for mode, count in mode_counts.items()},
             "mode_counts": mode_counts,
-            "avg_confidence": float(np.mean([d.confidence for d in self._decision_history])),
-            "avg_latency_ms": float(np.mean([d.duration_ms for d in self._decision_history])),
+            "avg_confidence": fmean(d.confidence for d in self._decision_history),
+            "avg_latency_ms": fmean(d.duration_ms for d in self._decision_history),
         }
 
 


### PR DESCRIPTION
## Summary
- `aragora/routing/__init__.py` eagerly imports `lara_router.py`, which had a top-level `import numpy as np` — but numpy is **not declared in pyproject.toml**. Any environment without numpy could not import `aragora.routing` at all, and every `tests/routing/` module failed collection with `ModuleNotFoundError`.
- numpy was only used for two `np.mean()` calls over lists of floats in `LaRARouter.get_metrics()`. This PR removes the numpy import entirely and uses `statistics.fmean` from the stdlib — same math, no dependency.

## Why this approach
Repo convention treats numpy as optional: `aragora/debate/similarity/backends.py` guards it with `try/except` + `HAS_NUMPY`, and `convergence/detector.py` / `evidence/claim_check.py` import it lazily inside functions. Since lara_router's usage is trivial, dropping the dependency outright is cleaner than adding a guard, and avoids declaring numpy as a core dependency for two mean() calls.

## Verification
- `aragora.routing` imports cleanly with numpy blocked via a `sys.meta_path` hook (simulating a numpy-less env)
- `tests/routing/`: 577 passed; 3 pre-existing failures in `test_auto_routing.py` (`KeyError: 'kimi'`, unrelated to this change)
- LaRA suites (`tests/research/test_lara_router.py`, `tests/scripts/test_bench_lara_routing.py`): 27 passed
- `get_metrics()` exercised end-to-end — output identical (plain `float` values as before)
- mypy + ruff clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)