### PR TITLE
fix(sdk-gate): intake cross-merge drift entry from #9366 x #9362 (main-red hotfix)

### DIFF
--- a/scripts/baselines/contract_drift_inventory.json
+++ b/scripts/baselines/contract_drift_inventory.json
@@ -389,6 +389,14 @@
     {
       "class": "discovered",
       "discovered_on": "2026-07-16",
+      "id": "python_sdk_drift:DELETE /api/memory/continuum/{param}",
+      "provenance": "cross-merge intake: #9366 delete_entry() call site made visible by #9362 extractor fix",
+      "source": "python_sdk_drift",
+      "status": "open"
+    },
+    {
+      "class": "discovered",
+      "discovered_on": "2026-07-16",
       "id": "python_sdk_drift:DELETE /api/memory/critiques",
       "provenance": "python extractor blindness fix (#9362)",
       "source": "python_sdk_drift",

--- a/scripts/baselines/verify_sdk_contracts.json
+++ b/scripts/baselines/verify_sdk_contracts.json
@@ -20,6 +20,7 @@
     "DELETE /api/keys/{param}",
     "DELETE /api/knowledge/mound/federation/regions/{param}",
     "DELETE /api/media/audio/{param}",
+    "DELETE /api/memory/continuum/{param}",
     "DELETE /api/memory/critiques",
     "DELETE /api/memory/pressure",
     "DELETE /api/memory/search",


### PR DESCRIPTION
## Summary

Main went red on the required `Generate & Validate` check at c8762f925c (#9362's merge commit): [#9366](https://github.com/synaptent/aragora/pull/9366) and [#9362](https://github.com/synaptent/aragora/pull/9362) were each green in isolation but semantically conflict — #9366's new `self._client.request("DELETE", f"/api/v1/memory/continuum/{memory_id}")` call site is only visible through #9362's un-blinded extractor, producing 1 NEW `python_sdk_drift` entry vs baseline. `Main Required Checks Auto Revert` is armed against the merge commit (reverting failed only due to the workflow's missing git identity — separate bug).

Fix-forward per the #9352 explained-intake path: baseline +1 (`DELETE /api/memory/continuum/{param}`) + inventory item (`class=discovered`, provenance referencing #9366/#9362).

## Test plan
- [x] `python scripts/verify_sdk_contracts.py --strict` → PASS
- [x] `python scripts/generate_contract_drift_inventory.py --check` → in sync (1048 open)
- [x] `pytest tests/sdk/test_openapi_sync.py tests/scripts/test_verify_sdk_contracts.py tests/scripts/test_check_contract_drift_ratchet.py` → 63 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)