### PR TITLE
fix(governance): enforce Tier-4 authority boundaries

### DIFF
--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -5039,8 +5039,8 @@ def _first_nonempty_line(text: str) -> str:
 
 
 def _matches_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
-    legacy = prefixes == TIER_2_PREFIXES
-    return any(path == p or (legacy or p[-1:] == "/") and path.startswith(p) for p in prefixes)
+    legacy = TIER_2_PREFIXES.__contains__
+    return any(path == p or ((legacy(p) or p[-1:] == "/") and path.startswith(p)) for p in prefixes)
 
 
 def _is_docs_tests_or_status_path(path: str) -> bool:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -5039,7 +5039,12 @@ def _first_nonempty_line(text: str) -> str:
 
 
 def _matches_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
-    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes)
+    # Tier 2 retains one historical filename-stem rule without a trailing slash.
+    allow_legacy_stems = prefixes == TIER_2_PREFIXES
+    return any(
+        path.startswith(prefix) if allow_legacy_stems or prefix.endswith("/") else path == prefix
+        for prefix in prefixes
+    )
 
 
 def _is_docs_tests_or_status_path(path: str) -> bool:

--- a/aragora/cli/commands/review_queue.py
+++ b/aragora/cli/commands/review_queue.py
@@ -5039,12 +5039,8 @@ def _first_nonempty_line(text: str) -> str:
 
 
 def _matches_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
-    # Tier 2 retains one historical filename-stem rule without a trailing slash.
-    allow_legacy_stems = prefixes == TIER_2_PREFIXES
-    return any(
-        path.startswith(prefix) if allow_legacy_stems or prefix.endswith("/") else path == prefix
-        for prefix in prefixes
-    )
+    legacy = prefixes == TIER_2_PREFIXES
+    return any(path == p or (legacy or p[-1:] == "/") and path.startswith(p) for p in prefixes)
 
 
 def _is_docs_tests_or_status_path(path: str) -> bool:

