### PR TITLE
fix(memory): evaluate prune age cutoff once for archive and delete

### DIFF
--- a/aragora/memory/store.py
+++ b/aragora/memory/store.py
@@ -1512,6 +1512,12 @@ class CritiqueStore(SQLiteStore):
         with self.connection() as conn:
             cursor = conn.cursor()
 
+            # Evaluate the age cutoff once so the archive SELECT and the
+            # DELETE match the exact same rows; separate julianday('now')
+            # calls could straddle the threshold and delete an unarchived row.
+            cursor.execute("SELECT julianday('now') - ?", (max_age_days,))
+            cutoff_julian = cursor.fetchone()[0]
+
             if archive:
                 # Move stale/unsuccessful patterns to archive table
                 cursor.execute(
@@ -1524,26 +1530,26 @@ class CritiqueStore(SQLiteStore):
                            failure_count, avg_severity, surprise_score, example_task,
                            created_at, updated_at
                     FROM patterns
-                    WHERE julianday('now') - julianday(updated_at) >= ?
+                    WHERE julianday(updated_at) <= ?
                       AND (
                         CAST(success_count AS REAL) /
                         NULLIF(success_count + failure_count, 0)
                       ) < ?
                     """,
-                    (max_age_days, min_success_rate),
+                    (cutoff_julian, min_success_rate),
                 )
 
             # Delete stale/unsuccessful patterns
             cursor.execute(
                 """
                 DELETE FROM patterns
-                WHERE julianday('now') - julianday(updated_at) >= ?
+                WHERE julianday(updated_at) <= ?
                   AND (
                     CAST(success_count AS REAL) /
                     NULLIF(success_count + failure_count, 0)
                   ) < ?
                 """,
-                (max_age_days, min_success_rate),
+                (cutoff_julian, min_success_rate),
             )
 
             pruned = cursor.rowcount


### PR DESCRIPTION
## Summary
`prune_stale_patterns` (aragora/memory/store.py) evaluated `julianday('now')` separately in the archive INSERT and the DELETE. A pattern crossing the `max_age_days` threshold in the interval between the two statements would be deleted without being archived. This computes the age cutoff once and shares it between both statements, making the two predicates match the exact same rows.

Semantics are unchanged: `julianday('now') - julianday(updated_at) >= N` is rewritten algebraically as `julianday(updated_at) <= julianday('now') - N` with the right-hand side evaluated once.

## Context
Follow-up nit found while verifying the #9311 prune-test flake fix (family: #9316, #9318 UTC stamp fixes).

## Testing
- `tests/storage/test_store_extended.py::TestPatternPruningExtended` + `tests/memory/test_memory_store.py` (65 tests) pass under TZ=UTC, Europe/Paris, Pacific/Kiritimati, America/Chicago
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)