### PR TITLE
fix(storage,insights): stamp governance and flip rows in UTC to match datetime('now')

### DIFF
--- a/aragora/insights/flip_detector.py
+++ b/aragora/insights/flip_detector.py
@@ -14,12 +14,12 @@ import logging
 import sqlite3
 import threading
 from dataclasses import dataclass, field
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
 from aragora.insights.database import InsightsDatabase
 from aragora.persistence.db_config import DatabaseType, get_db_path
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 if TYPE_CHECKING:
     from aragora.debate.similarity.backends import SimilarityBackend
@@ -45,7 +45,7 @@ class FlipEvent:
     similarity_score: float  # How similar the claims are (high = contradiction likely)
     flip_type: str  # "contradiction", "refinement", "retraction", "qualification"
     domain: str | None = None
-    detected_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    detected_at: str = field(default_factory=utc_now_iso_naive)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""

--- a/aragora/storage/governance/store.py
+++ b/aragora/storage/governance/store.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +25,7 @@ from aragora.storage.backends import (
     PostgreSQLBackend,
     SQLiteBackend,
 )
+from aragora.utils.datetime_helpers import utc_now_iso_naive
 
 from .metrics import (
     record_governance_approval,
@@ -45,7 +46,7 @@ def _parse_datetime(val: Any) -> datetime:
             return datetime.fromisoformat(val)
         except ValueError as e:
             logger.warning("Failed to parse datetime value: %s", e)
-    return datetime.now()
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 class GovernanceStore:
@@ -209,7 +210,7 @@ class GovernanceStore:
         Returns:
             The approval_id
         """
-        now = datetime.now().isoformat()
+        now = utc_now_iso_naive()
 
         if self.backend_type == "postgresql":
             sql = """
@@ -277,7 +278,7 @@ class GovernanceStore:
         Returns:
             True if updated
         """
-        now = datetime.now().isoformat()
+        now = utc_now_iso_naive()
 
         updates = ["status = ?"]
         params: list = [status]
@@ -428,7 +429,7 @@ class GovernanceStore:
         Returns:
             The verification_id
         """
-        now = datetime.now().isoformat()
+        now = utc_now_iso_naive()
 
         if self.backend_type == "postgresql":
             sql = """
@@ -580,7 +581,7 @@ class GovernanceStore:
         Returns:
             The decision_id
         """
-        now = datetime.now().isoformat()
+        now = utc_now_iso_naive()
 
         if self.backend_type == "postgresql":
             sql = """

--- a/tests/insights/test_flip_detector_timestamp_utc.py
+++ b/tests/insights/test_flip_detector_timestamp_utc.py
@@ -1,0 +1,80 @@
+"""Timestamp UTC-consistency regression tests for FlipDetector.
+
+``FlipEvent.detected_at`` rows are aged with UTC ``datetime('now', '-1 day')``
+in ``get_flip_summary`` (recent_24h window), so naive local-time stamps skew
+the window by the machine's UTC offset (same bug family as PRs #9316/#9318;
+see tests/memory/test_continuum_timestamp_utc.py).
+"""
+
+import os
+import sqlite3
+import time
+
+import pytest
+
+from aragora.insights.flip_detector import FlipDetector, FlipEvent
+
+MAX_SKEW_SECONDS = 300
+
+
+def _pin_timezone(tz: str):
+    """Force a specific process-local timezone; restores the old one after."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("requires time.tzset (POSIX)")
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+
+@pytest.fixture
+def positive_offset_timezone():
+    """UTC+14, no DST: local stamps would lead datetime('now') by 14h."""
+    yield from _pin_timezone("Pacific/Kiritimati")
+
+
+def _make_flip() -> FlipEvent:
+    return FlipEvent(
+        id="flip-tz",
+        agent_name="claude",
+        original_claim="a",
+        new_claim="not a",
+        original_confidence=0.9,
+        new_confidence=0.9,
+        original_debate_id="d1",
+        new_debate_id="d2",
+        original_position_id="p1",
+        new_position_id="p2",
+        similarity_score=0.9,
+        flip_type="contradiction",
+    )
+
+
+class TestFlipDetectorTimestampUTCConsistency:
+    def test_detected_at_stamps_utc(self, tmp_path, positive_offset_timezone):
+        detector = FlipDetector(db_path=tmp_path / "flips_tz.db")
+        detector._store_flip(_make_flip())
+
+        with sqlite3.connect(detector.db_path) as conn:
+            row = conn.execute(
+                "SELECT (julianday('now') - julianday(detected_at)) * 86400.0 "
+                "FROM detected_flips WHERE id = 'flip-tz'"
+            ).fetchone()
+        assert row is not None and row[0] is not None
+        age = row[0]
+        # At UTC+14 a local stamp would look ~14h in the future (age ~ -50400s)
+        # and drop out of the recent_24h window early on the other side.
+        assert abs(age) < MAX_SKEW_SECONDS, f"detected_at skewed by {age:.0f}s vs UTC"
+
+    def test_fresh_flip_counts_in_recent_24h(self, tmp_path, positive_offset_timezone):
+        detector = FlipDetector(db_path=tmp_path / "flips_tz2.db")
+        detector._store_flip(_make_flip())
+        summary = detector.get_flip_summary()
+        assert summary["recent_24h"] >= 1

