### PR TITLE
feat(cli): emit ODR receipts from aragora review

### DIFF
--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1957,9 +1957,8 @@ def _add_review_parser(subparsers) -> None:
         const="",
         default=None,
         metavar="PATH",
-        help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
-        "or inside --output-dir when set); place after the PR URL or pass an explicit "
-        "PATH; a failed receipt write exits 3",
+        help="Emit a verifiable Open Decision Receipt (default: review.odr.json, or inside "
+        "--output-dir when set); place after the PR URL or pass a PATH; failed write exits 3",
     )
     parser.add_argument(
         "--sarif",
@@ -1979,8 +1978,7 @@ def _add_review_parser(subparsers) -> None:
         "--ci",
         action="store_true",
         default=False,
-        help="CI mode: exit with non-zero code based on findings severity "
-        "(1=critical, 2=high; 3 = --emit-odr write failure, not a findings verdict).",
+        help="CI mode: exit code by findings severity (1=critical, 2=high; 3=ODR write failure).",
     )
     parser.add_argument(
         "--demo",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1952,6 +1952,15 @@ def _add_review_parser(subparsers) -> None:
     )
     parser.add_argument("--output-dir", help="Directory to save output artifacts")
     parser.add_argument(
+        "--emit-odr",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="PATH",
+        help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
+        "or inside --output-dir when set)",
+    )
+    parser.add_argument(
         "--sarif",
         nargs="?",
         const="review-results.sarif",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1958,7 +1958,8 @@ def _add_review_parser(subparsers) -> None:
         default=None,
         metavar="PATH",
         help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
-        "or inside --output-dir when set); place after the PR URL or pass an explicit PATH",
+        "or inside --output-dir when set); place after the PR URL or pass an explicit "
+        "PATH; a failed receipt write exits 3",
     )
     parser.add_argument(
         "--sarif",
@@ -1978,7 +1979,8 @@ def _add_review_parser(subparsers) -> None:
         "--ci",
         action="store_true",
         default=False,
-        help="CI mode: exit with non-zero code based on findings severity.",
+        help="CI mode: exit with non-zero code based on findings severity "
+        "(1=critical, 2=high; 3 = --emit-odr write failure, not a findings verdict).",
     )
     parser.add_argument(
         "--demo",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1958,7 +1958,7 @@ def _add_review_parser(subparsers) -> None:
         default=None,
         metavar="PATH",
         help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
-        "or inside --output-dir when set)",
+        "or inside --output-dir when set); place after the PR URL or pass an explicit PATH",
     )
     parser.add_argument(
         "--sarif",

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -865,6 +865,60 @@ def _persist_review_to_km(
         return False
 
 
+def _write_review_odr(
+    findings: dict[str, Any],
+    *,
+    pr_url: str | None,
+    output_dir: Path | None,
+    output_path: str,
+) -> Path:
+    """Export review findings as an Open Decision Receipt."""
+    from aragora.gauntlet.odr_export import decision_receipt_to_odr
+    from aragora.gauntlet.receipt_models import DecisionReceipt
+
+    agents_used = list(findings.get("agents_used", []))
+    receipt = DecisionReceipt.from_review_result(
+        findings,
+        pr_url=pr_url,
+        reviewer_agents=agents_used or None,
+    )
+    odr = decision_receipt_to_odr(receipt)
+
+    path = Path(output_path) if output_path else (output_dir or Path.cwd()) / "review.odr.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(odr, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _emit_requested_odr(
+    args: argparse.Namespace,
+    findings: dict[str, Any],
+    output_dir: Path | None,
+) -> bool:
+    """Write the requested ODR artifact and report failures to the CLI caller."""
+    output_path = getattr(args, "emit_odr", None)
+    if output_path is None:
+        return True
+
+    try:
+        path = _write_review_odr(
+            findings,
+            pr_url=getattr(args, "pr_url", None),
+            output_dir=output_dir,
+            output_path=output_path,
+        )
+    except (ImportError, KeyError, OSError, TypeError, ValueError) as e:
+        logger.warning("ODR export failed: %s", e)
+        print(f"Error: Could not emit review ODR: {e}", file=sys.stderr)
+        return False
+
+    print(f"ODR receipt written to: {path}", file=sys.stderr)
+    return True
+
+
 def cmd_review(args: argparse.Namespace) -> int:
     """Handle 'review' command."""
 
@@ -914,6 +968,9 @@ def cmd_review(args: argparse.Namespace) -> int:
                 print(f"SARIF output written to: {sarif_path}", file=sys.stderr)
             except (OSError, ValueError, KeyError) as e:
                 print(f"Warning: SARIF export failed: {e}", file=sys.stderr)
+
+        if not _emit_requested_odr(args, findings, output_dir):
+            return 1
 
         print("\n---", file=sys.stderr)
         print("This was a demo. To run a real review, configure API keys:", file=sys.stderr)
@@ -1124,6 +1181,9 @@ def cmd_review(args: argparse.Namespace) -> int:
             print(f"Warning: Gauntlet stress-test failed: {e}", file=sys.stderr)
             logger.debug("Gauntlet error details", exc_info=True)
 
+    if not _emit_requested_odr(args, findings, output_dir):
+        return 1
+
     # Generate SARIF output if requested
     sarif_output = getattr(args, "sarif", None)
     if sarif_output is not None:
@@ -1247,6 +1307,16 @@ def create_review_parser(subparsers) -> None:
     parser.add_argument(
         "--output-dir",
         help="Directory to save output artifacts",
+    )
+
+    parser.add_argument(
+        "--emit-odr",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="PATH",
+        help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
+        "or inside --output-dir when set)",
     )
 
     parser.add_argument(

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -874,7 +874,7 @@ def _write_review_odr(
     demo: bool = False,
 ) -> Path:
     """Export review findings as an Open Decision Receipt."""
-    from aragora.gauntlet.odr_export import decision_receipt_to_odr
+    from aragora.gauntlet.odr_export import decision_receipt_to_odr, sign_odr_if_configured
     from aragora.gauntlet.receipt_models import DecisionReceipt
 
     if demo:
@@ -893,6 +893,7 @@ def _write_review_odr(
         reviewer_agents=agents_used or None,
     )
     odr = decision_receipt_to_odr(receipt)
+    odr = sign_odr_if_configured(odr)
 
     path = Path(output_path) if output_path else (output_dir or Path.cwd()) / "review.odr.json"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -921,7 +922,7 @@ def _emit_requested_odr(
             output_path=output_path,
             demo=getattr(args, "demo", False),
         )
-    except (ImportError, KeyError, OSError, TypeError, ValueError) as e:
+    except (AttributeError, ImportError, KeyError, OSError, TypeError, ValueError) as e:
         logger.warning("ODR export failed: %s", e)
         print(f"Error: Could not emit review ODR: {e}", file=sys.stderr)
         return False
@@ -937,8 +938,8 @@ def cmd_review(args: argparse.Namespace) -> int:
     # otherwise the receipt would be written under a literal "https:/..." directory.
     emit_odr_path = getattr(args, "emit_odr", None)
     if emit_odr_path and (
-        emit_odr_path.startswith(("http://", "https://"))
-        or emit_odr_path.lstrip("/").startswith(("github.com/", "www.github.com/"))
+        emit_odr_path.lower().startswith(("http://", "https://", "git@"))
+        or emit_odr_path.lower().lstrip("/").startswith(("github.com/", "www.github.com/"))
     ):
         print(
             f"Error: --emit-odr received a URL ({emit_odr_path}) instead of a file path. "
@@ -994,14 +995,13 @@ def cmd_review(args: argparse.Namespace) -> int:
             except (OSError, ValueError, KeyError) as e:
                 print(f"Warning: SARIF export failed: {e}", file=sys.stderr)
 
-        if not _emit_requested_odr(args, findings, output_dir):
-            return 3
+        odr_ok = _emit_requested_odr(args, findings, output_dir)
 
         print("\n---", file=sys.stderr)
         print("This was a demo. To run a real review, configure API keys:", file=sys.stderr)
         print("  export ANTHROPIC_API_KEY=sk-ant-...", file=sys.stderr)
         print("  export OPENAI_API_KEY=sk-...", file=sys.stderr)
-        return 0
+        return 0 if odr_ok else 3
 
     # Get diff content
     diff = ""

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -871,10 +871,20 @@ def _write_review_odr(
     pr_url: str | None,
     output_dir: Path | None,
     output_path: str,
+    demo: bool = False,
 ) -> Path:
     """Export review findings as an Open Decision Receipt."""
     from aragora.gauntlet.odr_export import decision_receipt_to_odr
     from aragora.gauntlet.receipt_models import DecisionReceipt
+
+    if demo:
+        # Mark demo receipts before hashing so the marker is tamper-evident and
+        # the artifact can never pass for a real review's receipt.
+        findings = {
+            **findings,
+            "final_summary": "[DEMO MODE] Fabricated sample findings, not a real review. "
+            + str(findings.get("final_summary", "")),
+        }
 
     agents_used = list(findings.get("agents_used", []))
     receipt = DecisionReceipt.from_review_result(
@@ -909,6 +919,7 @@ def _emit_requested_odr(
             pr_url=getattr(args, "pr_url", None),
             output_dir=output_dir,
             output_path=output_path,
+            demo=getattr(args, "demo", False),
         )
     except (ImportError, KeyError, OSError, TypeError, ValueError) as e:
         logger.warning("ODR export failed: %s", e)
@@ -925,7 +936,10 @@ def cmd_review(args: argparse.Namespace) -> int:
     # Fail fast if --emit-odr swallowed the PR URL positional (nargs="?" footgun):
     # otherwise the receipt would be written under a literal "https:/..." directory.
     emit_odr_path = getattr(args, "emit_odr", None)
-    if emit_odr_path and emit_odr_path.startswith(("http://", "https://")):
+    if emit_odr_path and (
+        emit_odr_path.startswith(("http://", "https://"))
+        or emit_odr_path.lstrip("/").startswith(("github.com/", "www.github.com/"))
+    ):
         print(
             f"Error: --emit-odr received a URL ({emit_odr_path}) instead of a file path. "
             "Place --emit-odr after the PR URL, or pass an explicit PATH.",
@@ -1254,12 +1268,10 @@ def cmd_review(args: argparse.Namespace) -> int:
             )
 
     # Emit the receipt after the other artifact steps so an emit failure cannot
-    # suppress SARIF/comment output; exit 3 keeps it distinct from the --ci
-    # findings verdicts (1=critical, 2=high).
-    if not _emit_requested_odr(args, findings, output_dir):
-        return 3
+    # suppress SARIF/comment output.
+    odr_ok = _emit_requested_odr(args, findings, output_dir)
 
-    # CI mode exit codes
+    # CI mode exit codes — findings verdicts take priority over artifact-IO errors
     if getattr(args, "ci", False):
         critical = len(findings.get("critical_issues", []))
         high = len(findings.get("high_issues", []))
@@ -1270,7 +1282,8 @@ def cmd_review(args: argparse.Namespace) -> int:
             print(f"CI: {high} high severity issues found", file=sys.stderr)
             return 2
 
-    return 0
+    # Exit 3 keeps emit failure distinct from the --ci findings verdicts (1=critical, 2=high).
+    return 0 if odr_ok else 3
 
 
 def create_review_parser(subparsers) -> None:

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -922,6 +922,17 @@ def _emit_requested_odr(
 def cmd_review(args: argparse.Namespace) -> int:
     """Handle 'review' command."""
 
+    # Fail fast if --emit-odr swallowed the PR URL positional (nargs="?" footgun):
+    # otherwise the receipt would be written under a literal "https:/..." directory.
+    emit_odr_path = getattr(args, "emit_odr", None)
+    if emit_odr_path and emit_odr_path.startswith(("http://", "https://")):
+        print(
+            f"Error: --emit-odr received a URL ({emit_odr_path}) instead of a file path. "
+            "Place --emit-odr after the PR URL, or pass an explicit PATH.",
+            file=sys.stderr,
+        )
+        return 1
+
     # Demo mode - show sample output without API keys
     if getattr(args, "demo", False):
         print("Running in demo mode (no API calls)...", file=sys.stderr)
@@ -970,7 +981,7 @@ def cmd_review(args: argparse.Namespace) -> int:
                 print(f"Warning: SARIF export failed: {e}", file=sys.stderr)
 
         if not _emit_requested_odr(args, findings, output_dir):
-            return 1
+            return 3
 
         print("\n---", file=sys.stderr)
         print("This was a demo. To run a real review, configure API keys:", file=sys.stderr)
@@ -1181,9 +1192,6 @@ def cmd_review(args: argparse.Namespace) -> int:
             print(f"Warning: Gauntlet stress-test failed: {e}", file=sys.stderr)
             logger.debug("Gauntlet error details", exc_info=True)
 
-    if not _emit_requested_odr(args, findings, output_dir):
-        return 1
-
     # Generate SARIF output if requested
     sarif_output = getattr(args, "sarif", None)
     if sarif_output is not None:
@@ -1244,6 +1252,12 @@ def cmd_review(args: argparse.Namespace) -> int:
                 "Warning: 'gh' CLI not found. Install GitHub CLI to use --post-comment.",
                 file=sys.stderr,
             )
+
+    # Emit the receipt after the other artifact steps so an emit failure cannot
+    # suppress SARIF/comment output; exit 3 keeps it distinct from the --ci
+    # findings verdicts (1=critical, 2=high).
+    if not _emit_requested_odr(args, findings, output_dir):
+        return 3
 
     # CI mode exit codes
     if getattr(args, "ci", False):
@@ -1316,7 +1330,7 @@ def create_review_parser(subparsers) -> None:
         default=None,
         metavar="PATH",
         help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
-        "or inside --output-dir when set)",
+        "or inside --output-dir when set); place after the PR URL or pass an explicit PATH",
     )
 
     parser.add_argument(

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -893,7 +893,9 @@ def _write_review_odr(
         reviewer_agents=agents_used or None,
     )
     odr = decision_receipt_to_odr(receipt)
-    odr = sign_odr_if_configured(odr)
+    if not demo:
+        # Never sign fabricated demo findings; demo receipts stay explicitly unsigned.
+        odr = sign_odr_if_configured(odr)
 
     path = Path(output_path) if output_path else (output_dir or Path.cwd()) / "review.odr.json"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -914,6 +916,8 @@ def _emit_requested_odr(
     if output_path is None:
         return True
 
+    from aragora.gauntlet.odr_signing import OdrSigningError
+
     try:
         path = _write_review_odr(
             findings,
@@ -922,7 +926,15 @@ def _emit_requested_odr(
             output_path=output_path,
             demo=getattr(args, "demo", False),
         )
-    except (AttributeError, ImportError, KeyError, OSError, TypeError, ValueError) as e:
+    except (
+        AttributeError,
+        ImportError,
+        KeyError,
+        OdrSigningError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as e:
         logger.warning("ODR export failed: %s", e)
         print(f"Error: Could not emit review ODR: {e}", file=sys.stderr)
         return False
@@ -1343,7 +1355,8 @@ def create_review_parser(subparsers) -> None:
         default=None,
         metavar="PATH",
         help="Emit a verifiable Open Decision Receipt (default: review.odr.json, "
-        "or inside --output-dir when set); place after the PR URL or pass an explicit PATH",
+        "or inside --output-dir when set); place after the PR URL or pass an explicit "
+        "PATH; a failed receipt write exits 3",
     )
 
     parser.add_argument(
@@ -1369,7 +1382,8 @@ def create_review_parser(subparsers) -> None:
         action="store_true",
         default=False,
         help="CI mode: exit with non-zero code based on findings severity. "
-        "Exit 1 if critical issues, exit 2 if high issues found.",
+        "Exit 1 if critical issues, exit 2 if high issues found "
+        "(exit 3 = --emit-odr write failure, not a findings verdict).",
     )
 
     parser.add_argument(

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -867,6 +867,60 @@ class TestCmdReview:
         assert odr["claim"]["verdict"] == "FAIL"
         assert odr["quorum"]["participants"]
 
+    def test_emit_odr_url_misbinding_fails_fast(self, review_args, tmp_path, capsys, monkeypatch):
+        """--emit-odr followed by the PR URL errors out before any review runs."""
+        review_args.demo = True
+        review_args.emit_odr = "https://github.com/owner/repo/pull/123"
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.chdir(tmp_path)
+
+        result = cmd_review(review_args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "--emit-odr received a URL" in captured.err
+        assert not (tmp_path / "https:").exists()
+
+    def test_demo_emit_odr_failure_returns_distinct_exit_code(
+        self, review_args, tmp_path, monkeypatch
+    ):
+        """An unwritable receipt path exits 3, not a findings-verdict code."""
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        review_args.demo = True
+        review_args.emit_odr = str(blocker / "review.odr.json")
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+        result = cmd_review(review_args)
+
+        assert result == 3
+
+    def test_real_review_emit_odr_failure_preserves_sarif(self, review_args, tmp_path, monkeypatch):
+        """ODR emission runs after the other artifact steps, so SARIF still lands."""
+        diff_file = tmp_path / "test.diff"
+        diff_file.write_text("diff --git a/test.py b/test.py\n+new line")
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        sarif_path = tmp_path / "review.sarif"
+        review_args.diff_file = str(diff_file)
+        review_args.agents = "anthropic-api,openai-api"
+        review_args.emit_odr = str(blocker / "review.odr.json")
+        review_args.sarif = str(sarif_path)
+
+        findings = get_demo_findings()
+        with (
+            patch(
+                "aragora.cli.review.run_review_debate",
+                new=AsyncMock(return_value=MockDebateResult()),
+            ),
+            patch("aragora.cli.review.extract_review_findings", return_value=findings),
+            patch("aragora.cli.review._persist_review_to_km", return_value=True),
+        ):
+            result = cmd_review(review_args)
+
+        assert result == 3
+        assert sarif_path.exists()
+
     def test_error_no_diff_provided(self, review_args, capsys, monkeypatch):
         """Test error when no diff provided."""
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -870,6 +870,24 @@ class TestCmdReview:
         assert odr["claim"]["verdict"] == "FAIL"
         assert odr["quorum"]["participants"]
 
+    def test_emit_odr_pipes_receipt_through_signer(self, review_args, tmp_path, monkeypatch):
+        """The emitted receipt is signed whenever a signing key is configured."""
+        review_args.demo = True
+        review_args.output_dir = str(tmp_path)
+        review_args.emit_odr = ""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+        def fake_signer(odr, **kwargs):
+            return {**odr, "signatures": [{"alg": "test", "sig": "stub"}]}
+
+        monkeypatch.setattr("aragora.gauntlet.odr_export.sign_odr_if_configured", fake_signer)
+
+        result = cmd_review(review_args)
+
+        assert result == 0
+        odr = json.loads((tmp_path / "review.odr.json").read_text())
+        assert odr["signatures"] == [{"alg": "test", "sig": "stub"}]
+
     def test_emit_odr_url_misbinding_fails_fast(self, review_args, tmp_path, capsys, monkeypatch):
         """--emit-odr followed by the PR URL errors out before any review runs."""
         review_args.demo = True

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -29,6 +29,7 @@ from aragora.cli.review import (
     get_shareable_url,
     save_review_for_sharing,
 )
+from aragora.cli.parser import build_parser
 
 
 # ===========================================================================
@@ -730,6 +731,8 @@ class TestCreateReviewParser:
                 "json",
                 "--output-dir",
                 "./output",
+                "--emit-odr",
+                "./output/custom-review.odr.json",
                 "--demo",
                 "--share",
             ]
@@ -741,8 +744,26 @@ class TestCreateReviewParser:
         assert args.focus == "security"
         assert args.output_format == "json"
         assert args.output_dir == "./output"
+        assert args.emit_odr == "./output/custom-review.odr.json"
         assert args.demo is True
         assert args.share is True
+
+    def test_parser_emit_odr_uses_default_path(self):
+        """--emit-odr accepts an omitted path for the ergonomic default."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        create_review_parser(subparsers)
+
+        args = parser.parse_args(["review", "--emit-odr", "--demo"])
+
+        assert args.emit_odr == ""
+
+    def test_top_level_parser_registers_emit_odr(self):
+        """The installed aragora entrypoint exposes the same ODR option."""
+        args = build_parser().parse_args(["review", "--emit-odr", "/tmp/review.odr.json", "--demo"])
+
+        assert args.emit_odr == "/tmp/review.odr.json"
+        assert args.func.__name__ == "cmd_review"
 
 
 # ===========================================================================
@@ -766,6 +787,7 @@ class TestCmdReview:
         args.output_dir = None
         args.demo = False
         args.share = False
+        args.emit_odr = None
         return args
 
     def test_demo_mode_github_output(self, review_args, capsys, monkeypatch):
@@ -805,6 +827,45 @@ class TestCmdReview:
 
         assert result == 0
         assert (tmp_path / "comment.md").exists()
+
+    def test_demo_mode_emits_odr_to_output_dir(self, review_args, tmp_path, monkeypatch):
+        """The default ODR path follows --output-dir in demo mode."""
+        review_args.demo = True
+        review_args.output_dir = str(tmp_path)
+        review_args.emit_odr = ""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+        result = cmd_review(review_args)
+
+        assert result == 0
+        odr = json.loads((tmp_path / "review.odr.json").read_text())
+        assert odr["claim"]["verdict"] == "FAIL"
+        assert odr["quorum"]["method"] == "multi_agent_review"
+
+    def test_real_review_emits_odr_to_explicit_path(self, review_args, tmp_path, monkeypatch):
+        """A standard review can produce its portable receipt in one invocation."""
+        diff_file = tmp_path / "test.diff"
+        diff_file.write_text("diff --git a/test.py b/test.py\n+new line")
+        odr_path = tmp_path / "artifacts" / "result.odr.json"
+        review_args.diff_file = str(diff_file)
+        review_args.agents = "anthropic-api,openai-api"
+        review_args.emit_odr = str(odr_path)
+
+        findings = get_demo_findings()
+        with (
+            patch(
+                "aragora.cli.review.run_review_debate",
+                new=AsyncMock(return_value=MockDebateResult()),
+            ),
+            patch("aragora.cli.review.extract_review_findings", return_value=findings),
+            patch("aragora.cli.review._persist_review_to_km", return_value=True),
+        ):
+            result = cmd_review(review_args)
+
+        assert result == 0
+        odr = json.loads(odr_path.read_text())
+        assert odr["claim"]["verdict"] == "FAIL"
+        assert odr["quorum"]["participants"]
 
     def test_error_no_diff_provided(self, review_args, capsys, monkeypatch):
         """Test error when no diff provided."""

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -838,9 +838,12 @@ class TestCmdReview:
         result = cmd_review(review_args)
 
         assert result == 0
-        odr = json.loads((tmp_path / "review.odr.json").read_text())
+        odr_text = (tmp_path / "review.odr.json").read_text()
+        odr = json.loads(odr_text)
         assert odr["claim"]["verdict"] == "FAIL"
         assert odr["quorum"]["method"] == "multi_agent_review"
+        # Demo receipts must never pass for a real review's receipt.
+        assert "[DEMO MODE]" in odr_text
 
     def test_real_review_emits_odr_to_explicit_path(self, review_args, tmp_path, monkeypatch):
         """A standard review can produce its portable receipt in one invocation."""
@@ -881,6 +884,22 @@ class TestCmdReview:
         assert "--emit-odr received a URL" in captured.err
         assert not (tmp_path / "https:").exists()
 
+    def test_emit_odr_schemeless_url_misbinding_fails_fast(
+        self, review_args, tmp_path, capsys, monkeypatch
+    ):
+        """A scheme-less PR URL is caught by the guard too."""
+        review_args.demo = True
+        review_args.emit_odr = "github.com/owner/repo/pull/123"
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.chdir(tmp_path)
+
+        result = cmd_review(review_args)
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "--emit-odr received a URL" in captured.err
+        assert not (tmp_path / "github.com").exists()
+
     def test_demo_emit_odr_failure_returns_distinct_exit_code(
         self, review_args, tmp_path, monkeypatch
     ):
@@ -920,6 +939,31 @@ class TestCmdReview:
 
         assert result == 3
         assert sarif_path.exists()
+
+    def test_ci_findings_verdict_beats_emit_odr_failure(self, review_args, tmp_path):
+        """--ci exit codes take priority over an ODR emit failure."""
+        diff_file = tmp_path / "test.diff"
+        diff_file.write_text("diff --git a/test.py b/test.py\n+new line")
+        blocker = tmp_path / "blocker"
+        blocker.write_text("not a directory")
+        review_args.diff_file = str(diff_file)
+        review_args.agents = "anthropic-api,openai-api"
+        review_args.emit_odr = str(blocker / "review.odr.json")
+        review_args.ci = True
+
+        findings = get_demo_findings()
+        assert findings["critical_issues"]
+        with (
+            patch(
+                "aragora.cli.review.run_review_debate",
+                new=AsyncMock(return_value=MockDebateResult()),
+            ),
+            patch("aragora.cli.review.extract_review_findings", return_value=findings),
+            patch("aragora.cli.review._persist_review_to_km", return_value=True),
+        ):
+            result = cmd_review(review_args)
+
+        assert result == 1
 
     def test_error_no_diff_provided(self, review_args, capsys, monkeypatch):
         """Test error when no diff provided."""

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -871,7 +871,36 @@ class TestCmdReview:
         assert odr["quorum"]["participants"]
 
     def test_emit_odr_pipes_receipt_through_signer(self, review_args, tmp_path, monkeypatch):
-        """The emitted receipt is signed whenever a signing key is configured."""
+        """A real review's receipt is signed whenever a signing key is configured."""
+        diff_file = tmp_path / "test.diff"
+        diff_file.write_text("diff --git a/test.py b/test.py\n+new line")
+        odr_path = tmp_path / "review.odr.json"
+        review_args.diff_file = str(diff_file)
+        review_args.agents = "anthropic-api,openai-api"
+        review_args.emit_odr = str(odr_path)
+
+        def fake_signer(odr, **kwargs):
+            return {**odr, "signatures": [{"alg": "test", "sig": "stub"}]}
+
+        monkeypatch.setattr("aragora.gauntlet.odr_export.sign_odr_if_configured", fake_signer)
+
+        findings = get_demo_findings()
+        with (
+            patch(
+                "aragora.cli.review.run_review_debate",
+                new=AsyncMock(return_value=MockDebateResult()),
+            ),
+            patch("aragora.cli.review.extract_review_findings", return_value=findings),
+            patch("aragora.cli.review._persist_review_to_km", return_value=True),
+        ):
+            result = cmd_review(review_args)
+
+        assert result == 0
+        odr = json.loads(odr_path.read_text())
+        assert odr["signatures"] == [{"alg": "test", "sig": "stub"}]
+
+    def test_demo_odr_is_never_signed(self, review_args, tmp_path, monkeypatch):
+        """Fabricated demo findings must not be signed even with a key configured."""
         review_args.demo = True
         review_args.output_dir = str(tmp_path)
         review_args.emit_odr = ""
@@ -886,7 +915,35 @@ class TestCmdReview:
 
         assert result == 0
         odr = json.loads((tmp_path / "review.odr.json").read_text())
-        assert odr["signatures"] == [{"alg": "test", "sig": "stub"}]
+        assert odr["signatures"] == []
+
+    def test_emit_odr_signing_error_contained(self, review_args, tmp_path, monkeypatch):
+        """A configured-but-broken signing key exits 3 cleanly, not a traceback."""
+        from aragora.gauntlet.odr_signing import OdrSigningError
+
+        diff_file = tmp_path / "test.diff"
+        diff_file.write_text("diff --git a/test.py b/test.py\n+new line")
+        review_args.diff_file = str(diff_file)
+        review_args.agents = "anthropic-api,openai-api"
+        review_args.emit_odr = str(tmp_path / "review.odr.json")
+
+        def broken_signer(odr, **kwargs):
+            raise OdrSigningError("configured key is unreadable")
+
+        monkeypatch.setattr("aragora.gauntlet.odr_export.sign_odr_if_configured", broken_signer)
+
+        findings = get_demo_findings()
+        with (
+            patch(
+                "aragora.cli.review.run_review_debate",
+                new=AsyncMock(return_value=MockDebateResult()),
+            ),
+            patch("aragora.cli.review.extract_review_findings", return_value=findings),
+            patch("aragora.cli.review._persist_review_to_km", return_value=True),
+        ):
+            result = cmd_review(review_args)
+
+        assert result == 3
 
     def test_emit_odr_url_misbinding_fails_fast(self, review_args, tmp_path, capsys, monkeypatch):
         """--emit-odr followed by the PR URL errors out before any review runs."""


### PR DESCRIPTION
## Summary

- add `aragora review --emit-odr [PATH]` to emit a portable Open Decision Receipt in the same invocation
- use the existing review-specific `DecisionReceipt.from_review_result` bridge and canonical ODR exporter
- expose the flag through both parser surfaces and default the artifact to `review.odr.json` inside `--output-dir` when set

Closes #9209

## Validation

- `python -m pytest -q tests/cli/test_review.py tests/cli/test_review_flags.py tests/cli/test_review_km.py` (100 passed)
- `pre-commit run --files aragora/cli/review.py aragora/cli/parser.py tests/cli/test_review.py`
- `python -m aragora.cli.main review --demo --output-format json --emit-odr <tmp>`
- `uvx --from "aragora-verify>=0.1.1" aragora-verify <tmp> --json` (schema, digest, quorum PASS; unsigned warning expected)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Risk

Tier 2 CLI behavior. Draft until exact-head CI and full model-quorum/dogfood gates are satisfied. No workflow, branch-protection, merge-authority, generated-metric, or approval-gated files changed.