### PR TITLE
test(debate): make checksum constant-time test robust on loaded runners

### DIFF
--- a/tests/debate/test_traces_performance.py
+++ b/tests/debate/test_traces_performance.py
@@ -274,17 +274,31 @@ class TestChecksumPerformance:
             _ = trace_with_events.checksum
             access_times.append(time.perf_counter() - start)
 
-        # Calculate statistics
-        avg_time = sum(access_times) / len(access_times)
-        max_time = max(access_times)
-
-        # All accesses should be roughly constant (allow for some variance).
-        # Sub-microsecond property lookups have high relative jitter from cache
-        # misses, GC, and scheduler noise, so allow a wider ratio plus a small
-        # absolute ceiling.
-        assert max_time < max(avg_time * 100, 5e-5), (
+        # Sub-microsecond property lookups have high relative jitter: on a
+        # loaded shared runner a single scheduler preemption can cost ~0.5ms,
+        # so comparing the raw max against the average is inherently flaky.
+        # Use robust statistics instead — the bulk of accesses (p95) must stay
+        # near the typical (median) cost, with a generous absolute ceiling.
+        sorted_times = sorted(access_times)
+        median_time = sorted_times[len(sorted_times) // 2]
+        p95_time = sorted_times[int(len(sorted_times) * 0.95)]
+        assert p95_time < max(median_time * 100, 1e-3), (
             f"Access times should be relatively constant. "
-            f"Avg: {avg_time:.6f}s, Max: {max_time:.6f}s"
+            f"Median: {median_time:.6f}s, p95: {p95_time:.6f}s"
+        )
+
+        # The actual O(1) guarantee: per-access cost must not grow with the
+        # number of prior accesses. Compare first-half vs second-half medians,
+        # which isolated hiccups cannot skew.
+        half = len(access_times) // 2
+        first_half = sorted(access_times[:half])
+        second_half = sorted(access_times[half:])
+        first_median = first_half[len(first_half) // 2]
+        second_median = second_half[len(second_half) // 2]
+        assert second_median < max(first_median * 10, 5e-5), (
+            f"Access times should not grow with access count. "
+            f"First-half median: {first_median:.6f}s, "
+            f"second-half median: {second_median:.6f}s"
         )
 
     def test_large_trace_caching_benefits(self):


### PR DESCRIPTION
## Summary
`tests/debate/test_traces_performance.py::TestChecksumPerformance::test_many_accesses_remain_constant_time` fails intermittently on CI runners under load (seen 2026-07-17 on run 29561291565, PR #9355 — a PR that doesn't touch debate code):

```
Access times should be relatively constant. Avg: 0.000001s, Max: 0.000553s
```

The assertion compared the raw **max** access time against the **average** over 1000 sub-microsecond samples, so a single ~0.5ms scheduler preemption on a shared runner was enough to fail it.

## Fix
Replace the max-vs-avg assertion with robust statistics, without weakening what the test guards (checksum access must not scale with access count):

- **p95 vs median** with a generous absolute ceiling (1ms) — the bulk of accesses must stay near typical cost; isolated hiccups no longer dominate.
- **First-half vs second-half median comparison** — directly asserts the O(1) property: per-access cost does not grow with the number of prior accesses. Medians per half cannot be skewed by isolated preemptions.

## Verification
- 20/20 consecutive passes idle
- 20/20 consecutive passes with all cores saturated by busy-loop processes (simulating a loaded runner)
- Full file: 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)