--- a/tests/storage/test_governance_timestamp_utc.py
+++ b/tests/storage/test_governance_timestamp_utc.py
@@ -1,0 +1,131 @@
+"""Timestamp UTC-consistency regression tests for GovernanceStore.
+
+Python-side timestamps must be UTC to match SQLite's ``datetime('now')``.
+
+``cleanup_old_records`` ages ``governance_approvals.requested_at`` and
+``governance_verifications.timestamp`` with UTC ``datetime('now', '-N days')``
+comparisons, so naive local-time stamps skew retention by the machine's UTC
+offset (same bug family as PRs #9316/#9318; see
+tests/memory/test_continuum_timestamp_utc.py).
+
+Tests pin far-from-UTC, DST-free timezones via time.tzset() so the skew is
+deterministic on any runner.
+"""
+
+import os
+import time
+
+import pytest
+
+from aragora.storage.governance.store import GovernanceStore
+
+# Freshly written stamps must agree with SQLite's UTC clock within this many
+# seconds. Any local-time stamp would be off by whole hours (>= 3600s).
+MAX_SKEW_SECONDS = 300
+
+
+def _pin_timezone(tz: str):
+    """Force a specific process-local timezone; restores the old one after."""
+    if not hasattr(time, "tzset"):
+        pytest.skip("requires time.tzset (POSIX)")
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = tz
+    time.tzset()
+    try:
+        yield
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+
+@pytest.fixture
+def positive_offset_timezone():
+    """UTC+14, no DST: local stamps would lead datetime('now') by 14h."""
+    yield from _pin_timezone("Pacific/Kiritimati")
+
+
+@pytest.fixture
+def negative_offset_timezone():
+    """UTC-12, no DST: local stamps would trail datetime('now') by 12h."""
+    yield from _pin_timezone("Etc/GMT+12")
+
+
+@pytest.fixture
+def store(tmp_path):
+    gov = GovernanceStore(db_path=str(tmp_path / "governance_tz.db"))
+    yield gov
+    gov.close()
+
+
+def _age_seconds(store: GovernanceStore, table: str, column: str) -> float:
+    """Age of the single row's timestamp as SQLite's UTC clock sees it."""
+    assert (table, column) in {
+        ("governance_approvals", "requested_at"),
+        ("governance_approvals", "approved_at"),
+        ("governance_verifications", "timestamp"),
+        ("governance_decisions", "timestamp"),
+    }
+    row = store._backend.fetch_one(
+        f"SELECT (julianday('now') - julianday({column})) * 86400.0 FROM {table}"  # noqa: S608
+    )
+    assert row is not None and row[0] is not None
+    return row[0]
+
+
+class TestGovernanceTimestampUTCConsistency:
+    """Fresh governance rows must not appear hours old/new to datetime('now')."""
+
+    def _save_approval(self, store: GovernanceStore) -> None:
+        store.save_approval(
+            approval_id="apr-tz",
+            title="tz check",
+            description="",
+            risk_level="low",
+            status="pending",
+            requested_by="tester",
+            changes=[],
+        )
+
+    def test_save_approval_stamps_utc(self, store, positive_offset_timezone):
+        self._save_approval(store)
+        age = _age_seconds(store, "governance_approvals", "requested_at")
+        assert abs(age) < MAX_SKEW_SECONDS, f"requested_at skewed by {age:.0f}s vs UTC"
+
+    def test_update_approval_status_stamps_utc(self, store, negative_offset_timezone):
+        self._save_approval(store)
+        store.update_approval_status("apr-tz", status="approved", approved_by="tester")
+        age = _age_seconds(store, "governance_approvals", "approved_at")
+        assert abs(age) < MAX_SKEW_SECONDS, f"approved_at skewed by {age:.0f}s vs UTC"
+
+    def test_save_verification_stamps_utc(self, store, positive_offset_timezone):
+        store.save_verification(
+            verification_id="ver-tz",
+            claim="claim",
+            context="ctx",
+            result={"ok": True},
+        )
+        age = _age_seconds(store, "governance_verifications", "timestamp")
+        assert abs(age) < MAX_SKEW_SECONDS, f"timestamp skewed by {age:.0f}s vs UTC"
+
+    def test_save_decision_stamps_utc(self, store, negative_offset_timezone):
+        store.save_decision(
+            decision_id="dec-tz",
+            debate_id="deb-tz",
+            conclusion="fine",
+            consensus_reached=True,
+            confidence=0.9,
+        )
+        age = _age_seconds(store, "governance_decisions", "timestamp")
+        assert abs(age) < MAX_SKEW_SECONDS, f"timestamp skewed by {age:.0f}s vs UTC"
+
+    def test_fresh_rows_survive_cleanup(self, store, positive_offset_timezone):
+        # Under local stamps at UTC+14 a fresh approval looked 14h in the
+        # future; at UTC-12 old rows aged out 12h early. Fresh completed rows
+        # must survive a 0-day retention boundary only by their true age.
+        self._save_approval(store)
+        store.update_approval_status("apr-tz", status="approved", approved_by="tester")
+        counts = store.cleanup_old_records(approvals_days=1, verifications_days=1)
+        assert counts["approvals"] == 0


