### PR TITLE
feat(drift): add route burn-down playbook and work packets

### DIFF
--- a/docs/runbooks/ROUTE_BURNDOWN_PLAYBOOK.md
+++ b/docs/runbooks/ROUTE_BURNDOWN_PLAYBOOK.md
@@ -1,0 +1,151 @@
+# Route Burn-Down Playbook
+
+This playbook is the mechanical disposition standard for the contract-drift
+program anchored at [issue #9378](https://github.com/synaptent/aragora/issues/9378).
+The canonical work list is
+`scripts/baselines/contract_drift_inventory.json`; generated packet membership
+is never hand-edited.
+
+## Preconditions
+
+1. Start from current `origin/main` in an isolated worktree.
+2. Read operator steering, claim the issue or PR lane, and acquire a work lease
+   for the exact files before editing.
+3. Confirm the inventory is internally consistent:
+
+   ```bash
+   python scripts/generate_contract_drift_inventory.py --check
+   ```
+
+4. Generate a fresh packet snapshot into an empty temporary directory:
+
+   ```bash
+   python scripts/route_burndown_batches.py \
+     --output-dir /tmp/aragora-route-burndown \
+     --batch-size 25 \
+     --json
+   ```
+
+Record the inventory commit, open-entry count, packet ID, and entry digest in
+the PR body. A packet is a snapshot, not a new source of truth.
+
+## Disposition Rules
+
+Probe real behavior before choosing a disposition. `ROUTES` membership alone
+does not prove a route is served: require a matching `can_handle` result and a
+real dispatch branch, with a focused handler test where practical.
+
+| Disposition | Use when | Required result |
+|---|---|---|
+| `DOCUMENT` | The server really serves the route, but the public spec omits it. | Add it through `scripts/generate_openapi.py` and the handler metadata used by the generator. Never hand-edit generated OpenAPI files. |
+| `WIRE` | An SDK or documented operation is not dispatched, but the capability should exist. | Implement the handler dispatch, document the operation, and add focused server and SDK contract tests. |
+| `REMOVE` | The operation is dead surface and should not exist. | Remove the handler, spec, and SDK surface together. Public SDK removal requires an explicit operator-reviewed compatibility decision; a Tier 0-2 worker may classify and escalate it but must not perform an unauthorized removal. |
+| `DEPRECATE+PARALLEL` | Public compatibility prevents immediate removal and a contract-correct replacement can ship alongside it. | Deprecate the old method and add the replacement using the #9366/#9367/#9371 pattern. This is staged migration, not closure: the old route must later be wired or removed before its drift entry can resolve. |
+
+**Deprecation alone never closes an entry.** A closing PR must make the
+operation contract-correct or remove the invoking surface under the required
+public-API authority.
+
+## Per-Entry Procedure
+
+1. Locate the inventory ID in its source baseline and in the Python/TypeScript
+   SDK, OpenAPI generator metadata, handler registry, and dispatch code.
+2. Record concrete served/unserved evidence. For a served claim, cite the
+   handler and focused dispatch test. For an unserved claim, cite the missing or
+   rejecting branch.
+3. Apply exactly one disposition. Do not combine unrelated cleanup with the
+   packet.
+4. Update generated specs and SDK artifacts only through their generators.
+5. Remove baseline entries only when the regenerated validator output proves
+   the violation is gone. Never lower a budget or delete inventory history.
+6. Regenerate the inventory. Resolved records remain append-only with
+   `status: resolved` and `resolved_on`; new unexplained records must fail
+   closed rather than be absorbed into the batch.
+
+If a packet mixes independent owners or dispositions, ship one coherent slice
+and leave the remaining IDs unchecked. A partial batch is valid only when its
+PR names the exact completed IDs and the next packet snapshot is regenerated
+after merge.
+
+## Closing Evidence Contract
+
+A burn-down PR is ready for exact-head review only when all of the following
+are true:
+
+1. **Manifest delta:** the diff in
+   `scripts/baselines/contract_drift_inventory.json` contains only the intended
+   open-to-resolved transitions. Baseline removals match validator output.
+2. **Focused behavior:** relevant handler, SDK, and generator tests pass. A
+   route is not credited from metadata-only evidence.
+3. **No regression:** both route and SDK validators pass against their
+   baselines:
+
+   ```bash
+   python scripts/validate_openapi_routes.py \
+     --spec docs/api/openapi_generated.json \
+     --baseline scripts/baselines/validate_openapi_routes.json \
+     --fail-on-missing
+   python scripts/verify_sdk_contracts.py \
+     --strict \
+     --baseline scripts/baselines/verify_sdk_contracts.json
+   ```
+
+4. **Spec and inventory fixed point:** regenerate the OpenAPI artifacts, then
+   regenerate and check the inventory. A second check must produce no diff:
+
+   ```bash
+   python scripts/generate_openapi.py --output docs/api/openapi_generated.json
+   python scripts/generate_openapi.py \
+     --output docs/api/openapi_generated.yaml \
+     --format yaml
+   python scripts/generate_contract_drift_inventory.py
+   python scripts/generate_contract_drift_inventory.py --check
+   git diff --check
+   ```
+
+5. **Ratchet:** the PR-mode contract-drift gate is non-worsening and the packet
+   reports the exact source-bucket reduction:
+
+   ```bash
+   python scripts/check_contract_drift_ratchet.py \
+     --mode pr \
+     --base-ref origin/main \
+     --strict \
+     --json
+   ```
+
+6. **Review last:** commit and push the final head, run normal checks, then
+   collect exact-head model evidence. Any later edit invalidates that evidence
+   and requires a new collection. P0/P1 or blocking dissent stops the batch.
+
+## Worker Boundaries
+
+- One coherent packet slice per PR; use draft first, then ready through normal
+  gates.
+- Ordinary Tier 0-2 workers may document served routes, wire bounded behavior,
+  add compatible parallel methods, and prepare decision evidence.
+- Do not edit `.github/workflows`, branch protection, release controls,
+  protected governance files, or other Tier 3/4 surfaces in this lane.
+- Do not remove a public SDK operation without the required operator decision.
+- Do not use `--admin`, force-push, weaken checks, skip tests, or treat a
+  cancelled optional job as evidence that a required gate passed.
+- Collect evidence after implementation and validation, never as a substitute
+  for them.
+
+## Handoff
+
+After a batch merges, regenerate into a new empty directory and select the
+lowest numbered packet with unchecked entries. The successor should run:
+
+```bash
+git fetch origin main
+python scripts/generate_contract_drift_inventory.py --check
+python scripts/route_burndown_batches.py \
+  --output-dir /tmp/aragora-route-burndown-next \
+  --batch-size 25 \
+  --json
+```
+
+Post the new open count, packet digest, merged PR, and source-bucket delta to
+issue #9378. Escalate wire-or-remove decisions as one bounded list rather than
+one operator interruption per entry.

--- a/scripts/route_burndown_batches.py
+++ b/scripts/route_burndown_batches.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import re
+import sys
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -81,7 +82,9 @@ def partition_items(items: list[dict[str, str]], batch_size: int) -> list[list[d
 
 def batch_digest(items: list[dict[str, str]]) -> str:
     """Return a short content identity for a packet's exact ordered ids."""
-    payload = "\n".join(item["id"] for item in items).encode()
+    payload = json.dumps(
+        [item["id"] for item in items], ensure_ascii=True, separators=(",", ":")
+    ).encode()
     return hashlib.sha256(payload).hexdigest()[:16]
 
 
@@ -226,7 +229,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
     parser.add_argument("--playbook", type=Path, default=DEFAULT_PLAYBOOK)
-    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Output directory (relative paths are resolved from the current directory)",
+    )
     parser.add_argument("--batch-size", type=int, default=25)
     parser.add_argument("--json", action="store_true", help="Print a machine-readable summary")
     args = parser.parse_args()
@@ -234,7 +242,7 @@ def main() -> int:
     inventory_path = _resolve_repo_path(args.inventory)
     playbook_path = _resolve_repo_path(args.playbook)
     if not playbook_path.is_file():
-        print(f"ERROR: playbook not found: {playbook_path}")
+        print(f"ERROR: playbook not found: {playbook_path}", file=sys.stderr)
         return 1
 
     try:
@@ -247,7 +255,7 @@ def main() -> int:
         )
         write_outputs(args.output_dir, outputs)
     except (InventoryError, ValueError, OSError) as exc:
-        print(f"ERROR: {exc}")
+        print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
     summary: dict[str, Any] = {

--- a/scripts/route_burndown_batches.py
+++ b/scripts/route_burndown_batches.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Emit deterministic work packets from the contract-drift inventory."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_INVENTORY = Path("scripts/baselines/contract_drift_inventory.json")
+DEFAULT_PLAYBOOK = Path("docs/runbooks/ROUTE_BURNDOWN_PLAYBOOK.md")
+GENERATED_BATCH = re.compile(r"batch-\d{3,}\.md$")
+VALID_STATUSES = frozenset({"open", "resolved"})
+
+
+class InventoryError(ValueError):
+    """The canonical inventory cannot safely produce work packets."""
+
+
+def _resolve_repo_path(path: Path) -> Path:
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def load_open_items(path: Path) -> list[dict[str, str]]:
+    """Load, validate, and sort open inventory records by stable id."""
+    try:
+        document = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise InventoryError(f"inventory not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise InventoryError(f"inventory is not valid JSON: {path}: {exc}") from exc
+
+    raw_items = document.get("items") if isinstance(document, dict) else None
+    if not isinstance(raw_items, list):
+        raise InventoryError("inventory must contain an 'items' list")
+
+    seen: set[str] = set()
+    open_items: list[dict[str, str]] = []
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, dict):
+            raise InventoryError(f"inventory item {index} must be an object")
+
+        item_id = raw_item.get("id")
+        source = raw_item.get("source")
+        status = raw_item.get("status")
+        if not isinstance(item_id, str) or not item_id.strip():
+            raise InventoryError(f"inventory item {index} has no stable id")
+        if item_id in seen:
+            raise InventoryError(f"duplicate inventory id: {item_id}")
+        seen.add(item_id)
+        if not isinstance(source, str) or not source.strip():
+            raise InventoryError(f"inventory item {item_id} has no source")
+        if status not in VALID_STATUSES:
+            raise InventoryError(f"inventory item {item_id} has unknown status: {status!r}")
+        if status != "open":
+            continue
+
+        open_items.append(
+            {
+                "id": item_id,
+                "source": source,
+                "class": str(raw_item.get("class", "unknown")),
+                "discovered_on": str(raw_item.get("discovered_on", "unknown")),
+            }
+        )
+
+    return sorted(open_items, key=lambda item: item["id"])
+
+
+def partition_items(items: list[dict[str, str]], batch_size: int) -> list[list[dict[str, str]]]:
+    """Partition an already canonicalized list without changing its order."""
+    if batch_size <= 0:
+        raise ValueError("batch size must be positive")
+    return [items[start : start + batch_size] for start in range(0, len(items), batch_size)]
+
+
+def batch_digest(items: list[dict[str, str]]) -> str:
+    """Return a short content identity for a packet's exact ordered ids."""
+    payload = "\n".join(item["id"] for item in items).encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def render_batch_packet(
+    number: int,
+    total_batches: int,
+    items: list[dict[str, str]],
+    *,
+    inventory_label: str,
+    playbook_label: str,
+) -> str:
+    batch_id = f"route-batch-{number:03d}"
+    sources = Counter(item["source"] for item in items)
+    lines = [f"# Route Burn-Down Batch {number:03d}", ""]
+    lines.extend(
+        [
+            f"- Batch ID: `{batch_id}`",
+            f"- Position: `{number}` of `{total_batches}`",
+            f"- Entries: `{len(items)}`",
+            f"- Entry digest: `{batch_digest(items)}`",
+            f"- Canonical inventory: `{inventory_label}`",
+            f"- Required playbook: `{playbook_label}`",
+            "",
+            "## Source Breakdown",
+            "",
+        ]
+    )
+    for source, count in sorted(sources.items()):
+        lines.append(f"- `{source}`: {count}")
+
+    lines.extend(["", "## Entry IDs", ""])
+    for item in items:
+        lines.append(
+            f"- [ ] `{item['id']}` "
+            f"(class: `{item['class']}`, discovered: `{item['discovered_on']}`)"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Completion Evidence",
+            "",
+            "- [ ] Every entry has a playbook disposition with repository evidence.",
+            "- [ ] The regenerated inventory delta contains only intended resolutions.",
+            "- [ ] Relevant route, SDK, and focused tests pass.",
+            "- [ ] Spec and inventory regeneration reach a fixed point.",
+            "- [ ] Exact-head model evidence is collected after the final edit.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_index(
+    batches: list[list[dict[str, str]]],
+    *,
+    batch_size: int,
+    inventory_label: str,
+    playbook_label: str,
+) -> str:
+    open_count = sum(len(batch) for batch in batches)
+    lines = [
+        "# Route Burn-Down Batch Map",
+        "",
+        f"- Canonical inventory: `{inventory_label}`",
+        f"- Required playbook: `{playbook_label}`",
+        f"- Open entries: `{open_count}`",
+        f"- Batch size: `{batch_size}`",
+        f"- Batch count: `{len(batches)}`",
+        "",
+        "Packets are a deterministic snapshot. Regenerate from the canonical inventory after",
+        "each merged burn-down PR; do not hand-edit packet membership.",
+        "",
+        "| Batch | Entries | Digest | First ID | Last ID | Packet |",
+        "|---|---:|---|---|---|---|",
+    ]
+    for number, items in enumerate(batches, start=1):
+        filename = f"batch-{number:03d}.md"
+        lines.append(
+            f"| `route-batch-{number:03d}` | {len(items)} | `{batch_digest(items)}` | "
+            f"`{items[0]['id']}` | `{items[-1]['id']}` | [{filename}]({filename}) |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_outputs(
+    items: list[dict[str, str]],
+    *,
+    batch_size: int,
+    inventory_label: str,
+    playbook_label: str,
+) -> dict[str, str]:
+    canonical_items = sorted(items, key=lambda item: item["id"])
+    batches = partition_items(canonical_items, batch_size)
+    outputs = {
+        "index.md": render_index(
+            batches,
+            batch_size=batch_size,
+            inventory_label=inventory_label,
+            playbook_label=playbook_label,
+        )
+    }
+    total_batches = len(batches)
+    for number, batch in enumerate(batches, start=1):
+        outputs[f"batch-{number:03d}.md"] = render_batch_packet(
+            number,
+            total_batches,
+            batch,
+            inventory_label=inventory_label,
+            playbook_label=playbook_label,
+        )
+    return outputs
+
+
+def write_outputs(output_dir: Path, outputs: dict[str, str]) -> None:
+    """Write a complete snapshot, refusing to leave obsolete batch packets."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stale = sorted(
+        path.name
+        for path in output_dir.iterdir()
+        if path.is_file() and GENERATED_BATCH.fullmatch(path.name) and path.name not in outputs
+    )
+    if stale:
+        names = ", ".join(stale)
+        raise InventoryError(
+            f"output directory contains stale generated packets ({names}); use an empty directory"
+        )
+
+    for filename, content in sorted(outputs.items()):
+        (output_dir / filename).write_text(content)
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", type=Path, default=DEFAULT_INVENTORY)
+    parser.add_argument("--playbook", type=Path, default=DEFAULT_PLAYBOOK)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--batch-size", type=int, default=25)
+    parser.add_argument("--json", action="store_true", help="Print a machine-readable summary")
+    args = parser.parse_args()
+
+    inventory_path = _resolve_repo_path(args.inventory)
+    playbook_path = _resolve_repo_path(args.playbook)
+    if not playbook_path.is_file():
+        print(f"ERROR: playbook not found: {playbook_path}")
+        return 1
+
+    try:
+        items = load_open_items(inventory_path)
+        outputs = build_outputs(
+            items,
+            batch_size=args.batch_size,
+            inventory_label=_display_path(inventory_path),
+            playbook_label=_display_path(playbook_path),
+        )
+        write_outputs(args.output_dir, outputs)
+    except (InventoryError, ValueError, OSError) as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    summary: dict[str, Any] = {
+        "inventory": _display_path(inventory_path),
+        "output_dir": str(args.output_dir),
+        "open_items": len(items),
+        "batch_size": args.batch_size,
+        "batch_count": len(outputs) - 1,
+        "index": str(args.output_dir / "index.md"),
+    }
+    if args.json:
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print(
+            f"Wrote {summary['batch_count']} batches for {summary['open_items']} open items "
+            f"to {summary['output_dir']}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/route_burndown_batches.py
+++ b/scripts/route_burndown_batches.py
@@ -200,6 +200,22 @@ def build_outputs(
     return outputs
 
 
+def summarize_batches(items: list[dict[str, str]], batch_size: int) -> list[dict[str, Any]]:
+    canonical_items = sorted(items, key=lambda item: item["id"])
+    summaries: list[dict[str, Any]] = []
+    for number, batch in enumerate(partition_items(canonical_items, batch_size), start=1):
+        summaries.append(
+            {
+                "id": f"route-batch-{number:03d}",
+                "entries": len(batch),
+                "digest": batch_digest(batch),
+                "first_id": batch[0]["id"],
+                "last_id": batch[-1]["id"],
+            }
+        )
+    return summaries
+
+
 def write_outputs(output_dir: Path, outputs: dict[str, str]) -> None:
     """Write a complete snapshot, refusing to leave obsolete batch packets."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -214,8 +230,17 @@ def write_outputs(output_dir: Path, outputs: dict[str, str]) -> None:
             f"output directory contains stale generated packets ({names}); use an empty directory"
         )
 
+    # The index is the validity marker. Remove an older index before packet
+    # writes and publish the new one last, so an interrupted write cannot look
+    # like a complete snapshot.
+    index_content = outputs.get("index.md")
+    (output_dir / "index.md").unlink(missing_ok=True)
     for filename, content in sorted(outputs.items()):
+        if filename == "index.md":
+            continue
         (output_dir / filename).write_text(content)
+    if index_content is not None:
+        (output_dir / "index.md").write_text(index_content)
 
 
 def _display_path(path: Path) -> str:
@@ -265,6 +290,7 @@ def main() -> int:
         "batch_size": args.batch_size,
         "batch_count": len(outputs) - 1,
         "index": str(args.output_dir / "index.md"),
+        "batches": summarize_batches(items, args.batch_size),
     }
     if args.json:
         print(json.dumps(summary, sort_keys=True))

