### PR TITLE
feat(governance): add contract drift authority surfaces

### DIFF
--- a/scripts/check_contract_drift_ratchet.py
+++ b/scripts/check_contract_drift_ratchet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Enforce contract drift governance: program burn-down and per-PR delta ratchet.
 
-Two modes:
+Three modes:
 
 - ``program`` (cron / dispatch / main): per-class scheduled targets over OPEN
   items in the canonical provenance-classified inventory. ``start_cohort``
@@ -31,13 +31,22 @@ Two modes:
   could cash in as fake burn-down, even delta-neutrally), as is any other
   integrity violation. The program status is still reported (informational)
   so PR authors see the burn-down state.
+
+- ``boundary``: independent schema-versioned validation of a governed
+  interval. It binds exact start/end SHAs, the standalone authority manifest,
+  immutable cohort/provenance artifacts, reconstructed projection and
+  partition facts, and every supplied evidence digest. Inherited conclusions
+  and mutating action traces fail closed; unmet immutable-release or rule-suite
+  prerequisites report ``blocked`` instead of passed.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
+import re
 import subprocess
 import sys
 from collections import defaultdict
@@ -58,6 +67,68 @@ COUNT_KEYS: tuple[tuple[str, str, str], ...] = (
     ("sdk_missing_from_both", "parity", "missing_from_both_sdks"),
 )
 
+BOUNDARY_SCHEMA_VERSION = 1
+BOUNDARY_NAMES = (
+    "corrective_bootstrap",
+    "route_truth",
+    "core_sdk",
+    "extended_sdk",
+    "final_seal",
+)
+BOUNDARY_EVIDENCE_SCHEMA = "contract-drift-boundary-evidence-v1"
+BOUNDARY_MANIFEST_SCHEMA = "contract-drift-boundary-manifest-v1"
+AUTHORITY_MANIFEST_SCHEMA = "cdg-authority-manifest-v1"
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+CANONICAL_SERIALIZATION = (
+    "UTF-8; no BOM; object keys sorted; compact separators comma/colon; "
+    "declared array orders; one terminal LF"
+)
+COHORT_ARTIFACT = {
+    "path": "library/contract-drift-original-cohort-v1.json",
+    "byte_length": 1_692_125,
+    "sha256": "565cd84a9a5d266f61b66bd7965e0a036e4817ef5fed32edb8c41a2dea6cc208",
+    "schema": "contract-drift-original-cohort-v1",
+}
+PROVENANCE_ARTIFACT = {
+    "path": "library/contract-drift-sdk-provenance-v1.json",
+    "byte_length": 898_099,
+    "sha256": "21ae1c30200cda6df51dbca7053bbbbde6241ab78a73347b0fe5e4d2ed79f07f",
+    "schema": "contract-drift-sdk-provenance-v1",
+}
+ORIGINAL_ID_SET_SHA256 = "c1235670c183b1887ba3fe4280fa0320f9fd6f4a85b8f346d4332ac2aebbe269"
+PROVENANCE_RECORD_SET_SHA256 = "0d30ce3b083344f19949da12ae2d92952757af0aea800b3f99d447458b6eeba0"
+PROJECTION_RECORD_SET_SHA256 = "2d6790a6f825c53047639d9433f40e3e10b5bfc9e357bcd161f6b341134775e5"
+SDK_ID_SET_SHA256 = "51a963079136a92a86485b56f6cef42aafc7749bfad146ce5fb37293524c5762"
+CORE_ID_SET_SHA256 = "b3a1755f027c998d507f13f3ba9093f769cea8720d44bfac12be6beccd626787"
+EXTENDED_ID_SET_SHA256 = "bb1fc41548778022dab3041bc05fc40a4da239a1bd4ad8b1ccbcd1007d90b252"
+BOUNDARY_DIGEST_FIELDS = (
+    "dependency_manifest_sha256",
+    "active_inventory_sha256",
+    "public_symbol_manifest_sha256",
+    "route_boundary_sha256",
+    "category_set_sha256",
+    "unit_set_sha256",
+    "core_set_sha256",
+    "extended_set_sha256",
+)
+MUTATING_HTTP_VERBS = {"POST", "PUT", "PATCH", "DELETE"}
+READ_ONLY_GIT_SUBCOMMANDS = {
+    "cat-file",
+    "diff",
+    "diff-tree",
+    "for-each-ref",
+    "log",
+    "ls-files",
+    "ls-tree",
+    "merge-base",
+    "rev-list",
+    "rev-parse",
+    "show",
+    "show-ref",
+    "status",
+}
+
 
 def _load_json_strict(path: Path, label: str) -> dict[str, Any]:
     if not path.exists():
@@ -69,6 +140,991 @@ def _load_json_strict(path: Path, label: str) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"{label} malformed (expected object): {path}")
     return data
