### PR TITLE
fix(governance): provenance-classified drift inventory + per-PR delta ratchet [Tier-3]

### DIFF
--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -9,6 +9,7 @@ on:
       - 'sdk/**'
       - 'docs/api/openapi*.json'
       - 'scripts/check_contract_drift_ratchet.py'
+      - 'scripts/generate_contract_drift_inventory.py'
       - 'scripts/contract_drift_report.py'
       - 'scripts/generate_contract_drift_backlog.py'
       - 'scripts/generate_contract_drift_issue_plan.py'

--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -81,6 +81,12 @@ jobs:
             --markdown-out /tmp/CONTRACT_DRIFT_ISSUE_PLAN.md \
             --json-out /tmp/CONTRACT_DRIFT_ISSUE_PLAN.json
 
+      - name: Fetch drift cohort commit
+        run: |
+          # 2026-04-17 program cohort commit: the ratchet derives cohort
+          # membership from it (git show) and fails closed if unavailable.
+          git fetch --no-tags --depth=1 origin 5cc7a81b77aeb6680613d441f74d72c435c8443c
+
       - name: Fetch PR base ref
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -81,9 +81,28 @@ jobs:
             --markdown-out /tmp/CONTRACT_DRIFT_ISSUE_PLAN.md \
             --json-out /tmp/CONTRACT_DRIFT_ISSUE_PLAN.json
 
-      - name: Enforce weekly ratchet
+      - name: Fetch PR base ref
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          python scripts/check_contract_drift_ratchet.py --strict --json > /tmp/contract-drift-ratchet.json
+          git fetch --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Enforce weekly ratchet
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            # Per-PR gate: strict non-worsening delta vs the base ref.
+            python scripts/check_contract_drift_ratchet.py \
+              --mode pr --base-ref "origin/${BASE_REF}" \
+              --strict --json > /tmp/contract-drift-ratchet.json
+          else
+            # Cron/dispatch/main: program-level burn-down schedule.
+            python scripts/check_contract_drift_ratchet.py \
+              --mode program --strict --json > /tmp/contract-drift-ratchet.json
+          fi
 
       - name: Write ratchet summary
         if: ${{ always() && !cancelled() }}
@@ -105,13 +124,27 @@ jobs:
           lines = [
               '## Contract Drift Ratchet',
               '',
+              f"- Mode: `{data.get('mode', 'program')}`",
               f"- As of: `{program['as_of']}`",
               f"- Start total: `{program['start_total_items']}`",
               f"- Current total: `{current['total_items']}`",
               f"- Target max: `{target['max_open_items']}`",
               f"- Delta to target: `{data['delta_to_target']:+d}`",
+              f"- Program passing: `{data.get('program_passing', data['passing'])}`",
               f"- Passing: `{data['passing']}`",
           ]
+          for cls in data.get('classes', []):
+              lines.append(
+                  f"- Class `{cls['name']}`: open `{cls['open_items']}` / "
+                  f"target `{cls['target_max']}` (passing: `{cls['passing']}`)"
+              )
+          pr_delta = data.get('pr_delta')
+          if pr_delta:
+              lines.append(f"- PR delta vs `{pr_delta['base_ref']}`:")
+              for key, d in pr_delta['counts'].items():
+                  lines.append(
+                      f"  - `{key}`: {d['base']} -> {d['head']} ({d['delta']:+d})"
+                  )
 
           summary = Path(Path.cwd() / 'ratchet-summary.md')
           summary.write_text('\n'.join(lines) + '\n')