--- a/scripts/route_burndown_batches.py
+++ b/scripts/route_burndown_batches.py
@@ -88,6 +88,10 @@ def batch_digest(items: list[dict[str, str]]) -> str:
     return hashlib.sha256(payload).hexdigest()[:16]
 
 
+def canonical_batches(items: list[dict[str, str]], batch_size: int) -> list[list[dict[str, str]]]:
+    return partition_items(sorted(items, key=lambda item: item["id"]), batch_size)
+
+
 def render_batch_packet(
     number: int,
     total_batches: int,
@@ -178,8 +182,7 @@ def build_outputs(
     inventory_label: str,
     playbook_label: str,
 ) -> dict[str, str]:
-    canonical_items = sorted(items, key=lambda item: item["id"])
-    batches = partition_items(canonical_items, batch_size)
+    batches = canonical_batches(items, batch_size)
     outputs = {
         "index.md": render_index(
             batches,
@@ -201,9 +204,8 @@ def build_outputs(
 
 
 def summarize_batches(items: list[dict[str, str]], batch_size: int) -> list[dict[str, Any]]:
-    canonical_items = sorted(items, key=lambda item: item["id"])
     summaries: list[dict[str, Any]] = []
-    for number, batch in enumerate(partition_items(canonical_items, batch_size), start=1):
+    for number, batch in enumerate(canonical_batches(items, batch_size), start=1):
         summaries.append(
             {
                 "id": f"route-batch-{number:03d}",
@@ -218,6 +220,8 @@ def summarize_batches(items: list[dict[str, str]], batch_size: int) -> list[dict
 
 def write_outputs(output_dir: Path, outputs: dict[str, str]) -> None:
     """Write a complete snapshot, refusing to leave obsolete batch packets."""
+    if "index.md" not in outputs:
+        raise InventoryError("generated outputs must include index.md")
     output_dir.mkdir(parents=True, exist_ok=True)
     stale = sorted(
         path.name
@@ -233,14 +237,13 @@ def write_outputs(output_dir: Path, outputs: dict[str, str]) -> None:
     # The index is the validity marker. Remove an older index before packet
     # writes and publish the new one last, so an interrupted write cannot look
     # like a complete snapshot.
-    index_content = outputs.get("index.md")
+    index_content = outputs["index.md"]
     (output_dir / "index.md").unlink(missing_ok=True)
     for filename, content in sorted(outputs.items()):
         if filename == "index.md":
             continue
         (output_dir / filename).write_text(content)
-    if index_content is not None:
-        (output_dir / "index.md").write_text(index_content)
+    (output_dir / "index.md").write_text(index_content)
 
 
 def _display_path(path: Path) -> str:

--- a/tests/scripts/test_route_burndown_batches.py
+++ b/tests/scripts/test_route_burndown_batches.py
@@ -1,0 +1,99 @@
+"""Tests for scripts/route_burndown_batches.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import route_burndown_batches as batches
+
+
+def _write_inventory(path: Path, items: list[dict[str, str]]) -> None:
+    path.write_text(json.dumps({"items": items}))
+
+
+def _item(
+    item_id: str, *, status: str = "open", source: str = "python_sdk_drift"
+) -> dict[str, str]:
+    return {
+        "id": item_id,
+        "source": source,
+        "status": status,
+        "class": "start_cohort",
+        "discovered_on": "2026-04-17",
+    }
+
+
+def test_load_open_items_sorts_and_excludes_resolved(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.json"
+    _write_inventory(
+        inventory,
+        [
+            _item("python_sdk_drift:Z"),
+            _item("python_sdk_drift:B", status="resolved"),
+            _item("python_sdk_drift:A"),
+        ],
+    )
+
+    result = batches.load_open_items(inventory)
+
+    assert [item["id"] for item in result] == [
+        "python_sdk_drift:A",
+        "python_sdk_drift:Z",
+    ]
+
+
+def test_load_open_items_rejects_duplicate_ids(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.json"
+    _write_inventory(inventory, [_item("python_sdk_drift:A"), _item("python_sdk_drift:A")])
+
+    with pytest.raises(batches.InventoryError, match="duplicate inventory id"):
+        batches.load_open_items(inventory)
+
+
+def test_partition_and_render_are_stable() -> None:
+    items = [_item(f"python_sdk_drift:{value}") for value in ("E", "A", "D", "B", "C")]
+
+    first = batches.build_outputs(
+        items,
+        batch_size=2,
+        inventory_label="inventory.json",
+        playbook_label="playbook.md",
+    )
+    second = batches.build_outputs(
+        list(reversed(items)),
+        batch_size=2,
+        inventory_label="inventory.json",
+        playbook_label="playbook.md",
+    )
+
+    assert first == second
+    assert sorted(first) == ["batch-001.md", "batch-002.md", "batch-003.md", "index.md"]
+    assert "`python_sdk_drift:A`" in first["batch-001.md"]
+    assert "`python_sdk_drift:C`" in first["batch-002.md"]
+    assert "Open entries: `5`" in first["index.md"]
+
+
+def test_packet_digest_changes_with_membership() -> None:
+    one = [_item("python_sdk_drift:A")]
+    two = [*one, _item("python_sdk_drift:B")]
+
+    assert batches.batch_digest(one) != batches.batch_digest(two)
+
+
+def test_write_outputs_refuses_stale_packet(tmp_path: Path) -> None:
+    (tmp_path / "batch-999.md").write_text("obsolete")
+
+    with pytest.raises(batches.InventoryError, match="stale generated packets"):
+        batches.write_outputs(tmp_path, {"index.md": "index\n"})
+
+
+def test_write_outputs_round_trip(tmp_path: Path) -> None:
+    outputs = {"index.md": "index\n", "batch-001.md": "packet\n"}
+
+    batches.write_outputs(tmp_path, outputs)
+    batches.write_outputs(tmp_path, outputs)
+
+    assert {path.name: path.read_text() for path in tmp_path.iterdir()} == outputs

--- a/tests/scripts/test_route_burndown_batches.py
+++ b/tests/scripts/test_route_burndown_batches.py
@@ -84,6 +84,29 @@ def test_packet_digest_changes_with_membership() -> None:
     assert batches.batch_digest([_item("A\nB")]) != batches.batch_digest([_item("A"), _item("B")])
 
 
+def test_batch_summary_exposes_machine_readable_identity() -> None:
+    items = [_item("python_sdk_drift:B"), _item("python_sdk_drift:A")]
+
+    summaries = batches.summarize_batches(items, batch_size=1)
+
+    assert summaries == [
+        {
+            "id": "route-batch-001",
+            "entries": 1,
+            "digest": batches.batch_digest([_item("python_sdk_drift:A")]),
+            "first_id": "python_sdk_drift:A",
+            "last_id": "python_sdk_drift:A",
+        },
+        {
+            "id": "route-batch-002",
+            "entries": 1,
+            "digest": batches.batch_digest([_item("python_sdk_drift:B")]),
+            "first_id": "python_sdk_drift:B",
+            "last_id": "python_sdk_drift:B",
+        },
+    ]
+
+
 def test_write_outputs_refuses_stale_packet(tmp_path: Path) -> None:
     (tmp_path / "batch-999.md").write_text("obsolete")
 
@@ -98,3 +121,22 @@ def test_write_outputs_round_trip(tmp_path: Path) -> None:
     batches.write_outputs(tmp_path, outputs)
 
     assert {path.name: path.read_text() for path in tmp_path.iterdir()} == outputs
+
+
+def test_write_outputs_removes_old_index_before_packet_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "index.md").write_text("old index\n")
+    original_write = Path.write_text
+
+    def fail_packet_write(path: Path, content: str, *args, **kwargs):
+        if path.name == "batch-001.md":
+            raise OSError("disk full")
+        return original_write(path, content, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", fail_packet_write)
+
+    with pytest.raises(OSError, match="disk full"):
+        batches.write_outputs(tmp_path, {"index.md": "new index\n", "batch-001.md": "packet\n"})
+
+    assert not (tmp_path / "index.md").exists()

--- a/tests/scripts/test_route_burndown_batches.py
+++ b/tests/scripts/test_route_burndown_batches.py
@@ -53,6 +53,22 @@ def test_load_open_items_rejects_duplicate_ids(tmp_path: Path) -> None:
         batches.load_open_items(inventory)
 
 
+def test_load_open_items_rejects_unknown_status(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.json"
+    _write_inventory(inventory, [_item("python_sdk_drift:A", status="pending")])
+
+    with pytest.raises(batches.InventoryError, match="unknown status"):
+        batches.load_open_items(inventory)
+
+
+def test_load_open_items_requires_items_list(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text("{}")
+
+    with pytest.raises(batches.InventoryError, match="must contain an 'items' list"):
+        batches.load_open_items(inventory)
+
+
 def test_partition_and_render_are_stable() -> None:
     items = [_item(f"python_sdk_drift:{value}") for value in ("E", "A", "D", "B", "C")]
 
@@ -74,6 +90,20 @@ def test_partition_and_render_are_stable() -> None:
     assert "`python_sdk_drift:A`" in first["batch-001.md"]
     assert "`python_sdk_drift:C`" in first["batch-002.md"]
     assert "Open entries: `5`" in first["index.md"]
+
+
+def test_empty_inventory_produces_index_only_snapshot() -> None:
+    outputs = batches.build_outputs(
+        [],
+        batch_size=25,
+        inventory_label="inventory.json",
+        playbook_label="playbook.md",
+    )
+
+    assert list(outputs) == ["index.md"]
+    assert "Open entries: `0`" in outputs["index.md"]
+    assert "Batch count: `0`" in outputs["index.md"]
+    assert batches.summarize_batches([], 25) == []
 
 
 def test_packet_digest_changes_with_membership() -> None:
@@ -112,6 +142,11 @@ def test_write_outputs_refuses_stale_packet(tmp_path: Path) -> None:
 
     with pytest.raises(batches.InventoryError, match="stale generated packets"):
         batches.write_outputs(tmp_path, {"index.md": "index\n"})
+
+
+def test_write_outputs_requires_index(tmp_path: Path) -> None:
+    with pytest.raises(batches.InventoryError, match="must include index.md"):
+        batches.write_outputs(tmp_path, {"batch-001.md": "packet\n"})
 
 
 def test_write_outputs_round_trip(tmp_path: Path) -> None:

--- a/tests/scripts/test_route_burndown_batches.py
+++ b/tests/scripts/test_route_burndown_batches.py
@@ -81,6 +81,7 @@ def test_packet_digest_changes_with_membership() -> None:
     two = [*one, _item("python_sdk_drift:B")]
 
     assert batches.batch_digest(one) != batches.batch_digest(two)
+    assert batches.batch_digest([_item("A\nB")]) != batches.batch_digest([_item("A"), _item("B")])
 
 
 def test_write_outputs_refuses_stale_packet(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add the durable DOCUMENT / WIRE / REMOVE / DEPRECATE+PARALLEL disposition standard for the #9378 contract-drift lane
- generate deterministic 25-entry work packets from the append-only canonical inventory
- fail closed on malformed or duplicate inventory records and incomplete or stale packet snapshots

## Live baseline
- exact base: bfc14c591013de87860f84638faa7f36e69de2bf
- canonical inventory: 1,071 open entries (the 1,049 count in #9378 is stale)
- packet map: 43 batches at size 25
- batch 001: 25 orphaned_in_spec entries, digest 28f5d1ae6bf5123f

This PR intentionally ships the standard and batcher separately from the first remediation batch. Batch 001 remains a later bounded PR.

## Validation
- python3 -m pytest tests/scripts/test_route_burndown_batches.py tests/scripts/test_generate_contract_drift_inventory.py tests/scripts/test_generate_contract_drift_issue_plan.py -q (27 passed)
- python3 -m ruff check scripts/route_burndown_batches.py tests/scripts/test_route_burndown_batches.py
- python3 -m ruff format --check scripts/route_burndown_batches.py tests/scripts/test_route_burndown_batches.py
- python3 -m mypy scripts/route_burndown_batches.py
- python3 scripts/check_docs_consistency.py
- python3 scripts/generate_contract_drift_inventory.py --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Exact-head evidence: Claude PASS + OpenAI PASS; no dissent. Nonblocking P3 observations remain visible in the review comments.

Part of #9378.