### PR TITLE
fix(tests): decouple routing-record honesty test from DEFAULT_FAMILIES (hidden-red on main)

### DIFF
--- a/tests/scripts/test_auto_evidence_cycle.py
+++ b/tests/scripts/test_auto_evidence_cycle.py
@@ -113,6 +113,7 @@ def _run(
     clock: Any = None,
     breaker_threshold: int = 3,
     write_routing_record: Any = None,
+    families: tuple[str, ...] | None = None,
 ) -> tuple[dict[str, Any], CollectRecorder, ReconcilerRecorder]:
     collect = collect or CollectRecorder()
     reconciler = reconciler or ReconcilerRecorder()
@@ -136,6 +137,7 @@ def _run(
         write_routing_record=write_routing_record,
         allow_legacy_apply=allow_legacy_apply,
         clock=(lambda: next(ticks) * 0.001) if clock is None else clock,
+        **({} if families is None else {"families": families}),
     )
     summary["_packet_calls"] = packet_calls
     return summary, collect, reconciler
@@ -776,7 +778,14 @@ def test_routing_record_fields_are_honest() -> None:
             }
         }
     )
-    _run([_pr(1)], {1: _entry(1, tier=1)}, apply=True, collect=collect, write_routing_record=writer)
+    _run(
+        [_pr(1)],
+        {1: _entry(1, tier=1)},
+        apply=True,
+        collect=collect,
+        write_routing_record=writer,
+        families=("claude", "grok"),
+    )
     (record,) = writer.records
     assert record["record_type"] == "routing_rationale"
     assert record["schema"] == cycle.ROUTING_RECORD_SCHEMA


### PR DESCRIPTION
## Summary
- Fixes a pre-existing hidden-red on `origin/main` in the path-gated scripts shard: `tests/scripts/test_auto_evidence_cycle.py::test_routing_record_fields_are_honest` fails on a pristine main checkout.
- Root cause: #8745 (1afb964515) changed `DEFAULT_FAMILIES` in `scripts/auto_evidence_cycle.py` from `("claude", "grok")` to `("claude", "openai")`, but the test still asserted the old default pair.
- Fix: the test's intent is that `families_requested` comes from *cycle configuration*, never the packet scan — so the `_run` helper now forwards an explicit `families` kwarg to `run_cycle`, and the test passes `("claude", "grok")` explicitly. This decouples the test from future `DEFAULT_FAMILIES` changes while preserving the regression guard.

## Test plan
- [x] `python3 -m pytest tests/scripts/test_auto_evidence_cycle.py -q` — 66 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)