### PR TITLE
fix(benchmarks): permit explicit external measurement output

### DIFF
--- a/docs/benchmarks/2026-07-factory-review-quorum-vs-single.md
+++ b/docs/benchmarks/2026-07-factory-review-quorum-vs-single.md
@@ -72,6 +72,7 @@ Set valid direct `XAI_API_KEY` and `MISTRAL_API_KEY` credentials, then run:
 ARAGORA_USE_SECRETS_MANAGER=false ARAGORA_SECRETS_STRICT=false \
   PYTHONPATH=. python3 scripts/measure_factory_review_quorum_vs_single.py collect \
   --providers grok mistral-api \
+  --allow-external-output \
   --output /tmp/factory-review-live-collection.json
 ```
 
@@ -83,10 +84,26 @@ The separate [`factory_review_quorum_vs_single_evidence.json`](factory_review_qu
 contains manual `golden_comment_id` mappings against the pinned validation records,
 and is not represented as raw model output.
 
+`grok` remains the provider and historical replay-fixture identifier used to
+invoke xAI. The machine-readable measurement result normalizes that provider's
+model family to canonical `xai`, matching the ODR receipts, and includes a
+`family_aliases` mapping. Keeping the fixture reviewer identifier unchanged
+preserves deterministic replay of the committed receipts.
+
 ### Deterministic measurement command
 
 ```bash
 PYTHONPATH=. python3 scripts/measure_factory_review_quorum_vs_single.py measure
