### PR TITLE
polish(m-stranger): fix cold-run frictions (#9185 #9186 #9187 #9188)

### DIFF
--- a/aragora-verify/CHANGELOG.md
+++ b/aragora-verify/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `aragora-verify` are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/) and the project uses semantic
 versioning.
 
+## [Unreleased]
+
+### Changed
+- Feeding a **native** Aragora receipt (what `aragora demo --receipt` /
+  `aragora receipt` write) still FAILs schema conformance, but the failure now
+  names the format mistake and the exact bridge command
+  (`aragora receipt export <file> --format odr -o receipt.odr.json`) instead of
+  only listing twelve missing ODR members (issue #9185). Exit codes are
+  unchanged.
+
 ## [0.1.1] — 2026-07-04 (03:28 UTC)
 
 ### Fixed

--- a/aragora-verify/src/aragora_verify/verifier.py
+++ b/aragora-verify/src/aragora_verify/verifier.py
@@ -374,6 +374,27 @@ def _weakening_warnings(doc: dict[str, Any]) -> list[str]:
     return warnings
 
 
+def _looks_like_native_receipt(doc: Any) -> bool:
+    """Heuristic: is ``doc`` a native Aragora ``DecisionReceipt`` rather than an
+    ODR document? ``aragora demo --receipt`` / ``aragora receipt`` write the
+    native format, and strangers feed it to this verifier directly (issue
+    #9185); an ODR document always carries ``odr_version``, while the native
+    format carries its own distinctive members."""
+    if not isinstance(doc, dict) or "odr_version" in doc:
+        return False
+    if not doc.get("receipt_id"):
+        return False
+    native_markers = ("artifact_hash", "gauntlet_id", "schema_version", "verdict")
+    return any(marker in doc for marker in native_markers)
+
+
+_NATIVE_RECEIPT_HINT = (
+    "input looks like a native Aragora receipt, not an ODR document -- convert "
+    "it first: aragora receipt export <file> --format odr -o receipt.odr.json, "
+    "then re-run aragora-verify on receipt.odr.json"
+)
+
+
 # ---------------------------------------------------------------------------
 # Top-level entry point
 # ---------------------------------------------------------------------------
@@ -393,7 +414,12 @@ def verify(
 
     structure_errors = validate_structure(doc)
     if structure_errors:
-        checks.append(Check("schema_conformance", FAIL, "; ".join(structure_errors[:12])))
+        detail = "; ".join(structure_errors[:12])
+        if _looks_like_native_receipt(doc):
+            # Name the actual mistake and the exact bridge command instead of
+            # dumping 12 opaque schema errors on the stranger (issue #9185).
+            detail = f"{detail} | {_NATIVE_RECEIPT_HINT}"
+        checks.append(Check("schema_conformance", FAIL, detail))
         # A structurally invalid receipt cannot be digested/verified meaningfully.
         return VerifyResult(
             ok=False, receipt_id=receipt_id, odr_digest="", checks=checks, warnings=[]

--- a/aragora-verify/tests/test_verifier.py
+++ b/aragora-verify/tests/test_verifier.py
@@ -49,6 +49,42 @@ def test_routing_must_be_reserved() -> None:
     assert result.ok is False
 
 
+def test_native_aragora_receipt_fails_with_export_hint() -> None:
+    """A native DecisionReceipt (what ``aragora demo --receipt`` writes) must
+    still FAIL, but the failure names the format mistake and the exact
+    ``aragora receipt export --format odr`` bridge command (issue #9185)."""
+    native = {
+        "receipt_id": "DR-MOCK-BCDFC27A",
+        "schema_version": "1.0",
+        "verdict": "consensus",
+        "artifact_hash": "e4a05033dc61c808",
+        "question": "Should we adopt microservices?",
+    }
+    result = verify(native)
+    assert result.ok is False
+    detail = _check(result, "schema_conformance").detail
+    assert "missing required member: odr_version" in detail
+    assert "native Aragora receipt" in detail
+    assert "aragora receipt export <file> --format odr" in detail
+
+
+def test_non_native_schema_failure_gets_no_native_hint() -> None:
+    """Arbitrary invalid JSON (not recognizably a native receipt) keeps the
+    plain schema errors -- no misleading export suggestion."""
+    result = verify({"receipt_id": "DR-X"})
+    assert result.ok is False
+    assert "native Aragora receipt" not in _check(result, "schema_conformance").detail
+
+
+def test_odr_document_with_schema_errors_gets_no_native_hint() -> None:
+    """A real ODR document with a defect is not misdiagnosed as native."""
+    doc = valid_odr()
+    del doc["claim"]
+    result = verify(doc)
+    assert result.ok is False
+    assert "native Aragora receipt" not in _check(result, "schema_conformance").detail
+
+
 # --- signatures ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Lane over the four stranger-sim MAJOR issues feeding the Jul 22 founder cold-run (offline path only: `pip install` → `aragora demo --offline --receipt` → `aragora receipt verify`). Triage against current main found three of the four already resolved by merged PRs; this PR lands the one remaining actionable friction.

### Per-issue disposition

| Issue | Disposition |
|---|---|
| #9185 | **Partially fixed here.** The README/quickstart half (missing `receipt export --format odr` bridge) already landed on main and passes end to end (reproduced locally: demo → `receipt verify` → `receipt export --format odr` → `aragora-verify` → VERIFIED, exit 0). The remaining friction — `aragora-verify` on a **native** receipt dumps 12 opaque schema errors with no guidance — is fixed here (issue's fix option 3). Refs #9185 (in-repo friction resolved; the issue's own reclassification receipt already recommends stale/disproven for the headline claim). |
| #9186 | **Already fixed on main** — export-by-file-path README example merged in #9212; the MINOR (`aragora receipt --help` omitting `odr`) is also already fixed on main (`export <file> --format X  Convert between html, md, json, sarif, pdf, csv, odr`). Nothing left to change. Refs #9186. |
| #9187 | **Already fixed on main** — PyPI quickstart long-description merged in #9197 (2026-07-16). The live PyPI page updates on the next release; that release op is outside this lane. Refs #9187. |
| #9188 | **Needs prod** — route carrier #8809 is merged, but the deployed API (release 2.0.3) predates it and the Ed25519 production key must be provisioned via the founder AWS Secrets Manager path. Production is currently down (Jul 16 outage); nothing actionable from a code lane. Refs #9188. |

### The change

`aragora-verify` fed the native receipt that `aragora demo --offline --receipt` writes now FAILs with a diagnosis instead of a wall of schema errors:

```
[FAIL] schema_conformance: missing required member: odr_version; … | input looks like a
native Aragora receipt, not an ODR document -- convert it first:
aragora receipt export <file> --format odr -o receipt.odr.json, then re-run aragora-verify
```

- Exit codes unchanged (still 1); no verification semantics change — text-only diagnosis on an already-failing check.
- Detection is conservative: dict without `odr_version` carrying `receipt_id` + a native marker (`artifact_hash` / `gauntlet_id` / `schema_version` / `verdict`). Defective real ODR documents keep the plain errors (covered by test).
- Ships in the standalone `aragora-verify` package; reaches PyPI strangers at the next 0.1.x release (CHANGELOG `Unreleased` entry added).

### Testing

- `aragora-verify` suite: **95 passed**
- `tests/gauntlet/test_odr_verify_cross_verifier_parity.py` + `tests/cli/test_offline_golden_path.py` (Offline Demo Smoke's test file): **22 passed**
- Live cold-run reproduced from this branch: demo → verify → export → `aragora-verify` all pass; native-receipt misuse now prints the bridge command (exit 1 preserved).

No workflow, CLAUDE.md, or SDK surface touched. Draft only — not for self-merge.

Refs #9185, Refs #9186, Refs #9187, Refs #9188

🤖 Generated with [Claude Code](https://claude.com/claude-code)