--- a/scripts/baselines/contract_drift_inventory.json
+++ b/scripts/baselines/contract_drift_inventory.json
@@ -1,0 +1,4143 @@
+{
+  "cohort_commit": "5cc7a81b77aeb6680613d441f74d72c435c8443c",
+  "generated_by": "scripts/generate_contract_drift_inventory.py",
+  "items": [
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/agent-evolution/elo-trends",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/agent-evolution/pending",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/agent-evolution/pending/{param}/approve",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/agent-evolution/pending/{param}/reject",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/agent-evolution/timeline",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/compliance/rbac-coverage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/debates/public/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/debates/public/{param}/og",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/inbox/messages/{param}/debate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/mcp/tools",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "missing_in_spec:/api/v1/relationship/{param}/*",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "missing_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/accounting/report",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/bots/slack/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/consent",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/execute",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/executions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/federation",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/coordination/workspaces",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/km/checkpoints/compare",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/batch/delete",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/merge",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/relationships",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/knowledge/facts/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "orphaned_in_spec:/api/v1/matches/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "orphaned_in_spec",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/budgets/{param}/overrides/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/checkpoints/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/ideas/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/ideas/{param}/edges/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/ideas/{param}/nodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/index/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/index/{param}/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/media/audio/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/podcast/episodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:DELETE /api/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/budgets/{param}/transactions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/budgets/{param}/trends",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/checkpoints/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/debates/{param}/checkpoints",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/decisions/plans",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/decisions/plans/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/decisions/plans/{param}/outcome",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/decisions/{param}/outcome",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/decisions/{param}/outcomes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/documents/search",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/documents/{param}/chunks",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/documents/{param}/download",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/ideas/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/index/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/index/{param}/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/media/audio/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/media/audio/{param}/transcription",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/personas/options",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/podcast/episodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/tenants/{param}/members",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/tenants/{param}/quotas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:GET /api/tenants/{param}/usage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PATCH /api/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PATCH /api/podcast/episodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PATCH /api/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/budgets/{param}/overrides",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/checkpoints/{param}/intervention",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/checkpoints/{param}/resume",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/debates/{param}/checkpoint",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/debates/{param}/podcast",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/decisions/{param}/cancel",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/decisions/{param}/retry",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/documents/{param}/reprocess",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/feedback/general",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/ideas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/ideas/{param}/edges",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/ideas/{param}/nodes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/ideas/{param}/promote",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index/embed-batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index/search",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index/{param}/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index/{param}/optimize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/index/{param}/rebuild",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/media/audio",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/media/audio/{param}/convert",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/personas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/tenants",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/tenants/{param}/members/invite",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/tenants/{param}/reactivate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:POST /api/tenants/{param}/suspend",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PUT /api/ideas/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PUT /api/ideas/{param}/nodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PUT /api/index/{param}/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "python_sdk_drift:PUT /api/tenants/{param}/quotas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/analytics/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/backups/schedules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/budgets/{param}/overrides/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/checkpoints/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/connectors/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/control-plane/schedules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/cross-pollination/subscribers/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/debates/{param}/notes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/debates/{param}/permanent",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/debates/{param}/tags",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/email/{param}/snooze",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/facts/relationships/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/facts/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/gmail/triage-rules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/index/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/index/{param}/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/integrations/wizard/providers/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/knowledge/mound/federation/regions/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/knowledge/mound/nodes/{param}/access",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/knowledge/mound/share",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/media/audio/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/memory/snapshots/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/partners/keys/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/payments/customer/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/payments/subscription/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/replays/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/transcription/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/users/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /api/webhooks/{param}/events",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:DELETE /inbox/accounts/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/feature-flags/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/organizations/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/organizations/{param}/credits",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/organizations/{param}/credits/expiring",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/organizations/{param}/credits/transactions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/security/rotation-status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/admin/users/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/agents/configs/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/agents/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/agents/{param}/quota",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/analytics/workspace/{param}/usage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/audit/resource/{param}/{param}/history",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/audit/security/debate/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/backups/schedules",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/batch/queue/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/batch/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/bindings/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/breakpoints/pending",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/breakpoints/{param}/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/budgets/{param}/transactions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/budgets/{param}/trends",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/checkpoints/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/connectors/{param}/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/connectors/{param}/syncs",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/connectors/{param}/syncs/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/consensus",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/control-plane/audit-logs/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/control-plane/metrics/agents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/control-plane/schedules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/dashboard",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/analytics/consensus",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/analytics/trends",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/archived",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/batch/{param}/results",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/hybrid/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/public/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/statistics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/statistics/agents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/stream",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/agent-statistics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/audience/suggestions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/checkpoints",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/quality",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/reasoning",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/replay",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/similar",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/debates/{param}/spectate/public",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/decisions/plans",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/decisions/plans/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/decisions/plans/{param}/outcome",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/decisions/{param}/outcome",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/decisions/{param}/outcomes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/devices/user/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/documents/search",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/documents/{param}/chunks",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/documents/{param}/download",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/email/{param}/snooze-suggestions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/evolution/ab-tests/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/evolution/ab-tests/{param}/active",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/external-agents/tasks/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/facts/relationships/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/facts/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/feature-flags/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/features/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/agents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/credentials/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/openclaw/audit",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/openclaw/credentials",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/openclaw/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/openclaw/metrics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/openclaw/sessions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/routing/rules",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gateway/routing/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/genesis/debates/{param}/tree",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/genesis/genomes/{param}/descendants",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/genesis/genomes/{param}/lineage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gmail/connection",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gmail/processed",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gmail/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/gusto/payrolls/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/incidents/{param}/notes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/index/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/index/{param}/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/available",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/config",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/wizard/providers/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/wizard/recommendations",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/wizard/status/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/integrations/wizard/{param}/workspaces",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/keys/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/knowledge/facts/relationships",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/knowledge/facts/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/knowledge/mound/graph/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/knowledge/mound/nodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/laboratory/agent/{param}/analysis",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/laboratory/experiments",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/leaderboard/agent/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/leaderboard/agent/{param}/elo-history",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/leaderboard/domain/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/learning/knowledge/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/learning/metrics/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/learning/patterns/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/learning/sessions/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/media/audio/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/media/audio/{param}/transcription",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/memory/context",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/memory/cross-debate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/memory/snapshots",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/memory/tier/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/metrics/debate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/moderation/config",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/modes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/alerts",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/dashboards",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/dashboards/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/health",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/logs",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/metrics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/slos",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/monitoring/traces",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/notifications/email/recipients",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/notifications/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/org/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/org/{param}/invitations/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/org/{param}/members/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/outcomes/impact",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/outcomes/search",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/outlook/oauth/callback",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/payments/customer/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/payments/subscription/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/payments/transaction/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/personas/options",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pipelines/{param}/items/{param}/transitions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pipelines/{param}/items/{param}/transitions/available",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/plans",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/plans/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/playbooks/{param}/run",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/playground/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/podcast/episodes/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/probes/reports/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pulse/analytics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pulse/scheduler/analytics",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pulse/scheduler/history",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/pulse/scheduler/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/rbac/assignments/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/rbac/permissions/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/rbac/roles/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/rbac/users/{param}/permissions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/events",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/evolution",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/export",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/forks",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/html",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/replays/{param}/summary",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/repository/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/selection/role-assigners",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/selection/scorers",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/selection/team-selectors",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/history",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/runs",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/runs/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/worktrees",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/self-improve/worktrees/autopilot/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/shared/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/skills/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/spectate/{param}/stream",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/tasks/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/tenants/{param}/channels/{param}/notifications",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/{param}/members",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/{param}/members/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/teams/{param}/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/tenants/{param}/members",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/tenants/{param}/quotas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/tenants/{param}/usage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/transcription/formats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/transcription/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/transcription/{param}/segments",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/events/categories",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/{param}/deliveries",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/{param}/deliveries/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/{param}/retry-policy",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/{param}/signing",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /api/webhooks/{param}/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/accounts",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/messages",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/messages/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/oauth/gmail",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/oauth/outlook",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/stats",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /inbox/trends",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /scim/v2/groups",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:GET /scim/v2/users",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/connectors/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/debates/{param}/metadata",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/facts/relationships/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/facts/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/gmail/triage-rules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/knowledge/mound/share",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/outlook/messages/{param}/read",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/policies/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/teams/tenants/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PATCH /api/teams/tenants/{param}/channels/{param}/notifications",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/ap/invoices/{param}/payment",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/ar/invoices/{param}/payment",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/ar/invoices/{param}/reminder",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/ar/invoices/{param}/send",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/connect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/accounting/reports",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/circuit-breakers/reset",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/emergency/activate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/emergency/deactivate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/organizations/{param}/credits",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/users/{param}/impersonate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/admin/users/{param}/suspend",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agent-dashboard/agents/{param}/pause",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agent-dashboard/agents/{param}/resume",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agent-dashboard/queue/prioritize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agents/{param}/calibrate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agents/{param}/disable",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agents/{param}/elo",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/agents/{param}/enable",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/analytics/connect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/analytics/query",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/analytics/reports/generate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/ap/batch-payments",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/ap/invoices",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/ap/optimize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/audience/suggestions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/auth/sessions/sweep",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/cleanup",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/schedules",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/{param}/restore",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/{param}/restore-test",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/{param}/verify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/backups/{param}/verify-comprehensive",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/budgets/{param}/overrides",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/checkpoints/{param}/intervention",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/checkpoints/{param}/resume",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/audit-verify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/eu-ai-act/audit",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/eu-ai-act/classify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/eu-ai-act/generate-bundle",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/gdpr/right-to-be-forgotten",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/hipaa/baa",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/hipaa/breach-assessment",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/hipaa/deidentify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/hipaa/detect-phi",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/compliance/hipaa/safe-harbor/verify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/connectors",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/connectors/{param}/sync",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/connectors/{param}/syncs/{param}/cancel",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/connectors/{param}/test",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/control-plane/agents/{param}/pause",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/control-plane/agents/{param}/resume",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/control-plane/queue/prioritize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/cross-pollination/conflicts/{param}/resolve",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/cross-pollination/federation/sync",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/cross-pollination/subscribe",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/cross-pollination/sync/trigger",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/batch/{param}/cancel",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/batch/{param}/retry",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/audience/suggestions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/checkpoint",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/evidence",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/make-permanent",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/notes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/restore",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/debates/{param}/tags",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/decisions/{param}/cancel",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/decisions/{param}/retry",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/devices/user/{param}/notify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/devices/{param}/notify",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/documents/{param}/reprocess",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/email/followups/{param}/resolve",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/email/{param}/snooze",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts/batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts/batch/delete",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts/merge",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts/relationships",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/facts/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/feedback/general",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/feedback/nps",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/gateway/devices/{param}/heartbeat",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/gusto/connect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/gusto/disconnect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/gusto/payrolls/{param}/journal-entry",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/inbox/messages/send",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/incidents/{param}/notes",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index/embed-batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index/search",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index/{param}/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index/{param}/optimize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/index/{param}/rebuild",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/integrations/wizard/providers/{param}/install",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/integrations/wizard/providers/{param}/refresh",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/integrations/wizard/{param}/disconnect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/integrations/wizard/{param}/test",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/embeddings",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/facts/batch",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/facts/batch/delete",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/facts/merge",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/facts/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/culture/documents",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/culture/promote",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/federation/regions",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/federation/sync/all",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/federation/sync/pull",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/federation/sync/push",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/global",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/global/promote",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/index/repository",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/nodes/{param}/access",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/mound/share",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/refresh",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/knowledge/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/learning/patterns/{param}/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/learning/sessions/{param}/stop",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/media/audio",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/media/audio/{param}/convert",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/onboarding/complete",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/outlook/messages/reply",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/outlook/messages/send",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/partners/register",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/authorize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/capture",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/charge",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/customer",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/refund",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/subscription",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/payments/void",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/personas",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/pipelines/{param}/items/{param}/transition",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/pipelines/{param}/items/{param}/transition/rollback",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/pipelines/{param}/items/{param}/transition/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/plans",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/plans/{param}/approve",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/plans/{param}/execute",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/plans/{param}/reject",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies/validate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies/violations/{param}/resolve",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies/{param}/disable",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies/{param}/enable",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/policies/{param}/toggle",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/replays/{param}/fork",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/skills/marketplace/publish",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/sme/teams/subscribe",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/tasks/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/tenants",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/tenants/{param}/members/invite",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/tenants/{param}/reactivate",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/tenants/{param}/suspend",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/debates/{param}/synthesize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/device",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/gather",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/gather/confirm",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/inbound",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/status",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/voice/synthesize",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/webhooks/{param}/deliveries/{param}/retry",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/webhooks/{param}/events",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /api/webhooks/{param}/rotate-secret",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /inbox/bulk-action",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /inbox/connect",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /inbox/messages/send",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /inbox/messages/{param}/reply",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:POST /inbox/triage",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/admin/feature-flags/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/admin/organizations/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/agents/{param}/quota",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/control-plane/schedules/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/index/{param}/documents/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/knowledge/mound/nodes/{param}/visibility",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/memory/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/payments/customer/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/payments/subscription/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/plans/{param}",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/users/{param}/role",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "start_cohort",
+      "discovered_on": "2026-04-17",
+      "id": "typescript_sdk_drift:PUT /api/webhooks/{param}/retry-policy",
+      "provenance": "2026-04-17 program baseline cohort",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    }
+  ],
+  "version": 1
+}

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -303,6 +303,20 @@ def build_ratchet_result(
         }
         base_counts = _counts_from_docs(base_docs)
 
+        # The schedule parameters themselves are immutable in pr mode: a PR
+        # that edits contract_drift_program.json is threshold inflation by
+        # definition (the #9325 ruling's banned move) and must be settled as
+        # its own operator-approved change over a red gate, never slipped in.
+        base_program = _git_doc(repo_root, base_ref, program_baseline)
+        head_program = _load_json_strict(program_baseline, "Program baseline")
+        for field in ("start_date", "start_total_items", "weekly_reduction", "grace_weeks"):
+            if base_program.get(field) != head_program.get(field):
+                integrity_issues.append(
+                    "Program baseline parameter changed in PR "
+                    f"({field}: {base_program.get(field)!r} -> {head_program.get(field)!r}); "
+                    "schedule changes require operator settlement, not a PR-mode pass"
+                )
+
         base_inventory = _git_doc(repo_root, base_ref, inventory_path)
         base_items = {
             i["id"]: i for i in base_inventory.get("items", []) if isinstance(i, dict) and "id" in i

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -147,6 +147,31 @@ def _evaluate_classes(
     return classes
 
 
+def _append_only_issues(
+    base_items: dict[str, dict[str, Any]], head_items: dict[str, dict[str, Any]]
+) -> list[str]:
+    """Append-only invariants for pr mode: history is immutable.
+
+    For every item present in the inventory at the base ref: ``class``,
+    ``discovered_on``, and ``provenance`` may not change (so reopening a
+    resolved item cannot reset its burn-down clock), and the item may not be
+    deleted. Status transitions (open<->resolved) remain allowed.
+    """
+    issues: list[str] = []
+    for item_id, base_item in base_items.items():
+        head_item = head_items.get(item_id)
+        if head_item is None:
+            issues.append(f"Inventory item deleted (inventory is append-only): {item_id}")
+            continue
+        for field in ("class", "discovered_on", "provenance"):
+            if head_item.get(field) != base_item.get(field):
+                issues.append(
+                    f"Immutable inventory field {field!r} changed for {item_id}: "
+                    f"{base_item.get(field)!r} -> {head_item.get(field)!r}"
+                )
+    return issues
+
+
 def build_ratchet_result(
     *,
     mode: str,
@@ -158,6 +183,7 @@ def build_ratchet_result(
     repo_root: Path,
     as_of: date,
     base_ref: str | None = None,
+    cohort_commit: str = inventory_mod.COHORT_COMMIT,
 ) -> dict[str, Any]:
     integrity_issues: list[str] = []
 
@@ -180,6 +206,17 @@ def build_ratchet_result(
             docs[alias] = {}
     counts = _counts_from_docs(docs)
 
+    cohort_ids: dict[str, str] | None = None
+    try:
+        cohort_ids = inventory_mod.collect_ids(
+            inventory_mod.load_git_docs(repo_root, cohort_commit)
+        )
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        integrity_issues.append(
+            f"Cohort commit {cohort_commit} unavailable in this checkout "
+            "(fetch it before running); cannot verify derivable metadata"
+        )
+
     inventory: dict[str, Any] = {"items": []}
     try:
         inventory = _load_json_strict(inventory_path, "Contract drift inventory")
@@ -188,6 +225,14 @@ def build_ratchet_result(
     else:
         current_ids = inventory_mod.collect_ids(docs)
         integrity_issues.extend(inventory_mod.find_sync_issues(inventory, current_ids))
+        if cohort_ids is not None:
+            integrity_issues.extend(
+                inventory_mod.find_metadata_issues(
+                    [i for i in inventory.get("items", []) if isinstance(i, dict)],
+                    cohort_ids,
+                    as_of=as_of,
+                )
+            )
 
     items = [i for i in inventory.get("items", []) if isinstance(i, dict)]
     classes: list[dict[str, Any]] = []
@@ -240,6 +285,20 @@ def build_ratchet_result(
             "parity": _git_doc(repo_root, base_ref, parity_baseline),
         }
         base_counts = _counts_from_docs(base_docs)
+
+        base_inventory = _git_doc(repo_root, base_ref, inventory_path)
+        base_items = {
+            i["id"]: i for i in base_inventory.get("items", []) if isinstance(i, dict) and "id" in i
+        }
+        head_items = {i["id"]: i for i in items if "id" in i}
+        append_only = _append_only_issues(base_items, head_items)
+        integrity_issues.extend(append_only)
+        result["integrity"] = {
+            "passing": not integrity_issues,
+            "issues": integrity_issues,
+        }
+        result["program_passing"] = result["program_passing"] and not integrity_issues
+
         deltas = {
             key: {
                 "base": base_counts[key],
@@ -344,6 +403,11 @@ def main() -> int:
         help="Canonical provenance-classified inventory path",
     )
     parser.add_argument(
+        "--cohort-commit",
+        default=inventory_mod.COHORT_COMMIT,
+        help="Commit whose baselines define the start cohort (derivable metadata)",
+    )
+    parser.add_argument(
         "--as-of",
         default=date.today().isoformat(),
         help="Date for ratchet evaluation (YYYY-MM-DD, default: today)",
@@ -363,6 +427,7 @@ def main() -> int:
             repo_root=args.repo_root,
             as_of=date.fromisoformat(args.as_of),
             base_ref=args.base_ref,
+            cohort_commit=args.cohort_commit,
         )
     except (ValueError, subprocess.CalledProcessError) as exc:
         print(f"FAIL (closed): {exc}", file=sys.stderr)

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -1,40 +1,78 @@
 #!/usr/bin/env python3
-"""Enforce week-over-week contract drift ratchet targets."""
+"""Enforce contract drift governance: program burn-down and per-PR delta ratchet.
+
+Two modes:
+
+- ``program`` (cron / dispatch / main): per-class scheduled targets over OPEN
+  items in the canonical provenance-classified inventory. ``start_cohort``
+  burns down from the 2026-04-17 program baseline (655 items, -10%/week,
+  read ONLY from scripts/baselines/contract_drift_program.json); each
+  ``discovered`` batch burns down from its own batch size and discovery date
+  on the same weekly reduction. Fails closed on missing/unparseable inputs,
+  inventory desync, unexplained baseline entries, or unknown classes.
+
+- ``pr``: strict non-worsening delta ratchet. Compares the five baseline-file
+  counts at HEAD against the merge base (``--base-ref``); FAILS if any count
+  increased or any integrity condition holds, PASSES on equal-or-lower counts
+  even while the program schedule is red. The program status is still
+  reported (informational) so PR authors see the burn-down state.
+"""
 
 from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
+from collections import defaultdict
 from datetime import date
 from pathlib import Path
 from typing import Any
 
+try:
+    from scripts import generate_contract_drift_inventory as inventory_mod
+except ImportError:  # executed directly: script dir is on sys.path
+    import generate_contract_drift_inventory as inventory_mod  # type: ignore[no-redef]
 
-def _load_json(path: Path) -> dict[str, Any]:
+COUNT_KEYS: tuple[tuple[str, str, str], ...] = (
+    ("verify_python_sdk_drift", "verify", "python_sdk_drift"),
+    ("verify_typescript_sdk_drift", "verify", "typescript_sdk_drift"),
+    ("routes_missing_in_spec", "routes", "missing_in_spec"),
+    ("routes_orphaned_in_spec", "routes", "orphaned_in_spec"),
+    ("sdk_missing_from_both", "parity", "missing_from_both_sdks"),
+)
+
+
+def _load_json_strict(path: Path, label: str) -> dict[str, Any]:
     if not path.exists():
-        return {}
-    return json.loads(path.read_text())
+        raise ValueError(f"{label} missing: {path}")
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} unparseable: {path} ({exc})") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} malformed (expected object): {path}")
+    return data
 
 
-def _count_current_total(
-    verify_baseline: Path,
-    routes_baseline: Path,
-    parity_baseline: Path,
-) -> dict[str, int]:
-    verify = _load_json(verify_baseline)
-    routes = _load_json(routes_baseline)
-    parity = _load_json(parity_baseline)
-
+def _counts_from_docs(docs: dict[str, dict[str, Any]]) -> dict[str, int]:
     counts = {
-        "verify_python_sdk_drift": len(verify.get("python_sdk_drift", [])),
-        "verify_typescript_sdk_drift": len(verify.get("typescript_sdk_drift", [])),
-        "routes_missing_in_spec": len(routes.get("missing_in_spec", [])),
-        "routes_orphaned_in_spec": len(routes.get("orphaned_in_spec", [])),
-        "sdk_missing_from_both": len(parity.get("missing_from_both_sdks", [])),
+        count_key: len(docs.get(alias, {}).get(list_key, []) or [])
+        for count_key, alias, list_key in COUNT_KEYS
     }
     counts["total_items"] = sum(counts.values())
     return counts
+
+
+def _git_doc(repo_root: Path, ref: str, path: Path) -> dict[str, Any]:
+    """Baseline file content at a git ref; missing at the ref means empty."""
+    rel = path.resolve().relative_to(repo_root.resolve()).as_posix()
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{ref}:{rel}"],
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout) if proc.returncode == 0 else {}
 
 
 def _target_after_weeks(start_total: int, weekly_reduction: float, weeks: int) -> int:
@@ -44,142 +82,305 @@ def _target_after_weeks(start_total: int, weekly_reduction: float, weeks: int) -
     return current
 
 
-def build_ratchet_result(
-    *,
-    program_baseline: Path,
-    verify_baseline: Path,
-    routes_baseline: Path,
-    parity_baseline: Path,
-    as_of: date,
-) -> dict[str, Any]:
-    program = _load_json(program_baseline)
-    if not program:
-        raise ValueError(
-            f"Program baseline missing or empty: {program_baseline}. "
-            "Create scripts/baselines/contract_drift_program.json first."
-        )
-
+def _load_program(program_baseline: Path) -> dict[str, Any]:
+    program = _load_json_strict(program_baseline, "Program baseline")
     start_date_raw = program.get("start_date")
-    start_total = int(program.get("start_total_items", 0))
-    weekly_reduction = float(program.get("weekly_reduction", 0.1))
+    start_total = int(program.get("start_total_items", -1))
+    weekly_reduction = float(program.get("weekly_reduction", -1.0))
     grace_weeks = int(program.get("grace_weeks", 0))
-
     if not start_date_raw:
         raise ValueError("Program baseline must include 'start_date'")
     if start_total < 0:
         raise ValueError("Program baseline has invalid 'start_total_items'")
     if not (0.0 < weekly_reduction < 1.0):
         raise ValueError("Program baseline 'weekly_reduction' must be between 0 and 1")
+    return {
+        "start_date": date.fromisoformat(start_date_raw),
+        "start_total_items": start_total,
+        "weekly_reduction": weekly_reduction,
+        "grace_weeks": grace_weeks,
+    }
 
-    start_date = date.fromisoformat(start_date_raw)
-    days_elapsed = max(0, (as_of - start_date).days)
-    weeks_elapsed = days_elapsed // 7
-    effective_weeks = max(0, weeks_elapsed - grace_weeks)
 
-    counts = _count_current_total(verify_baseline, routes_baseline, parity_baseline)
-    target_max = _target_after_weeks(start_total, weekly_reduction, effective_weeks)
-    current_total = counts["total_items"]
+def _evaluate_classes(
+    program: dict[str, Any], items: list[dict[str, Any]], as_of: date
+) -> list[dict[str, Any]]:
+    """Per-class scheduled targets over OPEN inventory items."""
+    weekly_reduction = program["weekly_reduction"]
+    weeks_elapsed = max(0, (as_of - program["start_date"]).days) // 7
+    effective_weeks = max(0, weeks_elapsed - program["grace_weeks"])
 
-    result = {
+    cohort_open = sum(1 for i in items if i["class"] == "start_cohort" and i["status"] == "open")
+    classes = [
+        {
+            "name": "start_cohort",
+            "batch_start": program["start_date"].isoformat(),
+            "batch_size": program["start_total_items"],
+            "weeks_elapsed": effective_weeks,
+            "open_items": cohort_open,
+            "target_max": _target_after_weeks(
+                program["start_total_items"], weekly_reduction, effective_weeks
+            ),
+        }
+    ]
+
+    batches: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in items:
+        if item["class"] == "discovered":
+            batches[item["discovered_on"]].append(item)
+    for discovered_on in sorted(batches):
+        batch = batches[discovered_on]
+        weeks = max(0, (as_of - date.fromisoformat(discovered_on)).days) // 7
+        classes.append(
+            {
+                "name": f"discovered:{discovered_on}",
+                "batch_start": discovered_on,
+                "batch_size": len(batch),
+                "weeks_elapsed": weeks,
+                "open_items": sum(1 for i in batch if i["status"] == "open"),
+                "target_max": _target_after_weeks(len(batch), weekly_reduction, weeks),
+            }
+        )
+
+    for cls in classes:
+        cls["passing"] = cls["open_items"] <= cls["target_max"]
+    return classes
+
+
+def build_ratchet_result(
+    *,
+    mode: str,
+    program_baseline: Path,
+    verify_baseline: Path,
+    routes_baseline: Path,
+    parity_baseline: Path,
+    inventory_path: Path,
+    repo_root: Path,
+    as_of: date,
+    base_ref: str | None = None,
+) -> dict[str, Any]:
+    integrity_issues: list[str] = []
+
+    program: dict[str, Any] | None = None
+    try:
+        program = _load_program(program_baseline)
+    except ValueError as exc:
+        integrity_issues.append(str(exc))
+
+    docs: dict[str, dict[str, Any]] = {}
+    for label, alias, path in (
+        ("verify_sdk_contracts baseline", "verify", verify_baseline),
+        ("validate_openapi_routes baseline", "routes", routes_baseline),
+        ("check_sdk_parity baseline", "parity", parity_baseline),
+    ):
+        try:
+            docs[alias] = _load_json_strict(path, label)
+        except ValueError as exc:
+            integrity_issues.append(str(exc))
+            docs[alias] = {}
+    counts = _counts_from_docs(docs)
+
+    inventory: dict[str, Any] = {"items": []}
+    try:
+        inventory = _load_json_strict(inventory_path, "Contract drift inventory")
+    except ValueError as exc:
+        integrity_issues.append(str(exc))
+    else:
+        current_ids = inventory_mod.collect_ids(docs)
+        integrity_issues.extend(inventory_mod.find_sync_issues(inventory, current_ids))
+
+    items = [i for i in inventory.get("items", []) if isinstance(i, dict)]
+    classes: list[dict[str, Any]] = []
+    if program is not None and not integrity_issues:
+        classes = _evaluate_classes(program, items, as_of)
+
+    total_open = sum(cls["open_items"] for cls in classes)
+    total_target = sum(cls["target_max"] for cls in classes)
+    program_passing = bool(classes) and all(cls["passing"] for cls in classes)
+
+    result: dict[str, Any] = {
+        "mode": mode,
         "program": {
-            "start_date": start_date.isoformat(),
+            "start_date": program["start_date"].isoformat() if program else None,
             "as_of": as_of.isoformat(),
-            "days_elapsed": days_elapsed,
-            "weeks_elapsed": weeks_elapsed,
-            "effective_weeks": effective_weeks,
-            "grace_weeks": grace_weeks,
-            "weekly_reduction": weekly_reduction,
-            "start_total_items": start_total,
+            "days_elapsed": max(0, (as_of - program["start_date"]).days) if program else 0,
+            "weeks_elapsed": (max(0, (as_of - program["start_date"]).days) // 7 if program else 0),
+            "effective_weeks": (
+                max(
+                    0,
+                    max(0, (as_of - program["start_date"]).days) // 7 - program["grace_weeks"],
+                )
+                if program
+                else 0
+            ),
+            "grace_weeks": program["grace_weeks"] if program else 0,
+            "weekly_reduction": program["weekly_reduction"] if program else None,
+            "start_total_items": program["start_total_items"] if program else None,
         },
         "current": counts,
-        "target": {
-            "max_open_items": target_max,
-        },
-        "delta_to_target": current_total - target_max,
-        "passing": current_total <= target_max,
+        "target": {"max_open_items": total_target},
+        "delta_to_target": total_open - total_target,
+        "classes": classes,
+        "integrity": {"passing": not integrity_issues, "issues": integrity_issues},
+        "program_passing": program_passing and not integrity_issues,
     }
+
+    if mode == "pr":
+        if not base_ref:
+            raise ValueError("--base-ref is required in pr mode")
+        subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{base_ref}^{{commit}}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        base_docs = {
+            "verify": _git_doc(repo_root, base_ref, verify_baseline),
+            "routes": _git_doc(repo_root, base_ref, routes_baseline),
+            "parity": _git_doc(repo_root, base_ref, parity_baseline),
+        }
+        base_counts = _counts_from_docs(base_docs)
+        deltas = {
+            key: {
+                "base": base_counts[key],
+                "head": counts[key],
+                "delta": counts[key] - base_counts[key],
+            }
+            for key, _alias, _list in COUNT_KEYS
+        }
+        increased = sorted(k for k, d in deltas.items() if d["delta"] > 0)
+        result["pr_delta"] = {
+            "base_ref": base_ref,
+            "counts": deltas,
+            "increased": increased,
+        }
+        result["passing"] = not increased and not integrity_issues
+    else:
+        result["passing"] = result["program_passing"]
+
     return result
 
 
+def _print_text(result: dict[str, Any]) -> None:
+    program = result["program"]
+    current = result["current"]
+    print(f"Contract Drift Ratchet [{result['mode']} mode]")
+    print("=" * 60)
+    print(
+        f"As of: {program['as_of']}  |  Start: {program['start_date']}  |  "
+        f"Weeks elapsed: {program['weeks_elapsed']} "
+        f"(effective: {program['effective_weeks']})"
+    )
+    print(
+        f"Start total: {program['start_total_items']}  |  "
+        f"Current total: {current['total_items']}  |  "
+        f"Target max: {result['target']['max_open_items']}"
+    )
+    print("-" * 60)
+    print(
+        "Source counts: "
+        f"py={current['verify_python_sdk_drift']} "
+        f"ts={current['verify_typescript_sdk_drift']} "
+        f"missing={current['routes_missing_in_spec']} "
+        f"orphaned={current['routes_orphaned_in_spec']} "
+        f"both={current['sdk_missing_from_both']}"
+    )
+    for cls in result["classes"]:
+        status = "PASS" if cls["passing"] else "FAIL"
+        print(
+            f"  class {cls['name']}: open={cls['open_items']} "
+            f"target<={cls['target_max']} (batch {cls['batch_size']} @ "
+            f"{cls['batch_start']}, {cls['weeks_elapsed']}w) [{status}]"
+        )
+    print(f"Delta to target: {result['delta_to_target']:+d}")
+    if result["mode"] == "pr":
+        pr_delta = result["pr_delta"]
+        print("-" * 60)
+        print(f"PR delta vs {pr_delta['base_ref']}:")
+        for key, d in pr_delta["counts"].items():
+            print(f"  {key}: {d['base']} -> {d['head']} ({d['delta']:+d})")
+        print(
+            "Program status (informational): " + ("PASS" if result["program_passing"] else "FAIL")
+        )
+    if not result["integrity"]["passing"]:
+        print("Integrity issues (fail closed):")
+        for issue in result["integrity"]["issues"]:
+            print(f"  - {issue}")
+    print("PASS" if result["passing"] else "FAIL")
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Check contract drift weekly ratchet target")
+    parser = argparse.ArgumentParser(description="Check contract drift ratchet")
+    parser.add_argument("--mode", choices=("program", "pr"), default="program")
+    parser.add_argument(
+        "--base-ref", default=None, help="Merge base ref for pr mode (e.g. origin/main)"
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
     parser.add_argument(
         "--program-baseline",
         type=Path,
         default=Path("scripts/baselines/contract_drift_program.json"),
-        help="Program baseline config path",
+        help="Program baseline config path (sole source of schedule numbers)",
     )
     parser.add_argument(
         "--verify-baseline",
         type=Path,
         default=Path("scripts/baselines/verify_sdk_contracts.json"),
-        help="verify_sdk_contracts baseline path",
     )
     parser.add_argument(
         "--routes-baseline",
         type=Path,
         default=Path("scripts/baselines/validate_openapi_routes.json"),
-        help="validate_openapi_routes baseline path",
     )
     parser.add_argument(
         "--parity-baseline",
         type=Path,
         default=Path("scripts/baselines/check_sdk_parity.json"),
-        help="check_sdk_parity baseline path",
+    )
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path(inventory_mod.DEFAULT_INVENTORY),
+        help="Canonical provenance-classified inventory path",
     )
     parser.add_argument(
         "--as-of",
         default=date.today().isoformat(),
         help="Date for ratchet evaluation (YYYY-MM-DD, default: today)",
     )
-    parser.add_argument("--strict", action="store_true", help="Exit 1 when above ratchet target")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 when failing")
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     args = parser.parse_args()
 
-    as_of = date.fromisoformat(args.as_of)
-    result = build_ratchet_result(
-        program_baseline=args.program_baseline,
-        verify_baseline=args.verify_baseline,
-        routes_baseline=args.routes_baseline,
-        parity_baseline=args.parity_baseline,
-        as_of=as_of,
-    )
+    try:
+        result = build_ratchet_result(
+            mode=args.mode,
+            program_baseline=args.program_baseline,
+            verify_baseline=args.verify_baseline,
+            routes_baseline=args.routes_baseline,
+            parity_baseline=args.parity_baseline,
+            inventory_path=args.inventory,
+            repo_root=args.repo_root,
+            as_of=date.fromisoformat(args.as_of),
+            base_ref=args.base_ref,
+        )
+    except (ValueError, subprocess.CalledProcessError) as exc:
+        print(f"FAIL (closed): {exc}", file=sys.stderr)
+        return 1
 
     if args.json:
         print(json.dumps(result, indent=2))
     else:
-        program = result["program"]
-        current = result["current"]
-        target = result["target"]
-        print("Contract Drift Ratchet")
-        print("=" * 60)
-        print(
-            f"As of: {program['as_of']}  |  Start: {program['start_date']}  |  "
-            f"Weeks elapsed: {program['weeks_elapsed']} (effective: {program['effective_weeks']})"
-        )
-        print(
-            f"Start total: {program['start_total_items']}  |  "
-            f"Current total: {current['total_items']}  |  "
-            f"Target max: {target['max_open_items']}"
-        )
-        print("-" * 60)
-        print(
-            "Source counts: "
-            f"py={current['verify_python_sdk_drift']} "
-            f"ts={current['verify_typescript_sdk_drift']} "
-            f"missing={current['routes_missing_in_spec']} "
-            f"orphaned={current['routes_orphaned_in_spec']} "
-            f"both={current['sdk_missing_from_both']}"
-        )
-        print(f"Delta to target: {result['delta_to_target']:+d}")
-        print("PASS" if result["passing"] else "FAIL")
+        _print_text(result)
+
+    if not result["integrity"]["passing"]:
+        # Integrity violations always fail closed, independent of --strict.
+        print("\nFAIL: contract drift integrity violation (fail closed).", file=sys.stderr)
+        return 1
 
     if args.strict and not result["passing"]:
-        message = "\nFAIL: Contract drift is above ratchet target."
-        if args.json:
-            print(message, file=sys.stderr)
-        else:
-            print(message)
+        message = "\nFAIL: Contract drift ratchet is failing."
+        print(message, file=sys.stderr if args.json else sys.stdout)
         return 1
 
     return 0

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -153,12 +153,20 @@ def _evaluate_classes(
 def _append_only_issues(
     base_items: dict[str, dict[str, Any]], head_items: dict[str, dict[str, Any]]
 ) -> list[str]:
-    """Append-only invariants for pr mode: history is immutable.
+    """Append-only lifecycle invariants for pr mode: history is immutable.
 
     For every item present in the inventory at the base ref: ``class``,
     ``discovered_on``, and ``provenance`` may not change (so reopening a
     resolved item cannot reset its burn-down clock), and the item may not be
-    deleted. Status transitions (open<->resolved) remain allowed.
+    deleted. Status transitions (open<->resolved) remain allowed for items
+    with base history.
+
+    Birth-state invariant: an item NEW at head (absent from the base
+    inventory) must be born ``open``. Resolution requires history — a
+    fabricated ``resolved`` item would otherwise inflate its batch_size and
+    pad that batch's scheduled target while leaving PR count deltas at zero.
+    (New open items are additionally required to be baseline-backed by the
+    global sync check, so a fabricated open item fails too.)
     """
     issues: list[str] = []
     for item_id, base_item in base_items.items():
@@ -172,6 +180,12 @@ def _append_only_issues(
                     f"Immutable inventory field {field!r} changed for {item_id}: "
                     f"{base_item.get(field)!r} -> {head_item.get(field)!r}"
                 )
+    for item_id, head_item in head_items.items():
+        if item_id not in base_items and head_item.get("status") != "open":
+            issues.append(
+                "New inventory item must be born open, not "
+                f"{head_item.get('status')!r} (resolution requires history): {item_id}"
+            )
     return issues
 
 

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from collections import defaultdict
@@ -76,10 +77,12 @@ def _git_doc(repo_root: Path, ref: str, path: Path) -> dict[str, Any]:
 
 
 def _target_after_weeks(start_total: int, weekly_reduction: float, weeks: int) -> int:
-    current = start_total
-    for _ in range(max(0, weeks)):
-        current = max(0, int(round(current * (1.0 - weekly_reduction))))
-    return current
+    # One-shot floored decay. The previous iterative int(round(n * 0.9)) had
+    # fixed points at 1-4 (e.g. round(4 * 0.9) == 4), so small per-batch
+    # clocks would never be required to reach zero and larger ones stalled
+    # at 4. floor(start * factor**weeks) is monotonic to 0.
+    factor = (1.0 - weekly_reduction) ** max(0, weeks)
+    return max(0, math.floor(start_total * factor))
 
 
 def _load_program(program_baseline: Path) -> dict[str, Any]:

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -167,8 +167,13 @@ def find_sync_issues(inventory: dict[str, Any], current_ids: dict[str, str]) -> 
         klass = item.get("class")
         if klass not in VALID_CLASSES:
             issues.append(f"Unknown class {klass!r} for inventory item {item_id}")
-        if not item.get("provenance"):
+        provenance = item.get("provenance") or ""
+        if not provenance:
             issues.append(f"Inventory item missing provenance: {item_id}")
+        elif klass == "discovered" and not PROVENANCE_REF.search(provenance):
+            # Hand-edited committed inventories must meet the same bar the
+            # generator enforces: discovered items need a PR/issue reference.
+            issues.append(f"Discovered item provenance lacks a PR/issue reference: {item_id}")
         if item.get("status") == "open":
             open_ids.add(item_id)
 

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Build/refresh the canonical provenance-classified contract drift inventory.
+
+Every entry in the three contract-drift baseline files becomes an inventory
+item with a stable id, a provenance class, and a discovery date:
+
+- Items present in the baselines at the 2026-04-17 program cohort commit
+  (5cc7a81b77) are classified ``start_cohort``.
+- Items that appear later REQUIRE an explicit ``--provenance`` containing a
+  PR/issue reference; without it the generator fails closed and lists the
+  unexplained items (no silent debt absorption).
+- Items that disappear from the baselines are marked ``resolved`` and are
+  never deleted (audit trail). Resolution is verifiable because the sibling
+  no-regression gates keep the baselines a superset of live violations, so
+  baseline pruning only happens when items are actually fixed.
+
+The inventory is deterministic and sorted; ``--check`` fails (exit 1) when
+the committed inventory is out of sync with the baselines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+COHORT_COMMIT = "5cc7a81b77aeb6680613d441f74d72c435c8443c"
+COHORT_DATE = "2026-04-17"
+COHORT_PROVENANCE = "2026-04-17 program baseline cohort"
+DEFAULT_INVENTORY = "scripts/baselines/contract_drift_inventory.json"
+VALID_CLASSES = frozenset({"start_cohort", "discovered"})
+PROVENANCE_REF = re.compile(r"#\d+|https?://\S+")
+
+# alias -> (repo-relative baseline path, tracked list keys)
+BASELINE_SPECS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "verify": (
+        "scripts/baselines/verify_sdk_contracts.json",
+        ("python_sdk_drift", "typescript_sdk_drift"),
+    ),
+    "routes": (
+        "scripts/baselines/validate_openapi_routes.json",
+        ("missing_in_spec", "orphaned_in_spec"),
+    ),
+    "parity": (
+        "scripts/baselines/check_sdk_parity.json",
+        ("missing_from_both_sdks",),
+    ),
+}
+
+
+def normalize_key(entry: Any) -> str:
+    if isinstance(entry, str):
+        return entry.strip()
+    return json.dumps(entry, sort_keys=True)
+
+
+def collect_ids(docs: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Map stable item id -> source list key for all baseline entries."""
+    ids: dict[str, str] = {}
+    for alias, (_path, list_keys) in BASELINE_SPECS.items():
+        doc = docs.get(alias) or {}
+        for list_key in list_keys:
+            for entry in doc.get(list_key, []) or []:
+                ids[f"{list_key}:{normalize_key(entry)}"] = list_key
+    return ids
+
+
+def load_working_docs(repo_root: Path) -> dict[str, dict[str, Any]]:
+    docs: dict[str, dict[str, Any]] = {}
+    for alias, (rel_path, _keys) in BASELINE_SPECS.items():
+        path = repo_root / rel_path
+        if not path.exists():
+            raise ValueError(f"Baseline file missing: {path}")
+        docs[alias] = json.loads(path.read_text())
+    return docs
+
+
+def load_git_docs(repo_root: Path, ref: str) -> dict[str, dict[str, Any]]:
+    """Read the baseline files at a git ref; a file missing at the ref is empty."""
+    subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    docs: dict[str, dict[str, Any]] = {}
+    for alias, (rel_path, _keys) in BASELINE_SPECS.items():
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "show", f"{ref}:{rel_path}"],
+            capture_output=True,
+            text=True,
+        )
+        docs[alias] = json.loads(proc.stdout) if proc.returncode == 0 else {}
+    return docs
+
+
+def build_inventory(
+    current_ids: dict[str, str],
+    cohort_ids: dict[str, str],
+    existing_items: list[dict[str, Any]],
+    *,
+    as_of: date,
+    provenance: str | None,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (sorted inventory items, unexplained new item ids)."""
+    items = {item["id"]: dict(item) for item in existing_items}
+    unexplained: list[str] = []
+
+    for item_id, list_key in current_ids.items():
+        record = items.get(item_id)
+        if record is not None:
+            if record.get("status") == "resolved":
+                record["status"] = "open"
+                record.pop("resolved_on", None)
+        elif item_id in cohort_ids:
+            items[item_id] = {
+                "id": item_id,
+                "source": list_key,
+                "class": "start_cohort",
+                "discovered_on": COHORT_DATE,
+                "provenance": COHORT_PROVENANCE,
+                "status": "open",
+            }
+        elif provenance:
+            items[item_id] = {
+                "id": item_id,
+                "source": list_key,
+                "class": "discovered",
+                "discovered_on": as_of.isoformat(),
+                "provenance": provenance,
+                "status": "open",
+            }
+        else:
+            unexplained.append(item_id)
+
+    for item_id, record in items.items():
+        if item_id not in current_ids and record.get("status") == "open":
+            record["status"] = "resolved"
+            record["resolved_on"] = as_of.isoformat()
+
+    return sorted(items.values(), key=lambda item: item["id"]), sorted(unexplained)
+
+
+def find_sync_issues(inventory: dict[str, Any], current_ids: dict[str, str]) -> list[str]:
+    """Integrity issues between an inventory document and live baseline ids."""
+    issues: list[str] = []
+    items = inventory.get("items")
+    if not isinstance(items, list):
+        return ["Inventory has no 'items' list"]
+
+    open_ids = set()
+    for item in items:
+        item_id = item.get("id", "<missing id>")
+        klass = item.get("class")
+        if klass not in VALID_CLASSES:
+            issues.append(f"Unknown class {klass!r} for inventory item {item_id}")
+        if not item.get("provenance"):
+            issues.append(f"Inventory item missing provenance: {item_id}")
+        if item.get("status") == "open":
+            open_ids.add(item_id)
+
+    for item_id in sorted(set(current_ids) - open_ids):
+        issues.append(f"Baseline entry not open in inventory (unexplained debt): {item_id}")
+    for item_id in sorted(open_ids - set(current_ids)):
+        issues.append(f"Inventory item open but absent from baselines (stale): {item_id}")
+    return issues
+
+
+def render_inventory(items: list[dict[str, Any]], cohort_commit: str) -> str:
+    doc = {
+        "version": 1,
+        "generated_by": "scripts/generate_contract_drift_inventory.py",
+        "cohort_commit": cohort_commit,
+        "items": items,
+    }
+    return json.dumps(doc, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--inventory", type=Path, default=None)
+    parser.add_argument("--cohort-commit", default=COHORT_COMMIT)
+    parser.add_argument("--as-of", default=date.today().isoformat())
+    parser.add_argument(
+        "--provenance",
+        default=None,
+        help="Required provenance (with a PR/issue link) for any post-cohort items",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail (exit 1) if the inventory is out of sync with the baselines",
+    )
+    args = parser.parse_args()
+
+    repo_root = args.repo_root
+    inventory_path = args.inventory or repo_root / DEFAULT_INVENTORY
+    as_of = date.fromisoformat(args.as_of)
+
+    if args.provenance is not None and not PROVENANCE_REF.search(args.provenance):
+        print("ERROR: --provenance must include a PR/issue reference (#123 or URL)")
+        return 1
+
+    try:
+        current_ids = collect_ids(load_working_docs(repo_root))
+        cohort_ids = collect_ids(load_git_docs(repo_root, args.cohort_commit))
+    except (ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    existing: dict[str, Any] = {"items": []}
+    if inventory_path.exists():
+        existing = json.loads(inventory_path.read_text())
+
+    if args.check:
+        if not inventory_path.exists():
+            print(f"FAIL: inventory missing: {inventory_path}")
+            return 1
+        issues = find_sync_issues(existing, current_ids)
+        if issues:
+            print("FAIL: inventory out of sync with baselines:")
+            for issue in issues:
+                print(f"  - {issue}")
+            return 1
+        print(f"OK: inventory in sync ({len(current_ids)} open items)")
+        return 0
+
+    items, unexplained = build_inventory(
+        current_ids,
+        cohort_ids,
+        existing.get("items", []),
+        as_of=as_of,
+        provenance=args.provenance,
+    )
+    if unexplained:
+        print(
+            "FAIL: post-cohort items without provenance (pass --provenance with a PR/issue link):"
+        )
+        for item_id in unexplained:
+            print(f"  - {item_id}")
+        return 1
+
+    inventory_path.write_text(render_inventory(items, args.cohort_commit))
+    open_count = sum(1 for item in items if item["status"] == "open")
+    resolved = len(items) - open_count
+    print(f"Wrote {inventory_path}: {open_count} open, {resolved} resolved")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -296,6 +296,15 @@ def main() -> int:
         return 1
 
     metadata_issues = find_metadata_issues(items, cohort_ids, as_of=as_of)
+    # Birth-state guard: the generator must never mint a resolved item that
+    # was not already present in the existing inventory file. Resolution is
+    # only ever a transition of recorded history, never a creation.
+    existing_ids = {i.get("id") for i in existing.get("items", []) if isinstance(i, dict)}
+    metadata_issues += [
+        f"Resolved item minted without prior history (must be born open): {item['id']}"
+        for item in items
+        if item.get("status") == "resolved" and item["id"] not in existing_ids
+    ]
     if metadata_issues:
         print("FAIL: inventory metadata invariants violated (refusing to write):")
         for issue in metadata_issues:

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -34,6 +34,7 @@ COHORT_DATE = "2026-04-17"
 COHORT_PROVENANCE = "2026-04-17 program baseline cohort"
 DEFAULT_INVENTORY = "scripts/baselines/contract_drift_inventory.json"
 VALID_CLASSES = frozenset({"start_cohort", "discovered"})
+VALID_STATUSES = frozenset({"open", "resolved"})
 PROVENANCE_REF = re.compile(r"#\d+|https?://\S+")
 
 # alias -> (repo-relative baseline path, tracked list keys)
@@ -171,6 +172,53 @@ def find_sync_issues(inventory: dict[str, Any], current_ids: dict[str, str]) -> 
     return issues
 
 
+def find_metadata_issues(
+    items: list[dict[str, Any]], cohort_ids: dict[str, str], *, as_of: date
+) -> list[str]:
+    """Derivable-metadata invariants (fail closed on forged classification).
+
+    - Any item whose id is in the cohort set MUST be class=start_cohort with
+      discovered_on=COHORT_DATE (cohort reclassification is impossible).
+    - No item may claim start_cohort unless its id is in the cohort set.
+    - ``discovered`` items must have discovered_on within [COHORT_DATE, as_of].
+    - Unknown status values, and resolved items without resolved_on, fail.
+    """
+    issues: list[str] = []
+    cohort_start = date.fromisoformat(COHORT_DATE)
+    for item in items:
+        item_id = item.get("id", "<missing id>")
+        status = item.get("status")
+        if status not in VALID_STATUSES:
+            issues.append(f"Unknown status {status!r} for inventory item {item_id}")
+        elif status == "resolved" and not item.get("resolved_on"):
+            issues.append(f"Resolved item missing resolved_on: {item_id}")
+
+        klass = item.get("class")
+        raw_discovered = item.get("discovered_on")
+        try:
+            discovered = date.fromisoformat(raw_discovered or "")
+        except ValueError:
+            issues.append(f"Invalid discovered_on {raw_discovered!r} for inventory item {item_id}")
+            continue
+
+        if item_id in cohort_ids:
+            if klass != "start_cohort" or raw_discovered != COHORT_DATE:
+                issues.append(
+                    f"Cohort item reclassified (must be start_cohort @ {COHORT_DATE}): "
+                    f"{item_id} (class={klass!r}, discovered_on={raw_discovered!r})"
+                )
+        elif klass == "start_cohort":
+            issues.append(
+                f"Item claims start_cohort but is not in the {COHORT_DATE} cohort: {item_id}"
+            )
+        elif klass == "discovered" and not (cohort_start <= discovered <= as_of):
+            issues.append(
+                f"discovered_on out of bounds [{COHORT_DATE}, {as_of.isoformat()}]: "
+                f"{item_id} ({raw_discovered})"
+            )
+    return issues
+
+
 def render_inventory(items: list[dict[str, Any]], cohort_commit: str) -> str:
     doc = {
         "version": 1,
@@ -223,6 +271,7 @@ def main() -> int:
             print(f"FAIL: inventory missing: {inventory_path}")
             return 1
         issues = find_sync_issues(existing, current_ids)
+        issues += find_metadata_issues(existing.get("items", []), cohort_ids, as_of=as_of)
         if issues:
             print("FAIL: inventory out of sync with baselines:")
             for issue in issues:
@@ -244,6 +293,13 @@ def main() -> int:
         )
         for item_id in unexplained:
             print(f"  - {item_id}")
+        return 1
+
+    metadata_issues = find_metadata_issues(items, cohort_ids, as_of=as_of)
+    if metadata_issues:
+        print("FAIL: inventory metadata invariants violated (refusing to write):")
+        for issue in metadata_issues:
+            print(f"  - {issue}")
         return 1
 
     inventory_path.write_text(render_inventory(items, args.cohort_commit))

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -155,8 +155,15 @@ def find_sync_issues(inventory: dict[str, Any], current_ids: dict[str, str]) -> 
         return ["Inventory has no 'items' list"]
 
     open_ids = set()
+    seen_ids: set[str] = set()
     for item in items:
         item_id = item.get("id", "<missing id>")
+        # Duplicate ids would inflate a discovered batch's size (and thus its
+        # scheduled target) while dict-collapsed append-only checks see only
+        # one row — every id must be unique.
+        if item_id in seen_ids:
+            issues.append(f"Duplicate inventory id: {item_id}")
+        seen_ids.add(item_id)
         klass = item.get("class")
         if klass not in VALID_CLASSES:
             issues.append(f"Unknown class {klass!r} for inventory item {item_id}")

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -718,3 +718,138 @@ def test_target_decay_has_no_fixed_points_and_reaches_zero():
             assert cur <= prev
             prev = cur
         assert ratchet._target_after_weeks(start, 0.1, 120) == 0
+
+
+def test_pr_mode_new_resolved_item_fails_birth_state(tmp_path: Path):
+    """An item absent from the base inventory must be born open; a fabricated
+    resolved item (delta-neutral by construction) is an integrity failure."""
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "typescript_sdk_drift:fake1",
+                "source": "typescript_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-06-01",
+                "provenance": "padding #666",
+                "status": "resolved",
+                "resolved_on": "2026-06-15",
+            }
+        ),
+    )
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["pr_delta"]["increased"] == []  # counts untouched by the fake
+    assert not result["integrity"]["passing"]
+    assert any("born open" in i for i in result["integrity"]["issues"])
+    assert not result["passing"]
+
+    # The sibling case: a new OPEN item without a baseline entry fails the
+    # global sync check (open items must be baseline-backed, new ones too).
+    def swap_to_ghost(inv):
+        inv["items"] = [i for i in inv["items"] if i["id"] != "typescript_sdk_drift:fake1"]
+        inv["items"].append(
+            {
+                "id": "typescript_sdk_drift:ghost",
+                "source": "typescript_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-07-16",
+                "provenance": "padding #666",
+                "status": "open",
+            }
+        )
+
+    _edit_inventory(paths, swap_to_ghost)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not result["integrity"]["passing"]
+    assert any("absent from baselines" in i for i in result["integrity"]["issues"])
+
+
+def test_pr_mode_batch_inflation_attack_fails(tmp_path: Path):
+    """Fake resolved items padding a batch's size + real new drift hidden in
+    the same list (net-zero open delta) must fail on the birth-state rule."""
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+
+    # Real new drift swapped in for a legitimately resolved item: same list,
+    # count unchanged, so the delta gate alone would pass.
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")
+    verify["python_sdk_drift"].append("evil1")
+    _write_json(paths["verify"], verify)
+
+    def mutate(inv):
+        for item in inv["items"]:
+            if item["id"] == "python_sdk_drift:b":
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+        inv["items"].append(
+            {
+                "id": "python_sdk_drift:evil1",
+                "source": "python_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-06-01",
+                "provenance": "explained in #666",
+                "status": "open",
+            }
+        )
+        # Batch padding: five fabricated resolved items in the same batch
+        # inflate batch_size 1 -> 6 and raise its scheduled target.
+        for i in range(5):
+            inv["items"].append(
+                {
+                    "id": f"python_sdk_drift:fake{i}",
+                    "source": "python_sdk_drift",
+                    "class": "discovered",
+                    "discovered_on": "2026-06-01",
+                    "provenance": "padding #666",
+                    "status": "resolved",
+                    "resolved_on": "2026-06-15",
+                }
+            )
+
+    _edit_inventory(paths, mutate)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["pr_delta"]["increased"] == []  # the attack is delta-neutral
+    assert not result["integrity"]["passing"]
+    born_open_issues = [i for i in result["integrity"]["issues"] if "born open" in i]
+    assert len(born_open_issues) == 5  # every fabricated item rejected
+    assert not result["passing"]
+
+
+def test_pr_mode_legitimate_lifecycle_two_generations(monkeypatch, tmp_path: Path):
+    """born open -> resolved with history -> retained: two real generator runs
+    bracketing a fix must pass pr mode end-to-end."""
+    paths, repo, cohort = _seed(tmp_path, program=RED_PROGRAM)
+
+    def run_gen(*extra: str) -> int:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "generate_contract_drift_inventory.py",
+                "--repo-root",
+                str(repo),
+                "--cohort-commit",
+                cohort,
+                *extra,
+            ],
+        )
+        return gen.main()
+
+    assert run_gen("--as-of", "2026-07-10") == 0  # generation 1: all born open
+    base = _commit(repo, "generation 1")
+
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")  # the item gets fixed
+    _write_json(paths["verify"], verify)
+    assert run_gen("--as-of", "2026-07-16") == 0  # generation 2: resolves it
+
+    items = {i["id"]: i for i in json.loads(paths["inventory"].read_text())["items"]}
+    assert items["python_sdk_drift:b"]["status"] == "resolved"
+    assert items["python_sdk_drift:b"]["resolved_on"] == "2026-07-16"
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort, mode="pr", base_ref=base)
+    assert result["integrity"]["passing"], result["integrity"]["issues"]
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+    assert result["passing"]

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -702,3 +702,19 @@ def test_pr_mode_missing_file_at_base_treated_as_empty(tmp_path: Path):
     result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     assert result["pr_delta"]["increased"] == ["sdk_missing_from_both"]
     assert not result["passing"]
+
+
+def test_target_decay_has_no_fixed_points_and_reaches_zero():
+    """Regression: iterative int(round(n*0.9)) stuck at 1-4 forever (review P2
+
+    on #9346); the one-shot floored decay must be monotonic to zero so small
+    discovered batches cannot satisfy their clocks indefinitely.
+    """
+    for start in (1, 2, 3, 4, 10, 655):
+        prev = ratchet._target_after_weeks(start, 0.1, 0)
+        assert prev == start
+        for weeks in range(1, 120):
+            cur = ratchet._target_after_weeks(start, 0.1, weeks)
+            assert cur <= prev
+            prev = cur
+        assert ratchet._target_after_weeks(start, 0.1, 120) == 0

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import scripts.check_contract_drift_ratchet as ratchet
 import scripts.generate_contract_drift_inventory as gen
 
+PROGRAM_REL = "scripts/baselines/contract_drift_program.json"
+
 
 def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -23,7 +25,7 @@ def _cohort_items(docs: dict[str, dict]) -> list[dict]:
             "id": item_id,
             "source": list_key,
             "class": "start_cohort",
-            "discovered_on": "2026-04-17",
+            "discovered_on": gen.COHORT_DATE,
             "provenance": gen.COHORT_PROVENANCE,
             "status": "open",
         }
@@ -36,6 +38,38 @@ def _write_inventory(path: Path, items: list[dict]) -> None:
     path.write_text(gen.render_inventory(sorted(items, key=lambda i: i["id"]), "test"))
 
 
+def _commit(repo: Path, msg: str = "snap") -> str:
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-qm",
+            msg,
+            "--allow-empty",
+        ],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _write_docs(repo: Path, docs: dict[str, dict]) -> None:
+    for alias, (rel_path, _keys) in gen.BASELINE_SPECS.items():
+        if alias in docs:
+            _write_json(repo / rel_path, docs[alias])
+
+
 def _seed(
     tmp_path: Path,
     *,
@@ -44,7 +78,10 @@ def _seed(
     parity: dict | None = None,
     program: dict | None = None,
     inventory_items: list[dict] | None = None,
-) -> dict[str, Path]:
+    commit: bool = True,
+) -> tuple[dict[str, Path], Path, str | None]:
+    """Create a git repo with baselines at canonical paths; the initial commit
+    is both the test's cohort commit and (for pr-mode tests) the base ref."""
     verify = (
         verify
         if verify is not None
@@ -57,34 +94,36 @@ def _seed(
     routes = (
         routes
         if routes is not None
-        else {
-            "missing_in_spec": ["m1", "m2"],
-            "orphaned_in_spec": ["o1"],
-        }
+        else {"missing_in_spec": ["m1", "m2"], "orphaned_in_spec": ["o1"]}
     )
     parity = parity if parity is not None else {"missing_from_both_sdks": ["p1", "p2"]}
     docs = {"verify": verify, "routes": routes, "parity": parity}
 
-    paths = {
-        "verify": tmp_path / "verify.json",
-        "routes": tmp_path / "routes.json",
-        "parity": tmp_path / "parity.json",
-        "program": tmp_path / "program.json",
-        "inventory": tmp_path / "inventory.json",
-    }
-    _write_json(paths["verify"], verify)
-    _write_json(paths["routes"], routes)
-    _write_json(paths["parity"], parity)
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    if not (repo / ".git").exists():
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+
+    _write_docs(repo, docs)
+    paths = {alias: repo / rel_path for alias, (rel_path, _k) in gen.BASELINE_SPECS.items()}
+    paths["program"] = repo / PROGRAM_REL
+    paths["inventory"] = repo / gen.DEFAULT_INVENTORY
     if program is not None:
         _write_json(paths["program"], program)
     items = inventory_items if inventory_items is not None else _cohort_items(docs)
     _write_inventory(paths["inventory"], items)
-    return paths
+
+    sha = _commit(repo, "cohort") if commit else None
+    return paths, repo, sha
 
 
-def _argv(paths: dict[str, Path], *extra: str) -> list[str]:
+def _argv(paths: dict[str, Path], repo: Path, cohort: str, *extra: str) -> list[str]:
     return [
         "check_contract_drift_ratchet.py",
+        "--repo-root",
+        str(repo),
+        "--cohort-commit",
+        cohort,
         "--program-baseline",
         str(paths["program"]),
         "--verify-baseline",
@@ -99,7 +138,7 @@ def _argv(paths: dict[str, Path], *extra: str) -> list[str]:
     ]
 
 
-def _result(paths: dict[str, Path], as_of: str, **kwargs) -> dict:
+def _result(paths: dict[str, Path], as_of: str, *, repo: Path, cohort: str, **kwargs) -> dict:
     return ratchet.build_ratchet_result(
         mode=kwargs.pop("mode", "program"),
         program_baseline=paths["program"],
@@ -107,10 +146,17 @@ def _result(paths: dict[str, Path], as_of: str, **kwargs) -> dict:
         routes_baseline=paths["routes"],
         parity_baseline=paths["parity"],
         inventory_path=paths["inventory"],
-        repo_root=kwargs.pop("repo_root", paths["verify"].parent),
+        repo_root=repo,
         as_of=date.fromisoformat(as_of),
+        cohort_commit=cohort,
         **kwargs,
     )
+
+
+def _edit_inventory(paths: dict[str, Path], mutate) -> None:
+    inventory = json.loads(paths["inventory"].read_text())
+    mutate(inventory)
+    paths["inventory"].write_text(json.dumps(inventory))
 
 
 # ---------------------------------------------------------------- program mode
@@ -118,7 +164,7 @@ def _result(paths: dict[str, Path], as_of: str, **kwargs) -> dict:
 
 def test_strict_passes_on_program_start(monkeypatch, tmp_path: Path):
     today = date.today().isoformat()
-    paths = _seed(
+    paths, repo, cohort = _seed(
         tmp_path,
         program={
             "start_date": today,
@@ -127,13 +173,13 @@ def test_strict_passes_on_program_start(monkeypatch, tmp_path: Path):
             "grace_weeks": 0,
         },
     )
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--strict", "--as-of", today))
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--strict", "--as-of", today))
     assert ratchet.main() == 0
 
 
 def test_strict_fails_when_above_target(monkeypatch, tmp_path: Path):
     today = date.today()
-    paths = _seed(
+    paths, repo, cohort = _seed(
         tmp_path,
         program={
             "start_date": today.isoformat(),
@@ -143,7 +189,7 @@ def test_strict_fails_when_above_target(monkeypatch, tmp_path: Path):
         },
     )
     as_of = (today + timedelta(days=8)).isoformat()
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--strict", "--as-of", as_of))
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--strict", "--as-of", as_of))
     assert ratchet.main() == 1
 
 
@@ -155,25 +201,38 @@ def test_program_numbers_read_only_from_program_baseline(tmp_path: Path):
         "weekly_reduction": 0.5,
         "grace_weeks": 0,
     }
-    paths = _seed(tmp_path, program=program)
-    result = _result(paths, "2026-06-08")
+    paths, repo, cohort = _seed(tmp_path, program=program)
+    result = _result(paths, "2026-06-08", repo=repo, cohort=cohort)
     assert result["program"]["start_total_items"] == 40
     assert result["target"]["max_open_items"] == 20  # 40 * 0.5 after one week
 
     _write_json(paths["program"], dict(program, start_total_items=80))
-    assert _result(paths, "2026-06-08")["target"]["max_open_items"] == 40
+    later = _result(paths, "2026-06-08", repo=repo, cohort=cohort)
+    assert later["target"]["max_open_items"] == 40
 
 
 def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
-    verify = {
-        "python_sdk_drift": ["a", "b"],
-        "typescript_sdk_drift": [f"d{i}" for i in range(1, 9)],  # d1..d8 open
-    }
+    cohort_verify = {"python_sdk_drift": ["a", "b"], "typescript_sdk_drift": []}
     routes = {"missing_in_spec": [], "orphaned_in_spec": []}
     parity = {"missing_from_both_sdks": []}
-    docs = {"verify": verify, "routes": routes, "parity": parity}
+    paths, repo, cohort = _seed(
+        tmp_path,
+        verify=cohort_verify,
+        routes=routes,
+        parity=parity,
+        program={
+            "start_date": "2026-06-01",
+            "start_total_items": 30,
+            "weekly_reduction": 0.1,
+            "grace_weeks": 0,
+        },
+    )
 
-    cohort = [i for i in _cohort_items(docs) if i["id"].startswith("python_sdk_drift")]
+    # Post-cohort: a discovered batch of 10 (8 still open) lands on 2026-06-01.
+    _write_json(
+        paths["verify"],
+        dict(cohort_verify, typescript_sdk_drift=[f"d{i}" for i in range(1, 9)]),
+    )
     discovered = [
         {
             "id": f"typescript_sdk_drift:d{i}",
@@ -184,23 +243,13 @@ def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
             "status": "open" if i <= 8 else "resolved",
             **({} if i <= 8 else {"resolved_on": "2026-06-10"}),
         }
-        for i in range(1, 11)  # batch_size 10, 8 open + 2 resolved
+        for i in range(1, 11)
     ]
-    paths = _seed(
-        tmp_path,
-        verify=verify,
-        routes=routes,
-        parity=parity,
-        program={
-            "start_date": "2026-06-01",
-            "start_total_items": 30,
-            "weekly_reduction": 0.1,
-            "grace_weeks": 0,
-        },
-        inventory_items=cohort + discovered,
-    )
+    docs = {"verify": cohort_verify, "routes": routes, "parity": parity}
+    _write_inventory(paths["inventory"], _cohort_items(docs) + discovered)
 
-    result = _result(paths, "2026-06-15")  # 2 weeks after both clocks start
+    result = _result(paths, "2026-06-15", repo=repo, cohort=cohort)
+    assert result["integrity"]["passing"], result["integrity"]["issues"]
     classes = {cls["name"]: cls for cls in result["classes"]}
 
     cohort_cls = classes["start_cohort"]
@@ -210,7 +259,7 @@ def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
     assert cohort_cls["passing"]
 
     batch = classes["discovered:2026-06-01"]
-    assert batch["batch_size"] == 10  # open + resolved, batch clock at its own date
+    assert batch["batch_size"] == 10  # open + resolved; clock starts at its own date
     assert batch["weeks_elapsed"] == 2
     assert batch["target_max"] == 8  # 10 -> 9 -> 8
     assert batch["open_items"] == 8  # resolved items excluded from open count
@@ -218,7 +267,7 @@ def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
     assert result["passing"]
 
     # One week later the batch target drops to 7 while 8 remain open -> FAIL.
-    later = _result(paths, "2026-06-22")
+    later = _result(paths, "2026-06-22", repo=repo, cohort=cohort)
     batch_later = {c["name"]: c for c in later["classes"]}["discovered:2026-06-01"]
     assert batch_later["target_max"] == 7
     assert not batch_later["passing"]
@@ -227,96 +276,184 @@ def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
 
 def test_fail_closed_missing_inventory(monkeypatch, tmp_path: Path):
     today = date.today().isoformat()
-    paths = _seed(
+    paths, repo, cohort = _seed(
         tmp_path,
         program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
     )
     paths["inventory"].unlink()
     # Fails even without --strict: integrity violations always fail closed.
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--as-of", today))
     assert ratchet.main() == 1
 
 
 def test_fail_closed_missing_program_baseline(monkeypatch, tmp_path: Path):
     today = date.today().isoformat()
-    paths = _seed(tmp_path)  # no program file written
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    paths, repo, cohort = _seed(tmp_path)  # no program file written
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--as-of", today))
     assert ratchet.main() == 1
 
 
 def test_fail_closed_unexplained_baseline_entry(monkeypatch, tmp_path: Path):
     today = date.today().isoformat()
-    paths = _seed(
+    paths, repo, cohort = _seed(
         tmp_path,
         program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
     )
     verify = json.loads(paths["verify"].read_text())
     verify["python_sdk_drift"].append("sneaky-new-item")  # baseline grows, no inventory
     _write_json(paths["verify"], verify)
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--as-of", today))
     assert ratchet.main() == 1
 
 
 def test_fail_closed_unknown_class(monkeypatch, tmp_path: Path):
     today = date.today().isoformat()
-    paths = _seed(
+    paths, repo, cohort = _seed(
         tmp_path,
         program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
     )
-    inventory = json.loads(paths["inventory"].read_text())
-    inventory["items"][0]["class"] = "grandfathered"
-    paths["inventory"].write_text(json.dumps(inventory))
-    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    _edit_inventory(paths, lambda inv: inv["items"][0].update(**{"class": "grandfathered"}))
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--as-of", today))
     assert ratchet.main() == 1
+
+
+def test_fail_closed_unknown_status(tmp_path: Path):
+    today = date.today().isoformat()
+    paths, repo, cohort = _seed(
+        tmp_path,
+        program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
+    )
+    _edit_inventory(paths, lambda inv: inv["items"][0].update(status="wip"))
+    result = _result(paths, today, repo=repo, cohort=cohort)
+    assert not result["integrity"]["passing"]
+    assert any("Unknown status" in issue for issue in result["integrity"]["issues"])
 
 
 def test_resolved_items_excluded_but_retained(tmp_path: Path):
     today = date.today().isoformat()
-    docs = {
-        "verify": {"python_sdk_drift": ["a"], "typescript_sdk_drift": []},
-        "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
-        "parity": {"missing_from_both_sdks": []},
-    }
-    items = _cohort_items(docs) + [
-        {
-            "id": "python_sdk_drift:gone",
-            "source": "python_sdk_drift",
-            "class": "start_cohort",
-            "discovered_on": "2026-04-17",
-            "provenance": gen.COHORT_PROVENANCE,
-            "status": "resolved",
-            "resolved_on": "2026-05-01",
-        }
-    ]
-    paths = _seed(
+    cohort_verify = {"python_sdk_drift": ["a", "gone"], "typescript_sdk_drift": []}
+    routes = {"missing_in_spec": [], "orphaned_in_spec": []}
+    parity = {"missing_from_both_sdks": []}
+    paths, repo, cohort = _seed(
         tmp_path,
-        verify=docs["verify"],
-        routes=docs["routes"],
-        parity=docs["parity"],
+        verify=cohort_verify,
+        routes=routes,
+        parity=parity,
         program={"start_date": today, "start_total_items": 5, "weekly_reduction": 0.1},
-        inventory_items=items,
     )
-    result = _result(paths, today)
-    assert result["integrity"]["passing"]
-    cohort = {c["name"]: c for c in result["classes"]}["start_cohort"]
-    assert cohort["open_items"] == 1  # resolved item not counted
+    # "gone" was fixed: pruned from the baseline, resolved in the inventory.
+    _write_json(paths["verify"], dict(cohort_verify, python_sdk_drift=["a"]))
+
+    def resolve_gone(inv):
+        for item in inv["items"]:
+            if item["id"] == "python_sdk_drift:gone":
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-05-01"
+
+    _edit_inventory(paths, resolve_gone)
+
+    result = _result(paths, today, repo=repo, cohort=cohort)
+    assert result["integrity"]["passing"], result["integrity"]["issues"]
+    cohort_cls = {c["name"]: c for c in result["classes"]}["start_cohort"]
+    assert cohort_cls["open_items"] == 1  # resolved item not counted
+    assert len(json.loads(paths["inventory"].read_text())["items"]) == 2  # retained
+
+
+def test_program_mode_future_discovered_on_fails(tmp_path: Path):
+    paths, repo, cohort = _seed(
+        tmp_path,
+        program={
+            "start_date": "2026-04-17",
+            "start_total_items": 10,
+            "weekly_reduction": 0.1,
+        },
+    )
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("future1")
+    _write_json(paths["verify"], verify)
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "python_sdk_drift:future1",
+                "source": "python_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-08-01",  # after as_of below
+                "provenance": "claimed in #9",
+                "status": "open",
+            }
+        ),
+    )
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort)
+    assert not result["integrity"]["passing"]
+    assert any("out of bounds" in issue for issue in result["integrity"]["issues"])
+
+
+def test_program_mode_pre_cohort_discovered_on_fails(tmp_path: Path):
+    paths, repo, cohort = _seed(
+        tmp_path,
+        program={
+            "start_date": "2026-04-17",
+            "start_total_items": 10,
+            "weekly_reduction": 0.1,
+        },
+    )
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("ancient1")
+    _write_json(paths["verify"], verify)
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "python_sdk_drift:ancient1",
+                "source": "python_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-01-01",  # before the program start
+                "provenance": "claimed in #9",
+                "status": "open",
+            }
+        ),
+    )
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort)
+    assert not result["integrity"]["passing"]
+    assert any("out of bounds" in issue for issue in result["integrity"]["issues"])
+
+
+def test_cohort_reclassification_fails_both_modes(monkeypatch, tmp_path: Path):
+    """Forging class=discovered with a fresh date on a cohort item must fail
+    integrity in BOTH modes (derivable-metadata invariant)."""
+    paths, repo, cohort = _seed(
+        tmp_path,
+        program={
+            "start_date": "2026-04-17",
+            "start_total_items": 10,
+            "weekly_reduction": 0.1,
+        },
+    )
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"][0].update(
+            **{
+                "class": "discovered",
+                "discovered_on": "2026-07-01",
+                "provenance": "forged reset #1",
+            }
+        ),
+    )
+
+    program_result = _result(paths, "2026-07-16", repo=repo, cohort=cohort)
+    assert not program_result["integrity"]["passing"]
+    assert any("reclassified" in i for i in program_result["integrity"]["issues"])
+
+    pr_result = _result(paths, "2026-07-16", repo=repo, cohort=cohort, mode="pr", base_ref=cohort)
+    assert not pr_result["integrity"]["passing"]
+    assert not pr_result["passing"]
+
+    monkeypatch.setattr(sys, "argv", _argv(paths, repo, cohort, "--as-of", "2026-07-16"))
+    assert ratchet.main() == 1  # exit 1 even without --strict
 
 
 # --------------------------------------------------------------------- pr mode
-
-
-def _git_repo_with_base(tmp_path: Path) -> str:
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"],
-        cwd=tmp_path,
-        check=True,
-    )
-    return subprocess.run(
-        ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
-    ).stdout.strip()
-
 
 # 10 items @ -10%/week from 2026-04-17: by 2026-07-16 the target is well below
 # the 10 seeded open items, so the program schedule is red at that as-of date.
@@ -329,54 +466,55 @@ RED_PROGRAM = {
 
 
 def test_pr_mode_passes_on_equal_counts_while_program_red(tmp_path: Path):
-    paths = _seed(tmp_path, program=RED_PROGRAM)
-    base = _git_repo_with_base(tmp_path)
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     assert result["passing"]
     assert not result["program_passing"]  # program schedule still honestly red
     assert result["pr_delta"]["increased"] == []
 
 
-def test_pr_mode_passes_on_decrease(tmp_path: Path):
-    paths = _seed(tmp_path, program=RED_PROGRAM)
-    base = _git_repo_with_base(tmp_path)
+def test_pr_mode_passes_on_decrease_via_legitimate_resolution(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
 
     verify = json.loads(paths["verify"].read_text())
     verify["python_sdk_drift"].remove("b")
     _write_json(paths["verify"], verify)
-    inventory = json.loads(paths["inventory"].read_text())
-    for item in inventory["items"]:
-        if item["id"] == "python_sdk_drift:b":
-            item["status"] = "resolved"
-            item["resolved_on"] = "2026-07-16"
-    paths["inventory"].write_text(json.dumps(inventory))
 
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
-    assert result["passing"]
+    def resolve_b(inv):
+        for item in inv["items"]:
+            if item["id"] == "python_sdk_drift:b":
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve_b)
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["integrity"]["passing"]  # open -> resolved is a legal transition
     assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+    assert result["passing"]
 
 
 def test_pr_mode_fails_on_any_single_list_increase(tmp_path: Path):
-    paths = _seed(tmp_path, program=RED_PROGRAM)
-    base = _git_repo_with_base(tmp_path)
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
 
     routes = json.loads(paths["routes"].read_text())
     routes["orphaned_in_spec"].append("o-new")
     _write_json(paths["routes"], routes)
-    inventory = json.loads(paths["inventory"].read_text())
-    inventory["items"].append(
-        {
-            "id": "orphaned_in_spec:o-new",
-            "source": "orphaned_in_spec",
-            "class": "discovered",
-            "discovered_on": "2026-07-16",
-            "provenance": "explained in #4242",
-            "status": "open",
-        }
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "orphaned_in_spec:o-new",
+                "source": "orphaned_in_spec",
+                "class": "discovered",
+                "discovered_on": "2026-07-16",
+                "provenance": "explained in #4242",
+                "status": "open",
+            }
+        ),
     )
-    paths["inventory"].write_text(json.dumps(inventory))
 
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     # Inventory is in sync (provenance recorded) yet the delta gate still fails.
     assert result["integrity"]["passing"]
     assert result["pr_delta"]["increased"] == ["routes_orphaned_in_spec"]
@@ -384,14 +522,13 @@ def test_pr_mode_fails_on_any_single_list_increase(tmp_path: Path):
 
 
 def test_pr_mode_fails_on_integrity_violation(monkeypatch, tmp_path: Path):
-    paths = _seed(tmp_path, program=RED_PROGRAM)
-    base = _git_repo_with_base(tmp_path)
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
 
     verify = json.loads(paths["verify"].read_text())
     verify["python_sdk_drift"].append("unexplained")  # not added to inventory
     _write_json(paths["verify"], verify)
 
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     assert not result["integrity"]["passing"]
     assert not result["passing"]
 
@@ -400,12 +537,12 @@ def test_pr_mode_fails_on_integrity_violation(monkeypatch, tmp_path: Path):
         "argv",
         _argv(
             paths,
+            repo,
+            base,
             "--mode",
             "pr",
             "--base-ref",
             base,
-            "--repo-root",
-            str(tmp_path),
             "--as-of",
             "2026-07-16",
         ),
@@ -413,14 +550,133 @@ def test_pr_mode_fails_on_integrity_violation(monkeypatch, tmp_path: Path):
     assert ratchet.main() == 1  # fails closed even without --strict
 
 
+def test_pr_mode_immutable_field_mutation_fails(tmp_path: Path):
+    """A PR may not rewrite class/discovered_on/provenance of an existing item."""
+    paths, repo, cohort = _seed(tmp_path, program=RED_PROGRAM)
+
+    # Base (post-cohort) commit adds a legitimate discovered item x1.
+    verify = json.loads(paths["verify"].read_text())
+    verify["typescript_sdk_drift"].append("x1")
+    _write_json(paths["verify"], verify)
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "typescript_sdk_drift:x1",
+                "source": "typescript_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-06-01",
+                "provenance": "tracked in #77",
+                "status": "open",
+            }
+        ),
+    )
+    base = _commit(repo, "base with x1")
+
+    # Head attempts to reset x1's burn-down clock. Counts are unchanged.
+    def reset_clock(inv):
+        for item in inv["items"]:
+            if item["id"] == "typescript_sdk_drift:x1":
+                item["discovered_on"] = "2026-07-01"
+
+    _edit_inventory(paths, reset_clock)
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort, mode="pr", base_ref=base)
+    assert result["pr_delta"]["increased"] == []  # only metadata was forged
+    assert not result["integrity"]["passing"]
+    assert any(
+        "Immutable inventory field 'discovered_on'" in i for i in result["integrity"]["issues"]
+    )
+    assert not result["passing"]
+
+
+def test_pr_mode_reopen_with_new_date_fails(tmp_path: Path):
+    """Reopening a resolved item must preserve its original clock."""
+    paths, repo, cohort = _seed(tmp_path, program=RED_PROGRAM)
+
+    # Base: x1 was discovered 2026-06-01 and already resolved.
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "typescript_sdk_drift:x1",
+                "source": "typescript_sdk_drift",
+                "class": "discovered",
+                "discovered_on": "2026-06-01",
+                "provenance": "tracked in #77",
+                "status": "resolved",
+                "resolved_on": "2026-06-10",
+            }
+        ),
+    )
+    base = _commit(repo, "base with resolved x1")
+
+    # Head: x1 regresses back into the baseline, reopened with a reset clock.
+    verify = json.loads(paths["verify"].read_text())
+    verify["typescript_sdk_drift"].append("x1")
+    _write_json(paths["verify"], verify)
+
+    def reopen_reset(inv):
+        for item in inv["items"]:
+            if item["id"] == "typescript_sdk_drift:x1":
+                item["status"] = "open"
+                item.pop("resolved_on", None)
+                item["discovered_on"] = "2026-07-01"  # forged clock reset
+
+    _edit_inventory(paths, reopen_reset)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort, mode="pr", base_ref=base)
+    assert not result["integrity"]["passing"]
+    assert any(
+        "Immutable inventory field 'discovered_on'" in i for i in result["integrity"]["issues"]
+    )
+
+    # Reopening with the ORIGINAL date keeps integrity clean; the PR still
+    # fails, but only via the count-increase delta gate (the regression).
+    def reopen_honest(inv):
+        for item in inv["items"]:
+            if item["id"] == "typescript_sdk_drift:x1":
+                item["discovered_on"] = "2026-06-01"
+
+    _edit_inventory(paths, reopen_honest)
+    honest = _result(paths, "2026-07-16", repo=repo, cohort=cohort, mode="pr", base_ref=base)
+    assert honest["integrity"]["passing"], honest["integrity"]["issues"]
+    assert honest["pr_delta"]["increased"] == ["verify_typescript_sdk_drift"]
+    assert not honest["passing"]
+
+
+def test_pr_mode_inventory_deletion_fails(tmp_path: Path):
+    """Deleting an item (instead of resolving it) violates append-only."""
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")
+    _write_json(paths["verify"], verify)
+    _edit_inventory(
+        paths,
+        lambda inv: inv.update(items=[i for i in inv["items"] if i["id"] != "python_sdk_drift:b"]),
+    )
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    # Counts decreased, but the audit trail was destroyed -> fail closed.
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+    assert not result["integrity"]["passing"]
+    assert any("append-only" in i for i in result["integrity"]["issues"])
+    assert not result["passing"]
+
+
 def test_pr_mode_missing_file_at_base_treated_as_empty(tmp_path: Path):
-    paths = _seed(tmp_path, parity={"missing_from_both_sdks": []}, program=RED_PROGRAM)
+    paths, repo, _ = _seed(
+        tmp_path,
+        parity={"missing_from_both_sdks": []},
+        program=RED_PROGRAM,
+        commit=False,
+    )
     paths["parity"].unlink()
-    base = _git_repo_with_base(tmp_path)  # base commit lacks parity file
+    base = _commit(repo, "base without parity file")  # also the cohort commit
 
     # HEAD parity file exists with zero entries: 0 vs empty-at-base -> equal, PASS.
     _write_json(paths["parity"], {"missing_from_both_sdks": []})
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     assert result["pr_delta"]["counts"]["sdk_missing_from_both"] == {
         "base": 0,
         "head": 0,
@@ -430,18 +686,19 @@ def test_pr_mode_missing_file_at_base_treated_as_empty(tmp_path: Path):
 
     # HEAD grows an entry: increase vs empty base -> FAIL (with inventory synced).
     _write_json(paths["parity"], {"missing_from_both_sdks": ["p-new"]})
-    inventory = json.loads(paths["inventory"].read_text())
-    inventory["items"].append(
-        {
-            "id": "missing_from_both_sdks:p-new",
-            "source": "missing_from_both_sdks",
-            "class": "discovered",
-            "discovered_on": "2026-07-16",
-            "provenance": "explained in #4242",
-            "status": "open",
-        }
+    _edit_inventory(
+        paths,
+        lambda inv: inv["items"].append(
+            {
+                "id": "missing_from_both_sdks:p-new",
+                "source": "missing_from_both_sdks",
+                "class": "discovered",
+                "discovered_on": "2026-07-16",
+                "provenance": "explained in #4242",
+                "status": "open",
+            }
+        ),
     )
-    paths["inventory"].write_text(json.dumps(inventory))
-    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
     assert result["pr_delta"]["increased"] == ["sdk_missing_from_both"]
     assert not result["passing"]

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -3,111 +3,445 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from datetime import date, timedelta
 from pathlib import Path
 
 import scripts.check_contract_drift_ratchet as ratchet
+import scripts.generate_contract_drift_inventory as gen
 
 
 def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
 
 
-def _seed_files(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
-    verify = tmp_path / "verify.json"
-    routes = tmp_path / "routes.json"
-    parity = tmp_path / "parity.json"
-    program = tmp_path / "program.json"
-
-    _write_json(
-        verify,
+def _cohort_items(docs: dict[str, dict]) -> list[dict]:
+    return [
         {
+            "id": item_id,
+            "source": list_key,
+            "class": "start_cohort",
+            "discovered_on": "2026-04-17",
+            "provenance": gen.COHORT_PROVENANCE,
+            "status": "open",
+        }
+        for item_id, list_key in sorted(gen.collect_ids(docs).items())
+    ]
+
+
+def _write_inventory(path: Path, items: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(gen.render_inventory(sorted(items, key=lambda i: i["id"]), "test"))
+
+
+def _seed(
+    tmp_path: Path,
+    *,
+    verify: dict | None = None,
+    routes: dict | None = None,
+    parity: dict | None = None,
+    program: dict | None = None,
+    inventory_items: list[dict] | None = None,
+) -> dict[str, Path]:
+    verify = (
+        verify
+        if verify is not None
+        else {
             "python_sdk_drift": ["a", "b"],
             "typescript_sdk_drift": ["x", "y", "z"],
             "missing_stable": [],
-        },
+        }
     )
-    _write_json(
-        routes,
-        {
+    routes = (
+        routes
+        if routes is not None
+        else {
             "missing_in_spec": ["m1", "m2"],
             "orphaned_in_spec": ["o1"],
-        },
+        }
     )
-    _write_json(parity, {"missing_from_both_sdks": ["p1", "p2"]})
+    parity = parity if parity is not None else {"missing_from_both_sdks": ["p1", "p2"]}
+    docs = {"verify": verify, "routes": routes, "parity": parity}
 
-    return verify, routes, parity, program
+    paths = {
+        "verify": tmp_path / "verify.json",
+        "routes": tmp_path / "routes.json",
+        "parity": tmp_path / "parity.json",
+        "program": tmp_path / "program.json",
+        "inventory": tmp_path / "inventory.json",
+    }
+    _write_json(paths["verify"], verify)
+    _write_json(paths["routes"], routes)
+    _write_json(paths["parity"], parity)
+    if program is not None:
+        _write_json(paths["program"], program)
+    items = inventory_items if inventory_items is not None else _cohort_items(docs)
+    _write_inventory(paths["inventory"], items)
+    return paths
+
+
+def _argv(paths: dict[str, Path], *extra: str) -> list[str]:
+    return [
+        "check_contract_drift_ratchet.py",
+        "--program-baseline",
+        str(paths["program"]),
+        "--verify-baseline",
+        str(paths["verify"]),
+        "--routes-baseline",
+        str(paths["routes"]),
+        "--parity-baseline",
+        str(paths["parity"]),
+        "--inventory",
+        str(paths["inventory"]),
+        *extra,
+    ]
+
+
+def _result(paths: dict[str, Path], as_of: str, **kwargs) -> dict:
+    return ratchet.build_ratchet_result(
+        mode=kwargs.pop("mode", "program"),
+        program_baseline=paths["program"],
+        verify_baseline=paths["verify"],
+        routes_baseline=paths["routes"],
+        parity_baseline=paths["parity"],
+        inventory_path=paths["inventory"],
+        repo_root=kwargs.pop("repo_root", paths["verify"].parent),
+        as_of=date.fromisoformat(as_of),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------- program mode
 
 
 def test_strict_passes_on_program_start(monkeypatch, tmp_path: Path):
-    verify, routes, parity, program = _seed_files(tmp_path)
     today = date.today().isoformat()
-
-    _write_json(
-        program,
-        {
+    paths = _seed(
+        tmp_path,
+        program={
             "start_date": today,
             "start_total_items": 10,
             "weekly_reduction": 0.1,
             "grace_weeks": 0,
         },
     )
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            "check_contract_drift_ratchet.py",
-            "--strict",
-            "--program-baseline",
-            str(program),
-            "--verify-baseline",
-            str(verify),
-            "--routes-baseline",
-            str(routes),
-            "--parity-baseline",
-            str(parity),
-            "--as-of",
-            today,
-        ],
-    )
-
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--strict", "--as-of", today))
     assert ratchet.main() == 0
 
 
 def test_strict_fails_when_above_target(monkeypatch, tmp_path: Path):
-    verify, routes, parity, program = _seed_files(tmp_path)
     today = date.today()
-    as_of = (today + timedelta(days=8)).isoformat()
-
-    _write_json(
-        program,
-        {
+    paths = _seed(
+        tmp_path,
+        program={
             "start_date": today.isoformat(),
             "start_total_items": 10,
             "weekly_reduction": 0.1,
             "grace_weeks": 0,
         },
     )
+    as_of = (today + timedelta(days=8)).isoformat()
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--strict", "--as-of", as_of))
+    assert ratchet.main() == 1
+
+
+def test_program_numbers_read_only_from_program_baseline(tmp_path: Path):
+    """Changing contract_drift_program.json (and nothing else) moves the target."""
+    program = {
+        "start_date": "2026-06-01",
+        "start_total_items": 40,
+        "weekly_reduction": 0.5,
+        "grace_weeks": 0,
+    }
+    paths = _seed(tmp_path, program=program)
+    result = _result(paths, "2026-06-08")
+    assert result["program"]["start_total_items"] == 40
+    assert result["target"]["max_open_items"] == 20  # 40 * 0.5 after one week
+
+    _write_json(paths["program"], dict(program, start_total_items=80))
+    assert _result(paths, "2026-06-08")["target"]["max_open_items"] == 40
+
+
+def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
+    verify = {
+        "python_sdk_drift": ["a", "b"],
+        "typescript_sdk_drift": [f"d{i}" for i in range(1, 9)],  # d1..d8 open
+    }
+    routes = {"missing_in_spec": [], "orphaned_in_spec": []}
+    parity = {"missing_from_both_sdks": []}
+    docs = {"verify": verify, "routes": routes, "parity": parity}
+
+    cohort = [i for i in _cohort_items(docs) if i["id"].startswith("python_sdk_drift")]
+    discovered = [
+        {
+            "id": f"typescript_sdk_drift:d{i}",
+            "source": "typescript_sdk_drift",
+            "class": "discovered",
+            "discovered_on": "2026-06-01",
+            "provenance": "batch from #1234",
+            "status": "open" if i <= 8 else "resolved",
+            **({} if i <= 8 else {"resolved_on": "2026-06-10"}),
+        }
+        for i in range(1, 11)  # batch_size 10, 8 open + 2 resolved
+    ]
+    paths = _seed(
+        tmp_path,
+        verify=verify,
+        routes=routes,
+        parity=parity,
+        program={
+            "start_date": "2026-06-01",
+            "start_total_items": 30,
+            "weekly_reduction": 0.1,
+            "grace_weeks": 0,
+        },
+        inventory_items=cohort + discovered,
+    )
+
+    result = _result(paths, "2026-06-15")  # 2 weeks after both clocks start
+    classes = {cls["name"]: cls for cls in result["classes"]}
+
+    cohort_cls = classes["start_cohort"]
+    assert cohort_cls["batch_size"] == 30
+    assert cohort_cls["target_max"] == ratchet._target_after_weeks(30, 0.1, 2)
+    assert cohort_cls["open_items"] == 2
+    assert cohort_cls["passing"]
+
+    batch = classes["discovered:2026-06-01"]
+    assert batch["batch_size"] == 10  # open + resolved, batch clock at its own date
+    assert batch["weeks_elapsed"] == 2
+    assert batch["target_max"] == 8  # 10 -> 9 -> 8
+    assert batch["open_items"] == 8  # resolved items excluded from open count
+    assert batch["passing"]
+    assert result["passing"]
+
+    # One week later the batch target drops to 7 while 8 remain open -> FAIL.
+    later = _result(paths, "2026-06-22")
+    batch_later = {c["name"]: c for c in later["classes"]}["discovered:2026-06-01"]
+    assert batch_later["target_max"] == 7
+    assert not batch_later["passing"]
+    assert not later["passing"]
+
+
+def test_fail_closed_missing_inventory(monkeypatch, tmp_path: Path):
+    today = date.today().isoformat()
+    paths = _seed(
+        tmp_path,
+        program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
+    )
+    paths["inventory"].unlink()
+    # Fails even without --strict: integrity violations always fail closed.
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    assert ratchet.main() == 1
+
+
+def test_fail_closed_missing_program_baseline(monkeypatch, tmp_path: Path):
+    today = date.today().isoformat()
+    paths = _seed(tmp_path)  # no program file written
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    assert ratchet.main() == 1
+
+
+def test_fail_closed_unexplained_baseline_entry(monkeypatch, tmp_path: Path):
+    today = date.today().isoformat()
+    paths = _seed(
+        tmp_path,
+        program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
+    )
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("sneaky-new-item")  # baseline grows, no inventory
+    _write_json(paths["verify"], verify)
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    assert ratchet.main() == 1
+
+
+def test_fail_closed_unknown_class(monkeypatch, tmp_path: Path):
+    today = date.today().isoformat()
+    paths = _seed(
+        tmp_path,
+        program={"start_date": today, "start_total_items": 10, "weekly_reduction": 0.1},
+    )
+    inventory = json.loads(paths["inventory"].read_text())
+    inventory["items"][0]["class"] = "grandfathered"
+    paths["inventory"].write_text(json.dumps(inventory))
+    monkeypatch.setattr(sys, "argv", _argv(paths, "--as-of", today))
+    assert ratchet.main() == 1
+
+
+def test_resolved_items_excluded_but_retained(tmp_path: Path):
+    today = date.today().isoformat()
+    docs = {
+        "verify": {"python_sdk_drift": ["a"], "typescript_sdk_drift": []},
+        "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
+        "parity": {"missing_from_both_sdks": []},
+    }
+    items = _cohort_items(docs) + [
+        {
+            "id": "python_sdk_drift:gone",
+            "source": "python_sdk_drift",
+            "class": "start_cohort",
+            "discovered_on": "2026-04-17",
+            "provenance": gen.COHORT_PROVENANCE,
+            "status": "resolved",
+            "resolved_on": "2026-05-01",
+        }
+    ]
+    paths = _seed(
+        tmp_path,
+        verify=docs["verify"],
+        routes=docs["routes"],
+        parity=docs["parity"],
+        program={"start_date": today, "start_total_items": 5, "weekly_reduction": 0.1},
+        inventory_items=items,
+    )
+    result = _result(paths, today)
+    assert result["integrity"]["passing"]
+    cohort = {c["name"]: c for c in result["classes"]}["start_cohort"]
+    assert cohort["open_items"] == 1  # resolved item not counted
+
+
+# --------------------------------------------------------------------- pr mode
+
+
+def _git_repo_with_base(tmp_path: Path) -> str:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"],
+        cwd=tmp_path,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+# 10 items @ -10%/week from 2026-04-17: by 2026-07-16 the target is well below
+# the 10 seeded open items, so the program schedule is red at that as-of date.
+RED_PROGRAM = {
+    "start_date": "2026-04-17",
+    "start_total_items": 10,
+    "weekly_reduction": 0.1,
+    "grace_weeks": 0,
+}
+
+
+def test_pr_mode_passes_on_equal_counts_while_program_red(tmp_path: Path):
+    paths = _seed(tmp_path, program=RED_PROGRAM)
+    base = _git_repo_with_base(tmp_path)
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    assert result["passing"]
+    assert not result["program_passing"]  # program schedule still honestly red
+    assert result["pr_delta"]["increased"] == []
+
+
+def test_pr_mode_passes_on_decrease(tmp_path: Path):
+    paths = _seed(tmp_path, program=RED_PROGRAM)
+    base = _git_repo_with_base(tmp_path)
+
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")
+    _write_json(paths["verify"], verify)
+    inventory = json.loads(paths["inventory"].read_text())
+    for item in inventory["items"]:
+        if item["id"] == "python_sdk_drift:b":
+            item["status"] = "resolved"
+            item["resolved_on"] = "2026-07-16"
+    paths["inventory"].write_text(json.dumps(inventory))
+
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    assert result["passing"]
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+
+
+def test_pr_mode_fails_on_any_single_list_increase(tmp_path: Path):
+    paths = _seed(tmp_path, program=RED_PROGRAM)
+    base = _git_repo_with_base(tmp_path)
+
+    routes = json.loads(paths["routes"].read_text())
+    routes["orphaned_in_spec"].append("o-new")
+    _write_json(paths["routes"], routes)
+    inventory = json.loads(paths["inventory"].read_text())
+    inventory["items"].append(
+        {
+            "id": "orphaned_in_spec:o-new",
+            "source": "orphaned_in_spec",
+            "class": "discovered",
+            "discovered_on": "2026-07-16",
+            "provenance": "explained in #4242",
+            "status": "open",
+        }
+    )
+    paths["inventory"].write_text(json.dumps(inventory))
+
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    # Inventory is in sync (provenance recorded) yet the delta gate still fails.
+    assert result["integrity"]["passing"]
+    assert result["pr_delta"]["increased"] == ["routes_orphaned_in_spec"]
+    assert not result["passing"]
+
+
+def test_pr_mode_fails_on_integrity_violation(monkeypatch, tmp_path: Path):
+    paths = _seed(tmp_path, program=RED_PROGRAM)
+    base = _git_repo_with_base(tmp_path)
+
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("unexplained")  # not added to inventory
+    _write_json(paths["verify"], verify)
+
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    assert not result["integrity"]["passing"]
+    assert not result["passing"]
 
     monkeypatch.setattr(
         sys,
         "argv",
-        [
-            "check_contract_drift_ratchet.py",
-            "--strict",
-            "--program-baseline",
-            str(program),
-            "--verify-baseline",
-            str(verify),
-            "--routes-baseline",
-            str(routes),
-            "--parity-baseline",
-            str(parity),
+        _argv(
+            paths,
+            "--mode",
+            "pr",
+            "--base-ref",
+            base,
+            "--repo-root",
+            str(tmp_path),
             "--as-of",
-            as_of,
-        ],
+            "2026-07-16",
+        ),
     )
+    assert ratchet.main() == 1  # fails closed even without --strict
 
-    assert ratchet.main() == 1
+
+def test_pr_mode_missing_file_at_base_treated_as_empty(tmp_path: Path):
+    paths = _seed(tmp_path, parity={"missing_from_both_sdks": []}, program=RED_PROGRAM)
+    paths["parity"].unlink()
+    base = _git_repo_with_base(tmp_path)  # base commit lacks parity file
+
+    # HEAD parity file exists with zero entries: 0 vs empty-at-base -> equal, PASS.
+    _write_json(paths["parity"], {"missing_from_both_sdks": []})
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    assert result["pr_delta"]["counts"]["sdk_missing_from_both"] == {
+        "base": 0,
+        "head": 0,
+        "delta": 0,
+    }
+    assert result["passing"]
+
+    # HEAD grows an entry: increase vs empty base -> FAIL (with inventory synced).
+    _write_json(paths["parity"], {"missing_from_both_sdks": ["p-new"]})
+    inventory = json.loads(paths["inventory"].read_text())
+    inventory["items"].append(
+        {
+            "id": "missing_from_both_sdks:p-new",
+            "source": "missing_from_both_sdks",
+            "class": "discovered",
+            "discovered_on": "2026-07-16",
+            "provenance": "explained in #4242",
+            "status": "open",
+        }
+    )
+    paths["inventory"].write_text(json.dumps(inventory))
+    result = _result(paths, "2026-07-16", mode="pr", base_ref=base, repo_root=tmp_path)
+    assert result["pr_delta"]["increased"] == ["sdk_missing_from_both"]
+    assert not result["passing"]

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -853,3 +853,22 @@ def test_pr_mode_legitimate_lifecycle_two_generations(monkeypatch, tmp_path: Pat
     assert result["integrity"]["passing"], result["integrity"]["issues"]
     assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
     assert result["passing"]
+
+
+def test_pr_mode_program_parameter_change_fails(tmp_path: Path):
+    """Round-5 review P2: editing contract_drift_program.json in a PR is
+
+    threshold inflation by definition and must fail pr-mode integrity even
+    though counts and inventory are untouched.
+    """
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+
+    program = json.loads(paths["program"].read_text())
+    program["start_total_items"] = 5000
+    _write_json(paths["program"], program)
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["pr_delta"]["increased"] == []
+    assert not result["integrity"]["passing"]
+    assert any("Program baseline parameter changed" in i for i in result["integrity"]["issues"])
+    assert not result["passing"]

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -219,3 +219,22 @@ def test_duplicate_inventory_ids_fail_sync(tmp_path):
     inventory = {"items": [item, dup_resolved]}
     issues = gen.find_sync_issues(inventory, {"python_sdk_drift:GET /api/x": "python_sdk_drift"})
     assert any("Duplicate inventory id" in i for i in issues)
+
+
+def test_discovered_provenance_requires_reference_in_committed_inventory():
+    """Round-5 review P2: hand-edited committed inventories must meet the
+
+    generator's bar — discovered items need a PR/issue reference in
+    provenance, not free text.
+    """
+    item = {
+        "id": "python_sdk_drift:GET /api/y",
+        "class": "discovered",
+        "discovered_on": "2026-06-01",
+        "provenance": "we decided this is fine",
+        "status": "open",
+    }
+    issues = gen.find_sync_issues(
+        {"items": [item]}, {"python_sdk_drift:GET /api/y": "python_sdk_drift"}
+    )
+    assert any("lacks a PR/issue reference" in i for i in issues)

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -1,0 +1,176 @@
+"""Tests for scripts/generate_contract_drift_inventory.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import scripts.generate_contract_drift_inventory as gen
+
+VERIFY = {
+    "python_sdk_drift": ["GET /a", "GET /b"],
+    "typescript_sdk_drift": ["ts1"],
+    "missing_stable": [],
+}
+ROUTES = {"missing_in_spec": ["m1"], "orphaned_in_spec": ["o1"]}
+PARITY = {"missing_from_both_sdks": []}
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _write_baselines(repo: Path, verify: dict, routes: dict, parity: dict) -> None:
+    _write_json(repo / "scripts/baselines/verify_sdk_contracts.json", verify)
+    _write_json(repo / "scripts/baselines/validate_openapi_routes.json", routes)
+    _write_json(repo / "scripts/baselines/check_sdk_parity.json", parity)
+
+
+def _init_repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_baselines(repo, VERIFY, ROUTES, PARITY)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "cohort"],
+        cwd=repo,
+        check=True,
+    )
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    return repo, sha
+
+
+def _run(monkeypatch, repo: Path, sha: str, *extra: str) -> int:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_contract_drift_inventory.py",
+            "--repo-root",
+            str(repo),
+            "--cohort-commit",
+            sha,
+            *extra,
+        ],
+    )
+    return gen.main()
+
+
+def _inventory(repo: Path) -> dict:
+    return json.loads((repo / gen.DEFAULT_INVENTORY).read_text())
+
+
+def test_cohort_items_classified_start_cohort(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+
+    items = _inventory(repo)["items"]
+    assert len(items) == 5
+    for item in items:
+        assert item["class"] == "start_cohort"
+        assert item["discovered_on"] == gen.COHORT_DATE
+        assert item["provenance"] == gen.COHORT_PROVENANCE
+        assert item["status"] == "open"
+    assert items == sorted(items, key=lambda i: i["id"])
+
+
+def test_output_deterministic(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+    first = (repo / gen.DEFAULT_INVENTORY).read_bytes()
+    assert _run(monkeypatch, repo, sha) == 0
+    assert (repo / gen.DEFAULT_INVENTORY).read_bytes() == first
+
+
+def test_resolved_items_retained_never_deleted(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+
+    verify = dict(VERIFY, python_sdk_drift=["GET /a"])  # GET /b fixed
+    _write_baselines(repo, verify, ROUTES, PARITY)
+    assert _run(monkeypatch, repo, sha, "--as-of", "2026-07-01") == 0
+
+    items = {i["id"]: i for i in _inventory(repo)["items"]}
+    assert len(items) == 5  # nothing deleted
+    resolved = items["python_sdk_drift:GET /b"]
+    assert resolved["status"] == "resolved"
+    assert resolved["resolved_on"] == "2026-07-01"
+    assert resolved["class"] == "start_cohort"
+    assert sum(1 for i in items.values() if i["status"] == "open") == 4
+
+
+def test_reopened_item_keeps_original_record(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+    _write_baselines(repo, dict(VERIFY, python_sdk_drift=["GET /a"]), ROUTES, PARITY)
+    assert _run(monkeypatch, repo, sha, "--as-of", "2026-07-01") == 0
+
+    _write_baselines(repo, VERIFY, ROUTES, PARITY)  # GET /b regresses back
+    assert _run(monkeypatch, repo, sha, "--as-of", "2026-07-02") == 0
+    item = {i["id"]: i for i in _inventory(repo)["items"]}["python_sdk_drift:GET /b"]
+    assert item["status"] == "open"
+    assert "resolved_on" not in item
+    assert item["class"] == "start_cohort"
+    assert item["discovered_on"] == gen.COHORT_DATE
+
+
+def test_new_item_without_provenance_fails_closed(monkeypatch, tmp_path: Path, capsys):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+    before = (repo / gen.DEFAULT_INVENTORY).read_bytes()
+
+    verify = dict(VERIFY, python_sdk_drift=[*VERIFY["python_sdk_drift"], "GET /new"])
+    _write_baselines(repo, verify, ROUTES, PARITY)
+    assert _run(monkeypatch, repo, sha) == 1
+    out = capsys.readouterr().out
+    assert "python_sdk_drift:GET /new" in out
+    assert (repo / gen.DEFAULT_INVENTORY).read_bytes() == before  # not absorbed
+
+
+def test_new_item_with_provenance_classified_discovered(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+    verify = dict(VERIFY, python_sdk_drift=[*VERIFY["python_sdk_drift"], "GET /new"])
+    _write_baselines(repo, verify, ROUTES, PARITY)
+
+    assert (
+        _run(
+            monkeypatch,
+            repo,
+            sha,
+            "--provenance",
+            "introduced by handler rework, tracked in #9999",
+            "--as-of",
+            "2026-07-02",
+        )
+        == 0
+    )
+    item = {i["id"]: i for i in _inventory(repo)["items"]}["python_sdk_drift:GET /new"]
+    assert item["class"] == "discovered"
+    assert item["discovered_on"] == "2026-07-02"
+    assert "#9999" in item["provenance"]
+
+
+def test_provenance_requires_pr_or_issue_reference(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha, "--provenance", "because reasons") == 1
+
+
+def test_check_mode(monkeypatch, tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    # Missing inventory fails.
+    assert _run(monkeypatch, repo, sha, "--check") == 1
+
+    assert _run(monkeypatch, repo, sha) == 0
+    assert _run(monkeypatch, repo, sha, "--check") == 0
+
+    # Baseline edited without regenerating -> out of sync.
+    verify = dict(VERIFY, python_sdk_drift=["GET /a"])
+    _write_baselines(repo, verify, ROUTES, PARITY)
+    assert _run(monkeypatch, repo, sha, "--check") == 1

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -200,3 +200,22 @@ def test_generator_never_mints_resolved(monkeypatch, tmp_path: Path):
     items = _inventory(repo)["items"]
     assert all(item["status"] == "open" for item in items)
     assert "python_sdk_drift:GET /b" not in {item["id"] for item in items}
+
+
+def test_duplicate_inventory_ids_fail_sync(tmp_path):
+    """Round-4 review P2: duplicated rows (especially resolved duplicates of a
+
+    discovered item) would inflate batch_size past dict-collapsed append-only
+    checks; every inventory id must be unique.
+    """
+    item = {
+        "id": "python_sdk_drift:GET /api/x",
+        "class": "discovered",
+        "discovered_on": "2026-06-01",
+        "provenance": "found via #9999",
+        "status": "open",
+    }
+    dup_resolved = dict(item, status="resolved", resolved_on="2026-07-01")
+    inventory = {"items": [item, dup_resolved]}
+    issues = gen.find_sync_issues(inventory, {"python_sdk_drift:GET /api/x": "python_sdk_drift"})
+    assert any("Duplicate inventory id" in i for i in issues)

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -188,3 +188,15 @@ def test_check_fails_on_tampered_cohort_classification(monkeypatch, tmp_path: Pa
     (repo / gen.DEFAULT_INVENTORY).write_text(json.dumps(inventory))
 
     assert _run(monkeypatch, repo, sha, "--check") == 1
+
+
+def test_generator_never_mints_resolved(monkeypatch, tmp_path: Path):
+    """An entry that vanished before the FIRST generation is simply absent —
+    the generator never fabricates resolved history for items it never saw."""
+    repo, sha = _init_repo(tmp_path)
+    _write_baselines(repo, dict(VERIFY, python_sdk_drift=["GET /a"]), ROUTES, PARITY)
+
+    assert _run(monkeypatch, repo, sha) == 0
+    items = _inventory(repo)["items"]
+    assert all(item["status"] == "open" for item in items)
+    assert "python_sdk_drift:GET /b" not in {item["id"] for item in items}

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -174,3 +174,17 @@ def test_check_mode(monkeypatch, tmp_path: Path):
     verify = dict(VERIFY, python_sdk_drift=["GET /a"])
     _write_baselines(repo, verify, ROUTES, PARITY)
     assert _run(monkeypatch, repo, sha, "--check") == 1
+
+
+def test_check_fails_on_tampered_cohort_classification(monkeypatch, tmp_path: Path):
+    """--check must reject a committed inventory whose cohort items were
+    reclassified (derivable-metadata invariant)."""
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+
+    inventory = _inventory(repo)
+    inventory["items"][0]["class"] = "discovered"
+    inventory["items"][0]["discovered_on"] = "2026-07-01"
+    (repo / gen.DEFAULT_INVENTORY).write_text(json.dumps(inventory))
+
+    assert _run(monkeypatch, repo, sha, "--check") == 1


### PR DESCRIPTION
## Summary

Compliant replacement for the Contract Drift Governance repair, superseding closed PR #9325 per the ruling in its closing comment:

> Resetting the baseline to 518 with 0% weekly reduction conflicts with the operator-approved non-weakening constraint, so this draft will not be settled or merged. The replacement repair will preserve the 655-item 2026-04-17 start and 10% weekly reduction, use a canonical provenance-classified live inventory, and fail closed without threshold inflation or unexplained debt absorption.

This PR follows those constraints exactly.

### The program schedule is untouched — and still red

`scripts/baselines/contract_drift_program.json` is byte-identical to main: **655 items @ 2026-04-17, −10%/week compounding**. Program mode today evaluates to target 185 vs 517 open items — **delta +332, FAIL**. That redness is correct and preserved; nothing in this PR absorbs the debt or moves the threshold.

(Measured note: the three baseline files sum to 518 raw entries, but one — `GET /api/podcast/episodes/{param}` in `python_sdk_drift` — is a literal duplicate string, so there are 517 unique open items. Both copies are 2026-04-17 cohort members; there are zero post-cohort additions on main.)

### What changes

1. **Canonical provenance-classified inventory** — `scripts/baselines/contract_drift_inventory.json`, built by the new `scripts/generate_contract_drift_inventory.py`. Every baseline entry gets a stable id, a class, a discovery date, and provenance:
   - All 517 currently-open items are verified original-cohort survivors (present in the baselines at cohort commit `5cc7a81b77`) → class `start_cohort`, provenance "2026-04-17 program baseline cohort".
   - Any future post-cohort item **requires** `--provenance` with a PR/issue link; without it the generator fails closed and lists the unexplained items. No silent debt absorption.
   - Items that leave the baselines are marked `resolved` with a date and are **never deleted** (audit trail). Resolution is verifiable because the sibling no-regression gates keep the baselines a superset of live violations, so baseline pruning only happens when items are actually fixed.
   - Deterministic sorted output; `--check` fails when the inventory is out of sync with the baselines.

2. **`scripts/check_contract_drift_ratchet.py` gains `--mode {program,pr}`** (default `program`; JSON output is a superset of the previous shape):
   - **program** (weekly cron / dispatch): per-class scheduled targets over OPEN inventory items. `start_cohort` burns down from 655 @ 2026-04-17 at −10%/week — numbers read **only** from `contract_drift_program.json`. Each future `discovered` batch burns down from its own batch size and discovery date on the same reduction. Fails closed on missing/unparseable inputs, inventory desync, unexplained baseline entries, or unknown classes.
   - **pr**: strict non-worsening delta ratchet. Compares the five baseline counts at HEAD vs `--base-ref` (missing file at base = empty); **FAILS if any single count increases** or any integrity condition holds; **PASSES on equal-or-lower counts even while the program schedule is red**. The program status is still emitted (informational) alongside the delta table.

3. **Workflow** (`contract-drift-governance.yml`): pull_request events fetch the base ref and run `--mode pr --base-ref origin/<base>`; cron/dispatch keep `--mode program`. The step summary now shows mode, per-class burn-down, and the PR delta table.

### Why this is a stronger per-PR signal, not a weakening

The status quo evaluated a program-level burn-down metric as a per-PR check: **every** contract-surface PR was red regardless of whether it improved or worsened drift — no gradient, and the merge queue was blocked repo-wide. The pr-mode gate makes every PR strictly accountable for its own delta: adding even one drift item fails, and unexplained items fail closed at the inventory layer. The **weekly cron remains the program-level escalation channel** — it still runs `--mode program` against the unchanged 655/−10% schedule and stays honestly red until the burn-down catches up.

### Verification

- `python3 -m pytest tests/scripts/test_check_contract_drift_ratchet.py tests/scripts/test_generate_contract_drift_inventory.py -q` → 22 passed
- `ruff check` clean on all changed Python files
- End-to-end: `--mode program --strict` → FAIL, delta +332 (correct, preserved); `--mode pr --base-ref origin/main --strict` → PASS with all five deltas +0
- `generate_contract_drift_inventory.py --check` → in sync (517 open items)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