--- a/tests/governance/test_contract_drift_measurement_authority_tier.py
+++ b/tests/governance/test_contract_drift_measurement_authority_tier.py
@@ -130,7 +130,7 @@ def test_canonical_and_merge_train_boundary_matrix_match(
     assert _canonical_matched_rule(path) == expected_rule
     assert tier4_merge_train.matches_serialized_path(path) == expected_rule
     tier, _name, _reason = review_queue._classify_model_review_tier([path])
-    assert (tier == 4) is (expected_rule is not None)
+    assert (tier == 4) == (expected_rule is not None)
 
 
 @pytest.mark.parametrize(
@@ -153,6 +153,11 @@ def test_existing_tier2_metric_stem_paths_remain_tier2(path: str) -> None:
     tier, name, _reason = review_queue._classify_model_review_tier([path])
     assert tier == 2
     assert name == "tier_2_live_automation"
+
+
+def test_tier2_metric_stem_matches_when_checked_as_single_rule() -> None:
+    prefix = "aragora/knowledge/mound/metrics"
+    assert review_queue._matches_prefix(f"{prefix}_health_bridge.py", (prefix,))
 
 
 @pytest.mark.parametrize("path", REPORTING_ONLY_PATHS + UNRELATED_SIBLING_PATHS)

--- a/tests/governance/test_contract_drift_measurement_authority_tier.py
+++ b/tests/governance/test_contract_drift_measurement_authority_tier.py
@@ -35,6 +35,8 @@ UNRELATED_SIBLING_PATHS = (
     "scripts/baselines/check_sdk_parity.json",
 )
 
+FILE_ROOT_SUFFIXES = (".bak", ".old", ".pyx", "/child", "x")
+
 
 def _assigned_string_literals(source_path: Path, assignment_name: str) -> tuple[str, ...]:
     tree = ast.parse(source_path.read_text(encoding="utf-8"))
@@ -54,6 +56,23 @@ def _assigned_string_literals(source_path: Path, assignment_name: str) -> tuple[
             raise AssertionError(f"{assignment_name} must contain only string literals")
         return values
     raise AssertionError(f"{assignment_name} assignment not found in {source_path}")
+
+
+def _assignment_line_span(source_path: Path, assignment_name: str) -> int:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
+            continue
+        if node.target.id == assignment_name:
+            return node.end_lineno - node.lineno
+    raise AssertionError(f"{assignment_name} assignment not found in {source_path}")
+
+
+def _canonical_matched_rule(path: str) -> str | None:
+    for prefix in review_queue.TIER_4_PREFIXES:
+        if review_queue._matches_prefix(path, (prefix,)):
+            return prefix
+    return None
 
 
 def test_authority_roots_are_tier4() -> None:
@@ -80,12 +99,60 @@ def test_classifier_and_merge_train_constants_match() -> None:
         tier4_merge_train.CONTRACT_DRIFT_AUTHORITY_CANONICAL_SOURCE
         == "aragora.cli.commands.review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES"
     )
-    assert set(tier4_merge_train.SERIALIZED_TIER4_PREFIXES) == set(review_queue.TIER_4_PREFIXES)
+    assert tier4_merge_train.SERIALIZED_TIER4_PREFIXES == review_queue.TIER_4_PREFIXES
 
 
 @pytest.mark.parametrize("path", EXPECTED_AUTHORITY_PREFIXES)
 def test_merge_train_matches_each_authority_root(path: str) -> None:
     assert tier4_merge_train.matches_serialized_path(path) == path
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_rule"),
+    [
+        *((root, root) for root in review_queue.TIER_4_PREFIXES),
+        *(
+            (f"{root}{suffix}", None)
+            for root in review_queue.TIER_4_PREFIXES
+            if not root.endswith("/")
+            for suffix in FILE_ROOT_SUFFIXES
+        ),
+        *(
+            (f"{root}nested/authority.txt", root)
+            for root in review_queue.TIER_4_PREFIXES
+            if root.endswith("/")
+        ),
+    ],
+)
+def test_canonical_and_merge_train_boundary_matrix_match(
+    path: str, expected_rule: str | None
+) -> None:
+    assert _canonical_matched_rule(path) == expected_rule
+    assert tier4_merge_train.matches_serialized_path(path) == expected_rule
+    tier, _name, _reason = review_queue._classify_model_review_tier([path])
+    assert (tier == 4) is (expected_rule is not None)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [root.rstrip("/") for root in review_queue.TIER_4_PREFIXES if root.endswith("/")],
+)
+def test_directory_authority_requires_slash_boundary(path: str) -> None:
+    assert _canonical_matched_rule(path) is None
+    assert tier4_merge_train.matches_serialized_path(path) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "aragora/knowledge/mound/metrics.py",
+        "aragora/knowledge/mound/metrics_health_bridge.py",
+    ),
+)
+def test_existing_tier2_metric_stem_paths_remain_tier2(path: str) -> None:
+    tier, name, _reason = review_queue._classify_model_review_tier([path])
+    assert tier == 2
+    assert name == "tier_2_live_automation"
 
 
 @pytest.mark.parametrize("path", REPORTING_ONLY_PATHS + UNRELATED_SIBLING_PATHS)
@@ -96,7 +163,7 @@ def test_reporting_and_unrelated_siblings_remain_below_tier4(path: str) -> None:
     assert path not in review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES
 
 
-def test_review_queue_changes_are_constants_only_for_cdg_classifier() -> None:
+def test_authority_constants_and_tuple_shape_remain_exact() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     review_queue_path = repo_root / "aragora/cli/commands/review_queue.py"
     merge_train_path = repo_root / "scripts/tier4_merge_train.py"
@@ -109,7 +176,17 @@ def test_review_queue_changes_are_constants_only_for_cdg_classifier() -> None:
         _assigned_string_literals(merge_train_path, "CONTRACT_DRIFT_AUTHORITY_PREFIXES")
         == EXPECTED_AUTHORITY_PREFIXES
     )
+    assert _assignment_line_span(review_queue_path, "CONTRACT_DRIFT_AUTHORITY_PREFIXES") == 0
 
-    parser_source = (repo_root / "aragora/cli/parser.py").read_text(encoding="utf-8")
-    for command_name in ("classify-tier", "authority-manifest", "boundary-validator"):
-        assert command_name not in parser_source
+
+@pytest.mark.parametrize(
+    "command_name",
+    ("classify-tier", "authority-manifest", "boundary-validator"),
+)
+def test_review_queue_parser_rejects_unapproved_authority_commands(command_name: str) -> None:
+    from aragora.cli.parser import build_parser
+
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["review-queue", command_name])
+    assert exc_info.value.code == 2

--- a/tests/scripts/test_tier4_merge_train.py
+++ b/tests/scripts/test_tier4_merge_train.py
@@ -101,6 +101,26 @@ def test_full_lane_queues_candidate() -> None:
     assert result["contended_surfaces"]["scripts/settle_tier4_pr.py"]["lane_full"] is True
 
 
