### PR TITLE
fix(cli): demo --receipt writes one receipt file and the banner names it

### DIFF
--- a/aragora/cli/demo.py
+++ b/aragora/cli/demo.py
@@ -382,7 +382,8 @@ def _print_receipt_summary(result: DebateResult, elapsed: float, receipt_file: s
         short_hash = artifact_hash[:12] + "..." if len(artifact_hash) > 12 else artifact_hash
         print(f"  Hash:         sha256:{short_hash}")
     print()
-    print(f"  Full receipt saved to: ./{receipt_file}")
+    display_path = receipt_file if Path(receipt_file).is_absolute() else f"./{receipt_file}"
+    print(f"  Full receipt saved to: {display_path}")
     print("=" * 64)
     print()
 
@@ -598,15 +599,24 @@ def _build_builtin_demo_result(topic: str) -> Any:
     )
 
 
-async def _run_demo_debate(topic: str) -> tuple[DebateResult, float]:
-    """Run a demo debate and return (result, elapsed_seconds)."""
+async def _run_demo_debate(
+    topic: str,
+    receipt_path: str | None = None,
+) -> tuple[DebateResult, float]:
+    """Run a demo debate and return (result, elapsed_seconds).
+
+    The receipt is written once, to ``receipt_path`` when provided (e.g. via
+    ``--receipt``), otherwise to ``aragora-demo-receipt.json`` in the CWD. The
+    receipt summary banner names whichever file was written.
+    """
+    receipt_target = receipt_path or "aragora-demo-receipt.json"
     if not HAS_ARAGORA_DEBATE or StyledMockAgent is None or Arena is None or DebateConfig is None:
         agent_names = [name for name, _ in _AGENT_CONFIGS]
         _print_banner(topic, agent_names)
         result = _build_builtin_demo_result(topic)
         elapsed = 0.0
         _print_result(result, elapsed)
-        receipt_file = _save_demo_receipt(result, elapsed, "aragora-demo-receipt.json")
+        receipt_file = _save_demo_receipt(result, elapsed, receipt_target)
         _print_receipt_summary(result, elapsed, receipt_file)
         return cast(Any, result), elapsed
 
@@ -692,8 +702,8 @@ async def _run_demo_debate(topic: str) -> tuple[DebateResult, float]:
 
     _print_result(result, elapsed)
 
-    # Auto-save receipt JSON to CWD
-    receipt_file = _save_demo_receipt(result, elapsed, "aragora-demo-receipt.json")
+    # Save the receipt once: --receipt path if given, else default in CWD
+    receipt_file = _save_demo_receipt(result, elapsed, receipt_target)
     _print_receipt_summary(result, elapsed, receipt_file)
 
     return result, elapsed