### PR DESCRIPTION
## Summary
Closes out the remaining members of the local-stamp-vs-UTC-age-math bug family (#9311 → #9316 → #9318), found by a repo-wide sweep of every `julianday('now')` / `datetime('now')` age comparison and its writers:

- **GovernanceStore** (`aragora/storage/governance/store.py`): `save_approval`, `update_approval_status`, `save_verification`, `save_decision` stamped `requested_at`/`approved_at`/`timestamp` with local `datetime.now().isoformat()`, while `cleanup_old_records` ages them with UTC `datetime('now', '-N days')` — retention skewed by the machine's UTC offset. `_parse_datetime`'s unparseable-value fallback also returned local now.
- **FlipDetector** (`aragora/insights/flip_detector.py`): `FlipEvent.detected_at` defaulted to local now, while `get_flip_summary`'s `recent_24h` window compares against `datetime('now', '-1 day')`.

All stamps now use the established `utc_now_iso_naive()` helper.

Sweep found everything else SAFE (evidence store, feedback, user store, impersonation, email store, persistent queue, spam classifier all stamp UTC or use SQLite-side CURRENT_TIMESTAMP).

## Testing
- New regression tests pin UTC+14 / UTC-12 timezones via tzset (pattern from tests/memory/test_continuum_timestamp_utc.py): 7 pass with fix, 5/7 fail against pre-fix source
- Existing suites: tests/storage/test_governance_store.py, tests/storage/governance/, tests/insights/test_flip_detector.py, tests/insights/test_insights_flip_detector.py — 89 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)