+
+
+def _canonical_json_bytes(value: Any, *, terminal_lf: bool = False) -> bytes:
+    rendered = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return rendered + (b"\n" if terminal_lf else b"")
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _duplicate_key_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_canonical_artifact(
+    path: Path,
+    *,
+    expected: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not path.exists():
+        raise ValueError(f"canonical artifact missing: {path}")
+    if path.is_symlink():
+        raise ValueError(f"canonical artifact may not be a symlink: {path}")
+    raw = path.read_bytes()
+    if len(raw) != expected["byte_length"]:
+        raise ValueError(
+            f"{expected['path']} byte length mismatch: {len(raw)} != {expected['byte_length']}"
+        )
+    digest = _sha256_bytes(raw)
+    if digest != expected["sha256"]:
+        raise ValueError(f"{expected['path']} SHA-256 mismatch: {digest} != {expected['sha256']}")
+    if raw.startswith(b"\xef\xbb\xbf"):
+        raise ValueError(f"{expected['path']} has a forbidden UTF-8 BOM")
+    if not raw.endswith(b"\n") or raw.count(b"\n") != 1:
+        raise ValueError(f"{expected['path']} must have exactly one terminal LF")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{expected['path']} is not UTF-8") from exc
+    try:
+        payload = json.loads(text, object_pairs_hook=_duplicate_key_object)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{expected['path']} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{expected['path']} must contain a JSON object")
+    if payload.get("schema") != expected["schema"]:
+        raise ValueError(
+            f"{expected['path']} schema mismatch: "
+            f"{payload.get('schema')!r} != {expected['schema']!r}"
+        )
+    if _canonical_json_bytes(payload, terminal_lf=True) != raw:
+        raise ValueError(f"{expected['path']} bytes are not canonical sorted-key JSON")
+    return payload, {
+        **expected,
+        "canonical_bytes_valid": True,
+        "canonical_serialization": CANONICAL_SERIALIZATION,
+    }
+
+
+def _digest_set(schema: str, values: list[str], field: str) -> str:
+    return _sha256_bytes(_canonical_json_bytes({"schema": schema, field: sorted(values)}))
+
+
+def _validate_original_cohort(cohort: dict[str, Any]) -> dict[str, Any]:
+    records = cohort.get("original_records")
+    if not isinstance(records, list) or len(records) != 655:
+        raise ValueError("canonical cohort must contain exactly 655 original_records")
+
+    category_counts: dict[str, int] = defaultdict(int)
+    original_ids: list[str] = []
+    sdk_records: dict[str, dict[str, Any]] = {}
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            raise ValueError(f"original record {index} is not an object")
+        category = record.get("category")
+        literal = record.get("exact_historical_literal_record")
+        if not isinstance(category, str) or not isinstance(literal, str):
+            raise ValueError(f"original record {index} has malformed identity fields")
+        id_payload = {
+            "category": category,
+            "exact_historical_literal_record": literal,
+            "schema": "cdg-original-record-id-v1",
+        }
+        id_payload_bytes = _canonical_json_bytes(id_payload)
+        payload_digest = _sha256_bytes(id_payload_bytes)
+        expected_id = f"cdg1:{payload_digest}"
+        if record.get("id_payload_byte_length") != len(id_payload_bytes):
+            raise ValueError(f"original record {index} id payload length mismatch")
+        if record.get("id_payload_sha256") != payload_digest:
+            raise ValueError(f"original record {index} id payload digest mismatch")
+        if record.get("original_record_id") != expected_id:
+            raise ValueError(f"original record {index} original_record_id mismatch")
+        original_ids.append(expected_id)
+        category_counts[category] += 1
+        if category in {"python_sdk_drift", "typescript_sdk_drift"}:
+            if not record.get("method"):
+                raise ValueError(f"SDK original record {expected_id} has null method")
+            sdk_records[expected_id] = record
+        elif record.get("method") is not None:
+            raise ValueError(f"path-level original record {expected_id} has a method")
+
+    if len(set(original_ids)) != 655:
+        raise ValueError("canonical cohort contains duplicate original_record_id values")
+    id_set = cohort.get("original_record_id_set")
+    if not isinstance(id_set, dict):
+        raise ValueError("canonical cohort lacks original_record_id_set")
+    if id_set.get("original_record_ids") != sorted(original_ids):
+        raise ValueError("canonical cohort original_record_id_set is not the exact sorted ID set")
+    id_set_digest = _digest_set(
+        "cdg-original-record-id-set-v1",
+        original_ids,
+        "original_record_ids",
+    )
+    if id_set.get("sha256") != id_set_digest or id_set_digest != ORIGINAL_ID_SET_SHA256:
+        raise ValueError("canonical cohort original-record ID-set digest mismatch")
+
+    declared_counts = cohort.get("counts")
+    if not isinstance(declared_counts, dict):
+        raise ValueError("canonical cohort lacks counts")
+    if declared_counts.get("records") != 655:
+        raise ValueError("canonical cohort declared record count mismatch")
+    if declared_counts.get("by_category") != dict(sorted(category_counts.items())):
+        raise ValueError("canonical cohort category counts mismatch")
+    if declared_counts.get("method_bearing_sdk_records") != 598:
+        raise ValueError("canonical cohort SDK record count mismatch")
+    if declared_counts.get("method_null_route_parity_records") != 57:
+        raise ValueError("canonical cohort path-level record count mismatch")
+
+    projection = cohort.get("operation_projection")
+    if not isinstance(projection, dict):
+        raise ValueError("canonical cohort lacks operation_projection")
+    projection_records = projection.get("records")
+    if not isinstance(projection_records, list) or len(projection_records) != 655:
+        raise ValueError("operation projection must contain 655 membership records")
+    projection_ids: list[str] = []
+    projection_digests: list[str] = []
+    edge_total = 0
+    multi_edge = 0
+    max_edges = 0
+    edge_count_distribution: dict[str, int] = defaultdict(int)
+    for index, record in enumerate(projection_records):
+        if not isinstance(record, dict):
+            raise ValueError(f"operation projection record {index} is not an object")
+        original_id = record.get("original_record_id")
+        projection_ids.append(str(original_id))
+        expected_record_digest = _sha256_bytes(
+            _canonical_json_bytes({k: v for k, v in record.items() if k != "record_sha256"})
+        )
+        if record.get("record_sha256") != expected_record_digest:
+            raise ValueError(f"operation projection record {index} digest mismatch")
+        projection_digests.append(expected_record_digest)
+        edges = record.get("operation_edges")
+        if not isinstance(edges, list) or not edges:
+            raise ValueError(f"operation projection record {index} has no operation_edges")
+        seen_edges: set[tuple[str, str]] = set()
+        for edge in edges:
+            if not isinstance(edge, dict):
+                raise ValueError(f"operation projection record {index} has malformed edge")
+            method = edge.get("method")
+            normalized_path = edge.get("normalized_path")
+            if method not in {
+                "GET",
+                "HEAD",
+                "POST",
+                "PUT",
+                "DELETE",
+                "CONNECT",
+                "OPTIONS",
+                "TRACE",
+                "PATCH",
+            }:
+                raise ValueError(f"operation projection record {index} has invalid method")
+            if not isinstance(normalized_path, str) or not normalized_path.startswith("/"):
+                raise ValueError(f"operation projection record {index} has invalid normalized_path")
+            if not isinstance(edge.get("evidence"), list) or not edge["evidence"]:
+                raise ValueError(f"operation projection record {index} has empty evidence")
+            edge_key = (method, normalized_path)
+            if edge_key in seen_edges:
+                raise ValueError(f"operation projection record {index} has duplicate edge")
+            seen_edges.add(edge_key)
+        edge_count = len(edges)
+        edge_total += edge_count
+        multi_edge += int(edge_count > 1)
+        max_edges = max(max_edges, edge_count)
+        edge_count_distribution[str(edge_count)] += 1
+
+    if sorted(projection_ids) != sorted(original_ids) or len(set(projection_ids)) != 655:
+        raise ValueError("operation projection membership does not biject with original IDs")
+    projection_digest = _digest_set(
+        "cdg-operation-projection-record-digest-set-v1",
+        projection_digests,
+        "record_sha256_values",
+    )
+    if (
+        projection.get("record_digest_set_sha256") != projection_digest
+        or projection_digest != PROJECTION_RECORD_SET_SHA256
+    ):
+        raise ValueError("operation projection record-digest-set mismatch")
+    if (edge_total, multi_edge, max_edges) != (666, 9, 4):
+        raise ValueError(
+            "operation projection cardinality mismatch "
+            f"(edges={edge_total}, multi={multi_edge}, max={max_edges})"
+        )
+    return {
+        "original_record_ids": sorted(original_ids),
+        "category_counts": dict(sorted(category_counts.items())),
+        "sdk_records": sdk_records,
+        "projection_membership_count": len(projection_records),
+        "projection_edge_count": edge_total,
+        "projection_multi_edge_originals": multi_edge,
+        "projection_max_edges": max_edges,
+        "projection_edge_count_distribution": dict(sorted(edge_count_distribution.items())),
+        "projection_record_digest_set_sha256": projection_digest,
+    }
+
+
+def _validate_sdk_provenance(
+    provenance: dict[str, Any],
+    cohort_summary: dict[str, Any],
+) -> dict[str, Any]:
+    records = provenance.get("records")
+    if not isinstance(records, list) or len(records) != 598:
+        raise ValueError("canonical SDK provenance must contain exactly 598 records")
+    cohort_sdk_records = cohort_summary["sdk_records"]
+    record_ids: list[str] = []
+    record_digests: list[str] = []
+    occurrence_count = 0
+    multi_atom_count = 0
+    partitions: dict[str, list[str]] = {"core": [], "extended": []}
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            raise ValueError(f"SDK provenance record {index} is not an object")
+        original_id = record.get("original_record_id")
+        if not isinstance(original_id, str) or original_id not in cohort_sdk_records:
+            raise ValueError(f"SDK provenance record {index} lacks a cohort link")
+        expected_digest = _sha256_bytes(
+            _canonical_json_bytes({k: v for k, v in record.items() if k != "record_sha256"})
+        )
+        if record.get("record_sha256") != expected_digest:
+            raise ValueError(f"SDK provenance record {index} digest mismatch")
+        cohort_record = cohort_sdk_records[original_id]
+        for field in (
+            "category",
+            "exact_historical_literal_record",
+            "id_payload_byte_length",
+            "id_payload_sha256",
+            "source_array_index",
+        ):
+            if record.get(field) != cohort_record.get(field):
+                raise ValueError(f"SDK provenance record {index} {field} link mismatch")
+        if cohort_record.get("sdk_language") != [record.get("sdk_language")]:
+            raise ValueError(f"SDK provenance record {index} sdk_language link mismatch")
+        if cohort_record.get("sdk_provenance_record_sha256") != expected_digest:
+            raise ValueError(f"SDK provenance record {index} cohort digest link mismatch")
+        atoms = record.get("provenance_atoms")
+        occurrences = record.get("source_occurrences")
+        if (
+            not isinstance(atoms, list)
+            or not atoms
+            or not all(isinstance(atom, str) and atom for atom in atoms)
+        ):
+            raise ValueError(f"SDK provenance record {index} has malformed provenance atoms")
+        if not isinstance(occurrences, list) or not occurrences:
+            raise ValueError(f"SDK provenance record {index} has no source occurrences")
+        partition = record.get("partition")
+        if not isinstance(partition, str) or partition not in partitions:
+            raise ValueError(f"SDK provenance record {index} has invalid partition")
+        partitions[partition].append(original_id)
+        record_ids.append(original_id)
+        record_digests.append(expected_digest)
+        occurrence_count += len(occurrences)
+        multi_atom_count += int(len(atoms) > 1)
+
+    if sorted(record_ids) != sorted(cohort_sdk_records) or len(set(record_ids)) != 598:
+        raise ValueError("SDK provenance records do not biject with cohort SDK records")
+    record_set_digest = _digest_set(
+        "cdg-sdk-provenance-record-digest-set-v1",
+        record_digests,
+        "record_sha256_values",
+    )
+    if (
+        provenance.get("record_digest_set_sha256") != record_set_digest
+        or record_set_digest != PROVENANCE_RECORD_SET_SHA256
+    ):
+        raise ValueError("SDK provenance record-digest-set mismatch")
+    counts = provenance.get("counts")
+    if not isinstance(counts, dict):
+        raise ValueError("SDK provenance lacks counts")
+    expected_counts = {
+        "records": 598,
+        "source_occurrences": 690,
+        "records_with_multiple_distinct_atoms": 12,
+        "core": 75,
+        "extended": 523,
+    }
+    for field, expected_value in expected_counts.items():
+        if counts.get(field) != expected_value:
+            raise ValueError(f"SDK provenance count {field} mismatch")
+    if occurrence_count != 690 or multi_atom_count != 12:
+        raise ValueError("SDK provenance reconstructed occurrence/atom counts mismatch")
+
+    all_sdk_ids = sorted(record_ids)
+    core_ids = sorted(partitions["core"])
+    extended_ids = sorted(partitions["extended"])
+    if set(core_ids) & set(extended_ids) or sorted(core_ids + extended_ids) != all_sdk_ids:
+        raise ValueError("SDK core/extended partition is not disjoint and exhaustive")
+    partition = provenance.get("partition")
+    if not isinstance(partition, dict):
+        raise ValueError("SDK provenance lacks partition descriptor")
+    digest_expectations = (
+        (
+            "sdk_original_record_id_set_sha256",
+            _digest_set("cdg-sdk-original-record-id-set-v1", all_sdk_ids, "original_record_ids"),
+            SDK_ID_SET_SHA256,
+        ),
+        (
+            "core_original_record_id_set_sha256",
+            _digest_set("cdg-core-original-record-id-set-v1", core_ids, "original_record_ids"),
+            CORE_ID_SET_SHA256,
+        ),
+        (
+            "extended_original_record_id_set_sha256",
+            _digest_set(
+                "cdg-extended-original-record-id-set-v1",
+                extended_ids,
+                "original_record_ids",
+            ),
+            EXTENDED_ID_SET_SHA256,
+        ),
+    )
+    for field, reconstructed, expected in digest_expectations:
+        if partition.get(field) != reconstructed or reconstructed != expected:
+            raise ValueError(f"SDK partition digest {field} mismatch")
+    return {
+        "record_count": len(records),
+        "source_occurrence_count": occurrence_count,
+        "multiple_atom_record_count": multi_atom_count,
+        "missing_provenance_count": 0,
+        "core_count": len(core_ids),
+        "extended_count": len(extended_ids),
+        "record_digest_set_sha256": record_set_digest,
+        "baseline_birth": provenance.get("baseline_birth"),
+        "dependencies": provenance.get("dependencies"),
+        "extraction_algorithm": provenance.get("extraction_algorithm"),
+        "sdk_original_record_id_set_sha256": SDK_ID_SET_SHA256,
+        "core_original_record_id_set_sha256": CORE_ID_SET_SHA256,
+        "extended_original_record_id_set_sha256": EXTENDED_ID_SET_SHA256,
+    }
+
+
+def _resolve_full_sha(repo_root: Path, ref: str, *, label: str) -> str:
+    if not FULL_SHA_RE.fullmatch(ref):
+        raise ValueError(f"{label} must be a full 40-character lowercase commit SHA")
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    resolved = proc.stdout.strip()
+    if resolved != ref:
+        raise ValueError(f"{label} did not resolve to the exact supplied commit SHA")
+    return resolved
+
+
+def _is_ancestor(repo_root: Path, start_sha: str, end_sha: str) -> bool:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", start_sha, end_sha],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def _load_json_no_duplicates(path: Path, *, label: str) -> dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"{label} missing: {path}")
+    if path.is_symlink():
+        raise ValueError(f"{label} may not be a symlink: {path}")
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_duplicate_key_object,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must contain a JSON object")
+    return payload
+
+
+def _validate_authority_manifest(
+    manifest: dict[str, Any],
+    *,
+    repo_root: Path,
+    end_sha: str,
+    cohort: dict[str, Any],
+    provenance: dict[str, Any],
+    cohort_summary: dict[str, Any],
+) -> dict[str, Any]:
+    if manifest.get("schema") != AUTHORITY_MANIFEST_SCHEMA:
+        raise ValueError("authority manifest schema mismatch")
+    if manifest.get("ref") != end_sha:
+        raise ValueError("authority manifest ref does not equal boundary end SHA")
+    repo_files = manifest.get("repo_files")
+    if (
+        not isinstance(repo_files, list)
+        or not repo_files
+        or not all(isinstance(path, str) and path for path in repo_files)
+    ):
+        raise ValueError("authority manifest repo_files must be a nonempty string list")
+    if repo_files != sorted(set(repo_files)):
+        raise ValueError("authority manifest repo_files must be sorted and unique")
+    file_bindings = manifest.get("file_bindings")
+    if not isinstance(file_bindings, list) or len(file_bindings) != len(repo_files):
+        raise ValueError("authority manifest file_bindings do not cover repo_files")
+    bound_paths = []
+    for binding in file_bindings:
+        if not isinstance(binding, dict):
+            raise ValueError("authority manifest contains a malformed file binding")
+        path = binding.get("path")
+        digest = binding.get("sha256")
+        if not isinstance(path, str) or not SHA256_RE.fullmatch(str(digest)):
+            raise ValueError("authority manifest file binding lacks path/SHA-256")
+        if not isinstance(binding.get("byte_length"), int) or binding["byte_length"] < 0:
+            raise ValueError("authority manifest file binding has invalid byte length")
+        if binding.get("effective_tier") != 4:
+            raise ValueError(f"authority manifest closure member is not Tier 4: {path}")
+        if not isinstance(binding.get("matched_authority_rule"), str):
+            raise ValueError(f"authority manifest closure member has no matched rule: {path}")
+        blob = subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "blob", f"{end_sha}:{path}"],
+            check=True,
+            capture_output=True,
+        ).stdout
+        oid = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--verify", f"{end_sha}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        if (
+            binding.get("git_blob_oid") != oid
+            or binding["byte_length"] != len(blob)
+            or digest != _sha256_bytes(blob)
+        ):
+            raise ValueError(f"authority manifest file binding does not match ref: {path}")
+        bound_paths.append(path)
+    if bound_paths != repo_files:
+        raise ValueError("authority manifest file bindings are not in repo_files order")
+    policy = manifest.get("policy")
+    if (
+        not isinstance(policy, dict)
+        or policy.get("canonical_policy_module") != "aragora.cli.commands.review_queue"
+        or policy.get("tier") != 4
+        or not isinstance(policy.get("policy_version"), int)
+        or policy["policy_version"] < 1
+    ):
+        raise ValueError("authority manifest canonical policy binding mismatch")
+    authority_roots = policy.get("authority_roots")
+    review_queue = inventory_mod._review_queue_module()
+    expected_roots = sorted(str(root) for root in review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES)
+    if (
+        not isinstance(authority_roots, list)
+        or authority_roots != expected_roots
+        or policy.get("policy_version") != review_queue.CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION
+        or policy.get("tier") != review_queue.CONTRACT_DRIFT_AUTHORITY_TIER
+        or not set(authority_roots) <= set(repo_files)
+    ):
+        raise ValueError("authority manifest authority roots are incomplete or noncanonical")
+    expected_closure = set(authority_roots) | {"aragora/cli/commands/review_queue.py"}
+    workflow_names = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-tree",
+            "--name-only",
+            end_sha,
+            ".github/workflows/",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    for workflow in workflow_names:
+        if not workflow.endswith(".yml"):
+            continue
+        workflow_blob = subprocess.run(
+            ["git", "-C", str(repo_root), "cat-file", "blob", f"{end_sha}:{workflow}"],
+            check=True,
+            capture_output=True,
+        ).stdout.decode("utf-8", errors="replace")
+        if any(root in workflow_blob for root in authority_roots):
+            expected_closure.add(workflow)
+    if repo_files != sorted(expected_closure):
+        raise ValueError("authority manifest repository closure mismatch")
+    mirror = manifest.get("merge_train_mirror")
+    if (
+        not isinstance(mirror, dict)
+        or mirror.get("path") != "scripts/tier4_merge_train.py"
+        or mirror.get("role") != "dependency_light_mirror"
+        or mirror.get("in_repo_files") is not False
+    ):
+        raise ValueError("authority manifest merge-train mirror binding mismatch")
+    mirror_blob = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "cat-file",
+            "blob",
+            f"{end_sha}:scripts/tier4_merge_train.py",
+        ],
+        check=True,
+        capture_output=True,
+    ).stdout
+    mirror_oid = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "rev-parse",
+            "--verify",
+            f"{end_sha}:scripts/tier4_merge_train.py",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if (
+        mirror.get("git_blob_oid") != mirror_oid
+        or mirror.get("byte_length") != len(mirror_blob)
+        or mirror.get("sha256") != _sha256_bytes(mirror_blob)
+    ):
+        raise ValueError("authority manifest merge-train mirror does not match ref")
+    digest = manifest.get("authority_manifest_sha256")
+    if not SHA256_RE.fullmatch(str(digest)):
+        raise ValueError("authority manifest lacks a valid authority_manifest_sha256")
+    reconstructed = _sha256_bytes(
+        _canonical_json_bytes(
+            {key: value for key, value in manifest.items() if key != "authority_manifest_sha256"}
+        )
+    )
+    if digest != reconstructed:
+        raise ValueError("authority manifest digest mismatch")
+
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, dict):
+        raise ValueError("authority manifest lacks canonical artifact bindings")
+    for key, expected in (
+        ("original_cohort", COHORT_ARTIFACT),
+        ("sdk_provenance", PROVENANCE_ARTIFACT),
+    ):
+        descriptor = artifacts.get(key)
+        if not isinstance(descriptor, dict):
+            raise ValueError(f"authority manifest lacks {key} artifact binding")
+        required = {
+            "logical_path": expected["path"],
+            "byte_length": expected["byte_length"],
+            "sha256": expected["sha256"],
+            "schema": expected["schema"],
+            "canonical_bytes": True,
+            "utf8_no_bom": True,
+            "single_terminal_lf": True,
+        }
+        if descriptor != required:
+            raise ValueError(f"authority manifest {key} artifact binding mismatch")
+
+    facts = manifest.get("inventory_facts")
+    if not isinstance(facts, dict):
+        raise ValueError("authority manifest lacks deterministic inventory facts")
+    if facts.get("inventory_schema") != "cdg-standalone-inventory-v1" or not SHA256_RE.fullmatch(
+        str(facts.get("inventory_sha256"))
+    ):
+        raise ValueError("authority manifest deterministic inventory digest mismatch")
+    if facts.get("membership_anchor") != cohort.get("membership_anchor"):
+        raise ValueError("authority manifest membership anchor mismatch")
+    if facts.get("membership_sources") != cohort.get("membership_sources"):
+        raise ValueError("authority manifest membership sources mismatch")
+    expected_facts = {
+        "original_record_total": 655,
+        "original_record_id_set_sha256": ORIGINAL_ID_SET_SHA256,
+        "category_counts": cohort_summary["category_counts"],
+        "method_bearing_sdk_records": 598,
+        "method_null_route_parity_records": 57,
+    }
+    for field, expected in expected_facts.items():
+        if facts.get(field) != expected:
+            raise ValueError(f"authority manifest inventory fact mismatch: {field}")
+    projection = facts.get("operation_projection")
+    if not isinstance(projection, dict) or (
+        projection.get("membership_count"),
+        projection.get("operation_edge_count"),
+        projection.get("multi_edge_membership_count"),
+        projection.get("max_operation_edges"),
+        projection.get("record_digest_set_sha256"),
+    ) != (655, 666, 9, 4, PROJECTION_RECORD_SET_SHA256):
+        raise ValueError("authority manifest operation projection facts mismatch")
+    provenance_facts = facts.get("sdk_provenance")
+    if not isinstance(provenance_facts, dict):
+        raise ValueError("authority manifest lacks SDK provenance facts")
+    for field in (
+        "baseline_birth",
+        "dependencies",
+        "extraction_algorithm",
+    ):
+        if provenance_facts.get(field) != provenance.get(field):
+            raise ValueError(f"authority manifest SDK provenance {field} mismatch")
+    provenance_expected = {
+        "record_count": 598,
+        "source_occurrence_count": 690,
+        "multi_atom_record_count": 12,
+        "missing_record_count": 0,
+        "record_digest_set_sha256": PROVENANCE_RECORD_SET_SHA256,
+    }
+    for field, expected_value in provenance_expected.items():
+        if provenance_facts.get(field) != expected_value:
+            raise ValueError(f"authority manifest SDK provenance fact mismatch: {field}")
+    partition = provenance_facts.get("partition")
+    if not isinstance(partition, dict) or (
+        partition.get("core_count"),
+        partition.get("extended_count"),
+        partition.get("sdk_original_record_id_set_sha256"),
+        partition.get("core_original_record_id_set_sha256"),
+        partition.get("extended_original_record_id_set_sha256"),
+    ) != (75, 523, SDK_ID_SET_SHA256, CORE_ID_SET_SHA256, EXTENDED_ID_SET_SHA256):
+        raise ValueError("authority manifest SDK partition facts mismatch")
+
+    active = facts.get("active_inventory")
+    if not isinstance(active, dict) or active.get("path") != inventory_mod.DEFAULT_INVENTORY:
+        raise ValueError("authority manifest active inventory binding mismatch")
+    active_blob = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "cat-file",
+            "blob",
+            f"{end_sha}:{inventory_mod.DEFAULT_INVENTORY}",
+        ],
+        check=True,
+        capture_output=True,
+    ).stdout
+    active_oid = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "rev-parse",
+            "--verify",
+            f"{end_sha}:{inventory_mod.DEFAULT_INVENTORY}",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    active_doc = json.loads(active_blob)
+    active_items = active_doc.get("items")
+    if not isinstance(active_items, list):
+        raise ValueError("authority manifest active inventory has no items list")
+    expected_active = {
+        "path": inventory_mod.DEFAULT_INVENTORY,
+        "git_blob_oid": active_oid,
+        "byte_length": len(active_blob),
+        "sha256": _sha256_bytes(active_blob),
+        "cohort_commit": str(active_doc.get("cohort_commit", "")),
+        "item_total": len(active_items),
+        "open_items": sum(
+            1 for item in active_items if isinstance(item, dict) and item.get("status") == "open"
+        ),
+        "resolved_items": sum(
+            1
+            for item in active_items
+            if isinstance(item, dict) and item.get("status") == "resolved"
+        ),
+    }
+    if active != expected_active:
+        raise ValueError("authority manifest active inventory does not match ref")
+    return {
+        "authority_manifest_sha256": digest,
+        "authority_repo_file_count": len(repo_files),
+        "authority_repo_files": repo_files,
+        "active_inventory_sha256": expected_active["sha256"],
+    }
+
+
+def _validate_action_audit(actions: Any) -> list[dict[str, Any]]:
+    if actions is None:
+        return []
+    if not isinstance(actions, list):
+        raise ValueError("boundary evidence actions must be a list")
+    validated: list[dict[str, Any]] = []
+    for index, action in enumerate(actions):
+        if not isinstance(action, dict):
+            raise ValueError(f"boundary evidence action {index} is malformed")
+        kind = action.get("kind")
+        if kind == "http":
+            method = str(action.get("method") or "").upper()
+            if method in MUTATING_HTTP_VERBS:
+                raise ValueError(f"mutating HTTP verb rejected: {method}")
+            if method not in {"GET", "HEAD"}:
+                raise ValueError(f"unsupported HTTP verb in read-only evidence: {method}")
+        elif kind == "git":
+            argv = action.get("argv")
+            if not isinstance(argv, list) or not argv:
+                raise ValueError(f"boundary evidence git action {index} lacks argv")
+            args = [str(arg) for arg in argv]
+            cursor = 1 if args and Path(args[0]).name == "git" else 0
+            subcommand = ""
+            while cursor < len(args):
+                arg = args[cursor]
+                if arg in {"-C", "-c", "--git-dir", "--work-tree", "--namespace"}:
+                    cursor += 2
+                    continue
+                if arg.startswith(("--git-dir=", "--work-tree=", "--namespace=")):
+                    cursor += 1
+                    continue
+                if arg.startswith("-"):
+                    cursor += 1
+                    continue
+                subcommand = arg
+                break
+            if subcommand not in READ_ONLY_GIT_SUBCOMMANDS:
+                raise ValueError(f"non-read-only git command rejected: {subcommand or '<missing>'}")
+        elif kind == "subprocess":
+            operation = str(action.get("operation") or "").lower()
+            if operation in {
+                "merge",
+                "release_upload",
+                "rerun",
+                "settle",
+                "status_mutation",
+                "tag_mutation",
+                "workflow_dispatch",
+            }:
+                raise ValueError(f"mutating subprocess action rejected: {operation}")
+            if action.get("mutating") is not False:
+                raise ValueError(f"subprocess action {index} is not explicitly read-only")
+        elif kind == "filesystem":
+            operation = str(action.get("operation") or "").lower()
+            if operation not in {"read", "stat"}:
+                raise ValueError(f"filesystem mutation rejected: {operation}")
+        else:
+            raise ValueError(f"boundary evidence action {index} has unsupported kind {kind!r}")
+        validated.append(action)
+    return validated
+
+
+def _validate_remote_resources(resources: Any) -> tuple[list[dict[str, Any]], str | None]:
+    if resources is None:
+        return [], None
+    if not isinstance(resources, list):
+        raise ValueError("boundary evidence remote_resources must be a list")
+    validated: list[dict[str, Any]] = []
+    moved_reason: str | None = None
+    for index, resource in enumerate(resources):
+        if not isinstance(resource, dict) or not isinstance(resource.get("resource"), str):
+            raise ValueError(f"boundary evidence remote resource {index} is malformed")
+        before = resource.get("before")
+        after = resource.get("after")
+        if not isinstance(before, dict) or not isinstance(after, dict):
+            raise ValueError(f"boundary evidence remote resource {index} lacks snapshots")
+        stable_fields = ("etag", "updated_at", "sha256")
+        if not any(before.get(field) is not None for field in stable_fields):
+            raise ValueError(
+                f"boundary evidence remote resource {index} lacks ETag, updated_at, or SHA-256"
+            )
+        for field in stable_fields:
+            value = before.get(field)
+            if value is not None and after.get(field) != value and moved_reason is None:
+                moved_reason = (
+                    f"remote resource moved during read-only probe: {resource['resource']}"
+                )
+        validated.append(resource)
+    return validated, moved_reason
+
+
+def _validate_boundary_evidence(
+    evidence: dict[str, Any],
+    *,
+    boundary: str,
+    start_sha: str,
+    end_sha: str,
+    authority_summary: dict[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    if evidence.get("schema") != BOUNDARY_EVIDENCE_SCHEMA:
+        raise ValueError("boundary evidence schema mismatch")
+    if evidence.get("boundary") != boundary:
+        raise ValueError("boundary evidence boundary name mismatch")
+    if evidence.get("start_sha") != start_sha or evidence.get("end_sha") != end_sha:
+        raise ValueError("boundary evidence start/end SHA mismatch")
+    if evidence.get("inherited_from_boundary") is not None:
+        raise ValueError("boundary evidence may not inherit a prior boundary conclusion")
+    if evidence.get("prior_boundary_manifest") is not None:
+        raise ValueError("boundary evidence may not embed a prior boundary manifest")
+    if evidence.get("authority_manifest_sha256") != authority_summary["authority_manifest_sha256"]:
+        raise ValueError("boundary evidence authority-manifest digest mismatch")
+    if evidence.get("active_inventory_sha256") != authority_summary["active_inventory_sha256"]:
+        raise ValueError("boundary evidence active-inventory digest mismatch")
+
+    digests: dict[str, str] = {
+        "authority_manifest_sha256": authority_summary["authority_manifest_sha256"]
+    }
+    for field in BOUNDARY_DIGEST_FIELDS:
+        value = evidence.get(field)
+        if not SHA256_RE.fullmatch(str(value)):
+            raise ValueError(f"boundary evidence missing valid digest: {field}")
+        digests[field] = str(value)
+    if digests["core_set_sha256"] != CORE_ID_SET_SHA256:
+        raise ValueError("boundary evidence core-set digest mismatch")
+    if digests["extended_set_sha256"] != EXTENDED_ID_SET_SHA256:
+        raise ValueError("boundary evidence extended-set digest mismatch")
+
+    actions = _validate_action_audit(evidence.get("actions"))
+    remote_resources, remote_blocked_reason = _validate_remote_resources(
+        evidence.get("remote_resources")
+    )
+    prereqs = evidence.get("external_prerequisites")
+    if not isinstance(prereqs, dict):
+        raise ValueError("boundary evidence lacks external_prerequisites")
+    release_claimed = prereqs.get("future_release_immutability_enabled") is True
+    blocked_reason = remote_blocked_reason
+    if blocked_reason is None:
+        if not release_claimed:
+            blocked_reason = "future GitHub Release immutability is not enabled"
+        else:
+            blocked_reason = (
+                "future GitHub Release immutability claim lacks an independent live "
+                "read-only GitHub verification"
+            )
+
+    governed_prs = evidence.get("governed_prs")
+    receipts = evidence.get("first_parent_receipts")
+    if not isinstance(governed_prs, list) or not isinstance(receipts, list):
+        raise ValueError("boundary evidence must contain governed_prs and first_parent_receipts")
+    return {
+        "digests": digests,
+        "actions": actions,
+        "remote_resources": remote_resources,
+        "external_prerequisites": prereqs,
+        "governed_prs": governed_prs,
+        "first_parent_receipts": receipts,
+        "source_receipts": evidence.get("source_receipts", []),
+        "attestation": evidence.get("attestation"),
+    }, blocked_reason
+
+
+def build_boundary_result(
+    *,
+    repo_root: Path,
+    schema_version: int,
+    boundary: str,
+    start_ref: str,
+    end_ref: str,
+    authority_manifest_path: Path | None,
+    cohort_artifact_path: Path | None,
+    sdk_provenance_artifact_path: Path | None,
+    evidence_path: Path | None,
+) -> dict[str, Any]:
+    if schema_version != BOUNDARY_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported boundary schema version {schema_version}; "
+            f"expected {BOUNDARY_SCHEMA_VERSION}"
+        )
+    if boundary not in BOUNDARY_NAMES:
+        raise ValueError(f"unsupported Contract Drift boundary: {boundary}")
+    start_sha = _resolve_full_sha(repo_root, start_ref, label="--start-ref")
+    end_sha = _resolve_full_sha(repo_root, end_ref, label="--end-ref")
+    if not _is_ancestor(repo_root, start_sha, end_sha):
+        raise ValueError("boundary start SHA is not an ancestor of end SHA")
+
+    try:
+        cohort_artifact_path = inventory_mod._discover_artifact_path(
+            cohort_artifact_path,
+            inventory_mod.COHORT_ARTIFACT_FILENAME,
+            repo_root,
+            inventory_mod.COHORT_LOGICAL_PATH,
+        )
+        sdk_provenance_artifact_path = inventory_mod._discover_artifact_path(
+            sdk_provenance_artifact_path,
+            inventory_mod.PROVENANCE_ARTIFACT_FILENAME,
+            repo_root,
+            inventory_mod.PROVENANCE_LOGICAL_PATH,
+        )
+    except inventory_mod.StandaloneError as exc:
+        raise ValueError(exc.message) from exc
+
+    cohort, cohort_descriptor = _load_canonical_artifact(
+        cohort_artifact_path,
+        expected=COHORT_ARTIFACT,
+    )
+    provenance, provenance_descriptor = _load_canonical_artifact(
+        sdk_provenance_artifact_path,
+        expected=PROVENANCE_ARTIFACT,
+    )
+    cohort_summary = _validate_original_cohort(cohort)
+    provenance_summary = _validate_sdk_provenance(provenance, cohort_summary)
+
+    if authority_manifest_path is None:
+        authority_manifest = inventory_mod._build_authority_manifest(
+            repo_root,
+            end_sha,
+            cohort_artifact_path,
+            sdk_provenance_artifact_path,
+        )
+    else:
+        authority_manifest = _load_json_no_duplicates(
+            authority_manifest_path,
+            label="Authority manifest",
+        )
+    authority_summary = _validate_authority_manifest(
+        authority_manifest,
+        repo_root=repo_root,
+        end_sha=end_sha,
+        cohort=cohort,
+        provenance=provenance,
+        cohort_summary=cohort_summary,
+    )
+    evidence_summary: dict[str, Any]
+    blocked_reason: str | None
+    if evidence_path is None:
+        evidence_summary = {
+            "status": "unavailable",
+            "required_schema": BOUNDARY_EVIDENCE_SCHEMA,
+            "authority_manifest_sha256": authority_summary["authority_manifest_sha256"],
+            "active_inventory_sha256": authority_summary["active_inventory_sha256"],
+        }
+        blocked_reason = "independent boundary evidence input is unavailable"
+    else:
+        evidence = _load_json_no_duplicates(evidence_path, label="Boundary evidence")
+        evidence_summary, blocked_reason = _validate_boundary_evidence(
+            evidence,
+            boundary=boundary,
+            start_sha=start_sha,
+            end_sha=end_sha,
+            authority_summary=authority_summary,
+        )
+
+    result: dict[str, Any] = {
+        "schema": BOUNDARY_MANIFEST_SCHEMA,
+        "schema_version": schema_version,
+        "status": "blocked" if blocked_reason else "pass",
+        "passing": blocked_reason is None,
+        "blocked_reason": blocked_reason,
+        "boundary": boundary,
+        "start_sha": start_sha,
+        "end_sha": end_sha,
+        "canonical_artifacts": {
+            "original_cohort": cohort_descriptor,
+            "sdk_provenance": provenance_descriptor,
+        },
+        "original_cohort": {
+            "record_count": 655,
+            "category_counts": cohort_summary["category_counts"],
+            "original_record_id_set_sha256": ORIGINAL_ID_SET_SHA256,
+            "membership_anchor": cohort.get("membership_anchor"),
+            "membership_sources": cohort.get("membership_sources"),
+        },
+        "sdk_provenance": provenance_summary,
+        "operation_projection": {
+            "schema": "cdg-operation-projection-v1",
+            "membership_count": cohort_summary["projection_membership_count"],
+            "edge_count": cohort_summary["projection_edge_count"],
+            "multi_edge_originals": cohort_summary["projection_multi_edge_originals"],
+            "maximum_edges_per_original": cohort_summary["projection_max_edges"],
+            "edge_count_distribution": cohort_summary["projection_edge_count_distribution"],
+            "record_digest_set_sha256": cohort_summary["projection_record_digest_set_sha256"],
+        },
+        "authority": authority_summary,
+        "evidence": evidence_summary,
+    }
+    result["manifest_sha256"] = _sha256_bytes(_canonical_json_bytes(result))
+    return result
 
 
 def _counts_from_docs(docs: dict[str, dict[str, Any]]) -> dict[str, int]:
@@ -506,7 +1562,40 @@ def _print_text(result: dict[str, Any]) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check contract drift ratchet")
-    parser.add_argument("--mode", choices=("program", "pr"), default="program")
+    parser.add_argument("--mode", choices=("program", "pr", "boundary"), default="program")
+    parser.add_argument(
+        "--schema-version",
+        type=int,
+        default=None,
+        help="Required manifest schema version for boundary mode",
+    )
+    parser.add_argument("--boundary", choices=BOUNDARY_NAMES, default=None)
+    parser.add_argument("--start-ref", default=None, help="Full interval start SHA")
+    parser.add_argument("--end-ref", default=None, help="Full interval end SHA")
+    parser.add_argument(
+        "--authority-manifest",
+        type=Path,
+        default=None,
+        help="Fresh standalone authority-manifest JSON for --end-ref",
+    )
+    parser.add_argument(
+        "--cohort-artifact",
+        type=Path,
+        default=None,
+        help="Canonical contract-drift-original-cohort-v1.json",
+    )
+    parser.add_argument(
+        "--sdk-provenance-artifact",
+        type=Path,
+        default=None,
+        help="Canonical contract-drift-sdk-provenance-v1.json",
+    )
+    parser.add_argument(
+        "--boundary-evidence",
+        type=Path,
+        default=None,
+        help="Independent contract-drift-boundary-evidence-v1 JSON",
+    )
     parser.add_argument(
         "--base-ref", default=None, help="Merge base ref for pr mode (e.g. origin/main)"
     )
@@ -551,6 +1640,66 @@ def main() -> int:
     parser.add_argument("--strict", action="store_true", help="Exit 1 when failing")
     parser.add_argument("--json", action="store_true", help="Emit JSON output")
     args = parser.parse_args()
+
+    if args.mode == "boundary":
+        required = {
+            "--schema-version": args.schema_version,
+            "--boundary": args.boundary,
+            "--start-ref": args.start_ref,
+            "--end-ref": args.end_ref,
+        }
+        missing = [flag for flag, value in required.items() if value is None]
+        if missing:
+            error = {
+                "schema": BOUNDARY_MANIFEST_SCHEMA,
+                "schema_version": args.schema_version,
+                "status": "fail",
+                "passing": False,
+                "error_code": "missing_required_boundary_input",
+                "error": f"missing required boundary argument(s): {', '.join(missing)}",
+            }
+            if args.json:
+                print(json.dumps(error, sort_keys=True, separators=(",", ":")))
+            else:
+                print(f"FAIL (closed): {error['error']}", file=sys.stderr)
+            return 1
+        try:
+            result = build_boundary_result(
+                repo_root=args.repo_root,
+                schema_version=args.schema_version,
+                boundary=args.boundary,
+                start_ref=args.start_ref,
+                end_ref=args.end_ref,
+                authority_manifest_path=args.authority_manifest,
+                cohort_artifact_path=args.cohort_artifact,
+                sdk_provenance_artifact_path=args.sdk_provenance_artifact,
+                evidence_path=args.boundary_evidence,
+            )
+        except (ValueError, subprocess.CalledProcessError) as exc:
+            error = {
+                "schema": BOUNDARY_MANIFEST_SCHEMA,
+                "schema_version": args.schema_version,
+                "status": "fail",
+                "passing": False,
+                "error_code": "boundary_validation_failed",
+                "error": str(exc),
+            }
+            if args.json:
+                print(json.dumps(error, sort_keys=True, separators=(",", ":")))
+            else:
+                print(f"FAIL (closed): {exc}", file=sys.stderr)
+            return 1
+        if args.json:
+            print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+        else:
+            print(
+                f"Contract Drift boundary {result['boundary']}: "
+                f"{result['status'].upper()} ({result['start_sha']}..{result['end_sha']})"
+            )
+            if result["blocked_reason"]:
+                print(f"Blocked: {result['blocked_reason']}")
+            print(f"Manifest SHA-256: {result['manifest_sha256']}")
+        return 0 if result["passing"] else 2
 
     try:
         result = build_ratchet_result(

--- a/scripts/generate_contract_drift_inventory.py
+++ b/scripts/generate_contract_drift_inventory.py
@@ -16,12 +16,30 @@ item with a stable id, a provenance class, and a discovery date:
 
 The inventory is deterministic and sorted; ``--check`` fails (exit 1) when
 the committed inventory is out of sync with the baselines.
+
+Standalone read-only surfaces (VAL-CDG-001 / VAL-CDG-002)
+---------------------------------------------------------
+
+Three additional modes never write to the repository, never touch the
+network, and read git state only through ref-pinned plumbing:
+
+- ``--authority-manifest --ref <full-sha> --json`` emits the Tier-4
+  authority closure manifest with per-file bindings and a canonical digest.
+- ``--classify-tier --changed-file <path> --ref <full-sha> --json`` reports
+  the canonical effective tier, matched authority rule, and manifest digest.
+- ``--ref <full-sha> --cohort-artifact <p> --sdk-provenance-artifact <p>
+  --json`` emits the canonical, digest-bound original-cohort inventory.
+
+Classification policy is imported from the canonical
+``aragora.cli.commands.review_queue`` module and is never duplicated here.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -264,6 +282,969 @@ def render_inventory(items: list[dict[str, Any]], cohort_commit: str) -> str:
     return json.dumps(doc, indent=2, sort_keys=True) + "\n"
 
 
+# ---------------------------------------------------------------------------
+# Standalone read-only authority/inventory surfaces (VAL-CDG-001/VAL-CDG-002)
+# ---------------------------------------------------------------------------
+
+FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+HTTP_METHOD_TOKENS = frozenset(
+    {"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"}
+)
+
+COHORT_ARTIFACT_FILENAME = "contract-drift-original-cohort-v1.json"
+PROVENANCE_ARTIFACT_FILENAME = "contract-drift-sdk-provenance-v1.json"
+COHORT_LOGICAL_PATH = f"library/{COHORT_ARTIFACT_FILENAME}"
+PROVENANCE_LOGICAL_PATH = f"library/{PROVENANCE_ARTIFACT_FILENAME}"
+COHORT_SCHEMA = "contract-drift-original-cohort-v1"
+PROVENANCE_SCHEMA = "contract-drift-sdk-provenance-v1"
+PROJECTION_SCHEMA = "cdg-operation-projection-v1"
+COHORT_BYTE_LENGTH = 1692125
+COHORT_SHA256 = "565cd84a9a5d266f61b66bd7965e0a036e4817ef5fed32edb8c41a2dea6cc208"
+PROVENANCE_BYTE_LENGTH = 898099
+PROVENANCE_SHA256 = "21ae1c30200cda6df51dbca7053bbbbde6241ab78a73347b0fe5e4d2ed79f07f"
+
+RATIFIED_ORIGINAL_ID_SET_SHA256 = "c1235670c183b1887ba3fe4280fa0320f9fd6f4a85b8f346d4332ac2aebbe269"
+RATIFIED_PROVENANCE_DIGEST_SET_SHA256 = (
+    "0d30ce3b083344f19949da12ae2d92952757af0aea800b3f99d447458b6eeba0"
+)
+RATIFIED_PROJECTION_DIGEST_SET_SHA256 = (
+    "2d6790a6f825c53047639d9433f40e3e10b5bfc9e357bcd161f6b341134775e5"
+)
+RATIFIED_SDK_ID_SET_SHA256 = "51a963079136a92a86485b56f6cef42aafc7749bfad146ce5fb37293524c5762"
+RATIFIED_CORE_ID_SET_SHA256 = "b3a1755f027c998d507f13f3ba9093f769cea8720d44bfac12be6beccd626787"
+RATIFIED_EXTENDED_ID_SET_SHA256 = "bb1fc41548778022dab3041bc05fc40a4da239a1bd4ad8b1ccbcd1007d90b252"
+
+RATIFIED_CATEGORY_COUNTS = {
+    "python_sdk_drift": 74,
+    "routes_missing_in_spec": 11,
+    "routes_orphaned_in_spec": 17,
+    "sdk_missing_from_both": 29,
+    "typescript_sdk_drift": 524,
+}
+SDK_CATEGORIES = ("python_sdk_drift", "typescript_sdk_drift")
+SDK_LANGUAGE_BY_CATEGORY = {
+    "python_sdk_drift": ["python"],
+    "typescript_sdk_drift": ["typescript"],
+    "sdk_missing_from_both": ["python", "typescript"],
+    "routes_missing_in_spec": [],
+    "routes_orphaned_in_spec": [],
+}
+PARTITION_RULE_VERSION = "cdg-sdk-partition-rule-v1"
+PARTITION_DOMAINS = frozenset(
+    {
+        "agents",
+        "debate",
+        "evaluation",
+        "evidence",
+        "explainability",
+        "knowledge",
+        "learning",
+        "memory",
+        "ml",
+        "ranking",
+        "reasoning",
+    }
+)
+
+EXPECTED_ORIGINAL_TOTAL = 655
+EXPECTED_SDK_RECORD_TOTAL = 598
+EXPECTED_ROUTE_PARITY_TOTAL = 57
+EXPECTED_SOURCE_OCCURRENCES = 690
+EXPECTED_MULTI_ATOM_RECORDS = 12
+EXPECTED_CORE_UNITS = 75
+EXPECTED_EXTENDED_UNITS = 523
+EXPECTED_OPERATION_EDGES = 666
+EXPECTED_MULTI_EDGE_MEMBERSHIPS = 9
+EXPECTED_MAX_OPERATION_EDGES = 4
+
+CANONICAL_CLASSIFIER_PATH = "aragora/cli/commands/review_queue.py"
+MERGE_TRAIN_MIRROR_PATH = "scripts/tier4_merge_train.py"
+WORKFLOW_DIR = ".github/workflows"
+
+INVENTORY_OUTPUT_SCHEMA = "cdg-standalone-inventory-v1"
+AUTHORITY_MANIFEST_SCHEMA = "cdg-authority-manifest-v1"
+CLASSIFICATION_OUTPUT_SCHEMA = "cdg-tier-classification-v1"
+ERROR_OUTPUT_SCHEMA = "cdg-standalone-error-v1"
+
+
+class StandaloneError(Exception):
+    """Fail-closed error with a machine-readable code for the standalone modes."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _set_digest(values: list[str], key: str, schema: str) -> str:
+    return _sha256_hex(_canonical_json_bytes({key: sorted(values), "schema": schema}))
+
+
+def _require(condition: bool, code: str, message: str) -> None:
+    if not condition:
+        raise StandaloneError(code, message)
+
+
+def _review_queue_module() -> Any:
+    # The sibling checkout's canonical policy must win over any installed copy
+    # so the manifest, classifier, and mirror are read at the same version.
+    repo_root = str(Path(__file__).resolve().parents[1])
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    from aragora.cli.commands import review_queue
+
+    return review_queue
+
+
+def _git_read(repo_root: Path, *argv: str) -> bytes | None:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *argv],
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def _resolve_exact_ref(repo_root: Path, ref: Any) -> str:
+    _require(
+        isinstance(ref, str) and bool(FULL_SHA_RE.fullmatch(ref)),
+        "ref_invalid",
+        "--ref must be an exact 40-character lowercase hex commit SHA",
+    )
+    out = _git_read(repo_root, "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}")
+    resolved = (out or b"").decode("ascii", errors="replace").strip()
+    _require(
+        resolved == ref,
+        "ref_unresolved",
+        f"--ref does not resolve to itself as a commit object: {ref}",
+    )
+    return ref
+
+
+def _validate_repo_relative_path(path: Any) -> str:
+    _require(
+        isinstance(path, str) and path != "",
+        "changed_file_invalid",
+        "changed file path must be a non-empty string",
+    )
+    _require(
+        path == path.strip() and "\\" not in path and "\x00" not in path,
+        "changed_file_invalid",
+        f"non-normalized changed file path rejected: {path!r}",
+    )
+    _require(
+        not path.startswith("/"),
+        "changed_file_invalid",
+        f"absolute changed file path rejected: {path!r}",
+    )
+    _require(
+        all(segment not in ("", ".", "..") for segment in path.split("/")),
+        "changed_file_invalid",
+        f"traversal or non-normalized changed file path rejected: {path!r}",
+    )
+    return path
+
+
+def _git_blob_at_ref(repo_root: Path, ref: str, path: str) -> bytes | None:
+    return _git_read(repo_root, "cat-file", "blob", f"{ref}:{path}")
+
+
+def _git_blob_oid(repo_root: Path, ref: str, path: str) -> str | None:
+    out = _git_read(repo_root, "rev-parse", "--verify", "--quiet", f"{ref}:{path}")
+    if out is None:
+        return None
+    return out.decode("ascii", errors="replace").strip()
+
+
+def _workflow_paths_at_ref(repo_root: Path, ref: str) -> list[str]:
+    out = _git_read(repo_root, "ls-tree", "--name-only", ref, f"{WORKFLOW_DIR}/")
+    if out is None:
+        return []
+    names = out.decode("utf-8", errors="replace").splitlines()
+    return sorted(name for name in names if name.endswith(".yml"))
+
+
+def _discover_artifact_path(
+    explicit: Path | None, filename: str, repo_root: Path, logical_path: str
+) -> Path:
+    if explicit is not None:
+        return Path(explicit)
+    candidates: list[Path] = []
+    mission_dir = os.environ.get("FACTORY_MISSION_DIR", "").strip()
+    if mission_dir:
+        candidates.append(Path(mission_dir) / "library" / filename)
+    settings_path = os.environ.get("FACTORY_RUNTIME_SETTINGS_PATH", "").strip()
+    if settings_path:
+        candidates.append(Path(settings_path).parent / "library" / filename)
+    candidates.append(Path(repo_root) / "library" / filename)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise StandaloneError("artifact_missing", f"canonical artifact not found: {logical_path}")
+
+
+def _load_canonical_artifact(
+    path: Path,
+    *,
+    logical_path: str,
+    expected_length: int,
+    expected_sha256: str,
+    expected_schema: str,
+) -> dict[str, Any]:
+    _require(
+        Path(path).is_file(),
+        "artifact_missing",
+        f"canonical artifact not found: {logical_path}",
+    )
+    _require(
+        not Path(path).is_symlink(),
+        "artifact_symlink_forbidden",
+        f"{logical_path}: symbolic links are forbidden",
+    )
+    raw = Path(path).read_bytes()
+    _require(
+        len(raw) == expected_length,
+        "artifact_byte_length_mismatch",
+        f"{logical_path}: expected {expected_length} bytes, found {len(raw)}",
+    )
+    _require(
+        _sha256_hex(raw) == expected_sha256,
+        "artifact_sha256_mismatch",
+        f"{logical_path}: SHA-256 does not match the canonical descriptor",
+    )
+    _require(
+        not raw.startswith(b"\xef\xbb\xbf"),
+        "artifact_noncanonical_bytes",
+        f"{logical_path}: UTF-8 BOM is forbidden",
+    )
+    _require(
+        raw.endswith(b"\n") and raw.count(b"\n") == 1,
+        "artifact_noncanonical_bytes",
+        f"{logical_path}: must contain exactly one terminal LF",
+    )
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise StandaloneError("artifact_not_utf8", f"{logical_path}: {exc}") from exc
+
+    def _reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise StandaloneError(
+                    "artifact_duplicate_key", f"{logical_path}: duplicate JSON key {key!r}"
+                )
+            result[key] = value
+        return result
+
+    try:
+        doc = json.loads(text, object_pairs_hook=_reject_duplicates)
+    except json.JSONDecodeError as exc:
+        raise StandaloneError("artifact_invalid_json", f"{logical_path}: {exc}") from exc
+    _require(
+        _canonical_json_bytes(doc) + b"\n" == raw,
+        "artifact_noncanonical_bytes",
+        f"{logical_path}: bytes are not compact sorted-key JSON plus one terminal LF",
+    )
+    _require(
+        isinstance(doc, dict) and doc.get("schema") == expected_schema,
+        "artifact_schema_mismatch",
+        f"{logical_path}: schema must be {expected_schema!r}",
+    )
+    return doc
+
+
+def _verify_original_records(cohort: dict[str, Any]) -> dict[str, Any]:
+    records = cohort.get("original_records")
+    _require(
+        isinstance(records, list) and len(records) == EXPECTED_ORIGINAL_TOTAL,
+        "cohort_count_mismatch",
+        f"expected exactly {EXPECTED_ORIGINAL_TOTAL} original records",
+    )
+    assert isinstance(records, list)
+    ids: list[str] = []
+    category_counts: dict[str, int] = {}
+    method_bearing = 0
+    method_null = 0
+    for record in records:
+        _require(
+            isinstance(record, dict),
+            "cohort_record_malformed",
+            "original record must be a JSON object",
+        )
+        category = record.get("category")
+        literal = record.get("exact_historical_literal_record")
+        _require(
+            category in RATIFIED_CATEGORY_COUNTS,
+            "cohort_unknown_category",
+            f"unknown original record category: {category!r}",
+        )
+        _require(
+            isinstance(literal, str) and literal != "",
+            "cohort_record_malformed",
+            "original record is missing its exact historical literal",
+        )
+        payload = _canonical_json_bytes(
+            {
+                "category": category,
+                "exact_historical_literal_record": literal,
+                "schema": "cdg-original-record-id-v1",
+            }
+        )
+        expected_id = "cdg1:" + _sha256_hex(payload)
+        _require(
+            record.get("id_payload_byte_length") == len(payload)
+            and record.get("id_payload_sha256") == _sha256_hex(payload)
+            and record.get("original_record_id") == expected_id,
+            "original_id_mismatch",
+            f"original_record_id does not reproduce for literal {literal!r}",
+        )
+        _require(
+            record.get("sdk_language") == SDK_LANGUAGE_BY_CATEGORY[category],
+            "cohort_record_malformed",
+            f"sdk_language must be category-derived provenance: {expected_id}",
+        )
+        method = record.get("method")
+        if category in SDK_CATEGORIES:
+            _require(
+                isinstance(method, str) and method in HTTP_METHOD_TOKENS,
+                "cohort_record_malformed",
+                f"SDK original must carry an exact uppercase method token: {expected_id}",
+            )
+            method_bearing += 1
+        else:
+            _require(
+                method is None,
+                "cohort_record_malformed",
+                f"path-level original must carry method=null: {expected_id}",
+            )
+            method_null += 1
+        category_counts[category] = category_counts.get(category, 0) + 1
+        ids.append(expected_id)
+    _require(
+        len(set(ids)) == EXPECTED_ORIGINAL_TOTAL,
+        "cohort_duplicate_original_id",
+        "duplicate original_record_id in cohort artifact",
+    )
+    _require(
+        category_counts == RATIFIED_CATEGORY_COUNTS,
+        "cohort_category_counts_mismatch",
+        f"category counts {category_counts} do not match the ratified schema",
+    )
+    _require(
+        method_bearing == EXPECTED_SDK_RECORD_TOTAL and method_null == EXPECTED_ROUTE_PARITY_TOTAL,
+        "cohort_method_plane_mismatch",
+        "method-bearing/path-level split must be exactly 598/57",
+    )
+    id_set_sha256 = _set_digest(ids, "original_record_ids", "cdg-original-record-id-set-v1")
+    _require(
+        id_set_sha256 == RATIFIED_ORIGINAL_ID_SET_SHA256,
+        "original_id_set_digest_mismatch",
+        f"recomputed original ID set digest {id_set_sha256} is not the ratified value",
+    )
+    return {
+        "ids": sorted(ids),
+        "category_counts": category_counts,
+        "id_set_sha256": id_set_sha256,
+    }
+
+
+def _atom_matches_domain(atom: Any, record_id: Any) -> bool:
+    _require(
+        isinstance(atom, str) and atom != "",
+        "provenance_partition_malformed",
+        f"provenance atom must be a non-empty string: {record_id}",
+    )
+    normalized = atom.replace("-", "_")
+    if normalized in PARTITION_DOMAINS:
+        return True
+    return normalized.endswith("s") and normalized[:-1] in PARTITION_DOMAINS
+
+
+def _verify_sdk_provenance(provenance: dict[str, Any], cohort: dict[str, Any]) -> dict[str, Any]:
+    records = provenance.get("records")
+    _require(
+        isinstance(records, list) and len(records) == EXPECTED_SDK_RECORD_TOTAL,
+        "provenance_count_mismatch",
+        f"expected exactly {EXPECTED_SDK_RECORD_TOTAL} SDK provenance records",
+    )
+    assert isinstance(records, list)
+    digest_by_id: dict[str, str] = {}
+    digests: list[str] = []
+    core_ids: list[str] = []
+    extended_ids: list[str] = []
+    occurrence_total = 0
+    multi_atom = 0
+    for record in records:
+        _require(
+            isinstance(record, dict),
+            "provenance_record_malformed",
+            "SDK provenance record must be a JSON object",
+        )
+        record_id = record.get("original_record_id")
+        body = {key: value for key, value in record.items() if key != "record_sha256"}
+        digest = _sha256_hex(_canonical_json_bytes(body))
+        _require(
+            record.get("record_sha256") == digest,
+            "provenance_record_digest_mismatch",
+            f"record_sha256 does not reproduce for {record_id}",
+        )
+        atoms = record.get("provenance_atoms")
+        _require(
+            isinstance(atoms, list) and len(atoms) > 0,
+            "provenance_partition_malformed",
+            f"provenance_atoms must be a non-empty array: {record_id}",
+        )
+        matches = [_atom_matches_domain(atom, record_id) for atom in atoms]
+        expected_partition = "core" if any(matches) else "extended"
+        _require(
+            record.get("partition") == expected_partition,
+            "provenance_partition_mismatch",
+            f"independently recomputed partition disagrees for {record_id}",
+        )
+        occurrences = record.get("source_occurrences")
+        _require(
+            isinstance(occurrences, list) and len(occurrences) > 0,
+            "provenance_occurrence_missing",
+            f"source_occurrences must be a non-empty array: {record_id}",
+        )
+        occurrence_total += len(occurrences)
+        if len(set(atoms)) > 1:
+            multi_atom += 1
+        _require(
+            isinstance(record_id, str) and record_id not in digest_by_id,
+            "provenance_duplicate_link",
+            f"duplicate or malformed original_record_id link: {record_id!r}",
+        )
+        digest_by_id[record_id] = digest
+        digests.append(digest)
+        if expected_partition == "core":
+            core_ids.append(record_id)
+        else:
+            extended_ids.append(record_id)
+    _require(
+        occurrence_total == EXPECTED_SOURCE_OCCURRENCES,
+        "provenance_occurrence_count_mismatch",
+        f"expected {EXPECTED_SOURCE_OCCURRENCES} source occurrences, found {occurrence_total}",
+    )
+    _require(
+        multi_atom == EXPECTED_MULTI_ATOM_RECORDS,
+        "provenance_multi_atom_count_mismatch",
+        f"expected {EXPECTED_MULTI_ATOM_RECORDS} multi-atom records, found {multi_atom}",
+    )
+    _require(
+        len(core_ids) == EXPECTED_CORE_UNITS and len(extended_ids) == EXPECTED_EXTENDED_UNITS,
+        "partition_count_mismatch",
+        f"core/extended partition must be exactly {EXPECTED_CORE_UNITS}/{EXPECTED_EXTENDED_UNITS}",
+    )
+    digest_set_sha256 = _set_digest(
+        digests, "record_sha256_values", "cdg-sdk-provenance-record-digest-set-v1"
+    )
+    _require(
+        digest_set_sha256 == RATIFIED_PROVENANCE_DIGEST_SET_SHA256,
+        "provenance_digest_set_mismatch",
+        "recomputed provenance record-digest-set is not the ratified value",
+    )
+    sdk_set_sha256 = _set_digest(
+        list(digest_by_id), "original_record_ids", "cdg-sdk-original-record-id-set-v1"
+    )
+    core_set_sha256 = _set_digest(
+        core_ids, "original_record_ids", "cdg-core-original-record-id-set-v1"
+    )
+    extended_set_sha256 = _set_digest(
+        extended_ids, "original_record_ids", "cdg-extended-original-record-id-set-v1"
+    )
+    _require(
+        sdk_set_sha256 == RATIFIED_SDK_ID_SET_SHA256
+        and core_set_sha256 == RATIFIED_CORE_ID_SET_SHA256
+        and extended_set_sha256 == RATIFIED_EXTENDED_ID_SET_SHA256,
+        "partition_set_digest_mismatch",
+        "recomputed SDK/core/extended ID set digests are not the pinned values",
+    )
+    cohort_sdk = [
+        record for record in cohort["original_records"] if record.get("category") in SDK_CATEGORIES
+    ]
+    _require(
+        {record["original_record_id"] for record in cohort_sdk} == set(digest_by_id),
+        "provenance_link_mismatch",
+        "SDK provenance records must map one-to-one onto cohort SDK originals",
+    )
+    for record in cohort_sdk:
+        _require(
+            record.get("sdk_provenance_record_sha256")
+            == digest_by_id[record["original_record_id"]],
+            "provenance_link_digest_mismatch",
+            f"cohort sdk_provenance_record_sha256 mismatch: {record['original_record_id']}",
+        )
+    return {
+        "record_count": EXPECTED_SDK_RECORD_TOTAL,
+        "source_occurrence_count": occurrence_total,
+        "multi_atom_record_count": multi_atom,
+        "missing_record_count": 0,
+        "record_digest_set_sha256": digest_set_sha256,
+        "baseline_birth": provenance.get("baseline_birth"),
+        "dependencies": provenance.get("dependencies"),
+        "extraction_algorithm": provenance.get("extraction_algorithm"),
+        "records": records,
+        "partition": {
+            "partition_rule_version": PARTITION_RULE_VERSION,
+            "core_count": len(core_ids),
+            "extended_count": len(extended_ids),
+            "intersection_count": 0,
+            "union_count": EXPECTED_SDK_RECORD_TOTAL,
+            "sdk_original_record_id_set_sha256": sdk_set_sha256,
+            "core_original_record_id_set_sha256": core_set_sha256,
+            "extended_original_record_id_set_sha256": extended_set_sha256,
+            "core_unit_ids": sorted(core_ids),
+            "extended_unit_ids": sorted(extended_ids),
+        },
+    }
+
+
+def _verify_operation_projection(cohort: dict[str, Any], original_ids: list[str]) -> dict[str, Any]:
+    projection = cohort.get("operation_projection")
+    _require(
+        isinstance(projection, dict) and projection.get("schema") == PROJECTION_SCHEMA,
+        "projection_schema_mismatch",
+        f"operation projection schema must be {PROJECTION_SCHEMA!r}",
+    )
+    assert isinstance(projection, dict)
+    records = projection.get("records")
+    _require(
+        isinstance(records, list) and len(records) == EXPECTED_ORIGINAL_TOTAL,
+        "projection_membership_mismatch",
+        f"expected exactly {EXPECTED_ORIGINAL_TOTAL} projection memberships",
+    )
+    assert isinstance(records, list)
+    membership_ids: list[str] = []
+    digests: list[str] = []
+    edge_total = 0
+    multi_edge = 0
+    max_edges = 0
+    edge_count_distribution: dict[str, int] = {}
+    for record in records:
+        _require(
+            isinstance(record, dict),
+            "projection_record_malformed",
+            "projection membership must be a JSON object",
+        )
+        record_id = record.get("original_record_id")
+        body = {key: value for key, value in record.items() if key != "record_sha256"}
+        digest = _sha256_hex(_canonical_json_bytes(body))
+        _require(
+            record.get("record_sha256") == digest,
+            "projection_record_digest_mismatch",
+            f"projection record_sha256 does not reproduce for {record_id}",
+        )
+        digests.append(digest)
+        edges = record.get("operation_edges")
+        _require(
+            isinstance(edges, list) and len(edges) > 0,
+            "projection_edges_missing",
+            f"projection membership must carry at least one edge: {record_id}",
+        )
+        for edge in edges:
+            _require(
+                isinstance(edge, dict)
+                and isinstance(edge.get("method"), str)
+                and edge.get("method") in HTTP_METHOD_TOKENS,
+                "projection_edge_method_invalid",
+                f"projection edge must carry an exact uppercase method token: {record_id}",
+            )
+            _require(
+                isinstance(edge.get("normalized_path"), str)
+                and edge.get("normalized_path") != ""
+                and isinstance(edge.get("evidence"), list)
+                and len(edge.get("evidence")) > 0,
+                "projection_edge_malformed",
+                f"projection edge must carry a normalized path and evidence: {record_id}",
+            )
+        if record.get("category") in SDK_CATEGORIES:
+            _require(
+                len(edges) == 1,
+                "projection_sdk_membership_edge_count_mismatch",
+                f"SDK projection membership must carry exactly one edge: {record_id}",
+            )
+        edge_total += len(edges)
+        if len(edges) > 1:
+            multi_edge += 1
+        max_edges = max(max_edges, len(edges))
+        key = str(len(edges))
+        edge_count_distribution[key] = edge_count_distribution.get(key, 0) + 1
+        membership_ids.append(record_id)
+    _require(
+        sorted(membership_ids) == original_ids,
+        "projection_membership_mismatch",
+        "projection must contain exactly one membership per original record",
+    )
+    _require(
+        edge_total == EXPECTED_OPERATION_EDGES
+        and multi_edge == EXPECTED_MULTI_EDGE_MEMBERSHIPS
+        and max_edges == EXPECTED_MAX_OPERATION_EDGES,
+        "projection_edge_counts_mismatch",
+        f"projection edge counts must be {EXPECTED_OPERATION_EDGES}/"
+        f"{EXPECTED_MULTI_EDGE_MEMBERSHIPS}/max {EXPECTED_MAX_OPERATION_EDGES}",
+    )
+    digest_set_sha256 = _set_digest(
+        digests, "record_sha256_values", "cdg-operation-projection-record-digest-set-v1"
+    )
+    _require(
+        digest_set_sha256 == RATIFIED_PROJECTION_DIGEST_SET_SHA256,
+        "projection_digest_set_mismatch",
+        "recomputed projection record-digest-set is not the ratified value",
+    )
+    return {
+        "schema": PROJECTION_SCHEMA,
+        "membership_count": EXPECTED_ORIGINAL_TOTAL,
+        "operation_edge_count": edge_total,
+        "multi_edge_membership_count": multi_edge,
+        "max_operation_edges": max_edges,
+        "edge_count_distribution": edge_count_distribution,
+        "record_digest_set_sha256": digest_set_sha256,
+        "records": records,
+    }
+
+
+def _active_inventory_binding(repo_root: Path, ref: str) -> dict[str, Any]:
+    raw = _git_blob_at_ref(repo_root, ref, DEFAULT_INVENTORY)
+    _require(
+        raw is not None,
+        "active_inventory_missing",
+        f"{DEFAULT_INVENTORY} not found at --ref",
+    )
+    assert raw is not None
+    try:
+        doc = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise StandaloneError(
+            "active_inventory_invalid", f"{DEFAULT_INVENTORY} at --ref is not valid JSON: {exc}"
+        ) from exc
+    items = doc.get("items") if isinstance(doc, dict) else None
+    _require(
+        isinstance(items, list),
+        "active_inventory_invalid",
+        f"{DEFAULT_INVENTORY} at --ref has no items list",
+    )
+    assert isinstance(doc, dict)
+    assert isinstance(items, list)
+    open_items = sum(1 for item in items if isinstance(item, dict) and item.get("status") == "open")
+    resolved_items = sum(
+        1 for item in items if isinstance(item, dict) and item.get("status") == "resolved"
+    )
+    return {
+        "path": DEFAULT_INVENTORY,
+        "git_blob_oid": _git_blob_oid(repo_root, ref, DEFAULT_INVENTORY),
+        "byte_length": len(raw),
+        "sha256": _sha256_hex(raw),
+        "cohort_commit": str(doc.get("cohort_commit", "")),
+        "item_total": len(items),
+        "open_items": open_items,
+        "resolved_items": resolved_items,
+    }
+
+
+def _artifact_descriptor(
+    logical_path: str, byte_length: int, sha256: str, schema: str
+) -> dict[str, Any]:
+    return {
+        "logical_path": logical_path,
+        "byte_length": byte_length,
+        "sha256": sha256,
+        "schema": schema,
+        "canonical_bytes": True,
+        "utf8_no_bom": True,
+        "single_terminal_lf": True,
+    }
+
+
+def _build_inventory_document(
+    repo_root: Path, ref: str, cohort_path: Path, provenance_path: Path
+) -> dict[str, Any]:
+    cohort = _load_canonical_artifact(
+        cohort_path,
+        logical_path=COHORT_LOGICAL_PATH,
+        expected_length=COHORT_BYTE_LENGTH,
+        expected_sha256=COHORT_SHA256,
+        expected_schema=COHORT_SCHEMA,
+    )
+    provenance = _load_canonical_artifact(
+        provenance_path,
+        logical_path=PROVENANCE_LOGICAL_PATH,
+        expected_length=PROVENANCE_BYTE_LENGTH,
+        expected_sha256=PROVENANCE_SHA256,
+        expected_schema=PROVENANCE_SCHEMA,
+    )
+    original = _verify_original_records(cohort)
+    provenance_facts = _verify_sdk_provenance(provenance, cohort)
+    projection_facts = _verify_operation_projection(cohort, original["ids"])
+    document = {
+        "schema": INVENTORY_OUTPUT_SCHEMA,
+        "status": "ok",
+        "ref": ref,
+        "artifacts": {
+            "original_cohort": _artifact_descriptor(
+                COHORT_LOGICAL_PATH, COHORT_BYTE_LENGTH, COHORT_SHA256, COHORT_SCHEMA
+            ),
+            "sdk_provenance": _artifact_descriptor(
+                PROVENANCE_LOGICAL_PATH,
+                PROVENANCE_BYTE_LENGTH,
+                PROVENANCE_SHA256,
+                PROVENANCE_SCHEMA,
+            ),
+        },
+        "membership_anchor": cohort.get("membership_anchor"),
+        "membership_sources": cohort.get("membership_sources"),
+        "original_record_total": EXPECTED_ORIGINAL_TOTAL,
+        "original_record_ids": original["ids"],
+        "original_record_id_set_sha256": original["id_set_sha256"],
+        "category_counts": original["category_counts"],
+        "method_bearing_sdk_records": EXPECTED_SDK_RECORD_TOTAL,
+        "method_null_route_parity_records": EXPECTED_ROUTE_PARITY_TOTAL,
+        "original_records": cohort["original_records"],
+        "operation_projection": projection_facts,
+        "sdk_provenance": provenance_facts,
+        "active_inventory": _active_inventory_binding(repo_root, ref),
+    }
+    document["inventory_sha256"] = _sha256_hex(_canonical_json_bytes(document))
+    return document
+
+
+def _inventory_facts(document: dict[str, Any]) -> dict[str, Any]:
+    projection = {
+        key: value for key, value in document["operation_projection"].items() if key != "records"
+    }
+    provenance = {
+        key: value for key, value in document["sdk_provenance"].items() if key != "records"
+    }
+    return {
+        "inventory_schema": document["schema"],
+        "inventory_sha256": document["inventory_sha256"],
+        "membership_anchor": document["membership_anchor"],
+        "membership_sources": document["membership_sources"],
+        "original_record_total": document["original_record_total"],
+        "original_record_id_set_sha256": document["original_record_id_set_sha256"],
+        "category_counts": document["category_counts"],
+        "method_bearing_sdk_records": document["method_bearing_sdk_records"],
+        "method_null_route_parity_records": document["method_null_route_parity_records"],
+        "operation_projection": projection,
+        "sdk_provenance": provenance,
+        "active_inventory": document["active_inventory"],
+    }
+
+
+def _matched_authority_rule(review_queue: Any, path: str) -> str | None:
+    for prefix in review_queue.TIER_4_PREFIXES:
+        if review_queue._matches_prefix(path, (prefix,)):
+            return prefix
+    return None
+
+
+def _authority_closure(review_queue: Any, repo_root: Path, ref: str) -> dict[str, str]:
+    roots = [str(prefix) for prefix in review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES]
+    reasons = dict.fromkeys(roots, "canonical_authority_root")
+    reasons.setdefault(CANONICAL_CLASSIFIER_PATH, "canonical_classification_policy")
+    for workflow in _workflow_paths_at_ref(repo_root, ref):
+        blob = _git_blob_at_ref(repo_root, ref, workflow)
+        if blob is None:
+            continue
+        text = blob.decode("utf-8", errors="replace")
+        if any(root in text for root in roots):
+            reasons.setdefault(workflow, "workflow_references_authority_root")
+    return reasons
+
+
+def _file_binding(
+    repo_root: Path, ref: str, path: str, review_queue: Any, reason: str
+) -> dict[str, Any]:
+    blob = _git_blob_at_ref(repo_root, ref, path)
+    _require(
+        blob is not None,
+        "closure_member_missing",
+        f"authority closure member missing at --ref: {path}",
+    )
+    assert blob is not None
+    tier, tier_name, _tier_reason = review_queue._classify_model_review_tier([path])
+    _require(
+        tier == review_queue.CONTRACT_DRIFT_AUTHORITY_TIER,
+        "closure_member_not_tier4",
+        f"authority closure member does not classify Tier 4: {path}",
+    )
+    return {
+        "path": path,
+        "git_blob_oid": _git_blob_oid(repo_root, ref, path),
+        "byte_length": len(blob),
+        "sha256": _sha256_hex(blob),
+        "closure_reason": reason,
+        "effective_tier": tier,
+        "tier_name": tier_name,
+        "matched_authority_rule": _matched_authority_rule(review_queue, path),
+    }
+
+
+def _build_authority_manifest(
+    repo_root: Path, ref: str, cohort_path: Path, provenance_path: Path
+) -> dict[str, Any]:
+    review_queue = _review_queue_module()
+    inventory_document = _build_inventory_document(repo_root, ref, cohort_path, provenance_path)
+    reasons = _authority_closure(review_queue, repo_root, ref)
+    repo_files = sorted(reasons)
+    file_bindings = [
+        _file_binding(repo_root, ref, path, review_queue, reasons[path]) for path in repo_files
+    ]
+    mirror_blob = _git_blob_at_ref(repo_root, ref, MERGE_TRAIN_MIRROR_PATH)
+    _require(
+        mirror_blob is not None,
+        "mirror_missing",
+        f"merge-train mirror missing at --ref: {MERGE_TRAIN_MIRROR_PATH}",
+    )
+    assert mirror_blob is not None
+    manifest = {
+        "schema": AUTHORITY_MANIFEST_SCHEMA,
+        "status": "ok",
+        "ref": ref,
+        "policy": {
+            "canonical_policy_module": "aragora.cli.commands.review_queue",
+            "policy_version": review_queue.CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION,
+            "tier": review_queue.CONTRACT_DRIFT_AUTHORITY_TIER,
+            "authority_roots": sorted(
+                str(prefix) for prefix in review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES
+            ),
+        },
+        "repo_files": repo_files,
+        "file_bindings": file_bindings,
+        "merge_train_mirror": {
+            "path": MERGE_TRAIN_MIRROR_PATH,
+            "git_blob_oid": _git_blob_oid(repo_root, ref, MERGE_TRAIN_MIRROR_PATH),
+            "byte_length": len(mirror_blob),
+            "sha256": _sha256_hex(mirror_blob),
+            "role": "dependency_light_mirror",
+            "in_repo_files": False,
+            "reason": (
+                "canonical policy does not classify the mirror itself as Tier 4; "
+                "bound as metadata only"
+            ),
+        },
+        "artifacts": inventory_document["artifacts"],
+        "inventory_facts": _inventory_facts(inventory_document),
+    }
+    manifest["authority_manifest_sha256"] = _sha256_hex(_canonical_json_bytes(manifest))
+    return manifest
+
+
+def _build_tier_classification(
+    repo_root: Path,
+    ref: str,
+    changed_files: list[str],
+    cohort_path: Path,
+    provenance_path: Path,
+) -> dict[str, Any]:
+    review_queue = _review_queue_module()
+    manifest = _build_authority_manifest(repo_root, ref, cohort_path, provenance_path)
+    tier, tier_name, tier_reason = review_queue._classify_model_review_tier(list(changed_files))
+    matched: str | None = None
+    for path in changed_files:
+        matched = _matched_authority_rule(review_queue, path)
+        if matched is not None:
+            break
+    return {
+        "schema": CLASSIFICATION_OUTPUT_SCHEMA,
+        "status": "ok",
+        "ref": ref,
+        "changed_files": list(changed_files),
+        "effective_tier": tier,
+        "tier_name": tier_name,
+        "tier_reason": tier_reason,
+        "matched_authority_path": matched,
+        "authority_manifest_sha256": manifest["authority_manifest_sha256"],
+        "inventory_facts": manifest["inventory_facts"],
+    }
+
+
+def _emit_standalone(document: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n")
+
+
+def run_standalone(args: argparse.Namespace) -> int:
+    if args.classify_tier and args.authority_manifest:
+        mode = "invalid"
+    elif args.classify_tier:
+        mode = "classify-tier"
+    elif args.authority_manifest:
+        mode = "authority-manifest"
+    else:
+        mode = "inventory"
+    try:
+        _require(
+            mode != "invalid",
+            "mode_conflict",
+            "--classify-tier and --authority-manifest are mutually exclusive",
+        )
+        repo_root = Path(args.repo_root)
+        ref = _resolve_exact_ref(repo_root, args.ref)
+        changed_files: list[str] = []
+        if mode == "classify-tier":
+            _require(
+                bool(args.changed_file),
+                "changed_file_required",
+                "--classify-tier requires at least one --changed-file",
+            )
+            changed_files = [_validate_repo_relative_path(path) for path in args.changed_file]
+        cohort_path = _discover_artifact_path(
+            args.cohort_artifact, COHORT_ARTIFACT_FILENAME, repo_root, COHORT_LOGICAL_PATH
+        )
+        provenance_path = _discover_artifact_path(
+            args.sdk_provenance_artifact,
+            PROVENANCE_ARTIFACT_FILENAME,
+            repo_root,
+            PROVENANCE_LOGICAL_PATH,
+        )
+        if mode == "inventory":
+            document = _build_inventory_document(repo_root, ref, cohort_path, provenance_path)
+        elif mode == "authority-manifest":
+            document = _build_authority_manifest(repo_root, ref, cohort_path, provenance_path)
+        else:
+            document = _build_tier_classification(
+                repo_root, ref, changed_files, cohort_path, provenance_path
+            )
+    except StandaloneError as exc:
+        _emit_standalone(
+            {
+                "schema": ERROR_OUTPUT_SCHEMA,
+                "status": "fail",
+                "mode": mode,
+                "error": {"code": exc.code, "message": exc.message},
+            }
+        )
+        return 1
+    except Exception as exc:  # fail closed: never emit a partial success artifact
+        _emit_standalone(
+            {
+                "schema": ERROR_OUTPUT_SCHEMA,
+                "status": "fail",
+                "mode": mode,
+                "error": {"code": "unhandled_error", "message": f"{type(exc).__name__}: {exc}"},
+            }
+        )
+        return 1
+    _emit_standalone(document)
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--repo-root", type=Path, default=Path("."))
@@ -280,7 +1261,48 @@ def main() -> int:
         action="store_true",
         help="Fail (exit 1) if the inventory is out of sync with the baselines",
     )
+    parser.add_argument(
+        "--ref",
+        default=None,
+        help="Exact full commit SHA for the standalone read-only modes",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON (standalone read-only modes)",
+    )
+    parser.add_argument(
+        "--authority-manifest",
+        action="store_true",
+        help="Emit the Tier-4 authority closure manifest at --ref (read-only)",
+    )
+    parser.add_argument(
+        "--classify-tier",
+        action="store_true",
+        help="Classify --changed-file paths with the canonical review_queue policy (read-only)",
+    )
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=None,
+        help="Repo-relative changed file path for --classify-tier (repeatable)",
+    )
+    parser.add_argument(
+        "--cohort-artifact",
+        type=Path,
+        default=None,
+        help=f"Path to the canonical {COHORT_LOGICAL_PATH} artifact",
+    )
+    parser.add_argument(
+        "--sdk-provenance-artifact",
+        type=Path,
+        default=None,
+        help=f"Path to the canonical {PROVENANCE_LOGICAL_PATH} artifact",
+    )
     args = parser.parse_args()
+
+    if args.authority_manifest or args.classify_tier or args.ref is not None:
+        return run_standalone(args)
 
     repo_root = args.repo_root
     inventory_path = args.inventory or repo_root / DEFAULT_INVENTORY

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -1174,10 +1174,10 @@ def _canonical_artifact_paths() -> tuple[Path, Path]:
     elif runtime_settings:
         library = Path(runtime_settings).resolve().parent / "library"
     else:
-        pytest.skip("Factory mission artifacts are unavailable in this environment")
-    cohort = library / "contract-drift-original-cohort-v1.json"
-    provenance = library / "contract-drift-sdk-provenance-v1.json"
-    if not cohort.exists() or not provenance.exists():
+        library = None
+    cohort = library / "contract-drift-original-cohort-v1.json" if library else None
+    provenance = library / "contract-drift-sdk-provenance-v1.json" if library else None
+    if cohort is None or provenance is None or not cohort.exists() or not provenance.exists():
         pytest.skip("canonical Contract Drift mission artifacts are unavailable")
     return cohort, provenance
 

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import date, timedelta
 from pathlib import Path
+
+import pytest
 
 import scripts.check_contract_drift_ratchet as ratchet
 import scripts.generate_contract_drift_inventory as gen
@@ -1158,3 +1161,534 @@ def test_pr_mode_program_parameter_change_fails(tmp_path: Path):
     assert not result["integrity"]["passing"]
     assert any("Program baseline parameter changed" in i for i in result["integrity"]["issues"])
     assert not result["passing"]
+
+
+# --------------------------------------------------------------- boundary mode
+
+
+def _canonical_artifact_paths() -> tuple[Path, Path]:
+    mission_dir = os.environ.get("FACTORY_MISSION_DIR")
+    runtime_settings = os.environ.get("FACTORY_RUNTIME_SETTINGS_PATH")
+    if mission_dir:
+        library = Path(mission_dir) / "library"
+    elif runtime_settings:
+        library = Path(runtime_settings).resolve().parent / "library"
+    else:
+        pytest.skip("Factory mission artifacts are unavailable in this environment")
+    cohort = library / "contract-drift-original-cohort-v1.json"
+    provenance = library / "contract-drift-sdk-provenance-v1.json"
+    if not cohort.exists() or not provenance.exists():
+        pytest.skip("canonical Contract Drift mission artifacts are unavailable")
+    return cohort, provenance
+
+
+def _boundary_repo() -> tuple[Path, str]:
+    repo = Path(ratchet.__file__).resolve().parents[1]
+    sha = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return repo, sha
+
+
+def _authority_manifest(sha: str) -> dict:
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, _head = _boundary_repo()
+    return gen._build_authority_manifest(
+        repo,
+        sha,
+        cohort_artifact,
+        provenance_artifact,
+    )
+
+
+def _redigest_authority(authority: dict) -> None:
+    body = {key: value for key, value in authority.items() if key != "authority_manifest_sha256"}
+    authority["authority_manifest_sha256"] = ratchet._sha256_bytes(
+        ratchet._canonical_json_bytes(body)
+    )
+
+
+def _boundary_evidence(
+    sha: str,
+    authority_sha256: str,
+    *,
+    active_inventory_sha256: str = "2" * 64,
+    release_immutable: bool = False,
+) -> dict:
+    digest = "2" * 64
+    return {
+        "schema": ratchet.BOUNDARY_EVIDENCE_SCHEMA,
+        "boundary": "corrective_bootstrap",
+        "start_sha": sha,
+        "end_sha": sha,
+        "authority_manifest_sha256": authority_sha256,
+        "dependency_manifest_sha256": digest,
+        "active_inventory_sha256": active_inventory_sha256,
+        "public_symbol_manifest_sha256": digest,
+        "route_boundary_sha256": digest,
+        "category_set_sha256": digest,
+        "unit_set_sha256": digest,
+        "core_set_sha256": ratchet.CORE_ID_SET_SHA256,
+        "extended_set_sha256": ratchet.EXTENDED_ID_SET_SHA256,
+        "governed_prs": [],
+        "first_parent_receipts": [],
+        "source_receipts": [],
+        "actions": [
+            {"kind": "filesystem", "operation": "read"},
+            {"kind": "git", "argv": ["git", "show", sha]},
+            {"kind": "http", "method": "GET"},
+            {"kind": "subprocess", "operation": "hash", "mutating": False},
+        ],
+        "remote_resources": [
+            {
+                "resource": "https://api.github.test/repos/synaptent/aragora",
+                "before": {"etag": '"stable"', "updated_at": "2026-07-17T00:00:00Z"},
+                "after": {"etag": '"stable"', "updated_at": "2026-07-17T00:00:00Z"},
+            }
+        ],
+        "external_prerequisites": {
+            "future_release_immutability_enabled": release_immutable,
+            "administration_read_verified": True,
+            "rule_suite": {"id": 123, "result": "pass", "bypassed": False},
+        },
+        "attestation": {"predicate": "synthetic-test"},
+    }
+
+
+def _write_boundary_inputs(
+    tmp_path: Path,
+    *,
+    release_immutable: bool = False,
+) -> tuple[Path, str, Path, Path]:
+    repo, sha = _boundary_repo()
+    authority = _authority_manifest(sha)
+    authority_path = tmp_path / "authority.json"
+    evidence_path = tmp_path / "evidence.json"
+    _write_json(authority_path, authority)
+    _write_json(
+        evidence_path,
+        _boundary_evidence(
+            sha,
+            authority["authority_manifest_sha256"],
+            active_inventory_sha256=authority["inventory_facts"]["active_inventory"]["sha256"],
+            release_immutable=release_immutable,
+        ),
+    )
+    return repo, sha, authority_path, evidence_path
+
+
+def _boundary_result(
+    tmp_path: Path,
+    *,
+    release_immutable: bool = False,
+) -> dict:
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(
+        tmp_path,
+        release_immutable=release_immutable,
+    )
+    return ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref=sha,
+        end_ref=sha,
+        authority_manifest_path=authority_path,
+        cohort_artifact_path=cohort_artifact,
+        sdk_provenance_artifact_path=provenance_artifact,
+        evidence_path=evidence_path,
+    )
+
+
+def test_boundary_mode_validates_schema_one_independently(tmp_path: Path):
+    result = _boundary_result(tmp_path)
+    assert result["status"] == "blocked"
+    assert not result["passing"]
+    assert "Release immutability" in result["blocked_reason"]
+    assert result["schema_version"] == 1
+    assert result["original_cohort"]["record_count"] == 655
+    assert result["sdk_provenance"]["record_count"] == 598
+    assert result["sdk_provenance"]["source_occurrence_count"] == 690
+    assert (
+        result["sdk_provenance"]["baseline_birth"]["commit_sha"]
+        == "af5edb22235d4c40a97fe3faa54168b406ab5696"
+    )
+    assert (
+        result["sdk_provenance"]["dependencies"]["verifier"]["git_blob_oid"]
+        == "2d2a0e866f722dab0fad29f4283d1158aad0c408"
+    )
+    assert result["operation_projection"] == {
+        "schema": "cdg-operation-projection-v1",
+        "membership_count": 655,
+        "edge_count": 666,
+        "multi_edge_originals": 9,
+        "maximum_edges_per_original": 4,
+        "edge_count_distribution": {"1": 646, "2": 8, "4": 1},
+        "record_digest_set_sha256": ratchet.PROJECTION_RECORD_SET_SHA256,
+    }
+    assert len(result["manifest_sha256"]) == 64
+
+
+def test_boundary_mode_accepts_standalone_generator_manifest(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha = _boundary_repo()
+    authority_path = tmp_path / "authority.json"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            str(repo / "scripts/generate_contract_drift_inventory.py"),
+            "--authority-manifest",
+            "--ref",
+            sha,
+            "--json",
+            "--repo-root",
+            str(repo),
+            "--cohort-artifact",
+            str(cohort_artifact),
+            "--sdk-provenance-artifact",
+            str(provenance_artifact),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    authority_path.write_text(proc.stdout, encoding="utf-8")
+    authority = json.loads(proc.stdout)
+    evidence_path = tmp_path / "evidence.json"
+    _write_json(
+        evidence_path,
+        _boundary_evidence(
+            sha,
+            authority["authority_manifest_sha256"],
+            active_inventory_sha256=authority["inventory_facts"]["active_inventory"]["sha256"],
+        ),
+    )
+
+    result = ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref=sha,
+        end_ref=sha,
+        authority_manifest_path=authority_path,
+        cohort_artifact_path=cohort_artifact,
+        sdk_provenance_artifact_path=provenance_artifact,
+        evidence_path=evidence_path,
+    )
+    assert result["status"] == "blocked"
+    assert not result["passing"]
+    assert (
+        result["authority"]["authority_manifest_sha256"] == authority["authority_manifest_sha256"]
+    )
+
+
+def test_boundary_cli_autodiscovers_artifacts_and_blocks_without_evidence(
+    monkeypatch,
+    capsys,
+):
+    repo, sha = _boundary_repo()
+    cohort_artifact, _provenance_artifact = _canonical_artifact_paths()
+    monkeypatch.setenv("FACTORY_MISSION_DIR", str(cohort_artifact.parent.parent))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "check_contract_drift_ratchet.py",
+            "--mode",
+            "boundary",
+            "--schema-version",
+            "1",
+            "--boundary",
+            "corrective_bootstrap",
+            "--start-ref",
+            sha,
+            "--end-ref",
+            sha,
+            "--repo-root",
+            str(repo),
+            "--json",
+        ],
+    )
+    assert ratchet.main() == 2
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "blocked"
+    assert result["passing"] is False
+    assert result["evidence"]["status"] == "unavailable"
+    assert result["canonical_artifacts"]["original_cohort"]["byte_length"] == 1_692_125
+
+
+def test_unsupported_schema_version_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    with pytest.raises(ValueError, match="unsupported boundary schema version"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=2,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_boundary_manifest_digest_mismatch_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    authority = json.loads(authority_path.read_text())
+    authority["authority_manifest_sha256"] = "0" * 64
+    _write_json(authority_path, authority)
+    with pytest.raises(ValueError, match="authority manifest digest mismatch"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_boundary_manifest_ref_binding_tamper_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    authority = json.loads(authority_path.read_text())
+    authority["file_bindings"][0]["byte_length"] += 1
+    authority["authority_manifest_sha256"] = ratchet._sha256_bytes(
+        ratchet._canonical_json_bytes(
+            {key: value for key, value in authority.items() if key != "authority_manifest_sha256"}
+        )
+    )
+    _write_json(authority_path, authority)
+    evidence = json.loads(evidence_path.read_text())
+    evidence["authority_manifest_sha256"] = authority["authority_manifest_sha256"]
+    _write_json(evidence_path, evidence)
+    with pytest.raises(ValueError, match="does not match ref"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_boundary_manifest_inventory_binding_tamper_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    authority = json.loads(authority_path.read_text())
+    authority["inventory_facts"]["operation_projection"]["operation_edge_count"] = 665
+    authority["authority_manifest_sha256"] = ratchet._sha256_bytes(
+        ratchet._canonical_json_bytes(
+            {key: value for key, value in authority.items() if key != "authority_manifest_sha256"}
+        )
+    )
+    _write_json(authority_path, authority)
+    evidence = json.loads(evidence_path.read_text())
+    evidence["authority_manifest_sha256"] = authority["authority_manifest_sha256"]
+    _write_json(evidence_path, evidence)
+    with pytest.raises(ValueError, match="operation projection facts mismatch"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_boundary_manifest_policy_under_scope_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    authority = json.loads(authority_path.read_text())
+    authority["policy"]["authority_roots"] = authority["policy"]["authority_roots"][:-1]
+    _redigest_authority(authority)
+    _write_json(authority_path, authority)
+    evidence = json.loads(evidence_path.read_text())
+    evidence["authority_manifest_sha256"] = authority["authority_manifest_sha256"]
+    _write_json(evidence_path, evidence)
+    with pytest.raises(ValueError, match="authority roots are incomplete or noncanonical"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_boundary_evidence_inheritance_fails_closed(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    evidence = json.loads(evidence_path.read_text())
+    evidence["inherited_from_boundary"] = "prior-boundary"
+    _write_json(evidence_path, evidence)
+    with pytest.raises(ValueError, match="may not inherit"):
+        ratchet.build_boundary_result(
+            repo_root=repo,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref=sha,
+            end_ref=sha,
+            authority_manifest_path=authority_path,
+            cohort_artifact_path=cohort_artifact,
+            sdk_provenance_artifact_path=provenance_artifact,
+            evidence_path=evidence_path,
+        )
+
+
+def test_release_immutability_or_rule_suite_prerequisite_blocks(tmp_path: Path):
+    result = _boundary_result(tmp_path, release_immutable=False)
+    assert result["status"] == "blocked"
+    assert not result["passing"]
+    assert "Release immutability" in result["blocked_reason"]
+    assert len(result["manifest_sha256"]) == 64
+
+
+def test_self_claimed_external_prerequisites_remain_blocked(tmp_path: Path):
+    result = _boundary_result(tmp_path, release_immutable=True)
+    assert result["status"] == "blocked"
+    assert not result["passing"]
+    assert "Release immutability" in result["blocked_reason"]
+
+
+def test_read_only_cli_rejects_mutating_http_verbs(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    for method in ("POST", "PUT", "PATCH", "DELETE"):
+        case_dir = tmp_path / method.lower()
+        case_dir.mkdir()
+        repo, sha, authority_path, evidence_path = _write_boundary_inputs(case_dir)
+        evidence = json.loads(evidence_path.read_text())
+        evidence["actions"].append({"kind": "http", "method": method})
+        _write_json(evidence_path, evidence)
+        with pytest.raises(ValueError, match="mutating HTTP verb rejected"):
+            ratchet.build_boundary_result(
+                repo_root=repo,
+                schema_version=1,
+                boundary="corrective_bootstrap",
+                start_ref=sha,
+                end_ref=sha,
+                authority_manifest_path=authority_path,
+                cohort_artifact_path=cohort_artifact,
+                sdk_provenance_artifact_path=provenance_artifact,
+                evidence_path=evidence_path,
+            )
+
+
+def test_read_only_cli_rejects_mutating_git_and_subprocess_actions(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    actions = (
+        {"kind": "git", "argv": ["git", "push", "origin", "main"]},
+        {"kind": "git", "argv": ["git", "-C", "/tmp/repo", "reset", "--hard", "HEAD"]},
+        {"kind": "git", "argv": ["git", "config", "user.name", "hostile"]},
+        {"kind": "git", "argv": ["git", "notes", "add", "-m", "hostile"]},
+        {"kind": "git", "argv": ["git", "replace", "HEAD", "HEAD^"]},
+        {"kind": "git", "argv": ["git", "symbolic-ref", "HEAD", "refs/heads/main"]},
+        {"kind": "subprocess", "operation": "merge", "mutating": True},
+        {"kind": "filesystem", "operation": "write"},
+    )
+    for index, action in enumerate(actions):
+        case_dir = tmp_path / str(index)
+        case_dir.mkdir()
+        repo, sha, authority_path, evidence_path = _write_boundary_inputs(case_dir)
+        evidence = json.loads(evidence_path.read_text())
+        evidence["actions"].append(action)
+        _write_json(evidence_path, evidence)
+        with pytest.raises(ValueError, match="rejected|mutating"):
+            ratchet.build_boundary_result(
+                repo_root=repo,
+                schema_version=1,
+                boundary="corrective_bootstrap",
+                start_ref=sha,
+                end_ref=sha,
+                authority_manifest_path=authority_path,
+                cohort_artifact_path=cohort_artifact,
+                sdk_provenance_artifact_path=provenance_artifact,
+                evidence_path=evidence_path,
+            )
+
+
+def test_read_only_cli_preserves_etag_and_updated_at(tmp_path: Path):
+    result = _boundary_result(tmp_path)
+    remote = result["evidence"]["remote_resources"][0]
+    assert remote["before"] == remote["after"]
+    assert remote["before"]["etag"] == '"stable"'
+    assert remote["before"]["updated_at"] == "2026-07-17T00:00:00Z"
+
+
+def test_read_only_cli_retries_or_blocks_on_concurrent_mutation(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+    evidence = json.loads(evidence_path.read_text())
+    evidence["remote_resources"][0]["after"]["etag"] = '"moved"'
+    _write_json(evidence_path, evidence)
+    result = ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref=sha,
+        end_ref=sha,
+        authority_manifest_path=authority_path,
+        cohort_artifact_path=cohort_artifact,
+        sdk_provenance_artifact_path=provenance_artifact,
+        evidence_path=evidence_path,
+    )
+    assert result["status"] == "blocked"
+    assert not result["passing"]
+    assert "remote resource moved" in result["blocked_reason"]
+
+
+def test_boundary_mode_is_deterministic_and_read_only(tmp_path: Path):
+    cohort_artifact, provenance_artifact = _canonical_artifact_paths()
+    repo, sha, authority_path, evidence_path = _write_boundary_inputs(tmp_path)
+
+    def status() -> str:
+        return subprocess.run(
+            ["git", "-C", str(repo), "status", "--porcelain=v1"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"},
+        ).stdout
+
+    kwargs = {
+        "repo_root": repo,
+        "schema_version": 1,
+        "boundary": "corrective_bootstrap",
+        "start_ref": sha,
+        "end_ref": sha,
+        "authority_manifest_path": authority_path,
+        "cohort_artifact_path": cohort_artifact,
+        "sdk_provenance_artifact_path": provenance_artifact,
+        "evidence_path": evidence_path,
+    }
+    for _attempt in range(3):
+        before = status()
+        first = ratchet._canonical_json_bytes(ratchet.build_boundary_result(**kwargs))
+        second = ratchet._canonical_json_bytes(ratchet.build_boundary_result(**kwargs))
+        after = status()
+        if before == after:
+            break
+    assert first == second
+    assert before == after

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 import scripts.generate_contract_drift_inventory as gen
 
@@ -271,3 +275,968 @@ def test_discovered_provenance_requires_reference_in_committed_inventory():
         {"items": [item]}, {"python_sdk_drift:GET /api/y": "python_sdk_drift"}
     )
     assert any("lacks a PR/issue reference" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Standalone read-only authority/inventory surface tests (VAL-CDG-001/002)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(gen.__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_contract_drift_inventory.py"
+
+
+def _canonical_bytes(doc: dict) -> bytes:
+    return json.dumps(doc, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _artifact_paths() -> tuple[Path, Path] | None:
+    roots: list[Path] = []
+    mission_dir = os.environ.get("FACTORY_MISSION_DIR", "").strip()
+    if mission_dir:
+        roots.append(Path(mission_dir) / "library")
+    settings_path = os.environ.get("FACTORY_RUNTIME_SETTINGS_PATH", "").strip()
+    if settings_path:
+        roots.append(Path(settings_path).parent / "library")
+    roots.append(REPO_ROOT / "library")
+    for root in roots:
+        cohort = root / gen.COHORT_ARTIFACT_FILENAME
+        provenance = root / gen.PROVENANCE_ARTIFACT_FILENAME
+        if cohort.is_file() and provenance.is_file():
+            return cohort, provenance
+    return None
+
+
+def _require_artifacts() -> tuple[Path, Path]:
+    found = _artifact_paths()
+    if found is None:
+        pytest.skip(
+            "canonical mission artifacts unavailable "
+            "(set FACTORY_MISSION_DIR or provide <repo>/library)"
+        )
+    return found
+
+
+def _artifact_args(artifacts: tuple[Path, Path]) -> list[str]:
+    return [
+        "--cohort-artifact",
+        str(artifacts[0]),
+        "--sdk-provenance-artifact",
+        str(artifacts[1]),
+    ]
+
+
+def _head_sha() -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_cli(*argv: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-B", str(SCRIPT_PATH), *argv],
+        capture_output=True,
+        cwd=str(cwd or REPO_ROOT),
+    )
+
+
+def _run_standalone(monkeypatch, capsys, *argv: str) -> tuple[int, dict]:
+    monkeypatch.setattr(sys, "argv", ["generate_contract_drift_inventory.py", *argv])
+    rc = gen.main()
+    return rc, json.loads(capsys.readouterr().out)
+
+
+def _independent_closure(sha: str) -> set[str]:
+    rq = gen._review_queue_module()
+    roots = list(rq.CONTRACT_DRIFT_AUTHORITY_PREFIXES)
+    names = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-tree", "--name-only", sha, ".github/workflows/"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    closure = set(roots) | {"aragora/cli/commands/review_queue.py"}
+    for name in names:
+        if not name.endswith(".yml"):
+            continue
+        blob = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "show", f"{sha}:{name}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        if any(root in blob for root in roots):
+            closure.add(name)
+    return closure
+
+
+def test_transitive_authority_dependencies_are_tier4():
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    proc = _run_cli(
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    )
+    assert proc.returncode == 0, proc.stdout
+    manifest = json.loads(proc.stdout)
+    rq = gen._review_queue_module()
+
+    repo_files = manifest["repo_files"]
+    assert repo_files == sorted(set(repo_files))
+    assert set(repo_files) == _independent_closure(sha)
+    assert set(rq.CONTRACT_DRIFT_AUTHORITY_PREFIXES) <= set(repo_files)
+    assert "aragora/cli/commands/review_queue.py" in repo_files
+    assert "scripts/tier4_merge_train.py" not in repo_files
+
+    for path in repo_files:
+        tier, _name, _reason = rq._classify_model_review_tier([path])
+        assert tier == 4, path
+    bindings = {binding["path"]: binding for binding in manifest["file_bindings"]}
+    assert sorted(bindings) == repo_files
+    for path, binding in bindings.items():
+        assert binding["effective_tier"] == 4
+        assert binding["matched_authority_rule"] is not None
+        assert len(binding["sha256"]) == 64
+        assert binding["byte_length"] > 0
+
+    mirror = manifest["merge_train_mirror"]
+    assert mirror["path"] == "scripts/tier4_merge_train.py"
+    assert mirror["in_repo_files"] is False
+    assert len(mirror["sha256"]) == 64
+
+    body = {k: v for k, v in manifest.items() if k != "authority_manifest_sha256"}
+    assert (
+        hashlib.sha256(_canonical_bytes(body)).hexdigest() == manifest["authority_manifest_sha256"]
+    )
+
+
+def test_classifier_and_merge_train_closure_match():
+    rq = gen._review_queue_module()
+    import scripts.tier4_merge_train as train
+
+    exact_roots = [*rq.CONTRACT_DRIFT_AUTHORITY_PREFIXES, "aragora/cli/commands/review_queue.py"]
+    matrix: list[str] = []
+    for root in exact_roots:
+        matrix += [root, f"{root}.bak", f"{root}.old", f"{root}.pyx", f"{root}/child"]
+    matrix += [
+        ".github/workflows/contract-drift-governance.yml",
+        ".github/workflows/nested/deep.yml",
+        "docs/CONTRACT_DRIFT.md",
+        "scripts/unrelated_sibling_tool.py",
+    ]
+    for path in matrix:
+        canonical_rule = next(
+            (p for p in rq.TIER_4_PREFIXES if rq._matches_prefix(path, (p,))), None
+        )
+        train_rule = train.matches_serialized_path(path)
+        assert canonical_rule == train_rule, path
+        tier = rq._classify_model_review_tier([path])[0]
+        assert (tier == 4) == (canonical_rule is not None), path
+        serialized = train.serialized_paths_for([path])
+        assert serialized == ({train_rule} if train_rule else set()), path
+    for root in exact_roots:
+        for suffix in (".bak", ".old", ".pyx", "/child"):
+            hostile = f"{root}{suffix}"
+            assert rq._classify_model_review_tier([hostile])[0] < 4, hostile
+            assert train.matches_serialized_path(hostile) is None, hostile
+
+
+def test_standalone_classifier_imports_and_calls_canonical_review_queue_policy(monkeypatch, capsys):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    rq = gen._review_queue_module()
+
+    sentinel_path = "scripts/nonexistent_probe_file.py"
+    real_classify = rq._classify_model_review_tier
+
+    def spy(files, *, pr=None):
+        if list(files) == [sentinel_path]:
+            return (3, "tier_3_sentinel_from_canonical_policy", "sentinel classification")
+        return real_classify(files, pr=pr)
+
+    monkeypatch.setattr(rq, "_classify_model_review_tier", spy)
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--classify-tier",
+        "--changed-file",
+        sentinel_path,
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    )
+    assert rc == 0
+    assert doc["effective_tier"] == 3
+    assert doc["tier_name"] == "tier_3_sentinel_from_canonical_policy"
+    assert doc["changed_files"] == [sentinel_path]
+
+    dropped_root = "scripts/sdk_path_normalize.py"
+    trimmed = tuple(
+        prefix for prefix in rq.CONTRACT_DRIFT_AUTHORITY_PREFIXES if prefix != dropped_root
+    )
+    assert len(trimmed) == len(rq.CONTRACT_DRIFT_AUTHORITY_PREFIXES) - 1
+    monkeypatch.setattr(rq, "CONTRACT_DRIFT_AUTHORITY_PREFIXES", trimmed)
+    rc, manifest = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    )
+    assert rc == 0
+    assert dropped_root not in manifest["repo_files"]
+    assert set(trimmed) <= set(manifest["repo_files"])
+    assert manifest["policy"]["authority_roots"] == sorted(trimmed)
+
+
+def test_canonical_tier_cli_is_read_only_and_digest_bound(tmp_path):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+
+    def _status() -> str:
+        return subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--untracked-files=all"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    before_status = _status()
+    before_artifact_bytes = (artifacts[0].read_bytes(), artifacts[1].read_bytes())
+    scratch_cwd = tmp_path / "empty-cwd"
+    scratch_cwd.mkdir()
+
+    classify = _run_cli(
+        "--classify-tier",
+        "--changed-file",
+        "scripts/validate_openapi_routes.py",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+        cwd=scratch_cwd,
+    )
+    manifest_proc = _run_cli(
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+        cwd=scratch_cwd,
+    )
+    assert classify.returncode == 0, classify.stdout
+    assert manifest_proc.returncode == 0, manifest_proc.stdout
+    assert _status() == before_status
+    assert (artifacts[0].read_bytes(), artifacts[1].read_bytes()) == before_artifact_bytes
+    assert list(scratch_cwd.iterdir()) == []
+
+    doc = json.loads(classify.stdout)
+    manifest = json.loads(manifest_proc.stdout)
+    assert doc["effective_tier"] == 4
+    assert doc["matched_authority_path"] == "scripts/validate_openapi_routes.py"
+    assert doc["authority_manifest_sha256"] == manifest["authority_manifest_sha256"]
+    body = {k: v for k, v in manifest.items() if k != "authority_manifest_sha256"}
+    assert (
+        hashlib.sha256(_canonical_bytes(body)).hexdigest() == manifest["authority_manifest_sha256"]
+    )
+    facts = doc["inventory_facts"]
+    assert facts == manifest["inventory_facts"]
+    assert facts["original_record_id_set_sha256"] == gen.RATIFIED_ORIGINAL_ID_SET_SHA256
+    assert len(facts["inventory_sha256"]) == 64
+
+
+def test_read_only_cli_is_deterministic_across_double_run():
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    art = _artifact_args(artifacts)
+    invocations = (
+        ["--authority-manifest", "--ref", sha, "--json", "--repo-root", str(REPO_ROOT), *art],
+        [
+            "--classify-tier",
+            "--changed-file",
+            "scripts/check_sdk_parity.py",
+            "--ref",
+            sha,
+            "--json",
+            "--repo-root",
+            str(REPO_ROOT),
+            *art,
+        ],
+        ["--ref", sha, "--json", "--repo-root", str(REPO_ROOT), *art],
+    )
+    for argv in invocations:
+        first = _run_cli(*argv)
+        second = _run_cli(*argv)
+        assert first.returncode == 0, first.stdout
+        assert second.returncode == 0, second.stdout
+        assert first.stdout == second.stdout
+        assert first.stdout.endswith(b"\n")
+
+
+def test_original_cohort_descriptor_is_immutable_across_authority_versions(monkeypatch, capsys):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    argv = [
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    ]
+    rc, baseline = _run_standalone(monkeypatch, capsys, *argv)
+    assert rc == 0
+
+    rq = gen._review_queue_module()
+    monkeypatch.setattr(
+        rq,
+        "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+        rq.CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION + 1,
+    )
+    rc, bumped = _run_standalone(monkeypatch, capsys, *argv)
+    assert rc == 0
+
+    assert bumped["authority_manifest_sha256"] != baseline["authority_manifest_sha256"]
+    assert bumped["artifacts"] == baseline["artifacts"]
+    assert bumped["inventory_facts"] == baseline["inventory_facts"]
+
+    descriptor = baseline["artifacts"]["original_cohort"]
+    assert descriptor["logical_path"] == gen.COHORT_LOGICAL_PATH
+    assert descriptor["byte_length"] == gen.COHORT_BYTE_LENGTH
+    assert descriptor["sha256"] == gen.COHORT_SHA256
+    provenance_descriptor = baseline["artifacts"]["sdk_provenance"]
+    assert provenance_descriptor["logical_path"] == gen.PROVENANCE_LOGICAL_PATH
+    assert provenance_descriptor["byte_length"] == gen.PROVENANCE_BYTE_LENGTH
+    assert provenance_descriptor["sha256"] == gen.PROVENANCE_SHA256
+
+
+def test_canonical_cohort_and_provenance_artifacts_are_in_authority_closure():
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    proc = _run_cli(
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    )
+    assert proc.returncode == 0, proc.stdout
+    manifest = json.loads(proc.stdout)
+
+    assert manifest["artifacts"]["original_cohort"] == {
+        "logical_path": gen.COHORT_LOGICAL_PATH,
+        "byte_length": gen.COHORT_BYTE_LENGTH,
+        "sha256": gen.COHORT_SHA256,
+        "schema": gen.COHORT_SCHEMA,
+        "canonical_bytes": True,
+        "utf8_no_bom": True,
+        "single_terminal_lf": True,
+    }
+    assert manifest["artifacts"]["sdk_provenance"] == {
+        "logical_path": gen.PROVENANCE_LOGICAL_PATH,
+        "byte_length": gen.PROVENANCE_BYTE_LENGTH,
+        "sha256": gen.PROVENANCE_SHA256,
+        "schema": gen.PROVENANCE_SCHEMA,
+        "canonical_bytes": True,
+        "utf8_no_bom": True,
+        "single_terminal_lf": True,
+    }
+
+    facts = manifest["inventory_facts"]
+    assert facts["membership_anchor"]["commit_sha"] == "6c4784330dca2d1709edf50b38f4d1201e92c83a"
+    assert [source["path"] for source in facts["membership_sources"]] == [
+        "scripts/baselines/verify_sdk_contracts.json",
+        "scripts/baselines/validate_openapi_routes.json",
+        "scripts/baselines/check_sdk_parity.json",
+    ]
+    assert facts["original_record_total"] == 655
+    assert facts["original_record_id_set_sha256"] == gen.RATIFIED_ORIGINAL_ID_SET_SHA256
+    assert facts["method_bearing_sdk_records"] == 598
+    assert facts["method_null_route_parity_records"] == 57
+    provenance_facts = facts["sdk_provenance"]
+    assert (
+        provenance_facts["baseline_birth"]["commit_sha"]
+        == "af5edb22235d4c40a97fe3faa54168b406ab5696"
+    )
+    assert (
+        provenance_facts["dependencies"]["verifier"]["git_blob_oid"]
+        == "2d2a0e866f722dab0fad29f4283d1158aad0c408"
+    )
+    assert (
+        provenance_facts["dependencies"]["normalizer"]["git_blob_oid"]
+        == "5710fcd04234f997586a187ff8e2ace42f30dddc"
+    )
+    assert provenance_facts["record_count"] == 598
+    assert provenance_facts["source_occurrence_count"] == 690
+    assert provenance_facts["multi_atom_record_count"] == 12
+    assert provenance_facts["missing_record_count"] == 0
+    assert provenance_facts["record_digest_set_sha256"] == gen.RATIFIED_PROVENANCE_DIGEST_SET_SHA256
+    partition = provenance_facts["partition"]
+    assert partition["core_count"] == 75
+    assert partition["extended_count"] == 523
+    assert partition["sdk_original_record_id_set_sha256"] == gen.RATIFIED_SDK_ID_SET_SHA256
+    assert partition["core_original_record_id_set_sha256"] == gen.RATIFIED_CORE_ID_SET_SHA256
+    assert (
+        partition["extended_original_record_id_set_sha256"] == gen.RATIFIED_EXTENDED_ID_SET_SHA256
+    )
+    projection = facts["operation_projection"]
+    assert projection["membership_count"] == 655
+    assert projection["operation_edge_count"] == 666
+    assert projection["multi_edge_membership_count"] == 9
+    assert projection["max_operation_edges"] == 4
+    assert projection["record_digest_set_sha256"] == gen.RATIFIED_PROJECTION_DIGEST_SET_SHA256
+
+    stdout_text = proc.stdout.decode("utf-8")
+    assert str(artifacts[0]) not in stdout_text
+    assert str(artifacts[0].parent) not in stdout_text
+
+
+def test_standalone_ref_rejects_abbreviated_unresolved_or_malformed_shas(monkeypatch, capsys):
+    head = _head_sha()
+    cases = (
+        (head[:12], "ref_invalid"),
+        (head.upper(), "ref_invalid"),
+        ("HEAD", "ref_invalid"),
+        ("main", "ref_invalid"),
+        ("f" * 40, "ref_unresolved"),
+    )
+    for ref, expected_code in cases:
+        rc, doc = _run_standalone(
+            monkeypatch,
+            capsys,
+            "--classify-tier",
+            "--changed-file",
+            "scripts/check_sdk_parity.py",
+            "--ref",
+            ref,
+            "--json",
+            "--repo-root",
+            str(REPO_ROOT),
+        )
+        assert rc == 1, ref
+        assert doc["status"] == "fail"
+        assert doc["error"]["code"] == expected_code, ref
+
+
+def test_standalone_artifact_tamper_fails_closed(monkeypatch, capsys, tmp_path):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    raw = artifacts[0].read_bytes()
+
+    tampered = bytearray(raw)
+    tampered[100] = (tampered[100] + 1) % 256
+    flipped = tmp_path / "cohort-flipped.json"
+    flipped.write_bytes(bytes(tampered))
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--cohort-artifact",
+        str(flipped),
+        "--sdk-provenance-artifact",
+        str(artifacts[1]),
+    )
+    assert rc == 1
+    assert doc["error"]["code"] == "artifact_sha256_mismatch"
+
+    truncated = tmp_path / "cohort-truncated.json"
+    truncated.write_bytes(raw[:-1])
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--cohort-artifact",
+        str(truncated),
+        "--sdk-provenance-artifact",
+        str(artifacts[1]),
+    )
+    assert rc == 1
+    assert doc["error"]["code"] == "artifact_byte_length_mismatch"
+
+    symlink = tmp_path / "cohort-symlink.json"
+    symlink.symlink_to(artifacts[0])
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--cohort-artifact",
+        str(symlink),
+        "--sdk-provenance-artifact",
+        str(artifacts[1]),
+    )
+    assert rc == 1
+    assert doc["error"]["code"] == "artifact_symlink_forbidden"
+
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        "--cohort-artifact",
+        str(tmp_path / "absent.json"),
+        "--sdk-provenance-artifact",
+        str(artifacts[1]),
+    )
+    assert rc == 1
+    assert doc["error"]["code"] == "artifact_missing"
+    assert gen.COHORT_LOGICAL_PATH in doc["error"]["message"]
+    assert str(tmp_path) not in doc["error"]["message"]
+
+
+def test_classify_tier_rejects_traversal_absolute_and_non_normalized_paths(monkeypatch, capsys):
+    sha = _head_sha()
+    hostile_paths = (
+        "/etc/passwd",
+        "../secrets",
+        "a/../b",
+        "a//b",
+        "./a",
+        "a/./b",
+        "a\\b",
+        "scripts/",
+        "",
+    )
+    for hostile in hostile_paths:
+        rc, doc = _run_standalone(
+            monkeypatch,
+            capsys,
+            "--classify-tier",
+            "--changed-file",
+            hostile,
+            "--ref",
+            sha,
+            "--json",
+            "--repo-root",
+            str(REPO_ROOT),
+        )
+        assert rc == 1, hostile
+        assert doc["error"]["code"] == "changed_file_invalid", hostile
+
+
+def test_classify_tier_hostile_file_variants_stay_below_tier4(monkeypatch, capsys):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    root = "scripts/check_sdk_parity.py"
+
+    def _classify(path: str) -> dict:
+        rc, doc = _run_standalone(
+            monkeypatch,
+            capsys,
+            "--classify-tier",
+            "--changed-file",
+            path,
+            "--ref",
+            sha,
+            "--json",
+            "--repo-root",
+            str(REPO_ROOT),
+            *_artifact_args(artifacts),
+        )
+        assert rc == 0, path
+        return doc
+
+    for hostile in (f"{root}.bak", f"{root}.old", f"{root}.pyx", f"{root}/child"):
+        doc = _classify(hostile)
+        assert doc["effective_tier"] < 4, hostile
+        assert doc["matched_authority_path"] is None, hostile
+
+    doc = _classify(root)
+    assert doc["effective_tier"] == 4
+    assert doc["matched_authority_path"] == root
+
+    doc = _classify(".github/workflows/contract-drift-governance.yml")
+    assert doc["effective_tier"] == 4
+    assert doc["matched_authority_path"] == ".github/workflows/"
+
+
+def test_authority_manifest_auto_discovers_mission_artifacts_and_fails_closed(
+    monkeypatch, capsys, tmp_path
+):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+
+    monkeypatch.setenv("FACTORY_MISSION_DIR", str(artifacts[0].parent.parent))
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+    )
+    assert rc == 0
+    assert doc["status"] == "ok"
+    assert doc["artifacts"]["original_cohort"]["logical_path"] == gen.COHORT_LOGICAL_PATH
+
+    monkeypatch.delenv("FACTORY_MISSION_DIR", raising=False)
+    monkeypatch.delenv("FACTORY_RUNTIME_SETTINGS_PATH", raising=False)
+    bare_repo, bare_sha = _init_repo(tmp_path)
+    rc, doc = _run_standalone(
+        monkeypatch,
+        capsys,
+        "--authority-manifest",
+        "--ref",
+        bare_sha,
+        "--json",
+        "--repo-root",
+        str(bare_repo),
+    )
+    assert rc == 1
+    assert doc["error"]["code"] == "artifact_missing"
+
+
+def _git_text(*argv: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *argv],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "GIT_OPTIONAL_LOCKS": "0"},
+    ).stdout
+
+
+def _top_level_ast_by_name(ref: str, path: str) -> dict[str, str]:
+    import ast
+
+    tree = ast.parse(_git_text("show", f"{ref}:{path}"))
+    result: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            result[node.name] = ast.dump(node, include_attributes=False)
+        elif isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    result[target.id] = ast.dump(node, include_attributes=False)
+    return result
+
+
+def _snapshot_read_only_state() -> dict[str, str]:
+    def digest(value: bytes) -> str:
+        return hashlib.sha256(value).hexdigest()
+
+    def digest_tree(root: Path, *, excluded: frozenset[str] = frozenset()) -> str:
+        hashed = hashlib.sha256()
+        for path in sorted(root.rglob("*")):
+            relative = path.relative_to(root)
+            if relative.parts and relative.parts[0] in excluded:
+                continue
+            hashed.update(relative.as_posix().encode())
+            if path.is_symlink():
+                hashed.update(os.readlink(path).encode())
+            elif path.is_file():
+                hashed.update(path.read_bytes())
+        return hashed.hexdigest()
+
+    def git_path(name: str) -> Path:
+        raw = _git_text("rev-parse", "--path-format=absolute", "--git-path", name).strip()
+        return Path(raw)
+
+    index = git_path("index")
+    worktree_gitdir = Path(_git_text("rev-parse", "--absolute-git-dir").strip())
+    common_gitdir = Path(
+        _git_text("rev-parse", "--path-format=absolute", "--git-common-dir").strip()
+    )
+    return {
+        "tracked_untracked": digest(
+            _git_text("status", "--porcelain=v1", "--untracked-files=all").encode()
+        ),
+        "index": digest(index.read_bytes()),
+        "worktree_gitdir": digest_tree(worktree_gitdir, excluded=frozenset({"index"})),
+        "common_gitdir": digest_tree(
+            common_gitdir,
+            excluded=frozenset({"objects", "refs", "logs", "worktrees"}),
+        ),
+        "objects": digest(
+            (
+                _git_text("rev-list", "--objects", "--all") + _git_text("count-objects", "-v")
+            ).encode()
+        ),
+        "refs": digest(_git_text("show-ref", "--head").encode()),
+        "reflogs": digest(_git_text("reflog", "show", "--all", "--format=%H %gD").encode()),
+    }
+
+
+def test_classifier_pr_changes_are_constants_only():
+    commit = "ee686e9d116c704ede146a6ec69dfe013b6c32be"
+    changed = set(_git_text("show", "--format=", "--name-only", commit).splitlines())
+    assert changed == {
+        "aragora/cli/commands/review_queue.py",
+        "scripts/tier4_merge_train.py",
+        "tests/governance/test_contract_drift_measurement_authority_tier.py",
+    }
+    allowed = {
+        "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+        "CONTRACT_DRIFT_AUTHORITY_TIER",
+        "CONTRACT_DRIFT_AUTHORITY_PREFIXES",
+        "CONTRACT_DRIFT_AUTHORITY_CANONICAL_SOURCE",
+        "TIER_4_PREFIXES",
+        "SERIALIZED_TIER4_PREFIXES",
+    }
+    for path in ("aragora/cli/commands/review_queue.py", "scripts/tier4_merge_train.py"):
+        before = _top_level_ast_by_name(f"{commit}^", path)
+        after = _top_level_ast_by_name(commit, path)
+        changed_symbols = {
+            name for name in set(before) | set(after) if before.get(name) != after.get(name)
+        }
+        assert changed_symbols <= allowed
+
+
+def test_matcher_repair_preserves_eight_constants_and_single_line_authority_tuple():
+    from aragora.cli.commands import review_queue
+
+    commit = "e8a0d165242737d3226b6d3360aa9e8ec014fd75"
+    before = _top_level_ast_by_name(f"{commit}^", "aragora/cli/commands/review_queue.py")
+    after = _top_level_ast_by_name(commit, "aragora/cli/commands/review_queue.py")
+    for name in (
+        "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+        "CONTRACT_DRIFT_AUTHORITY_TIER",
+        "CONTRACT_DRIFT_AUTHORITY_PREFIXES",
+        "TIER_4_PREFIXES",
+    ):
+        assert before[name] == after[name]
+    assert len(review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES) == 8
+    source = Path(review_queue.__file__).read_text(encoding="utf-8")
+    assert "    *CONTRACT_DRIFT_AUTHORITY_PREFIXES," in source.splitlines()
+
+
+def test_file_authority_roots_match_exact_equality_only():
+    from aragora.cli.commands import review_queue
+
+    exact_roots = [root for root in review_queue.TIER_4_PREFIXES if not root.endswith("/")]
+    for root in exact_roots:
+        assert review_queue._matches_prefix(root, (root,))
+        for suffix in (".bak", ".old", ".pyx", "/child"):
+            assert not review_queue._matches_prefix(f"{root}{suffix}", (root,))
+
+
+def test_directory_authority_roots_match_descendants():
+    from aragora.cli.commands import review_queue
+
+    directory_roots = [root for root in review_queue.TIER_4_PREFIXES if root.endswith("/")]
+    assert directory_roots
+    for root in directory_roots:
+        assert review_queue._matches_prefix(f"{root}one.yml", (root,))
+        assert review_queue._matches_prefix(f"{root}nested/two.yml", (root,))
+        assert not review_queue._matches_prefix(root.rstrip("/"), (root,))
+
+
+def test_review_queue_and_merge_train_report_identical_match_and_serialization():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    matrix: list[str] = []
+    for root in review_queue.TIER_4_PREFIXES:
+        if root.endswith("/"):
+            matrix.extend((f"{root}one.yml", f"{root}nested/two.yml"))
+        else:
+            matrix.extend((root, f"{root}.bak", f"{root}.old", f"{root}.pyx", f"{root}/child"))
+    for path in matrix:
+        canonical = next(
+            (
+                root
+                for root in review_queue.TIER_4_PREFIXES
+                if review_queue._matches_prefix(path, (root,))
+            ),
+            None,
+        )
+        mirrored = tier4_merge_train.matches_serialized_path(path)
+        assert canonical == mirrored
+        assert (review_queue._classify_model_review_tier([path])[0] == 4) == (mirrored is not None)
+
+
+def test_file_root_suffix_and_child_variants_are_below_tier4_and_unserialized():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    for root in review_queue.TIER_4_PREFIXES:
+        if root.endswith("/"):
+            continue
+        for suffix in (".bak", ".old", ".pyx", "/child"):
+            path = f"{root}{suffix}"
+            assert review_queue._classify_model_review_tier([path])[0] < 4
+            assert tier4_merge_train.serialized_paths_for([path]) == set()
+
+
+def test_exact_authority_roots_serialize_and_contend():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    for index, root in enumerate(review_queue.TIER_4_PREFIXES, start=1):
+        path = f"{root}probe.yml" if root.endswith("/") else root
+        empty = tier4_merge_train.evaluate_merge_train([path], [])
+        occupied = tier4_merge_train.evaluate_merge_train(
+            [path],
+            [
+                {
+                    "number": 9000 + index,
+                    "createdAt": "2026-07-17T00:00:00Z",
+                    "files": [{"path": path}],
+                }
+            ],
+        )
+        assert empty["decision"] == tier4_merge_train.ALLOW
+        assert occupied["decision"] == tier4_merge_train.QUEUE
+        assert occupied["blocking_prs"] == [9000 + index]
+        assert occupied["candidate_surfaces"] == [root]
+
+
+def test_directory_descendants_remain_tier4():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    for root in review_queue.TIER_4_PREFIXES:
+        if not root.endswith("/"):
+            continue
+        for path in (f"{root}one.yml", f"{root}nested/two.yml"):
+            assert review_queue._classify_model_review_tier([path])[0] == 4
+            assert tier4_merge_train.serialized_paths_for([path]) == {root}
+
+
+def test_parser_prohibition_is_behavioral_or_targeted_ast_registration():
+    from aragora.cli.parser import build_parser
+
+    parser = build_parser()
+    for command in ("classify-tier", "authority-manifest", "boundary-validator"):
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["review-queue", command])
+        assert exc_info.value.code == 2
+
+
+def test_matcher_repair_has_no_parser_dispatch_handler_or_settlement_scope():
+    commit = "e8a0d165242737d3226b6d3360aa9e8ec014fd75"
+    changed = set(_git_text("show", "--format=", "--name-only", commit).splitlines())
+    assert changed == {
+        "aragora/cli/commands/review_queue.py",
+        "tests/governance/test_contract_drift_measurement_authority_tier.py",
+        "tests/scripts/test_tier4_merge_train.py",
+    }
+    before = _top_level_ast_by_name(f"{commit}^", "aragora/cli/commands/review_queue.py")
+    after = _top_level_ast_by_name(commit, "aragora/cli/commands/review_queue.py")
+    changed_symbols = {
+        name for name in set(before) | set(after) if before.get(name) != after.get(name)
+    }
+    assert changed_symbols == {"_matches_prefix"}
+
+
+def test_read_only_cli_hashes_worktree_index_gitdirs_objects_refs_and_reflogs():
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    argv = (
+        "--authority-manifest",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+    )
+    for _attempt in range(3):
+        before = _snapshot_read_only_state()
+        first = _run_cli(*argv)
+        second = _run_cli(*argv)
+        after = _snapshot_read_only_state()
+        if before == after:
+            break
+    assert before == after
+    assert first.returncode == second.returncode == 0
+    assert first.stdout == second.stdout
+    assert set(before) == {
+        "tracked_untracked",
+        "index",
+        "worktree_gitdir",
+        "common_gitdir",
+        "objects",
+        "refs",
+        "reflogs",
+    }
+
+
+def test_read_only_cli_allows_only_scratch_and_output_writes(tmp_path: Path):
+    artifacts = _require_artifacts()
+    sha = _head_sha()
+    scratch = tmp_path / "scratch"
+    output = tmp_path / "output"
+    scratch.mkdir()
+    output.mkdir()
+    proc = _run_cli(
+        "--classify-tier",
+        "--changed-file",
+        "scripts/check_contract_drift_ratchet.py",
+        "--ref",
+        sha,
+        "--json",
+        "--repo-root",
+        str(REPO_ROOT),
+        *_artifact_args(artifacts),
+        cwd=scratch,
+    )
+    assert proc.returncode == 0
+    (output / "classification.json").write_bytes(proc.stdout)
+    assert list(scratch.iterdir()) == []
+    assert [path.name for path in output.iterdir()] == ["classification.json"]
+
+
+def test_reporting_only_paths_remain_below_tier4():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    for path in (
+        "scripts/contract_drift_report.py",
+        "scripts/generate_contract_drift_backlog.py",
+        "scripts/generate_contract_drift_issue_plan.py",
+    ):
+        assert review_queue._classify_model_review_tier([path])[0] < 4
+        assert tier4_merge_train.matches_serialized_path(path) is None
+
+
+def test_unrelated_sibling_path_is_not_overclassified():
+    from aragora.cli.commands import review_queue
+    from scripts import tier4_merge_train
+
+    for path in (
+        "scripts/check_cross_sdk_parity.py",
+        "scripts/sdk_parity_audit.py",
+        "scripts/baselines/validate_openapi_routes.json",
+        "scripts/baselines/check_sdk_parity.json",
+    ):
+        assert review_queue._classify_model_review_tier([path])[0] < 4
+        assert tier4_merge_train.matches_serialized_path(path) is None


### PR DESCRIPTION
## Summary
- add deterministic standalone authority-manifest, tier-classification, and canonical inventory modes
- add independent schema-v1 boundary validation with exact Git-byte, cohort, provenance, partition, projection, and inventory bindings
- add hostile-negative, deterministic, and read-only mutation proofs for the complete VAL-CDG-001 contract

## Exact frozen binding
- `BASE_SHA=7571a0f04443a7963c9e4203bc1b7a6505b4e652`
- `HEAD_SHA=b52d877dd2e474d806aed60d3bbb55b189324579`
- `AUTHORITY_MANIFEST_SHA256=eabdc76857bf97b5e4391944462b53e67b7db71f0a13bbc3ddc46150ca102ab4`
- two commits over base, both with the required Factory co-author trailer

## Authority constraints
- imports and calls `aragora.cli.commands.review_queue._classify_model_review_tier`
- does not edit `aragora/cli/commands/review_queue.py` or `aragora/cli/parser.py`
- binds the immutable mission cohort and provenance artifacts by canonical bytes, length, SHA-256, and reconstructed facts
- remains read-only, except for explicit scratch/output destinations

## Validation
- exact VAL-CDG-001 collection: 26 unique nodes
- exact VAL-CDG-001 execution: 26 passed
- complete focused suite: 230 passed
- smoke tier: 138 passed
- skip-marker audit: 87 versus baseline 85, within the allowed +2 threshold; the refreshed CI Skip Marker Audit passed
- `make lint`, Ruff check/format, scoped mypy, differential typecheck, import smoke, pre-commit/push hooks, and automation PR preflight passed
- frozen-head manifest/classifier/boundary integration passed; boundary status is correctly `blocked` until independent release-immutability evidence exists
- all five non-quorum required contexts are green
- advisory `Metrics Drift / check` reproduces on the exact base (`docs/` has 1085 Markdown files while base `docs/METRICS.md` records 1082); this PR changes zero docs files

## Exact-head model evidence
- Gemini: PASS, counted, dogfood present
- Grok: PASS, counted, dogfood present
- OpenAI: P2-only CHANGES-REQUESTED, severity-gated advisory; no P0/P1 and no unresolved dissent
- merge packet: Tier 4, counted families `gemini` + `grok`, status `human_preapproval_required`

## Tier-4 settlement state
The read-only settle-only precondition evaluation is green: exact head matches, the sole required failure is `aragora-merge-quorum`, and its log proves missing human settlement. The next action is human-only:

```bash
python3 scripts/settle_tier4_pr.py \
  --settle-only \
  --pr 9416 \
  --head b52d877dd2e474d806aed60d3bbb55b189324579 \
  --repo synaptent/aragora \
  --trusted-operator-login scarmani \
  --json
```

After settlement, run a distinct quorum workflow attempt, rerun exact-head `--check`, reread both `main` and PR head, then use normal protected squash merge with `--match-head-commit`. Never use `--admin` or `--merge-apply`.

## Reviewer context
- canonical policy remains in `aragora/cli/commands/review_queue.py`
- merge-train mirror remains in `scripts/tier4_merge_train.py`
- new authority surfaces are limited to the two standalone scripts and their focused tests