@@ -867,23 +877,18 @@ def _save_live_demo_receipt(
 
 def _run_mock_demo(args: argparse.Namespace) -> None:
     """Run the offline mock demo using aragora-debate package or builtin."""
+    receipt_path = getattr(args, "receipt", None)
     if not HAS_ARAGORA_DEBATE:
         topic = getattr(args, "topic", None) or DEMO_TASKS.get(
             getattr(args, "name", None) or _DEFAULT_DEMO, {}
         ).get("topic", "Should we adopt microservices?")
-        result, elapsed = asyncio.run(_run_demo_debate(topic))
-        receipt_path = getattr(args, "receipt", None)
-        if receipt_path:
-            _save_demo_receipt(result, elapsed, receipt_path)
+        asyncio.run(_run_demo_debate(topic, receipt_path=receipt_path))
         return
 
     # Use existing aragora-debate based logic
-    receipt_path = getattr(args, "receipt", None)
     custom_topic = getattr(args, "topic", None)
     if custom_topic:
-        result, elapsed = asyncio.run(_run_demo_debate(custom_topic))
-        if receipt_path:
-            _save_demo_receipt(result, elapsed, receipt_path)
+        asyncio.run(_run_demo_debate(custom_topic, receipt_path=receipt_path))
         return
 
     demo_name = getattr(args, "name", None) or _DEFAULT_DEMO
@@ -911,11 +916,7 @@ def run_demo(
         return None
 
     topic = DEMO_TASKS[demo_name]["topic"]
-    result, elapsed = asyncio.run(_run_demo_debate(topic))
-
-    if receipt_path:
-        saved = _save_demo_receipt(result, elapsed, receipt_path)
-        print(f"\n  Receipt saved to: {saved}")
+    result, _elapsed = asyncio.run(_run_demo_debate(topic, receipt_path=receipt_path))
 
     return result
 

--- a/tests/cli/test_demo_command.py
+++ b/tests/cli/test_demo_command.py
@@ -510,6 +510,94 @@ class TestOfflineMockFallback:
         assert "DECISION RECEIPT" in captured.out
 
 
+class TestReceiptSingleWrite:
+    """A --receipt run writes exactly one receipt file and the banner names it.
+
+    Regression for the dual-write bug: ``_run_demo_debate`` always wrote
+    ``aragora-demo-receipt.json`` (and the banner pointed at it) while the
+    user's ``--receipt`` path was written silently as a second file.
+    """
+
+    def test_builtin_fallback_receipt_flag_writes_only_requested_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(name="microservices", topic=None, receipt="r.json")
+
+        with patch("aragora.cli.demo.HAS_ARAGORA_DEBATE", False):
+            _run_mock_demo(args)
+
+        assert (tmp_path / "r.json").exists()
+        assert not (tmp_path / "aragora-demo-receipt.json").exists()
+        captured = capsys.readouterr()
+        assert "Full receipt saved to: ./r.json" in captured.out
+
+    def test_custom_topic_receipt_flag_writes_only_requested_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(name=None, topic="Should we use Kubernetes?", receipt="r.json")
+
+        _run_mock_demo(args)
+
+        assert (tmp_path / "r.json").exists()
+        assert not (tmp_path / "aragora-demo-receipt.json").exists()
+        captured = capsys.readouterr()
+        assert "Full receipt saved to: ./r.json" in captured.out
+
+    def test_named_demo_receipt_flag_writes_only_requested_file(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(name="microservices", topic=None, receipt="r.json")
+
+        _run_mock_demo(args)
+
+        assert (tmp_path / "r.json").exists()
+        assert not (tmp_path / "aragora-demo-receipt.json").exists()
+        captured = capsys.readouterr()
+        assert "Full receipt saved to: ./r.json" in captured.out
+
+    def test_absolute_receipt_path_named_without_dot_slash_prefix(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        receipt_path = tmp_path / "sub" / "r.json"
+        receipt_path.parent.mkdir()
+        args = argparse.Namespace(name="microservices", topic=None, receipt=str(receipt_path))
+
+        _run_mock_demo(args)
+
+        assert receipt_path.exists()
+        assert not (tmp_path / "aragora-demo-receipt.json").exists()
+        captured = capsys.readouterr()
+        assert f"Full receipt saved to: {receipt_path}" in captured.out
+        assert f"./{receipt_path}" not in captured.out
+
+    def test_no_receipt_flag_keeps_default_file(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(name="microservices", topic=None, receipt=None)
+
+        _run_mock_demo(args)
+
+        assert (tmp_path / "aragora-demo-receipt.json").exists()
+        captured = capsys.readouterr()
+        assert "Full receipt saved to: ./aragora-demo-receipt.json" in captured.out
+
+    def test_requested_receipt_verifies(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(name="microservices", topic=None, receipt="r.json")
+
+        _run_mock_demo(args)
+        capsys.readouterr()  # drain demo output
+
+        saved = json.loads((tmp_path / "r.json").read_text())
+        assert saved.get("artifact_hash")
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_receipt_verify(argparse.Namespace(receipt="r.json", verbose=False))
+        assert exc_info.value.code == 0
+
+
 class TestServerDemoHelper:
     def test_run_server_demo_uses_serve_demo_flag(self, capsys):
         from aragora.cli import demo as demo_module

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -15,6 +15,23 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _restore_aragora_offline_env():
+    """cmd_ask demo mode sets ARAGORA_OFFLINE=1 in os.environ as a product side
+    effect. monkeypatch.delenv of an absent var registers nothing to undo, so
+    without this the leaked value poisons later tests on the same xdist worker
+    (run_debate silently goes offline -> learn=False -> CritiqueStore skipped).
+    """
+    import os
+
+    prev = os.environ.get("ARAGORA_OFFLINE")
+    yield
+    if prev is None:
+        os.environ.pop("ARAGORA_OFFLINE", None)
+    else:
+        os.environ["ARAGORA_OFFLINE"] = prev
+
+
+@pytest.fixture(autouse=True)
 def _stub_cmd_ask_global_side_effects(request):
     """Keep cmd_ask tests hermetic unless a test explicitly exercises cleanup semantics."""
     from aragora.cli.commands import debate as debate_cmd


### PR DESCRIPTION
## Problem

`aragora demo --offline --receipt r.json` dual-wrote receipts confusingly:

- `_run_demo_debate()` always saved `aragora-demo-receipt.json` and the DECISION RECEIPT banner printed "Full receipt saved to: ./aragora-demo-receipt.json"
- `_run_mock_demo()` (and `run_demo()`) then additionally wrote the user's `--receipt` path silently, producing two receipt files with divergent timestamps for one run
- Result: a user passing `--receipt r.json` saw a banner pointing at a different file

## Fix

Pass the requested receipt path down into `_run_demo_debate()`:

- exactly one receipt file is written per run — the `--receipt` path when given, else the default `aragora-demo-receipt.json`
- the banner names the file actually written
- absolute `--receipt` paths are displayed as-is instead of with a bogus `./` prefix

## Tests

New `TestReceiptSingleWrite` class in `tests/cli/test_demo_command.py` covering: builtin-fallback branch (`HAS_ARAGORA_DEBATE=False`), custom-topic branch, named-demo branch, absolute-path display, default-file behavior with no flag, and `aragora receipt verify` round-trip of the requested file. Verified end-to-end via the real CLI (single file written, banner correct, receipt verifies VALID 3/3).

Pre-existing, unrelated: `tests/cli/test_cli_main.py::TestRunDebate` fails when run after `test_offline_golden_path.py` on a clean tree too (cross-file pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)