+def test_cap_one_contention_is_deterministic_for_exact_authority_file() -> None:
+    authority = "scripts/check_contract_drift_ratchet.py"
+    open_prs = [
+        _pr(9412, [authority], created="2026-07-17T20:01:00Z"),
+        _pr(9410, [authority], created="2026-07-17T19:59:00Z"),
+    ]
+
+    first = train.evaluate_merge_train([authority], open_prs=open_prs, cap=1)
+    second = train.evaluate_merge_train([authority], open_prs=list(reversed(open_prs)), cap=1)
+
+    assert first == second
+    assert first["decision"] == train.QUEUE
+    assert first["blocking_prs"] == [9410, 9412]
+    assert first["contended_surfaces"][authority] == {
+        "open_pr_numbers": [9410, 9412],
+        "head_pr": 9410,
+        "lane_full": True,
+    }
+
+
 def test_cap_two_allows_second_pr() -> None:
     open_prs = [_pr(8405, ["scripts/settle_tier4_pr.py"], created="2026-06-14T04:00:00Z")]
     result = train.evaluate_merge_train(
@@ -232,7 +252,7 @@ def test_serialized_prefixes_match_canonical_tier4() -> None:
         "aragora.cli.commands.review_queue",
         reason="review_queue import closure unavailable in this environment",
     )
-    assert set(train.SERIALIZED_TIER4_PREFIXES) == set(review_queue.TIER_4_PREFIXES), (
+    assert train.SERIALIZED_TIER4_PREFIXES == review_queue.TIER_4_PREFIXES, (
         "scripts/tier4_merge_train.py SERIALIZED_TIER4_PREFIXES has drifted from "
         "review_queue.TIER_4_PREFIXES — re-sync the vendored copy."
     )


### PR DESCRIPTION
## Summary

- make exact Tier-4 authority file roots match by equality only while slash-terminated directory roots continue matching descendants
- preserve historical Tier-2 filename-stem behavior and keep the serialized merge-train matcher in behavioral parity without changing its production code
- replace the whole-source parser substring guard with behavioral parser rejection, and add boundary, parity, tuple-shape, and cap-one serialization regression coverage

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test improvement

## Related Issues

Mission feature: `cdg-tier4-authority-matcher-semantics`

## Checklist

### Before Submitting

- [x] I have read the repository operating and contribution guidance
- [x] My code follows the project's code style (`make lint`; `ruff format --check`)
- [x] I have added tests that prove the fix works
- [x] Focused, full review-queue, typecheck, import, and smoke validation pass
- [x] No documentation change is needed
- [x] My commit message follows conventional commit format

### Code Quality

- [x] No new `# type: ignore` comments
- [x] No hardcoded secrets or credentials
- [x] Error handling remains unchanged
- [x] Changed production code retains type hints

### For Bug Fixes

- [x] Root cause is identified: non-slash exact file roots were matched with unrestricted `startswith`
- [x] Regression cases cover `.bak`, `.old`, `.pyx`, `/child`, slash boundaries, and directory descendants
- [x] Canonical and merge-train matched-rule parity is asserted across the full Tier-4 matrix

## Test Plan

```bash
python3 -m pytest tests/governance/test_contract_drift_measurement_authority_tier.py tests/scripts/test_tier4_merge_train.py tests/cli/commands/test_review_queue.py -q
# 453 passed

make lint
ruff format --check aragora/cli/commands/review_queue.py tests/governance/test_contract_drift_measurement_authority_tier.py tests/scripts/test_tier4_merge_train.py
python3 -m mypy aragora/cli/commands/review_queue.py --ignore-missing-imports --show-error-codes --no-pretty
make test-smoke
python3 -m pytest -m smoke tests/smoke/test_smoke.py -q --timeout=30
# 16 passed

bash scripts/automation_pr_preflight.sh origin/main HEAD
```

## Additional Notes

- Tier 4: exact-head human settlement is required before a distinct post-settlement quorum run and protected squash merge.
- Production changes are limited to `review_queue._matches_prefix`; `scripts/tier4_merge_train.py` and `aragora/cli/parser.py` are unchanged.
- `CONTRACT_DRIFT_AUTHORITY_PREFIXES`, its single-line tuple shape, and `TIER_4_PREFIXES` are byte-identical to the base.
- The six operator-approved overlapping PRs were only read for exact-head safety checks and were not edited, rebased, commented on, closed, superseded, or adopted.
