### PR TITLE
fix(ci): RCP cancels queued advisory runs only — stop killing in-flight checks [Tier-4]

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -208,7 +208,15 @@ jobs:
               for (const run of runs) {
                 if (run.head_sha !== headSha) continue;
                 if (run.id === selfRunId) continue;
-                if (run.status !== 'queued' && run.status !== 'in_progress') continue;
+                // Only cancel QUEUED runs. An in-progress run already holds a
+                // runner, so cancelling it frees no queue capacity; it only
+                // converts a 1-5 minute advisory check into a red "cancelled"
+                // conclusion that the cancelled-run guardian deliberately does
+                // not rerun (its manifest covers required workflows only),
+                // creating a manual-rerun tax that stalls merge settlement on
+                // long-lived PRs. Queue-pressure relief is fully preserved:
+                // queued advisory runs still yield to required checks.
+                if (run.status !== 'queued') continue;
                 // Fail closed on a broken (empty) keep-list: cancel nothing.
                 if (keepListEmpty) continue;
                 passConsidered += 1;

--- a/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
+++ b/docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md
@@ -1,5 +1,47 @@
 # PR Workflow-Run Cancellation — Diagnosis & Mitigation Plan
 
+## Correction (2026-07-16): the canceller is in-repo — Required Check Priority
+
+The "external cancellation actor" conclusion below is **retracted**. The canceller
+is `.github/workflows/required-check-priority.yml` (RCP) itself. RCP runs on every
+`pull_request` event and performs 4 sweeps (10 s apart) that cancelled every queued
+**and in-progress** advisory `pull_request` run at the PR head not in its
+keep-list.
+
+Smoking gun: RCP run **29520862671** cancelled runs 29520863012 / 29520863349 /
+29520863087 / 29520862378 on PR #9346 seconds after creation, with no newer push.
+Its sweep log reads:
+
+```
+Canceled run 29520863012 (Module Tier Drift)
+…
+Sweep 1/4: considered 14, canceled 4
+```
+
+This also explains every "external actor" signature observed below: the raciness
+(a fast advisory run survives if it finishes before a sweep reaches it — hence
+Portability Lint's ~50/50 split), the selectivity (only non-keep-listed advisory
+`pull_request` runs), and why `push`-to-main runs are always green (RCP only
+triggers on `pull_request`). M2 ("identify & scope the external canceller") is
+resolved: no org-level App or account automation is involved.
+
+The rerun side of the loop is by design, not a gap: the cancelled-run guardian
+(`.github/workflows/pr-cancelled-run-guardian.yml`, driven by
+`scripts/ci/required_workflow_manifest.json`) deliberately reruns **only**
+manifest/keep-listed workflows — advisory cancellations "are that system working
+and stay cancelled" (see below). So every RCP-cancelled advisory run persisted as
+a red `cancelled` conclusion until a human rerun, which blocked the conservative
+merge executor on every long-lived PR (repeated manual reruns observed on
+PRs #9170, #9322, #9346 on 2026-07-15/16).
+
+**Fix applied:** RCP's sweep now cancels **queued runs only**
+(`if (run.status !== 'queued') continue;`). In-progress runs already hold a
+runner, so cancelling them saved nothing; queued advisory runs still yield to
+required checks, preserving all queue-pressure relief. The queued-only invariant
+is enforced by `scripts/check_required_check_priority_policy.py`.
+
+---
+
 Status: **diagnosis + plan (no code/CI changes in this doc).** Companion to
 `docs/governance/MODULE_TIER_DRIFT_GUARDIAN.md`, which established that the recurring
 `check`/`portability` reds on PRs are **cancellations, not drift**. This doc pins

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -80,6 +80,16 @@ REQUIRED_CONTEXT_TO_WORKFLOW_PATH = {
     "TypeScript SDK Type Check": ".github/workflows/sdk-test.yml",
 }
 
+# The cancellation sweep must only ever cancel QUEUED runs. Cancelling an
+# in_progress run frees no queue capacity (the run already holds a runner)
+# and leaves a red "cancelled" conclusion on advisory checks that the
+# cancelled-run guardian deliberately does not rerun, forcing manual reruns
+# before merge settlement. See PR run 29520862671 (2026-07-15), which
+# cancelled in-flight advisory runs on PR #9346 seconds after creation.
+_QUEUED_ONLY_STATUS_FILTER_RE = re.compile(
+    r"if\s*\(\s*run\.status\s*!==\s*(['\"])queued\1\s*\)\s*continue;"
+)
+
 
 def _extract_js_set_items(workflow_text: str, set_name: str) -> list[str] | None:
     pattern = r"const\s+" + re.escape(set_name) + r"\s*=\s*new Set\(\[(?P<body>.*?)\]\);"
@@ -406,6 +416,13 @@ def find_required_check_priority_violations(
     missing_required_names = sorted(REQUIRED_KEEP_WORKFLOW_NAMES - name_set)
     for name in missing_required_names:
         violations.append(f"missing required keep workflow name: {name}")
+
+    if not _QUEUED_ONLY_STATUS_FILTER_RE.search(workflow_text):
+        violations.append(
+            "cancellation sweep is not restricted to queued runs: expected "
+            "`if (run.status !== 'queued') continue;` (in_progress runs must "
+            "never be cancelled)"
+        )
 
     if repo_root is not None:
         mapped_workflows: dict[str, str] = {}

--- a/scripts/retrigger_cancelled_pr_runs.py
+++ b/scripts/retrigger_cancelled_pr_runs.py
@@ -1,24 +1,39 @@
 #!/usr/bin/env python3
-"""Re-run unexpectedly cancelled PROTECTED PR workflow runs once.
+"""Re-run unexpectedly cancelled PROTECTED PR workflow runs — and advisory
+runs displaced while still QUEUED — once each.
 
 Cancellation-provenance-aware M1 guardian (docs/governance/
-PR_RUN_CANCELLATION_DIAGNOSIS.md). The repo INTENTIONALLY cancels
+PR_RUN_CANCELLATION_DIAGNOSIS.md). The repo INTENTIONALLY cancels QUEUED
 non-required advisory ``pull_request`` runs through
-``.github/workflows/required-check-priority.yml`` — those cancellations are
-the prioritization system working and must stay cancelled. What must never
-stay terminal-cancelled is the PROTECTED class: required checks and the
+``.github/workflows/required-check-priority.yml`` (RCP) — that displacement
+is the prioritization system working, and this guardian completes it by
+rescheduling exactly those displaced runs once, so no run ends terminally
+``cancelled`` merely because it yielded queue capacity. What must never stay
+terminal-cancelled at all is the PROTECTED class: required checks and the
 priority keep-list (observed live 2026-07-09: keep-listed test shards killed
 mid-run — one at 96% all-passing — each clearing on manual rerun at 30-90min
 settlement latency).
 
-Provenance rule: a cancelled run is rerun-eligible ONLY if its workflow is in
+Provenance rule: a cancelled run is rerun-eligible if its workflow is in
 ``scripts/ci/required_workflow_manifest.json`` (the versioned protected
-manifest mirroring the priority keep-list) — i.e. only
-``unexpected_required_cancellation``, never ``intentional_advisory_priority``.
+manifest mirroring the priority keep-list) —
+``unexpected_required_cancellation`` — OR, one narrow exception, if it is an
+advisory run that NEVER EXECUTED: a lazy jobs probe shows no job/step ever
+started, meaning required-check-priority.yml displaced it while it was still
+QUEUED (``queued_phase_advisory_displacement``). The exception is safe
+because (a) it is bounded once per ``run_attempt`` like every other rerun,
+(b) it never touches runs that actually started — an advisory run cancelled
+mid-execution (e.g. at Checkout) stays cancelled, and upstream RCP's
+queued-only rule now guarantees in-flight advisory runs are never cancelled
+at all, so the rerun cannot loop with the canceller — and (c) without it
+every queued-phase displacement ends as a terminal red ``cancelled``
+conclusion that taxes merge settlement. Advisory runs with any executed
+work remain ``intentional_advisory_priority`` and stay cancelled.
 
-A protected cancelled run is re-run ONLY when ALL hold:
+A cancelled run is re-run ONLY when ALL hold:
 - ``conclusion == cancelled`` and the event is a PR event;
-- its workflow path/name is in the protected manifest;
+- its workflow path is in the protected manifest, OR the never-executed
+  jobs probe above confirms a queued-phase advisory displacement;
 - its ``head_sha`` equals the PR's CURRENT head (not superseded);
 - no newer run of the same workflow+branch exists (rerun would be moot);
 - the PR is open and not draft;
@@ -36,6 +51,7 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -134,6 +150,8 @@ class GitHubClient:
                 page_items = data
             elif isinstance(data, dict) and "workflow_runs" in data:
                 page_items = data["workflow_runs"]
+            elif isinstance(data, dict) and "jobs" in data:
+                page_items = data["jobs"]
             else:
                 raise GitHubApiError(
                     f"Expected list-like response for paginated endpoint {path}, got {type(data)}"
@@ -178,6 +196,19 @@ class GitHubClient:
         truncated = len(normalized) > max_runs
         return normalized[:max_runs], truncated
 
+    def list_run_jobs(self, run_id: int, max_pages: int = 3) -> list[dict[str, Any]]:
+        """Jobs of one run, for the queued-phase (never-executed) probe.
+
+        Called LAZILY — only for advisory candidates that already passed every
+        other guard — so the API budget is bounded by surviving candidates,
+        not by --max-runs."""
+        jobs = self.paginate(
+            f"/repos/{self.repo}/actions/runs/{run_id}/jobs",
+            query={"per_page": 100},
+            max_pages=max_pages,
+        )
+        return [j for j in jobs if isinstance(j, dict)]
+
     def rerun_workflow_run(self, run_id: int) -> tuple[bool, str]:
         try:
             self.post(f"/repos/{self.repo}/actions/runs/{run_id}/rerun")
@@ -212,6 +243,29 @@ def compute_active_head_pairs(open_pulls: list[dict[str, Any]]) -> set[tuple[str
     return active
 
 
+def run_never_executed(jobs: list[dict[str, Any]]) -> bool:
+    """True iff a cancelled run was displaced while still QUEUED, i.e. it
+    never executed anything. Two independent signals, either suffices:
+
+    - every job has a null/empty ``started_at`` (nothing was ever assigned a
+      runner), OR
+    - no job contains any step with a non-null ``started_at`` (GitHub can
+      stamp a job-level ``started_at`` on queued-cancelled jobs, but a STEP
+      ``started_at`` appears only when the job genuinely began executing).
+
+    A run cancelled mid-execution — e.g. at the Checkout step — HAS a started
+    step and returns False; that class is eliminated upstream by RCP's
+    queued-only cancellation rule and is never this guardian's to undo."""
+    if all(not job.get("started_at") for job in jobs):
+        return True
+    return not any(
+        step.get("started_at")
+        for job in jobs
+        for step in job.get("steps") or []
+        if isinstance(step, dict)
+    )
+
+
 def compute_reruns(
     runs: list[dict[str, Any]],
     *,
@@ -221,11 +275,31 @@ def compute_reruns(
     ttl_hours: float,
     protected_paths: set[str],
     events: set[str] | None = None,
+    fetch_jobs: Callable[[int], list[dict[str, Any]] | None] | None = None,
 ) -> list[dict[str, Any]]:
-    """Select PROTECTED cancelled PR runs that deserve exactly one honest rerun.
+    """Select cancelled PR runs that deserve exactly one honest rerun.
 
-    Advisory workflows outside the protected manifest are intentionally
-    cancelled by required-check-priority.yml and are never selected."""
+    Two classes qualify; everything else stays cancelled:
+
+    - ``unexpected_required_cancellation`` — the workflow is in the protected
+      manifest (required checks + priority keep-list).
+    - ``queued_phase_advisory_displacement`` — the workflow is advisory (not
+      in the manifest) but the run NEVER EXECUTED: the jobs probe shows no
+      started job/step, i.e. required-check-priority.yml displaced it while
+      it was still queued. One rerun is safe: it is bounded by the
+      run_attempt == 1 marker like every other rerun, and it cannot loop with
+      the canceller because RCP now cancels queued runs only — once the rerun
+      starts executing, priority sweeps can no longer touch it.
+
+    An advisory run that actually STARTED (e.g. cancelled at the Checkout
+    step) is never selected — intentional_advisory_priority stays cancelled —
+    and that mid-execution class is eliminated upstream by RCP's queued-only
+    rule anyway. The jobs probe is LAZY: it fires only for advisory
+    candidates that already passed every other guard (attempt, head pair, PR
+    association, TTL, supersession), so API spend scales with surviving
+    candidates, not --max-runs. ``fetch_jobs=None`` (or a probe returning
+    ``None``) disables/fails the advisory class CLOSED: only protected runs
+    are then selected."""
     considered_events = events or PR_EVENTS
     cutoff = now - timedelta(hours=ttl_hours)
     # Supersession is judged ONLY among runs of the same PR event class AND
@@ -263,7 +337,8 @@ def compute_reruns(
         # a display NAME is free. The residual blast radius is one bounded
         # rerun (run_attempt==1 marker), never authority.
         workflow_path = str(run.get("path", "")).split("@")[0].strip()
-        if workflow_path not in protected_paths:
+        is_protected = workflow_path in protected_paths
+        if not is_protected and fetch_jobs is None:
             continue  # intentional_advisory_priority cancellation: stays cancelled
         if int(run.get("run_attempt") or 1) != 1:
             continue  # once-per-run marker: a rerun already happened
@@ -298,6 +373,21 @@ def compute_reruns(
         newest = newest_by_group.get(group)
         if newest is not None and (created, int(run.get("id") or 0)) < newest:
             continue  # a newer same-head run of this workflow supersedes this one
+        classification = "unexpected_required_cancellation"
+        if not is_protected:
+            # LAZY jobs probe — deliberately the LAST guard, reached only by
+            # advisory candidates that survived every cheap guard above, so
+            # each 20-minute pass spends at most one extra API call per
+            # surviving candidate (not per --max-runs run scanned).
+            assert fetch_jobs is not None  # guarded above
+            jobs = fetch_jobs(int(run.get("id") or 0))
+            if jobs is None or not run_never_executed(jobs):
+                # Probe failed (fail closed: cannot PROVE it never executed)
+                # or the run genuinely started before cancellation — an
+                # in-flight advisory cancellation is not this guardian's to
+                # undo.
+                continue
+            classification = "queued_phase_advisory_displacement"
         reruns.append(
             {
                 "run_id": int(run.get("id") or 0),
@@ -305,6 +395,7 @@ def compute_reruns(
                 "branch": branch,
                 "sha": sha,
                 "created_at": str(run.get("created_at", "")),
+                "classification": classification,
             }
         )
     return reruns
@@ -372,6 +463,17 @@ def main(argv: list[str] | None = None) -> int:
         )
     active_head_pairs = compute_active_head_pairs(open_pulls)
     open_pr_numbers = {int(pr.get("number") or 0) for pr in open_pulls if not bool(pr.get("draft"))}
+
+    def fetch_jobs(run_id: int) -> list[dict[str, Any]] | None:
+        try:
+            return client.list_run_jobs(run_id)
+        except GitHubApiError as exc:
+            # Fail CLOSED per run: without a readable jobs probe we cannot
+            # prove the run never executed, so it stays cancelled — but loud,
+            # so a permanently broken probe never looks green on schedule.
+            print(f"jobs probe failed for run {run_id}: {exc}", file=sys.stderr)
+            return None
+
     reruns = compute_reruns(
         runs,
         active_head_pairs=active_head_pairs,
@@ -379,6 +481,7 @@ def main(argv: list[str] | None = None) -> int:
         ttl_hours=args.ttl_hours,
         protected_paths=protected_paths,
         open_pr_numbers=open_pr_numbers,
+        fetch_jobs=fetch_jobs,
     )
     apply_failures = 0
     for item in reruns:

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -64,6 +64,11 @@ jobs:
               'Tests',
               'OpenAPI Spec',
             ]);
+            for (const run of runs) {
+              if (run.head_sha !== headSha) continue;
+              if (run.id === selfRunId) continue;
+              if (run.status !== 'queued') continue;
+            }
 """
 
 
@@ -292,6 +297,9 @@ jobs:
               'Tests',
               'OpenAPI Spec',
             ]);
+            for (const run of runs) {
+              if (run.status !== 'queued') continue;
+            }
 """
     violations = find_required_check_priority_violations(text, repo_root=repo_root)
     assert violations
@@ -488,6 +496,33 @@ jobs:
         repo_root=repo_root,
     )
 
+    assert violations == []
+
+
+def test_policy_rejects_in_progress_cancellation_status_filter() -> None:
+    # The pre-fix filter (`queued` OR `in_progress`) cancelled in-flight
+    # advisory runs, leaving red "cancelled" conclusions the guardian never
+    # reruns. The policy must reject it.
+    text = _valid_workflow_text().replace(
+        "if (run.status !== 'queued') continue;",
+        "if (run.status !== 'queued' && run.status !== 'in_progress') continue;",
+    )
+    violations = find_required_check_priority_violations(text)
+    assert any("not restricted to queued runs" in v for v in violations)
+
+
+def test_policy_rejects_missing_queued_only_status_filter() -> None:
+    lines = [line for line in _valid_workflow_text().splitlines() if "run.status" not in line]
+    violations = find_required_check_priority_violations("\n".join(lines))
+    assert any("not restricted to queued runs" in v for v in violations)
+
+
+def test_policy_accepts_double_quoted_queued_only_status_filter() -> None:
+    text = _valid_workflow_text().replace(
+        "if (run.status !== 'queued') continue;",
+        'if (run.status !== "queued") continue;',
+    )
+    violations = find_required_check_priority_violations(text)
     assert violations == []
 
 

--- a/tests/scripts/test_retrigger_cancelled_pr_runs.py
+++ b/tests/scripts/test_retrigger_cancelled_pr_runs.py
@@ -150,9 +150,9 @@ def test_active_head_pairs_excludes_drafts_and_keeps_name_collisions(mod) -> Non
 
 
 def test_advisory_cancellation_is_intentional_and_never_rerun(mod) -> None:
-    """Portability Lint is NOT in the protected manifest: its PR-open
-    cancellation is required-check-priority.yml working as designed
-    (intentional_advisory_priority), so the guardian must leave it alone."""
+    """Portability Lint is NOT in the protected manifest: without a jobs
+    probe (fetch_jobs=None) the advisory class is disabled entirely and its
+    PR-open cancellation stays intentional_advisory_priority — fail closed."""
     advisory = _run(name="Portability Lint", path=".github/workflows/portability.yml")
     reruns = mod.compute_reruns(
         [advisory], active_head_pairs=_heads(), now=NOW, ttl_hours=6.0, **_protected(mod)
@@ -316,3 +316,167 @@ def test_run_pr_association_must_intersect_open_prs_when_named(mod) -> None:
         **_protected(mod),
     )
     assert sorted(r["run_id"] for r in reruns) == [2, 3]
+
+
+# --- queued-phase advisory displacement (#9351 round 2) -----------------------
+
+_ADVISORY_PATH = ".github/workflows/module-tier-drift.yml"
+
+
+def _advisory_run(run_id: int = 1, **kwargs) -> dict:
+    kwargs.setdefault("name", "Module Tier Drift")
+    kwargs.setdefault("path", _ADVISORY_PATH)
+    return _run(run_id, **kwargs)
+
+
+def _queued_jobs() -> list[dict]:
+    """Jobs of a run cancelled while still queued: nothing ever started."""
+    return [
+        {"started_at": None, "steps": []},
+        {"started_at": None, "steps": [{"name": "Set up job", "started_at": None}]},
+    ]
+
+
+def _checkout_jobs() -> list[dict]:
+    """Jobs of a run cancelled at the Checkout step: execution began."""
+    return [
+        {
+            "started_at": "2026-07-10T11:00:00Z",
+            "steps": [
+                {"name": "Set up job", "started_at": "2026-07-10T11:00:01Z"},
+                {"name": "Checkout", "started_at": "2026-07-10T11:00:05Z"},
+            ],
+        }
+    ]
+
+
+class _CountingFetcher:
+    def __init__(self, jobs) -> None:
+        self.jobs = jobs
+        self.calls: list[int] = []
+
+    def __call__(self, run_id: int):
+        self.calls.append(run_id)
+        return self.jobs
+
+
+def test_queued_phase_advisory_displacement_is_selected_once(mod) -> None:
+    """An advisory run displaced while QUEUED (no job/step ever started) is
+    the residual settlement tax: the guardian now reruns it exactly once,
+    classified distinctly so reports separate it from the protected class."""
+    fetcher = _CountingFetcher(_queued_jobs())
+    reruns = mod.compute_reruns(
+        [_advisory_run()],
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert [r["run_id"] for r in reruns] == [1]
+    assert reruns[0]["classification"] == "queued_phase_advisory_displacement"
+    assert fetcher.calls == [1]
+
+
+def test_checkout_phase_advisory_run_stays_cancelled(mod) -> None:
+    """An advisory run that STARTED (cancelled at Checkout) has a started
+    step: it is not a queued-phase displacement and stays cancelled — that
+    class is eliminated upstream by RCP's queued-only rule."""
+    fetcher = _CountingFetcher(_checkout_jobs())
+    reruns = mod.compute_reruns(
+        [_advisory_run()],
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert reruns == []
+    assert fetcher.calls == [1]  # probe ran (all other guards passed), said no
+
+
+def test_protected_selection_unchanged_and_never_probed(mod) -> None:
+    """Protected-manifest behavior is byte-identical: selected under the same
+    guards, classified unexpected_required_cancellation, and the jobs probe
+    is never spent on it."""
+    fetcher = _CountingFetcher(_queued_jobs())
+    reruns = mod.compute_reruns(
+        [_run()],
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert [r["run_id"] for r in reruns] == [1]
+    assert reruns[0]["classification"] == "unexpected_required_cancellation"
+    assert fetcher.calls == []
+
+
+def test_attempt_2_advisory_is_never_rerun_again(mod) -> None:
+    """run_attempt > 1 bounds the advisory class exactly like the protected
+    one: once per run, even if the probe would say never-executed."""
+    fetcher = _CountingFetcher(_queued_jobs())
+    reruns = mod.compute_reruns(
+        [_advisory_run(attempt=2)],
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert reruns == []
+    assert fetcher.calls == []  # cheap guard rejected it before any API spend
+
+
+def test_jobs_probe_is_lazy_only_surviving_candidates_pay(mod) -> None:
+    """Advisory runs failing ANY earlier guard (stale head, attempt 2, TTL,
+    supersession) never trigger a jobs fetch; only the single surviving
+    candidate costs one probe call (API budget vs --max-runs 300)."""
+    fetcher = _CountingFetcher(_queued_jobs())
+    runs = [
+        _advisory_run(1, sha="b" * 40),  # stale head pair
+        _advisory_run(2, attempt=2),  # already rerun once
+        _advisory_run(3, age_hours=9.0),  # outside TTL
+        _advisory_run(4, age_hours=2.0),  # superseded by run 5 below
+        _advisory_run(5, conclusion="success", age_hours=0.5),  # not cancelled
+        _advisory_run(6, workflow_id=99, path=".github/workflows/other-advisory.yml"),
+    ]
+    reruns = mod.compute_reruns(
+        runs,
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert [r["run_id"] for r in reruns] == [6]
+    assert fetcher.calls == [6]
+
+
+def test_failed_jobs_probe_fails_closed(mod) -> None:
+    """A probe returning None (API error upstream) cannot PROVE the run never
+    executed, so the run stays cancelled."""
+    fetcher = _CountingFetcher(None)
+    reruns = mod.compute_reruns(
+        [_advisory_run()],
+        active_head_pairs=_heads(),
+        now=NOW,
+        ttl_hours=6.0,
+        fetch_jobs=fetcher,
+        **_protected(mod),
+    )
+    assert reruns == []
+    assert fetcher.calls == [1]
+
+
+def test_run_never_executed_signal_matrix(mod) -> None:
+    """Either never-executed signal suffices: all job started_at null, OR no
+    step started_at anywhere (GitHub stamps job started_at on some
+    queued-cancelled jobs without ever running a step). A started step is
+    always disqualifying; zero jobs means nothing ever executed."""
+    assert mod.run_never_executed([]) is True
+    assert mod.run_never_executed(_queued_jobs()) is True
+    # Job-level stamp but no step ever started: still queued-phase.
+    assert mod.run_never_executed([{"started_at": "2026-07-10T11:00:00Z", "steps": []}]) is True
+    assert mod.run_never_executed(_checkout_jobs()) is False


### PR DESCRIPTION
## Diagnosis (verified)

`.github/workflows/required-check-priority.yml` (RCP) is the "external cancellation actor" from `docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md` — it was in-repo all along. On every `pull_request` event RCP runs 4 sweeps (10 s apart) that cancel every **queued AND in-progress** advisory `pull_request` run at the PR head that isn't in its keep-list.

**Smoking gun:** RCP run [29520862671](https://github.com/synaptent/aragora/actions/runs/29520862671) cancelled runs 29520863012 / 29520863349 / 29520863087 / 29520862378 on PR #9346 seconds after creation, with **no newer push**. Sweep log: `Canceled run 29520863012 (Module Tier Drift)` … `Sweep 1/4: considered 14, canceled 4`.

The other half of the churn is by design: the cancelled-run guardian (`pr-cancelled-run-guardian.yml` + `scripts/ci/required_workflow_manifest.json`) deliberately reruns **only** keep-listed workflows, so advisory reds persist as `cancelled` conclusions until a manual rerun. The conservative merge executor treats those reds as blocking, so **every long-lived PR** pays a manual-rerun tax before settlement.

**Settlement-latency impact (2026-07-15/16):** repeated manual reruns were required on PRs #9170, #9322, and #9346 solely to clear RCP-inflicted cancelled advisory checks.

## Fix (minimal)

Restrict RCP's cancellation to `status === 'queued'` runs only — never cancel `in_progress` runs.

- An in-progress run **already holds a runner**: cancelling it frees zero queue capacity, and these advisory runs finish in 1-5 minutes anyway. Cancelling only converts them into red `cancelled` conclusions the guardian will never rerun.
- **Queue-pressure relief is fully preserved:** queued advisory runs still yield to required checks, which is the entire point of RCP.
- Keep-list, sweep structure, fail-closed empty-keep-list guard, and required-context defensive check are all unchanged. No new `${{ }}` interpolation; injection-safety patterns preserved.

## Alternatives considered

1. **Keep-list expansion** (add the advisory workflows to `alwaysKeepWorkflowPaths`/manifest): would stop the churn but also exempts them from queue-yielding entirely, defeating RCP's purpose, and requires perpetual list maintenance for every new advisory workflow. Queued-only fixes the class, not the instances.
2. **Guardian-rerun expansion** (rerun cancelled advisory runs too): treats the symptom and *doubles* runner spend — RCP cancels an in-flight run, the guardian re-queues it from scratch, and RCP's next sweep may cancel it again (rerun loop risk). Queued-only removes the wasteful cancellation instead of paying to undo it.

Queued-only dominates both: smaller diff, no new spend, no list maintenance, and the guardian's conservative no-advisory-rerun policy can stay exactly as designed.

## Changes

- `.github/workflows/required-check-priority.yml` — status filter narrowed to `queued` with rationale comment (~line 211)
- `scripts/check_required_check_priority_policy.py` — the existing keep-list policy guard now also enforces the queued-only invariant (regression protection against reverting to the two-status filter)
- `tests/scripts/test_check_required_check_priority_policy.py` — 3 new tests: rejects the pre-fix `queued || in_progress` filter, rejects a missing filter, accepts double-quoted variant; fixture updated. 16/16 pass.
- `docs/governance/PR_RUN_CANCELLATION_DIAGNOSIS.md` — dated correction section retracting the "external actor" conclusion, naming RCP as the canceller with the run-29520862671 evidence, and noting the guardian's by-design no-rerun policy (M2 resolved)

## Test state

The cancellation loop itself is inline `actions/github-script` JS with no JS test harness; it is guarded indirectly via the Python policy checker above (the repo's established pattern for this workflow). `pytest tests/scripts/test_check_required_check_priority_policy.py` — 16 passed. Workflow YAML parses; extracted inline JS passes `node --check`.

## Tier-4

This PR modifies a workflow file. **Operator settlement required — do not auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round-2 completion: the guardian now clears queued-phase displacements (commit 4fdf8948c6)

Round-1 review (openai P2) correctly noted a **residual settlement tax**: even with RCP restricted to queued-only cancellation, a displaced queued advisory run still ends as a terminal red `cancelled` conclusion, because the guardian (`scripts/retrigger_cancelled_pr_runs.py`, cron `*/20`) reruns only manifest-protected workflows. This round completes the two-part design:

1. **RCP cancels only QUEUED advisory runs** (round 1) — in-flight work is never killed, so no run is ever cancelled mid-execution by priority sweeps.
2. **The guardian reruns exactly those queued-phase displacements, once** (this commit) — a cancelled run outside the protected manifest becomes rerun-eligible **iff it never executed**: a jobs probe (`GET /actions/runs/{id}/jobs`) must show no job/step with a non-null `started_at`. A run cancelled at e.g. the Checkout step has started steps and stays ineligible (that class no longer occurs, per part 1).

Together: **no advisory run ever ends terminally `cancelled` due to priority displacement, and no in-flight run is ever killed.** The rerun cannot loop with the canceller: once the rerun starts executing, RCP's queued-only rule can no longer touch it, and `run_attempt == 1` bounds the guardian to one rerun per run regardless.

Guard parity and budget:

- The new class passes **all** existing guards identically: `run_attempt == 1`, active (branch, sha) head pair, open non-draft PR association, TTL on cancellation time, supersession-by-newest-same-group, path-based matching.
- The jobs probe is **lazy** — fetched only for advisory candidates that survived every cheap guard, so API spend scales with surviving candidates (typically 0-4 per pass), not with `--max-runs 300`. Probe failures fail **closed** (run stays cancelled) and loud (stderr).
- Output classifies the new class as `queued_phase_advisory_displacement` vs `unexpected_required_cancellation`, so guardian reports distinguish the two.
- `tests/scripts/test_retrigger_cancelled_pr_runs.py`: 7 new tests (queued-phase selected + classified; checkout-phase never selected; protected behavior unchanged and never probed; attempt-2 bounded; laziness asserted via fetcher call counts; failed probe fails closed; never-executed signal matrix). **26/26 pass**; ruff clean.

This supersedes the round-1 "Alternatives considered #2" objection: rerunning *in-flight* cancellations would have doubled runner spend and risked rerun loops, but rerunning *never-executed* displacements re-queues work that was never paid for, and part 1 removes the loop risk.
