### PR TITLE
fix(ci): set git identity before auto-revert (empty ident failure)

### DIFF
--- a/.github/workflows/main-required-checks-auto-revert.yml
+++ b/.github/workflows/main-required-checks-auto-revert.yml
@@ -65,6 +65,12 @@ jobs:
             exit 1
           fi
 
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Evaluate and revert failed required checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/auto_revert_main_required_failures.py
+++ b/scripts/auto_revert_main_required_failures.py
@@ -188,6 +188,27 @@ def _run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, cwd=cwd, text=True, capture_output=True, check=False)
 
 
+GIT_BOT_NAME = "github-actions[bot]"
+GIT_BOT_EMAIL = "41898282+github-actions[bot]@users.noreply.github.com"
+
+
+def ensure_git_identity(repo_path: Path) -> tuple[bool, str]:
+    """Ensure a git author identity exists so revert/amend commits succeed.
+
+    CI runners often have no git identity configured; without one, ``git
+    revert`` fails with "Author identity unknown / empty ident name". An
+    already-configured identity (local or global) is left untouched.
+    """
+    for key, value in (("user.name", GIT_BOT_NAME), ("user.email", GIT_BOT_EMAIL)):
+        check_proc = _run(["git", "config", key], cwd=repo_path)
+        if check_proc.returncode == 0 and check_proc.stdout.strip():
+            continue
+        set_proc = _run(["git", "config", key, value], cwd=repo_path)
+        if set_proc.returncode != 0:
+            return False, set_proc.stderr.strip() or f"failed to set git {key}"
+    return True, "ok"
+
+
 def _append_markers_to_last_commit(repo_path: Path) -> tuple[bool, str]:
     body_proc = _run(["git", "log", "-1", "--pretty=%B"], cwd=repo_path)
     if body_proc.returncode != 0:
@@ -204,6 +225,10 @@ def _append_markers_to_last_commit(repo_path: Path) -> tuple[bool, str]:
 
 
 def perform_revert(repo_path: Path, *, target_sha: str, base_branch: str) -> tuple[bool, str]:
+    identity_ok, identity_msg = ensure_git_identity(repo_path)
+    if not identity_ok:
+        return False, identity_msg
+
     fetch_proc = _run(["git", "fetch", "origin", base_branch], cwd=repo_path)
     if fetch_proc.returncode != 0:
         return False, fetch_proc.stderr.strip() or "git fetch failed"

--- a/tests/scripts/test_auto_revert_main_required_failures.py
+++ b/tests/scripts/test_auto_revert_main_required_failures.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import scripts.auto_revert_main_required_failures as auto_revert
 from scripts.auto_revert_main_required_failures import (
+    ensure_git_identity,
     evaluate_required_contexts,
     select_latest_check_runs,
     should_skip_commit_message,
@@ -51,3 +58,59 @@ def test_should_skip_commit_message_for_reverts_and_marked_commits() -> None:
     assert should_skip_commit_message('Revert "feat: add thing"') is True
     assert should_skip_commit_message("fix: x\n\n[auto-revert-required-checks]") is True
     assert should_skip_commit_message("feat: normal commit") is False
+
+
+def _completed(cmd: list[str], returncode: int, stdout: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+
+def test_ensure_git_identity_sets_bot_identity_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        if len(cmd) == 3:  # read: git config <key> — unset on CI runners
+            return _completed(cmd, 1)
+        return _completed(cmd, 0)
+
+    monkeypatch.setattr(auto_revert, "_run", fake_run)
+
+    ok, msg = ensure_git_identity(tmp_path)
+
+    assert ok is True
+    assert msg == "ok"
+    assert ["git", "config", "user.name", auto_revert.GIT_BOT_NAME] in calls
+    assert ["git", "config", "user.email", auto_revert.GIT_BOT_EMAIL] in calls
+
+
+def test_ensure_git_identity_preserves_existing_identity(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
+        calls.append(cmd)
+        return _completed(cmd, 0, stdout="Existing User\n")
+
+    monkeypatch.setattr(auto_revert, "_run", fake_run)
+
+    ok, _ = ensure_git_identity(tmp_path)
+
+    assert ok is True
+    assert all(len(cmd) == 3 for cmd in calls)  # reads only, no writes
+
+
+def test_ensure_git_identity_reports_failure_to_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    def fake_run(cmd: list[str], cwd: Path) -> subprocess.CompletedProcess:
+        return _completed(cmd, 1)
+
+    monkeypatch.setattr(auto_revert, "_run", fake_run)
+
+    ok, msg = ensure_git_identity(tmp_path)
+
+    assert ok is False
+    assert "user.name" in msg


### PR DESCRIPTION
## Summary
The **Main Required Checks Auto Revert** workflow decides to revert but then dies with `Auto-revert failed: Author identity unknown / fatal: empty ident name (for <runner@...>) not allowed` — the runner never gets a git `user.name`/`user.email` before `git revert` runs. Example failing runs: [29547108569](https://github.com/synaptent/aragora/actions/runs/29547108569) and [29547051848](https://github.com/synaptent/aragora/actions/runs/29547051848) (target_sha `c8762f925c`).

## Changes
- **`.github/workflows/main-required-checks-auto-revert.yml`**: new `Configure git identity` step (static strings, no untrusted input) setting `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` before the evaluate/revert step.
- **`scripts/auto_revert_main_required_failures.py`**: `ensure_git_identity()` called at the top of `perform_revert()` as a defensive fallback — covers both `git revert` and the follow-up `git commit --amend` (marker append), and protects any other caller/environment. An already-configured identity (local or global) is left untouched.
- **`tests/scripts/test_auto_revert_main_required_failures.py`**: 3 new unit tests — sets bot identity when missing, preserves existing identity, reports failure to set.

## Validation
- `pytest tests/scripts/test_auto_revert_main_required_failures.py` — 6/6 pass
- `actionlint` on the workflow — clean
- `ruff check` on changed Python files — clean
- Temp-repo simulation with no git identity (`GIT_CONFIG_GLOBAL=/dev/null`): after `ensure_git_identity()`, revert commits are authored as `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>`
- Pre-existing mypy warning at line 51 (`request.addinfourl`) is identical on `origin/main` — not introduced here
- Post-merge live check: `gh workflow run main-required-checks-auto-revert.yml -f sha=<sha> -f dry_run=true` exercises the full path without reverting/pushing

## Notes
Touches CI/revert automation (per `docs/AGENT_OPERATING_CONTRACT.md`) — opened as a PR for review, no direct push to main. Both changes are additive; no existing behavior changes when an identity is already configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)