### PR TITLE
test(server): isolate entrypoint runtime environment

### DIFF
--- a/tests/server/test_server_entrypoint.py
+++ b/tests/server/test_server_entrypoint.py
@@ -3,10 +3,31 @@ from __future__ import annotations
 import logging
 import os
 
+import pytest
+
 from aragora.server.__main__ import (
     LOCAL_DEMO_HANDLER_TIERS,
     _configure_runtime_environment,
 )
+
+
+_RUNTIME_ENV_KEYS = (
+    "ARAGORA_OFFLINE",
+    "ARAGORA_DEMO_MODE",
+    "ARAGORA_DB_BACKEND",
+    "ARAGORA_ENV",
+    "ARAGORA_HANDLER_TIERS",
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_runtime_environment():
+    """Keep runtime defaults set by one entrypoint test out of later tests."""
+    original = {key: os.environ[key] for key in _RUNTIME_ENV_KEYS if key in os.environ}
+    yield
+    for key in _RUNTIME_ENV_KEYS:
+        os.environ.pop(key, None)
+    os.environ.update(original)
 
 
 def test_offline_mode_keeps_optional_handlers(monkeypatch):


### PR DESCRIPTION
## Summary
- restore all runtime variables mutated by server entrypoint tests after each test
- prevent `ARAGORA_DEMO_MODE=true` from leaking into later worker-local initialization tests
- keep the fix scoped to the polluting test module

## Root cause
`test_explicit_handler_tiers_are_not_overwritten` exercised the offline defaults while monkeypatching only `ARAGORA_HANDLER_TIERS`. `_configure_runtime_environment` also set `ARAGORA_DEMO_MODE`, so that untracked value survived fixture teardown and activated demo seeding in a later class-spec mock.

## Validation
- polluter then victim: 2 passed
- victim then polluter: 2 passed
- `tests/server/test_server_entrypoint.py tests/server/test_initialization_root.py`: 48 passed
- ruff check and format check: passed
- automation PR preflight: passed
- `make ci-required`: ruff passed; stopped at the existing repository-wide mypy baseline (1,983 errors in 537 production files)

Fixes #9383