### PR TITLE
fix(sdk): deprecate key/value memory methods, add contract-correct entry APIs

### DIFF
--- a/scripts/baselines/contract_drift_inventory.json
+++ b/scripts/baselines/contract_drift_inventory.json
@@ -947,6 +947,14 @@
       "status": "open"
     },
     {
+      "class": "discovered",
+      "discovered_on": "2026-07-16",
+      "id": "typescript_sdk_drift:DELETE /api/memory/continuum/{param}",
+      "provenance": "PR #9366: contract-correct deleteEntry calls DELETE /api/v1/memory/continuum/{id} (served by MemoryHandler.handle_delete) but the generated spec lacks the route (generator ROUTES gap, see #9360)",
+      "source": "typescript_sdk_drift",
+      "status": "open"
+    },
+    {
       "class": "start_cohort",
       "discovered_on": "2026-04-17",
       "id": "typescript_sdk_drift:DELETE /api/memory/snapshots/{param}",

--- a/scripts/baselines/verify_sdk_contracts.json
+++ b/scripts/baselines/verify_sdk_contracts.json
@@ -490,7 +490,8 @@
     "POST /api/webhooks/{param}/deliveries/{param}/retry",
     "POST /api/webhooks/{param}/events",
     "POST /api/webhooks/{param}/rotate-secret",
-    "PUT /api/webhooks/{param}/retry-policy"
+    "PUT /api/webhooks/{param}/retry-policy",
+    "DELETE /api/memory/continuum/{param}"
   ],
   "missing_stable": [
     "PATCH /api/v1/debates/export/batch/{param}/results",

--- a/sdk/python/aragora_sdk/namespaces/memory.py
+++ b/sdk/python/aragora_sdk/namespaces/memory.py
@@ -194,6 +194,41 @@ class MemoryAPI:
         """
         return self.list_critiques(agent=agent, limit=limit, offset=offset)
 
+    def store(
+        self,
+        content: str,
+        *,
+        tier: str = "fast",
+        importance: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Store a new memory entry in continuum memory.
+
+        Args:
+            content: The memory content to store
+            tier: Target memory tier (fast, medium, slow, glacial)
+            importance: Importance score between 0.0 and 1.0
+
+        Returns:
+            Dict with the stored entry ID and tier
+        """
+        body: dict[str, Any] = {"content": content, "tier": tier}
+        if importance is not None:
+            body["importance"] = importance
+        return self._client.request("POST", "/api/v1/memory/store", json=body)
+
+    def delete_entry(self, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a continuum memory entry by ID.
+
+        Args:
+            memory_id: ID of the entry to delete (as returned by store())
+
+        Returns:
+            Dict with success flag and message (404 if the entry does not exist)
+        """
+        return self._client.request("DELETE", f"/api/v1/memory/continuum/{memory_id}")
+
     def store_critique(
         self,
         critique: str,
@@ -649,6 +684,41 @@ class AsyncMemoryAPI:
         Alias for list_critiques() for TypeScript SDK compatibility.
         """
         return await self.list_critiques(agent=agent, limit=limit, offset=offset)
+
+    async def store(
+        self,
+        content: str,
+        *,
+        tier: str = "fast",
+        importance: float | None = None,
+    ) -> dict[str, Any]:
+        """
+        Store a new memory entry in continuum memory.
+
+        Args:
+            content: The memory content to store
+            tier: Target memory tier (fast, medium, slow, glacial)
+            importance: Importance score between 0.0 and 1.0
+
+        Returns:
+            Dict with the stored entry ID and tier
+        """
+        body: dict[str, Any] = {"content": content, "tier": tier}
+        if importance is not None:
+            body["importance"] = importance
+        return await self._client.request("POST", "/api/v1/memory/store", json=body)
+
+    async def delete_entry(self, memory_id: str) -> dict[str, Any]:
+        """
+        Delete a continuum memory entry by ID.
+
+        Args:
+            memory_id: ID of the entry to delete (as returned by store())
+
+        Returns:
+            Dict with success flag and message (404 if the entry does not exist)
+        """
+        return await self._client.request("DELETE", f"/api/v1/memory/continuum/{memory_id}")
 
     async def store_critique(
         self,

--- a/sdk/python/tests/test_memory.py
+++ b/sdk/python/tests/test_memory.py
@@ -220,6 +220,44 @@ class TestContinuumOperations:
             )
             client.close()
 
+    def test_store_entry(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"id": "mem-123", "tier": "slow"}
+            client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+            result = client.memory.store("Important insight", tier="slow", importance=0.9)
+            mock_request.assert_called_once_with(
+                "POST",
+                "/api/v1/memory/store",
+                json={"content": "Important insight", "tier": "slow", "importance": 0.9},
+            )
+            assert result["id"] == "mem-123"
+            client.close()
+
+    def test_store_entry_defaults(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"id": "mem-456", "tier": "fast"}
+            client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+            result = client.memory.store("Quick note")
+            mock_request.assert_called_once_with(
+                "POST",
+                "/api/v1/memory/store",
+                json={"content": "Quick note", "tier": "fast"},
+            )
+            assert result["tier"] == "fast"
+            client.close()
+
+    def test_delete_entry(self) -> None:
+        with patch.object(AragoraClient, "request") as mock_request:
+            mock_request.return_value = {"success": True, "message": "deleted"}
+            client = AragoraClient(base_url="https://api.aragora.ai", api_key="test-key")
+            result = client.memory.delete_entry("mem-123")
+            mock_request.assert_called_once_with(
+                "DELETE",
+                "/api/v1/memory/continuum/mem-123",
+            )
+            assert result["success"] is True
+            client.close()
+
 
 # ===========================================================================
 # Critique Operations Tests
@@ -348,6 +386,33 @@ class TestAsyncMemory:
             result = await client.memory.stats()
             mock_request.assert_called_once_with("GET", "/api/v1/memory/stats")
             assert result["total_entries"] == 1000
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_store_entry(self) -> None:
+        with patch.object(AragoraAsyncClient, "request") as mock_request:
+            mock_request.return_value = {"id": "mem-789", "tier": "medium"}
+            client = AragoraAsyncClient(base_url="https://api.aragora.ai", api_key="test-key")
+            result = await client.memory.store("Async insight", tier="medium")
+            mock_request.assert_called_once_with(
+                "POST",
+                "/api/v1/memory/store",
+                json={"content": "Async insight", "tier": "medium"},
+            )
+            assert result["id"] == "mem-789"
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_delete_entry(self) -> None:
+        with patch.object(AragoraAsyncClient, "request") as mock_request:
+            mock_request.return_value = {"success": True, "message": "deleted"}
+            client = AragoraAsyncClient(base_url="https://api.aragora.ai", api_key="test-key")
+            result = await client.memory.delete_entry("mem-789")
+            mock_request.assert_called_once_with(
+                "DELETE",
+                "/api/v1/memory/continuum/mem-789",
+            )
+            assert result["success"] is True
             await client.close()
 
     @pytest.mark.asyncio

--- a/sdk/typescript/examples/memory-patterns.ts
+++ b/sdk/typescript/examples/memory-patterns.ts
@@ -506,9 +506,9 @@ async function demonstrateContinuumMemory(): Promise<void> {
       }
     );
 
-    console.log(`  Found ${retrieveResult.entries.length} entries (total: ${retrieveResult.total})`);
+    console.log(`  Found ${retrieveResult.memories.length} entries (count: ${retrieveResult.count})`);
 
-    for (const entry of retrieveResult.entries.slice(0, 3)) {
+    for (const entry of retrieveResult.memories.slice(0, 3)) {
       console.log(`\n  [${entry.tier}] ${entry.content.substring(0, 60)}...`);
       console.log(`    Importance: ${entry.importance}`);
       console.log(`    Tags: ${entry.tags?.join(', ') || 'none'}`);

--- a/sdk/typescript/src/__tests__/client.test.ts
+++ b/sdk/typescript/src/__tests__/client.test.ts
@@ -213,6 +213,45 @@ describe('AragoraClient', () => {
       expect(result).toBeNull();
     });
 
+    it('should store a continuum memory entry', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({ id: 'mem-123', tier: 'slow' })),
+      });
+
+      const result = await client.storeMemoryEntry('Important insight', {
+        tier: 'slow',
+        importance: 0.9,
+      });
+
+      expect(result.id).toBe('mem-123');
+      expect(result.tier).toBe('slow');
+      const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(url).toContain('/api/v1/memory/store');
+      expect(JSON.parse(init.body)).toEqual({
+        content: 'Important insight',
+        tier: 'slow',
+        importance: 0.9,
+      });
+    });
+
+    it('should delete a continuum memory entry by ID', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(JSON.stringify({
+          success: true,
+          message: 'Memory mem-123 deleted successfully',
+        })),
+      });
+
+      const result = await client.deleteMemoryEntry('mem-123');
+
+      expect(result.success).toBe(true);
+      const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1];
+      expect(url).toContain('/api/v1/memory/continuum/mem-123');
+      expect(init.method).toBe('DELETE');
+    });
+
     it('should search memory', async () => {
       const mockEntries = {
         entries: [

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -3019,6 +3019,11 @@ export class AragoraClient {
   /**
    * Store a value in memory.
    *
+   * @deprecated The server does not implement a key/value memory API.
+   * POST /api/v1/memory/store expects `{ content, tier?, importance? }` and
+   * rejects this method's `{ key, value }` payload with 400. Use
+   * {@link storeMemoryEntry} instead.
+   *
    * @param key - Memory key
    * @param value - Value to store
    * @param options - Storage options
@@ -3039,7 +3044,33 @@ export class AragoraClient {
   }
 
   /**
+   * Store a new entry in continuum memory.
+   *
+   * Matches the server contract for POST /api/v1/memory/store
+   * (`{ content, tier?, importance? }` -> `{ id, tier }`).
+   *
+   * @param content - The memory content to store
+   * @param options - Storage options (tier defaults to 'fast', importance to 0.5)
+   * @returns The stored entry ID and tier
+   */
+  async storeMemoryEntry(content: string, options?: {
+    tier?: 'fast' | 'medium' | 'slow' | 'glacial';
+    importance?: number;
+  }): Promise<{ id: string; tier: string }> {
+    return this.request<{ id: string; tier: string }>('POST', '/api/v1/memory/store', {
+      body: {
+        content,
+        ...options,
+      },
+    });
+  }
+
+  /**
    * Retrieve a value from memory by key.
+   *
+   * @deprecated The server does not implement GET /api/v1/memory/retrieve,
+   * so this method always resolves to `null` (the 404 is swallowed). Use
+   * {@link retrieveFromContinuum} to query continuum memory instead.
    *
    * @param key - Memory key
    * @param options - Retrieval options
@@ -3065,6 +3096,10 @@ export class AragoraClient {
   /**
    * Delete a memory entry.
    *
+   * @deprecated The server does not implement DELETE /api/v1/memory/delete,
+   * so this method always rejects with a 404. Use {@link deleteMemoryEntry}
+   * with the entry ID returned by {@link storeMemoryEntry} instead.
+   *
    * @param key - Memory key
    * @param tier - Optional tier to delete from
    */
@@ -3072,6 +3107,21 @@ export class AragoraClient {
     return this.request<{ deleted: boolean }>('DELETE', '/api/v1/memory/delete', {
       params: { key, tier },
     });
+  }
+
+  /**
+   * Delete a continuum memory entry by ID.
+   *
+   * Matches the server contract for DELETE /api/v1/memory/continuum/{id}
+   * (returns `{ success, message }`; 404 if the entry does not exist).
+   *
+   * @param memoryId - ID of the entry to delete (as returned by storeMemoryEntry)
+   */
+  async deleteMemoryEntry(memoryId: string): Promise<{ success: boolean; message: string }> {
+    return this.request<{ success: boolean; message: string }>(
+      'DELETE',
+      `/api/v1/memory/continuum/${encodeURIComponent(memoryId)}`
+    );
   }
 
   // ===========================================================================
@@ -3282,17 +3332,25 @@ export class AragoraClient {
    *
    * @example
    * ```typescript
-   * const { entries } = await client.retrieveFromContinuum('database optimization', {
+   * const { memories } = await client.retrieveFromContinuum('database optimization', {
    *   tier: 'slow',
    *   limit: 5
    * });
-   * entries.forEach(e => console.log(e.content));
+   * memories.forEach(m => console.log(m.content));
    * ```
    */
-  async retrieveFromContinuum(query: string, options?: ContinuumRetrieveOptions): Promise<{ entries: MemoryEntry[] }> {
-    return this.request<{ entries: MemoryEntry[] }>('GET', '/api/memory/continuum/retrieve', {
-      params: { q: query, ...options },
-    });
+  async retrieveFromContinuum(
+    query: string,
+    options?: ContinuumRetrieveOptions
+  ): Promise<{ memories: MemoryEntry[]; count: number }> {
+    const params: Record<string, unknown> = { query };
+    if (options?.tier) params.tiers = options.tier;
+    if (options?.limit !== undefined) params.limit = options.limit;
+    return this.request<{ memories: MemoryEntry[]; count: number }>(
+      'GET',
+      '/api/memory/continuum/retrieve',
+      { params }
+    );
   }
 
   /**

--- a/sdk/typescript/src/namespaces/__tests__/memory.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/memory.test.ts
@@ -141,30 +141,32 @@ describe('MemoryAPI Namespace', () => {
     });
 
     it('should store a continuum entry', async () => {
-      mockClient.storeMemoryEntry.mockResolvedValue({ id: 'mem-123', tier: 'fast' });
+      mockClient.request.mockResolvedValue({ id: 'mem-123', tier: 'fast' });
 
       const result = await api.storeEntry('User prefers dark theme', {
         tier: 'fast',
         importance: 0.8,
       });
 
-      expect(mockClient.storeMemoryEntry).toHaveBeenCalledWith('User prefers dark theme', {
-        tier: 'fast',
-        importance: 0.8,
+      expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/v1/memory/store', {
+        body: { content: 'User prefers dark theme', tier: 'fast', importance: 0.8 },
       });
       expect(result.id).toBe('mem-123');
       expect(result.tier).toBe('fast');
     });
 
     it('should delete a continuum entry by ID', async () => {
-      mockClient.deleteMemoryEntry.mockResolvedValue({
+      mockClient.request.mockResolvedValue({
         success: true,
         message: 'Memory mem-123 deleted successfully',
       });
 
       const result = await api.deleteEntry('mem-123');
 
-      expect(mockClient.deleteMemoryEntry).toHaveBeenCalledWith('mem-123');
+      expect(mockClient.request).toHaveBeenCalledWith(
+        'DELETE',
+        '/api/v1/memory/continuum/mem-123'
+      );
       expect(result.success).toBe(true);
     });
 

--- a/sdk/typescript/src/namespaces/__tests__/memory.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/memory.test.ts
@@ -20,6 +20,8 @@ interface MockClient {
   storeMemory: Mock;
   retrieveMemory: Mock;
   deleteMemory: Mock;
+  storeMemoryEntry: Mock;
+  deleteMemoryEntry: Mock;
   getMemoryStats: Mock;
   searchMemory: Mock;
   getMemoryTiers: Mock;
@@ -40,6 +42,8 @@ describe('MemoryAPI Namespace', () => {
       storeMemory: vi.fn(),
       retrieveMemory: vi.fn(),
       deleteMemory: vi.fn(),
+      storeMemoryEntry: vi.fn(),
+      deleteMemoryEntry: vi.fn(),
       getMemoryStats: vi.fn(),
       searchMemory: vi.fn(),
       getMemoryTiers: vi.fn(),
@@ -134,6 +138,34 @@ describe('MemoryAPI Namespace', () => {
 
       expect(mockClient.deleteMemory).toHaveBeenCalledWith('key', 'glacial');
       expect(result.deleted).toBe(true);
+    });
+
+    it('should store a continuum entry', async () => {
+      mockClient.storeMemoryEntry.mockResolvedValue({ id: 'mem-123', tier: 'fast' });
+
+      const result = await api.storeEntry('User prefers dark theme', {
+        tier: 'fast',
+        importance: 0.8,
+      });
+
+      expect(mockClient.storeMemoryEntry).toHaveBeenCalledWith('User prefers dark theme', {
+        tier: 'fast',
+        importance: 0.8,
+      });
+      expect(result.id).toBe('mem-123');
+      expect(result.tier).toBe('fast');
+    });
+
+    it('should delete a continuum entry by ID', async () => {
+      mockClient.deleteMemoryEntry.mockResolvedValue({
+        success: true,
+        message: 'Memory mem-123 deleted successfully',
+      });
+
+      const result = await api.deleteEntry('mem-123');
+
+      expect(mockClient.deleteMemoryEntry).toHaveBeenCalledWith('mem-123');
+      expect(result.success).toBe(true);
     });
 
     it('should update an existing memory entry', async () => {
@@ -416,19 +448,21 @@ describe('MemoryAPI Namespace', () => {
 
     it('should retrieve from continuum', async () => {
       mockClient.retrieveFromContinuum.mockResolvedValue({
-        entries: [{ key: 'e1', value: 'context data', tier: 'medium' }],
+        memories: [{ id: 'e1', content: 'context data', tier: 'medium' }],
+        count: 1,
       });
 
       const result = await api.retrieveFromContinuum('context');
 
       expect(mockClient.retrieveFromContinuum).toHaveBeenCalledWith('context', undefined);
-      expect(result.entries).toHaveLength(1);
+      expect(result.memories).toHaveLength(1);
+      expect(result.count).toBe(1);
     });
 
     it('should retrieve continuum with options', async () => {
       mockClient.request.mockResolvedValue({
-        entries: [{ key: 'e1', value: 'data' }],
-        total: 5,
+        memories: [{ id: 'e1', content: 'data' }],
+        count: 5,
       });
 
       const result = await api.retrieveContinuum('user preferences', {

--- a/sdk/typescript/src/namespaces/memory.ts
+++ b/sdk/typescript/src/namespaces/memory.ts
@@ -316,12 +316,17 @@ interface MemoryClientInterface {
     tier?: MemoryTierType;
   }): Promise<{ value: unknown; tier: string; metadata?: Record<string, unknown> } | null>;
   deleteMemory(key: string, tier?: MemoryTierType): Promise<{ deleted: boolean }>;
+  storeMemoryEntry(content: string, options?: {
+    tier?: MemoryTierType;
+    importance?: number;
+  }): Promise<{ id: string; tier: string }>;
+  deleteMemoryEntry(memoryId: string): Promise<{ success: boolean; message: string }>;
   getMemoryStats(): Promise<MemoryStats>;
   searchMemory(params: MemorySearchParams): Promise<{ entries: MemoryEntry[] }>;
   getMemoryTiers(): Promise<{ tiers: MemoryTierStats[] }>;
   getMemoryCritiques(options?: PaginationParams): Promise<{ critiques: CritiqueEntry[] }>;
   storeToContinuum(content: string, options?: ContinuumStoreOptions): Promise<ContinuumStoreResult>;
-  retrieveFromContinuum(query: string, options?: ContinuumRetrieveOptions): Promise<{ entries: MemoryEntry[] }>;
+  retrieveFromContinuum(query: string, options?: ContinuumRetrieveOptions): Promise<{ memories: MemoryEntry[]; count: number }>;
   getContinuumStats(): Promise<MemoryStats>;
   consolidateMemory(): Promise<{ success: boolean }>;
   request<T = unknown>(
@@ -345,10 +350,10 @@ interface MemoryClientInterface {
  * const client = createClient({ baseUrl: 'https://api.aragora.ai' });
  *
  * // Store a memory entry
- * await client.memory.store('user-preference', { theme: 'dark' });
+ * const { id } = await client.memory.storeEntry('User prefers dark theme', { tier: 'fast' });
  *
- * // Retrieve memory
- * const entry = await client.memory.retrieve('user-preference');
+ * // Retrieve memories by query
+ * const { memories } = await client.memory.retrieveContinuum('user preferences');
  *
  * // Search memory
  * const results = await client.memory.search('theme settings');
@@ -362,6 +367,10 @@ export class MemoryAPI {
 
   /**
    * Store a value in memory.
+   *
+   * @deprecated The server does not implement a key/value memory API;
+   * POST /api/v1/memory/store rejects this payload with 400. Use
+   * {@link storeEntry} instead.
    */
   async store(
     key: string,
@@ -377,7 +386,27 @@ export class MemoryAPI {
   }
 
   /**
+   * Store a new memory entry in continuum memory.
+   *
+   * Matches the server contract for POST /api/v1/memory/store
+   * ({ content, tier?, importance? } -> { id, tier }).
+   */
+  async storeEntry(
+    content: string,
+    options?: {
+      tier?: 'fast' | 'medium' | 'slow' | 'glacial';
+      importance?: number;
+    }
+  ): Promise<{ id: string; tier: string }> {
+    return this.client.storeMemoryEntry(content, options);
+  }
+
+  /**
    * Retrieve a value from memory by key.
+   *
+   * @deprecated The server does not implement GET /api/v1/memory/retrieve,
+   * so this always resolves to `null`. Use {@link retrieveContinuum} to
+   * query continuum memory instead.
    */
   async retrieve(
     key: string,
@@ -388,12 +417,26 @@ export class MemoryAPI {
 
   /**
    * Delete a memory entry by key.
+   *
+   * @deprecated The server does not implement DELETE /api/v1/memory/delete,
+   * so this always rejects with a 404. Use {@link deleteEntry} with the
+   * entry ID returned by {@link storeEntry} instead.
    */
   async delete(
     key: string,
     tier?: 'fast' | 'medium' | 'slow' | 'glacial'
   ): Promise<{ deleted: boolean }> {
     return this.client.deleteMemory(key, tier);
+  }
+
+  /**
+   * Delete a continuum memory entry by ID.
+   *
+   * Matches the server contract for DELETE /api/v1/memory/continuum/{id}
+   * ({ success, message }; 404 if the entry does not exist).
+   */
+  async deleteEntry(memoryId: string): Promise<{ success: boolean; message: string }> {
+    return this.client.deleteMemoryEntry(memoryId);
   }
 
   /**
@@ -440,7 +483,7 @@ export class MemoryAPI {
   async retrieveFromContinuum(
     query: string,
     options?: ContinuumRetrieveOptions
-  ): Promise<{ entries: MemoryEntry[] }> {
+  ): Promise<{ memories: MemoryEntry[]; count: number }> {
     return this.client.retrieveFromContinuum(query, options);
   }
 
@@ -687,7 +730,7 @@ export class MemoryAPI {
       limit?: number;
       min_importance?: number;
     }
-  ): Promise<{ entries: MemoryEntry[]; total: number }> {
+  ): Promise<{ memories: MemoryEntry[]; count: number }> {
     const params: Record<string, unknown> = {
       query,
       limit: options?.limit ?? 10,

--- a/sdk/typescript/src/namespaces/memory.ts
+++ b/sdk/typescript/src/namespaces/memory.ts
@@ -398,7 +398,9 @@ export class MemoryAPI {
       importance?: number;
     }
   ): Promise<{ id: string; tier: string }> {
-    return this.client.storeMemoryEntry(content, options);
+    return this.client.request('POST', '/api/v1/memory/store', {
+      body: { content, ...options },
+    });
   }
 
   /**
@@ -436,7 +438,10 @@ export class MemoryAPI {
    * ({ success, message }; 404 if the entry does not exist).
    */
   async deleteEntry(memoryId: string): Promise<{ success: boolean; message: string }> {
-    return this.client.deleteMemoryEntry(memoryId);
+    return this.client.request(
+      'DELETE',
+      `/api/v1/memory/continuum/${encodeURIComponent(memoryId)}`
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

The TS SDK's `storeMemory` / `retrieveMemory` / `deleteMemory` (and the `client.memory.store/retrieve/delete` namespace wrappers) target a key/value memory API the server never implemented:

| SDK method | Wire call | Server reality |
|---|---|---|
| `storeMemory(key, value, opts)` | POST `/api/v1/memory/store` with `{key, value, ...}` | Handler requires `{content, tier?, importance?}` → **400 "Missing required field: content"**; returns `{id, tier}`, not the declared `{stored, tier}` |
| `retrieveMemory(key)` | GET `/api/v1/memory/retrieve` | **Route does not exist** (only `/api/v1/memory/continuum/retrieve` does); the method swallows the 404 and **silently resolves to `null` on every call** |
| `deleteMemory(key, tier)` | DELETE `/api/v1/memory/delete` | **Route does not exist** (only `/api/v1/memory/continuum/{id}`); always rejects 404 |

None of these can ever have worked against this server, so there are no functioning callers to preserve.

## Decision: deprecate in place, add contract-correct parallels

Chosen over an in-place signature rewrite because the operating contract treats SDK signature changes/removals as an operator-review, never-auto-merge class — and because open PR #9365 already started down the parallel-method path with `storeEntry`. This PR is **additive**: no existing signature changes.

- `@deprecated` JSDoc on the three client methods + three namespace wrappers, each explaining the actual server contract and pointing at the replacement
- **New** `client.storeMemoryEntry(content, {tier?, importance?}) → {id, tier}` and namespace `memory.storeEntry(...)` — same public signature as #9365's parallel method, but delegating through the client for testability; the Python `MemoryAPI.store()` hunk matches #9365 verbatim, so the rebase either way is trivial
- **New** `client.deleteMemoryEntry(id) → {success, message}` / `memory.deleteEntry(id)` → DELETE `/api/v1/memory/continuum/{id}`
- **Bug fix** on the retrieve replacement: `retrieveFromContinuum` sent `q`/`tier` where the handler reads `query`/`tiers` (filters were silently ignored), and declared `{entries}` where the server returns `{memories, count}`. Params fixed; declared type now truthful (`retrieveContinuum` namespace type likewise). Note: this return-*type* correction changes no runtime behavior — the old type was unconditionally false — but flagging it for review since it can surface compile errors in downstream code that was already broken at runtime.
- Python SDK: matching `store()` + `delete_entry()` on sync and async `MemoryAPI`

## Relationship to PR #9365

#9365 adds namespace-level `storeEntry` (TS) and sync-only `store()` (Python) as a side item of its OpenAPI phantom-verb fix. This PR supersedes those two hunks with identical public signatures plus the retrieve/delete halves; whichever merges second has a trivial conflict.

## Verification

- `tsc` 6.0.3 `--noEmit`: clean
- `eslint src`: 0 errors (pre-existing `no-explicit-any` warnings untouched)
- `vitest`: 1717/1717 across 83 files (new tests for `storeMemoryEntry`/`deleteMemoryEntry`/`storeEntry`/`deleteEntry` wire contracts)
- `sdk/python` pytest: 26/26 (new sync+async `store`/`delete_entry` tests); mypy 2.1.0 clean
- `check_sdk_parity.py --strict --allow-missing`, `check_cross_sdk_parity.py`, `check_sdk_namespace_parity.py`: all PASS, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)