### PR TITLE
fix(governance): dedupe verify baseline + fail closed on duplicate baseline entries

### DIFF
--- a/scripts/baselines/verify_sdk_contracts.json
+++ b/scripts/baselines/verify_sdk_contracts.json
@@ -50,7 +50,6 @@
     "DELETE /api/media/audio/{param}",
     "GET /api/media/audio/{param}",
     "GET /api/media/audio/{param}/transcription",
-    "GET /api/podcast/episodes/{param}",
     "POST /api/media/audio",
     "POST /api/media/audio/{param}/convert",
     "GET /api/personas/options",

--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -222,6 +222,10 @@ def build_ratchet_result(
             integrity_issues.append(str(exc))
             docs[alias] = {}
     counts = _counts_from_docs(docs)
+    # Duplicated baseline entries inflate the raw counts above while the
+    # id-deduped inventory sees one item; fail closed (head docs only —
+    # history at the base ref or cohort commit is never re-judged).
+    integrity_issues.extend(inventory_mod.find_duplicate_entry_issues(docs))
 
     cohort_ids: dict[str, str] | None = None
     try:

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -71,6 +71,27 @@ def collect_ids(docs: dict[str, dict[str, Any]]) -> dict[str, str]:
     return ids
 
 
+def find_duplicate_entry_issues(docs: dict[str, dict[str, Any]]) -> list[str]:
+    """Duplicate entries within a baseline list (fail closed on hand edits).
+
+    The inventory dedupes by normalized id, but the ratchet counts raw list
+    lengths — a duplicated entry inflates the count-based ratchet by one and
+    becomes a count-decrease freebie when later removed. Every baseline entry
+    must be unique.
+    """
+    issues: list[str] = []
+    for alias, (_path, list_keys) in BASELINE_SPECS.items():
+        doc = docs.get(alias) or {}
+        for list_key in list_keys:
+            seen: set[str] = set()
+            for entry in doc.get(list_key, []) or []:
+                item_id = f"{list_key}:{normalize_key(entry)}"
+                if item_id in seen:
+                    issues.append(f"Duplicate baseline entry: {item_id}")
+                seen.add(item_id)
+    return issues
+
+
 def load_working_docs(repo_root: Path) -> dict[str, dict[str, Any]]:
     docs: dict[str, dict[str, Any]] = {}
     for alias, (rel_path, _keys) in BASELINE_SPECS.items():
@@ -268,10 +289,18 @@ def main() -> int:
         return 1
 
     try:
-        current_ids = collect_ids(load_working_docs(repo_root))
+        working_docs = load_working_docs(repo_root)
+        current_ids = collect_ids(working_docs)
         cohort_ids = collect_ids(load_git_docs(repo_root, args.cohort_commit))
     except (ValueError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
         print(f"ERROR: {exc}")
+        return 1
+
+    duplicate_issues = find_duplicate_entry_issues(working_docs)
+    if duplicate_issues:
+        print("FAIL: duplicate baseline entries (dedupe the baseline lists first):")
+        for issue in duplicate_issues:
+            print(f"  - {issue}")
         return 1
 
     existing: dict[str, Any] = {"items": []}

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -494,6 +494,48 @@ def test_pr_mode_passes_on_decrease_via_legitimate_resolution(tmp_path: Path):
     assert result["passing"]
 
 
+def test_duplicate_baseline_entry_fails_integrity_program_mode(tmp_path: Path):
+    """A duplicated baseline entry inflates the count-based ratchet while the
+    id-deduped inventory holds one item — fail closed rather than let the
+    duplicate sit as a count-decrease freebie."""
+    verify = {"python_sdk_drift": ["a", "a", "b"], "typescript_sdk_drift": [], "missing_stable": []}
+    paths, repo, cohort = _seed(tmp_path, verify=verify, program=RED_PROGRAM)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=cohort)
+    assert not result["integrity"]["passing"]
+    assert any(
+        "Duplicate baseline entry: python_sdk_drift:a" in i for i in result["integrity"]["issues"]
+    )
+    assert not result["passing"]
+
+
+def test_pr_mode_inherited_duplicate_fails_despite_equal_counts(tmp_path: Path):
+    """A duplicate present at base AND head leaves every count delta at zero —
+    only the duplicate integrity check catches it."""
+    verify = {"python_sdk_drift": ["a", "a", "b"], "typescript_sdk_drift": [], "missing_stable": []}
+    paths, repo, base = _seed(tmp_path, verify=verify, program=RED_PROGRAM)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["pr_delta"]["increased"] == []
+    assert not result["integrity"]["passing"]
+    assert not result["passing"]
+
+
+def test_pr_mode_passes_on_duplicate_removal(tmp_path: Path):
+    """Removing a duplicated baseline entry is a pure dedup: count decreases by
+    one, the inventory (already deduped by id) needs no change, and pr mode
+    passes."""
+    verify = {"python_sdk_drift": ["a", "a", "b"], "typescript_sdk_drift": [], "missing_stable": []}
+    paths, repo, base = _seed(tmp_path, verify=verify, program=RED_PROGRAM)
+
+    deduped = json.loads(paths["verify"].read_text())
+    deduped["python_sdk_drift"] = ["a", "b"]
+    _write_json(paths["verify"], deduped)
+
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["integrity"]["passing"]
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+    assert result["passing"]
+
+
 def test_pr_mode_fails_on_any_single_list_increase(tmp_path: Path):
     paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
 

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -221,6 +221,39 @@ def test_duplicate_inventory_ids_fail_sync(tmp_path):
     assert any("Duplicate inventory id" in i for i in issues)
 
 
+def test_duplicate_baseline_entries_fail_closed(monkeypatch, tmp_path: Path, capsys):
+    """A duplicate baseline entry inflates count-based ratchet totals while the
+    id-deduped inventory sees one item — a latent count-decrease freebie. The
+    generator refuses to run (check or write) over duplicated baselines."""
+    repo, sha = _init_repo(tmp_path)
+    assert _run(monkeypatch, repo, sha) == 0
+    assert _run(monkeypatch, repo, sha, "--check") == 0
+
+    verify = dict(VERIFY, python_sdk_drift=[*VERIFY["python_sdk_drift"], "GET /a"])
+    _write_baselines(repo, verify, ROUTES, PARITY)
+    assert _run(monkeypatch, repo, sha, "--check") == 1
+    assert "Duplicate baseline entry: python_sdk_drift:GET /a" in capsys.readouterr().out
+
+    before = (repo / gen.DEFAULT_INVENTORY).read_bytes()
+    assert _run(monkeypatch, repo, sha) == 1  # write mode refuses too
+    assert (repo / gen.DEFAULT_INVENTORY).read_bytes() == before
+
+
+def test_find_duplicate_entry_issues_unit():
+    docs = {
+        "verify": {
+            "python_sdk_drift": ["GET /a", "GET /a", "GET /b"],
+            "typescript_sdk_drift": ["ts1"],
+        },
+        "routes": {"missing_in_spec": ["m1"], "orphaned_in_spec": []},
+        "parity": {"missing_from_both_sdks": []},
+    }
+    issues = gen.find_duplicate_entry_issues(docs)
+    assert issues == ["Duplicate baseline entry: python_sdk_drift:GET /a"]
+    docs["verify"]["python_sdk_drift"] = ["GET /a", "GET /b"]
+    assert gen.find_duplicate_entry_issues(docs) == []
+
+
 def test_discovered_provenance_requires_reference_in_committed_inventory():
     """Round-5 review P2: hand-edited committed inventories must meet the
 


### PR DESCRIPTION
## Summary

`python_sdk_drift` in `scripts/baselines/verify_sdk_contracts.json` contained `GET /api/podcast/episodes/{param}` twice (introduced by the hand edit in 168c77024a, after the clean cohort commit). The contract-drift inventory dedupes by normalized id, so it showed **517** open items while raw baseline counts totaled **518** — inflating the count-based ratchet by one and sitting as a latent count-decrease freebie.

## Changes

- **Remove the duplicate entry** — pure dedup (70 → 69 py / 518 → 517 total). Inventory ids are unchanged, so the committed inventory stays in sync with no regeneration.
- **Fail closed on duplicate baseline entries.** No tool writes this baseline (`verify_sdk_contracts.py` is read-only and loads it as sets — the dup came from a manual edit), so instead of dedupe-on-write this adds `find_duplicate_entry_issues()` to the inventory module and enforces it:
  - in `check_contract_drift_ratchet.py` as an integrity issue (both modes; head docs only — base-ref/cohort history is never re-judged)
  - in `generate_contract_drift_inventory.py` on both `--check` and write paths (refuses to absorb duplicated baselines)

  This matches the existing "hand-edited baselines must meet the generator's bar" pattern and closes the delta-blind case: a duplicate inherited at both base and head leaves every pr-mode count delta at zero, so only an integrity check can catch it. Note this tightens the drift gate (same Tier-3 governance surface as #9346); main is duplicate-free after this PR's own dedup.

## Verification

- `pytest tests/scripts/test_check_contract_drift_ratchet.py tests/scripts/test_generate_contract_drift_inventory.py` — **43/43 pass** (5 new tests: unit, generator fail-closed, program-mode integrity, inherited-dup delta-blind case, pure-dedup removal passes pr mode)
- Ratchet **program mode**: integrity clean, `py=69`, total 517 == inventory open count (schedule red is the pre-existing burn-down state, informational)
- Ratchet **pr mode vs origin/main**: **PASS** — `verify_python_sdk_drift: 70 -> 69 (-1)`, all other deltas 0, no integrity issues
- `generate_contract_drift_inventory.py --check`: `OK: inventory in sync (517 open items)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)