### PR TITLE
docs: record decoupled SDK release cadence (#9234) + cold-run/dim-4 deferral decisions

### DIFF
--- a/docs-site/docs/guides/sdk.md
+++ b/docs-site/docs/guides/sdk.md
@@ -25,6 +25,17 @@ Canonical migration path: [Python SDK migration](./python-sdk-migration).
 pip install aragora-sdk
 ```
 
+### Release cadence (recorded operator policy, 2026-07-16)
+
+`aragora-sdk` on PyPI follows a **decoupled release cadence**: the repository's
+`sdk/python/` may be ahead of the latest published wheel between releases
+(e.g. the repo can declare 2.9.0 while PyPI serves 2.8.0). This is intentional —
+releases are operator-gated and cut deliberately, not on every merge.
+Compatibility expectation: the published PyPI version always targets the
+`/api/v1` surface of the same or newer server release, and published versions
+never regress. If you need repo-tip SDK behavior before it is published,
+install from source (below). Tracking issue for this policy: #9234.
+
 Or install the full control plane package (includes the SDK and server):
 
 ```bash

--- a/docs/SDK_GUIDE.md
+++ b/docs/SDK_GUIDE.md
@@ -20,6 +20,17 @@ Canonical migration path: [Python SDK migration](./guides/PYTHON_SDK_MIGRATION.m
 pip install aragora-sdk
 ```
 
+### Release cadence (recorded operator policy, 2026-07-16)
+
+`aragora-sdk` on PyPI follows a **decoupled release cadence**: the repository's
+`sdk/python/` may be ahead of the latest published wheel between releases
+(e.g. the repo can declare 2.9.0 while PyPI serves 2.8.0). This is intentional —
+releases are operator-gated and cut deliberately, not on every merge.
+Compatibility expectation: the published PyPI version always targets the
+`/api/v1` surface of the same or newer server release, and published versions
+never regress. If you need repo-tip SDK behavior before it is published,
+install from source (below). Tracking issue for this policy: #9234.
+
 Or install the full control plane package (includes the SDK and server):
 
 ```bash

--- a/docs/SDK_QUICKSTART_PYTHON.md
+++ b/docs/SDK_QUICKSTART_PYTHON.md
@@ -12,6 +12,11 @@ Get started with Aragora in under 5 minutes.
 pip install aragora-sdk
 ```
 
+> **Version note:** PyPI releases are cut deliberately and may trail the
+> repository (decoupled cadence, recorded in #9234 — see
+> [SDK_GUIDE.md](SDK_GUIDE.md#release-cadence-recorded-operator-policy-2026-07-16)).
+> Install from source if you need repo-tip behavior.
+
 ## Basic Usage
 
 ```python

--- a/docs/status/QUALITY_BAR.md
+++ b/docs/status/QUALITY_BAR.md
@@ -36,6 +36,18 @@ closest available human proxy, strictly better evidence than an agent sim, and
 the natural authority on whether the experience is good enough to spend a
 stranger on. Rung 1's artifact lands in `docs/artifacts/` like any other run.
 
+**Recorded deferrals (operator decision, 2026-07-16):** production
+(api.aragora.ai) is offline pending an AWS billing resolution. Consequently:
+(1) the **Jul 22 founder cold-run executes the offline bounded path only**
+(`pip install` → `aragora demo --offline --receipt` → `aragora receipt verify`)
+— this still satisfies rung 1, whose gate for the Jul 30 decision is "zero
+blocking failures on the bounded path"; (2) the **dimension-4 instrument
+(fresh production receipt) and the W1 founder-MFA prod receipt are deferred**
+with the blocking failure named: AWS account suspension (billing). Per the
+ladder's own rule this deferral is re-reviewed at every weekly digest — never
+silently, never indefinitely. Restoration plan and cost diagnosis are tracked
+in the AWS billing support case (operator-side) and the Jul 16 run log.
+
 **Kill-switch integrity:** simulated runs (rung 0) and founder cold-runs
 (rung 1) are *internal* evidence. They never satisfy the 30-day plan's
 "external artifacts ≥1 per 14 days" metric. Only genuinely external artifacts


### PR DESCRIPTION
## What

Operator decisions recorded on 2026-07-16 (chat instruction):

1. **#9234 — option 2 chosen:** `aragora-sdk` follows a decoupled PyPI release cadence. Public install guidance (SDK_GUIDE.md, SDK_QUICKSTART_PYTHON.md) now states the policy and the compatibility expectation (published versions target `/api/v1` of same-or-newer server, never regress; install from source for repo-tip).
2. **Quality-bar recorded deferrals:** the Jul 22 founder cold-run executes the offline bounded path only, and the dim-4 fresh-production-receipt instrument + W1 founder-MFA prod receipt are deferred with the blocking failure named (AWS account suspension, billing) — re-reviewed at every weekly digest per the ladder's own rule.

Refs #9234. Tier 0 (docs/status only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)