### PR TITLE
fix(routing): guard select_provider metrics read in decision-stakes route() (#9322 advisory follow-up)

### DIFF
--- a/aragora/routing/decision_stakes_router.py
+++ b/aragora/routing/decision_stakes_router.py
@@ -21,6 +21,7 @@ Related to the ODR epic (#8223): the routing decision is decision-semantics.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,8 @@ TierClass = str  # COST_EFFICIENT | FRONTIER
 # IS that wiring for execution routing, so its record reuses the same schema and
 # flips the flag to ``True``.
 ROUTING_RATIONALE_SCHEMA = "aragora.routing_rationale/v1"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -189,6 +192,9 @@ class DecisionStakesRouter:
         # caller's budget, and caller exclusions — the set the choice was
         # really made among. ``get_candidates`` applies the exact filter
         # ``select_provider`` uses.
+        # select_provider does its own fresh metrics read, so it sits inside
+        # the same guard: a store that flakes between reads must still yield
+        # the recorded no-selection rationale, never escape route().
         try:
             frontier = self._optimizer.get_pareto_frontier()
             candidates = self._optimizer.get_candidates(
@@ -196,24 +202,21 @@ class DecisionStakesRouter:
                 budget_remaining=budget_remaining,
                 exclude_providers=exclude_providers,
             )
-            metrics_available = True
-        except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError):
-            # Never let metric gaps break routing — record empty sets and skip
-            # selection (it reads the same metrics store and would fail too).
-            frontier = []
-            candidates = []
-            metrics_available = False
-
-        selected = (
-            self._optimizer.select_provider(
+            selected = self._optimizer.select_provider(
                 strategy=policy.strategy,
                 budget_remaining=budget_remaining,
                 min_quality=policy.min_quality,
                 exclude_providers=exclude_providers,
             )
-            if metrics_available
-            else None
-        )
+            metrics_available = True
+        except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError) as e:
+            # Never let metric gaps break routing — record empty sets and no
+            # selection, with the rationale naming the metrics gap.
+            logger.warning("provider metrics unavailable; routing without selection: %s", e)
+            frontier = []
+            candidates = []
+            selected = None
+            metrics_available = False
 
         constraints = (
             f"strategy={policy.strategy.value}, min_quality={policy.min_quality}"

--- a/tests/routing/test_decision_stakes_router.py
+++ b/tests/routing/test_decision_stakes_router.py
@@ -217,3 +217,26 @@ def test_broken_metrics_store_yields_recorded_no_selection_not_crash() -> None:
     assert rationale.models_considered == []
     assert rationale.frontier_before_constraints == []
     assert "metrics unavailable" in rationale.selection_reason
+
+
+def test_store_flaking_on_selection_read_yields_recorded_no_selection_not_crash() -> None:
+    # get_pareto_frontier, get_candidates, and select_provider each do their
+    # own fresh get_all_metrics read. A transient failure that hits only the
+    # select_provider read (e.g. a network-backed store) must still produce
+    # the honest no-selection rationale, not escape route().
+    class _FlakyStore(_Store):
+        def __init__(self, metrics: list[ProviderMetrics], succeed_reads: int) -> None:
+            super().__init__(metrics)
+            self._reads_left = succeed_reads
+
+        def get_all_metrics(self) -> dict[str, ProviderMetrics]:
+            if self._reads_left <= 0:
+                raise OSError("metrics backend connection reset")
+            self._reads_left -= 1
+            return super().get_all_metrics()
+
+    store = _FlakyStore(list(_METRICS.values()), succeed_reads=2)
+    router = DecisionStakesRouter(CostQualityOptimizer(store))
+    rationale = router.route(2)
+    assert rationale.selected_provider is None
+    assert "metrics unavailable" in rationale.selection_reason


### PR DESCRIPTION
## Summary

Applies the advisory model-review finding on #9322 (claude reviewer, [review comment](https://github.com/synaptent/aragora/pull/9322#issuecomment-4986549588), first bullet):

> the comment "Never let metric gaps break routing" overstates: `select_provider()` reads the same store two lines later unwrapped, so a store `OSError` still raises out of `route()`.

`select_provider()` performs its own fresh `get_all_metrics()` read, but was called *outside* the try/except in `route()` that exists to guarantee metric gaps never break routing. A transient store failure that hits only that read (succeeds for `get_pareto_frontier`/`get_candidates`, then flakes — e.g. `OSError` from a network-backed store) propagated out of `route()` instead of producing the honest "provider metrics unavailable" no-selection `RoutingRationale`.

## Changes

- Move the `select_provider` call inside the guarded region so any store exception yields the recorded no-selection rationale instead of raising.
- Log the swallowed exception (`logger.warning` with static message + `%s`, per repo pattern) — the same review bullet flagged the silent swallow as un-auditable.
- Regression test: a flaky store that succeeds for exactly the first two `get_all_metrics` reads then raises `OSError` on the selection read; asserts `route()` returns a rationale with the metrics-unavailable reason and does not raise. Written first and observed failing with the escaped `OSError` before the fix.

## Notes

- **Stacked on `claude/recover-decision-stakes-router` (PR #9322)** since the router only exists on that branch; GitHub will retarget this PR to `main` once #9322 merges and its branch is deleted.

## Testing

- `python3 -m pytest tests/routing -x -q` → 602 passed
- `mypy aragora/routing/decision_stakes_router.py` → clean
- `ruff check` / `ruff format --check` on both touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)