### PR TITLE
polish(m-stranger): apply #9247 advisory review findings

### DIFF
--- a/aragora/cli/commands/decide.py
+++ b/aragora/cli/commands/decide.py
@@ -106,6 +106,7 @@ def _run_decide_demo_builtin_fallback(
     }
 
     print("  Mode: Built-in offline demo agents (no API keys required)")
+    print("        (aragora-debate package unavailable; using built-in fallback)")
     print()
     print("=" * 60)
     print("DECISION SUMMARY")

--- a/aragora/cli/demo.py
+++ b/aragora/cli/demo.py
@@ -605,6 +605,7 @@ async def _run_demo_debate(topic: str) -> tuple[DebateResult, float]:
         _print_banner(topic, agent_names)
         print()
         print("  Mode: Built-in offline demo agents (no API keys required)")
+        print("        (aragora-debate package unavailable; using built-in fallback)")
         print()
         result = _build_builtin_demo_result(topic)
         elapsed = 0.0

--- a/scripts/check_docs_consistency.py
+++ b/scripts/check_docs_consistency.py
@@ -21,8 +21,6 @@ ARCHIVE_REFERENCE_WHITELIST = {
     "docs/ARAGORA_BUSINESS_SUMMARY.md": "redirect stub to the archived business snapshot",
     "docs/OMNIVOROUS_ROADMAP.md": "redirect stub to the archived roadmap snapshot",
     "docs/STRATEGY_INDEX.md": "canonical map from retired docs to live replacements",
-    "docs/ROADMAP_EVOLUTION.md": "tombstone that explicitly points readers to the archived brief that motivated its retirement",
-    "docs/STATUS.md": "compatibility mirror that intentionally links to the archived thesis-settlement ledger for continuity",
     "docs/archive/README.md": "archive policy and inventory",
 }
 # Files/patterns where metric numbers are intentionally historical, local-suite scoped,


### PR DESCRIPTION
Applies the two advisory findings from claude's independent review of #9247 (which settled on the openai PASS under severity-gated dissent — findings verified correct before applying):

- **[P2]** Remove the `ARCHIVE_REFERENCE_WHITELIST` entries for `docs/ROADMAP_EVOLUTION.md` and `docs/STATUS.md`: neither doc contains an archive-path link the check flags (checker passes without them), the rationale strings asserted links that don't exist, and the STATUS.md entry permanently exempted a live, frequently-edited doc from the archive-reference gate.
- **[P3]** The offline-demo fallback banner now retains the cause (`aragora-debate package unavailable`) alongside the no-keys framing, so operators debugging a broken install see why they got the fallback.

Verified: `python scripts/check_docs_consistency.py` all checks PASS; `pytest tests/cli -k 'demo_fallback or starter_uses_demo'` 2 passed.

Closes the advisory tail from https://github.com/synaptent/aragora/pull/9247#issuecomment (claude review, head e431437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)