### PR TITLE
docs(metrics): refresh repository counts (#9283)

### DIFF
--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -20,9 +20,9 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,292 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,983,060 | `docs/METRICS.md` |
-| Automated tests | 224,110 test functions | `docs/METRICS.md` |
-| Test files | 5,486 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,983,421 | `docs/METRICS.md` |
+| Automated tests | 224,180 test functions | `docs/METRICS.md` |
+| Test files | 5,489 | `docs/METRICS.md` |
 | API operations | 3,081 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,292 tracked Python files | 145 top-level modules | 224,110 test functions across 5,486 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,292 tracked Python files | 145 top-level modules | 224,180 test functions across 5,489 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,292 Python files | 224,110 tests | 3,081 API operations across 2,876 paths
+**Total**: 230+ features | 4,292 Python files | 224,180 tests | 3,081 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -159,7 +159,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,292
-- **Tests**: 224,110 across 5,486 test files
+- **Tests**: 224,180 across 5,489 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,081 across 2,876 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,7 +766,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 224,110 tests across 5,486 test files
+- **Test coverage**: 224,180 tests across 5,489 test files
 - **Source files**: 4,292 Python files under `aragora/`
 - **API surface**: 3,081 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -15,9 +15,9 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Version | 2.9.0 | `pyproject.toml` |
 | Python files under `aragora/` | 4,292 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,983,060 | `docs/METRICS.md` |
-| Automated tests | 224,110 test functions | `docs/METRICS.md` |
-| Test files | 5,486 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,983,421 | `docs/METRICS.md` |
+| Automated tests | 224,180 test functions | `docs/METRICS.md` |
+| Test files | 5,489 | `docs/METRICS.md` |
 | API operations | 3,081 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,292 tracked Python files | 145 top-level modules | 224,110 test functions across 5,486 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,292 tracked Python files | 145 top-level modules | 224,180 test functions across 5,489 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -13,11 +13,11 @@
 | Metric | Value | Source | Command |
 |---|---|---|---|
 | Python files under aragora/ | `4292` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1983060` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python lines of code under aragora/ | `1983421` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5486` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `224110` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `859` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5489` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `224180` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `865` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `84` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2876` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3081` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -154,7 +154,7 @@ For the full current-status narrative, use the canonical doc:
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
 - **Python files (`aragora/`)**: 4,292
-- **Tests**: 224,110 across 5,486 test files
+- **Tests**: 224,180 across 5,489 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,081 across 2,876 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,7 +761,7 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 224,110 tests across 5,486 test files
+- **Test coverage**: 224,180 tests across 5,489 test files
 - **Source files**: 4,292 Python files under `aragora/`
 - **API surface**: 3,081 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,292 Python files | 224,110 tests | 3,081 API operations across 2,876 paths
+**Total**: 230+ features | 4,292 Python files | 224,180 tests | 3,081 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---


### PR DESCRIPTION
## Summary

- refresh the legacy exact repository counts from current main
- regenerate the five canonical generated metric blocks and their five docs-site mirrors
- unblock #9407 without mixing generated observation churn into the metrics foundation branch

Part of #9283. Unblocks #9407.

## Scope

Base: `73132298d2714d47574457733bb38eb89d677be2`

This is a mechanical docs-only refresh. It does not change collectors, thresholds, workflows, required checks, or branch protection. The long-term removal of this snapshot race remains #9283.

## Validation

- `python3 scripts/regenerate_metrics.py --check`
- 34 focused metrics/doc-stat tests passed
- `python3 scripts/check_docs_consistency.py`
- metrics, generated blocks, and docs-site sync are idempotent on a second run
- Docusaurus production build passed; it reported only the existing broken-link warnings
- `python3 -m ruff check scripts/regenerate_metrics.py scripts/doc_stats.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

The triggering drift was `@pytest.mark.parametrize decorators`: committed `859`, current main `865`.