+```
+
+The default command writes only to the committed in-repository result and fixture
+paths. A read-only checkout can instead use explicit external destinations:
+
+```bash
+PYTHONPATH=. python3 scripts/measure_factory_review_quorum_vs_single.py measure \
+  --allow-external-output \
+  --outcome-dir /tmp/factory-review-outcomes \
+  --output /tmp/factory-review-results.json
 ```
 
 That command spends nothing. It fails closed on missing cases, mismatched SHAs,
@@ -122,7 +139,7 @@ Two cases meet the narrow claim. Both are machine-readable in the result JSON:
   confirms the literal Italian string.
 
 For each case, `quorum.distinct_model_families` is `2`,
-`quorum.families` is `["grok", "mistral"]`, and `receipt_path` points to a
+`quorum.families` is `["mistral", "xai"]`, and `receipt_path` points to a
 verifiable ODR produced from the paired live findings. The result JSON and each
 fixture carry the live collection digest plus a manual-adjudication disclosure:
 

--- a/docs/benchmarks/factory_review_quorum_vs_single_results.json
+++ b/docs/benchmarks/factory_review_quorum_vs_single_results.json
@@ -27,7 +27,7 @@
       "head_sha": "cb7212e11dbdbc1813237ad129c7bc108f944e3d",
       "models": [
         {
-          "family": "grok",
+          "family": "xai",
           "finding_set": [
             {
               "body": "In organization_auditlogs.py:70, enable_advanced references organization_context which is not defined or imported in the shown diff (or the original function scope). This will raise NameError on every request when the optimized path is taken.",
@@ -118,8 +118,8 @@
         ],
         "distinct_model_families": 2,
         "families": [
-          "grok",
-          "mistral"
+          "mistral",
+          "xai"
         ],
         "missed_golden_ids": [],
         "true_positive_golden_ids": [
@@ -155,7 +155,7 @@
       "head_sha": "3647ba7360b8d157e4a294a650a365b6aca070d8",
       "models": [
         {
-          "family": "grok",
+          "family": "xai",
           "finding_set": [
             {
               "body": "updateDevice returns ErrDeviceLimitReached whenever rowsAffected==0 (e.g., new device_id outside the narrow time window), but this error is also used to signal the actual limit. Callers cannot distinguish the cases.",
@@ -268,8 +268,8 @@
         "caught_beyond_baseline_golden_ids": [],
         "distinct_model_families": 2,
         "families": [
-          "grok",
-          "mistral"
+          "mistral",
+          "xai"
         ],
         "missed_golden_ids": [],
         "true_positive_golden_ids": [
@@ -323,7 +323,7 @@
       "head_sha": "5d77e7ea7d431aa0a6b65904457b7471bd050e81",
       "models": [
         {
-          "family": "grok",
+          "family": "xai",
           "finding_set": [
             {
               "body": "POLICY_SOME_HTML allows only br/p/strong/b (no 'a'). santizeAnchors + sanitize removes <a> even when English source has them. Results in loss of links (e.g. FreeOTP, Play Store) in fi/lt/sk/sv/zh_CN account messages and many email/login files.",
@@ -451,8 +451,8 @@
         ],
         "distinct_model_families": 2,
         "families": [
-          "grok",
-          "mistral"
+          "mistral",
+          "xai"
         ],
         "missed_golden_ids": [
           "2743702343",
@@ -468,14 +468,17 @@
       "validation_url": "https://raw.githubusercontent.com/droid-code-review-evals/review-droid-benchmark/2dfbbd6edcd5eea19495e725d611cb104c9e8f4d/results/review_droid_run_gpt_5p2_2026-01-28/validations/droid-keycloak_pr_7_validation.json"
     }
   ],
+  "family_aliases": {
+    "grok": "xai"
+  },
   "kind": "factory_review_quorum_vs_single_measurement",
   "live_collection": "docs/benchmarks/factory_review_quorum_vs_single_live_collection.json",
   "live_collection_canonical_sha256": "8c675aa9f61d9962fcbe71f5e8265f68f9e334358d04dd5365f4fd4e59e603a9",
   "manifest": "docs/benchmarks/factory_review_benchmark_manifest.json",
   "manifest_blob_sha": "a810d4319a798c7980deccedef1f5df8cc86568f",
   "quorum_families": [
-    "grok",
-    "mistral"
+    "mistral",
+    "xai"
   ],
   "schema_version": 1,
   "summary": {

--- a/scripts/measure_factory_review_quorum_vs_single.py
+++ b/scripts/measure_factory_review_quorum_vs_single.py
@@ -46,6 +46,9 @@ PROVIDER_FAMILIES = {
     "grok": "grok",
     "mistral-api": "mistral",
 }
+FAMILY_ALIASES = {
+    "grok": "xai",
+}
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -68,6 +71,31 @@ def _write_json(path: Path, value: object) -> None:
 def _canonical_sha256(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _canonical_family(family: str) -> str:
+    return FAMILY_ALIASES.get(family, family)
+
+
+def _resolve_output_path(path: Path, *, label: str, allow_external: bool) -> Path:
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(REPO_ROOT.resolve())
+    except ValueError as exc:
+        if not allow_external:
+            raise ValueError(
+                f"{label} is outside the repository; pass --allow-external-output "
+                "to permit external writes"
+            ) from exc
+    return resolved
+
+
+def _output_path_label(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT.resolve()))
+    except ValueError:
+        return str(resolved)
 
 
 def _manifest_cases(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -393,7 +421,7 @@ def measure(
         quorum_matches: set[str] = set()
         for model in models:
             provider = str(model.get("provider", ""))
-            family = str(model.get("family", ""))
+            family = _canonical_family(str(model.get("family", "")))
             all_families.add(family)
             matches: set[str] = set()
             for finding in model.get("findings", []):
@@ -424,7 +452,7 @@ def measure(
             )
         if baseline_matches is None:
             raise ValueError(f"{case_id}: named baseline {baseline_provider} is absent")
-        families = {str(model["family"]) for model in models}
+        families = {_canonical_family(str(model["family"])) for model in models}
         if len(families) < 2:
             raise ValueError(f"{case_id}: quorum has fewer than two distinct families")
 
@@ -453,7 +481,7 @@ def measure(
                     "missed_golden_ids": sorted(golden_ids - quorum_matches),
                     "caught_beyond_baseline_golden_ids": sorted(quorum_matches - baseline_matches),
                 },
-                "collect_outcome_fixture": str(fixture_path.relative_to(REPO_ROOT)),
+                "collect_outcome_fixture": _output_path_label(fixture_path),
                 "receipt_path": (f"docs/benchmarks/receipts/{case_id}-receipt.odr.json"),
             }
         )
@@ -476,6 +504,7 @@ def measure(
         "live_collection": str(DEFAULT_LIVE_COLLECTION.relative_to(REPO_ROOT)),
         "live_collection_canonical_sha256": live_collection_sha256,
         "adjudication_scope": "manual golden_comment_id mappings only; finding text is live output",
+        "family_aliases": dict(sorted(FAMILY_ALIASES.items())),
         "baseline_provider": baseline_provider,
         "quorum_families": sorted(all_families),
         "cases": measured_cases,
@@ -495,6 +524,11 @@ def build_parser() -> argparse.ArgumentParser:
     collect.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     collect.add_argument("--providers", nargs="+", default=["grok", "mistral-api"])
     collect.add_argument("--output", type=Path, required=True)
+    collect.add_argument(
+        "--allow-external-output",
+        action="store_true",
+        help="permit --output outside the repository (disabled by default)",
+    )
 
     offline = subparsers.add_parser("measure", help="measure committed evidence offline")
     offline.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
@@ -503,16 +537,31 @@ def build_parser() -> argparse.ArgumentParser:
     offline.add_argument("--baseline-provider", default="mistral-api")
     offline.add_argument("--outcome-dir", type=Path, default=DEFAULT_OUTCOME_DIR)
     offline.add_argument("--output", type=Path, default=DEFAULT_RESULTS)
+    offline.add_argument(
+        "--allow-external-output",
+        action="store_true",
+        help="permit --output and --outcome-dir outside the repository (disabled by default)",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
+        output_path = _resolve_output_path(
+            args.output,
+            label="--output",
+            allow_external=args.allow_external_output,
+        )
         manifest = _read_json(args.manifest)
         if args.command == "collect":
             result = asyncio.run(collect_live(manifest, providers=args.providers))
         else:
+            outcome_dir = _resolve_output_path(
+                args.outcome_dir,
+                label="--outcome-dir",
+                allow_external=args.allow_external_output,
+            )
             evidence = _read_json(args.evidence)
             live_collection = _read_json(args.live_collection)
             result = measure(
@@ -520,13 +569,13 @@ def main(argv: list[str] | None = None) -> int:
                 evidence,
                 live_collection,
                 baseline_provider=args.baseline_provider,
-                outcome_dir=args.outcome_dir,
+                outcome_dir=outcome_dir,
             )
-        _write_json(args.output, result)
+        _write_json(output_path, result)
     except (OSError, RuntimeError, ValueError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps({"output": str(args.output), "cases": len(result["cases"])}, sort_keys=True))
+    print(json.dumps({"output": str(output_path), "cases": len(result["cases"])}, sort_keys=True))
     return 0
 
 

--- a/tests/scripts/test_measure_factory_review_quorum_vs_single.py
+++ b/tests/scripts/test_measure_factory_review_quorum_vs_single.py
@@ -71,6 +71,10 @@ def test_measure_records_named_single_miss_and_emits_collect_outcome(
     assert "golden_comment_id=2743651586" in fixture["items"][0]["body"]
     assert "live reviewer output collection canonical sha256:" in fixture["action_reason"]
     assert result["adjudication_scope"].startswith("manual golden_comment_id mappings only")
+    assert result["family_aliases"] == {"grok": "xai"}
+    assert result["quorum_families"] == ["mistral", "xai"]
+    assert case["models"][0]["provider"] == "grok"
+    assert case["models"][0]["family"] == "xai"
 
 
 def test_manifest_rejects_moving_validation_url() -> None:
@@ -174,3 +178,80 @@ def test_measure_uses_live_text_instead_of_rewritten_adjudication(
     assert result["cases"][0]["models"][0]["finding_set"][0]["body"].startswith(
         "In organization_auditlogs.py"
     )
+
+
+def _main_measure_args(*, output: Path, outcome_dir: Path) -> list[str]:
+    return [
+        "measure",
+        "--manifest",
+        str(ARTIFACT_DIR / "factory_review_benchmark_manifest.json"),
+        "--evidence",
+        str(ARTIFACT_DIR / "factory_review_quorum_vs_single_evidence.json"),
+        "--live-collection",
+        str(ARTIFACT_DIR / "factory_review_quorum_vs_single_live_collection.json"),
+        "--outcome-dir",
+        str(outcome_dir),
+        "--output",
+        str(output),
+    ]
+
+
+def _configure_fake_repo(tmp_path: Path, monkeypatch: object) -> Path:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    monkeypatch.setattr(measure_script, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(measure_script, "DEFAULT_MANIFEST", repo_root / "manifest.json")
+    monkeypatch.setattr(measure_script, "DEFAULT_LIVE_COLLECTION", repo_root / "live.json")
+    return repo_root
+
+
+def test_external_output_requires_explicit_opt_in(tmp_path: Path, monkeypatch: object) -> None:
+    _configure_fake_repo(tmp_path, monkeypatch)
+    external_dir = tmp_path / "external"
+    output = external_dir / "results.json"
+
+    assert measure_script.main(_main_measure_args(output=output, outcome_dir=external_dir)) == 2
+    assert not output.exists()
+
+
+def test_external_output_succeeds_with_explicit_opt_in(
+    tmp_path: Path,
+    monkeypatch: object,
+) -> None:
+    _configure_fake_repo(tmp_path, monkeypatch)
+    external_dir = tmp_path / "external"
+    output = external_dir / "results.json"
+    args = _main_measure_args(output=output, outcome_dir=external_dir)
+
+    assert measure_script.main([*args, "--allow-external-output"]) == 0
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["cases"][0]["collect_outcome_fixture"] == str(
+        (external_dir / "droid-sentry-pr-6.collect-outcome.json").resolve()
+    )
+    assert result["quorum_families"] == ["mistral", "xai"]
+
+
+def test_default_in_tree_output_behavior_is_unchanged(
+    tmp_path: Path,
+    monkeypatch: object,
+) -> None:
+    repo_root = _configure_fake_repo(tmp_path, monkeypatch)
+    outcome_dir = repo_root / "fixtures"
+    output = repo_root / "results.json"
+
+    assert measure_script.main(_main_measure_args(output=output, outcome_dir=outcome_dir)) == 0
+    result = json.loads(output.read_text(encoding="utf-8"))
+    assert result["cases"][0]["collect_outcome_fixture"] == (
+        "fixtures/droid-sentry-pr-6.collect-outcome.json"
+    )
+
+
+def test_missing_input_still_fails_closed(tmp_path: Path, monkeypatch: object) -> None:
+    repo_root = _configure_fake_repo(tmp_path, monkeypatch)
+    output = repo_root / "results.json"
+    args = _main_measure_args(output=output, outcome_dir=repo_root / "fixtures")
+    missing_manifest_index = args.index("--manifest") + 1
+    args[missing_manifest_index] = str(tmp_path / "missing-manifest.json")
+
+    assert measure_script.main(args) == 2
+    assert not output.exists()


### PR DESCRIPTION
## Summary

- add an explicit `--allow-external-output` gate for benchmark collection and measurement writes while keeping in-repo defaults unchanged
- normalize the machine-readable measurement family from provider alias `grok` to canonical `xai` and record the alias explicitly
- preserve historical replay-fixture reviewer IDs and committed ODR receipts byte-for-byte
- document read-only-checkout usage and add focused fail-closed regressions

## Validation

- `python -m pytest tests/scripts/test_measure_factory_review_quorum_vs_single.py -q` (12 passed)
- external-output smoke succeeds with the flag and exits 2 without it
- deterministic measurement regeneration leaves all three committed fixtures unchanged
- regenerated Sentry receipt is byte-identical to the committed ODR and verifies with canonical digest `f586b427...`
- `python scripts/check_docs_consistency.py`
- `python scripts/validate_doc_links.py`
- `python scripts/ci/check_docs_links.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and push hooks pass, including ruff, ruff-format, mypy, gitleaks, and portability

## Settlement

Per #9231, this is a parked Tier-2 operator-review PR. Auto-merge is not enabled.

Closes #9231