### PR TITLE
feat(compliance): Art.14 human-oversight attestation + oversight-pack generator (#8230)

### DIFF
--- a/aragora-verify/src/aragora_verify/odr_schema.json
+++ b/aragora-verify/src/aragora_verify/odr_schema.json
@@ -242,7 +242,37 @@
           "additionalProperties": true
         },
         "attested_at": { "type": "string" },
-        "method": { "type": "string" }
+        "method": { "type": "string" },
+        "execution_identity": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "role": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "Identity that executed the decision, recorded distinct from the oversight attestor (ODR-6 / #8230)."
+        },
+        "observed": {
+          "type": "object",
+          "properties": {
+            "head_sha": { "type": "string" },
+            "evidence_digest": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "What the attestor saw when accepting the risk: head SHA and evidence digest."
+        },
+        "mechanism": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "type": "string" },
+            "context": { "type": "string" },
+            "ref": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "How the attestation was recorded, e.g. settlement_status (aragora/human-settlement) or preapproval_comment, with a resolvable ref."
+        }
       },
       "if": {
         "properties": { "disposition": { "const": "human_attested" } }

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -121,6 +121,10 @@ def _check_attestation(errors: list[str], value: Any) -> None:
     execution_identity = value.get("execution_identity")
     if "execution_identity" in value and not isinstance(execution_identity, dict):
         errors.append("attestation.execution_identity: must be an object")
+    elif isinstance(execution_identity, dict):
+        for key in ("id", "name", "role"):
+            if key in execution_identity and not isinstance(execution_identity.get(key), str):
+                errors.append(f"attestation.execution_identity.{key}: must be a string")
     observed = value.get("observed")
     if "observed" in value and not isinstance(observed, dict):
         errors.append("attestation.observed: must be an object")

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -125,6 +125,20 @@ def _check_attestation(errors: list[str], value: Any) -> None:
         for key in ("id", "name", "role"):
             if key in execution_identity and not isinstance(execution_identity.get(key), str):
                 errors.append(f"attestation.execution_identity.{key}: must be a string")
+        attestor_obj = value.get("attestor")
+        attestor_id = attestor_obj.get("id") if isinstance(attestor_obj, dict) else None
+        execution_id = execution_identity.get("id")
+        if (
+            disposition == "human_attested"
+            and isinstance(attestor_id, str)
+            and isinstance(execution_id, str)
+            and attestor_id.strip()
+            and attestor_id.strip().lower() == execution_id.strip().lower()
+        ):
+            errors.append(
+                "attestation: attestor.id must differ from execution_identity.id "
+                "(self-attestation is not oversight)"
+            )
     observed = value.get("observed")
     if "observed" in value and not isinstance(observed, dict):
         errors.append("attestation.observed: must be an object")

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -115,6 +115,13 @@ def _check_attestation(errors: list[str], value: Any) -> None:
         errors.append("attestation.disposition: must be 'human_attested' or 'autonomous'")
     if disposition == "human_attested" and not isinstance(value.get("attestor"), dict):
         errors.append("attestation.attestor: required object when disposition is human_attested")
+    attestor = value.get("attestor")
+    if "attestor" in value and not isinstance(attestor, dict):
+        errors.append("attestation.attestor: must be an object")
+    elif isinstance(attestor, dict):
+        for key in ("id", "name", "role"):
+            if key in attestor and not isinstance(attestor.get(key), str):
+                errors.append(f"attestation.attestor.{key}: must be a string")
     # Oversight extension members (ODR-6 / #8230): validate shapes when
     # present, mirroring the bundled JSON schema so installs without the
     # optional jsonschema extra reject the same malformed blocks.

--- a/aragora-verify/src/aragora_verify/schema.py
+++ b/aragora-verify/src/aragora_verify/schema.py
@@ -115,6 +115,29 @@ def _check_attestation(errors: list[str], value: Any) -> None:
         errors.append("attestation.disposition: must be 'human_attested' or 'autonomous'")
     if disposition == "human_attested" and not isinstance(value.get("attestor"), dict):
         errors.append("attestation.attestor: required object when disposition is human_attested")
+    # Oversight extension members (ODR-6 / #8230): validate shapes when
+    # present, mirroring the bundled JSON schema so installs without the
+    # optional jsonschema extra reject the same malformed blocks.
+    execution_identity = value.get("execution_identity")
+    if "execution_identity" in value and not isinstance(execution_identity, dict):
+        errors.append("attestation.execution_identity: must be an object")
+    observed = value.get("observed")
+    if "observed" in value and not isinstance(observed, dict):
+        errors.append("attestation.observed: must be an object")
+    elif isinstance(observed, dict):
+        for key in ("head_sha", "evidence_digest"):
+            if key in observed and not isinstance(observed.get(key), str):
+                errors.append(f"attestation.observed.{key}: must be a string")
+    mechanism = value.get("mechanism")
+    if "mechanism" in value and not isinstance(mechanism, dict):
+        errors.append("attestation.mechanism: must be an object")
+    elif isinstance(mechanism, dict):
+        mech_type = mechanism.get("type")
+        if not isinstance(mech_type, str) or not mech_type:
+            errors.append("attestation.mechanism.type: required non-empty string")
+        for key in ("context", "ref"):
+            if key in mechanism and not isinstance(mechanism.get(key), str):
+                errors.append(f"attestation.mechanism.{key}: must be a string")
 
 
 def _check_signatures(errors: list[str], value: Any) -> None:

--- a/aragora-verify/tests/test_attestation_members.py
+++ b/aragora-verify/tests/test_attestation_members.py
@@ -63,3 +63,11 @@ def test_self_attested_block_rejected() -> None:
     odr["attestation"]["execution_identity"] = {"id": "Scarmani"}
     errors = validate_structure(odr)
     assert any("must differ" in e for e in errors)
+
+
+def test_non_string_attestor_fields_rejected() -> None:
+    odr = _attested(valid_odr())
+    odr["attestation"]["attestor"] = {"id": 123, "role": ["oversight"]}
+    errors = validate_structure(odr)
+    assert any("attestor.id: must be a string" in e for e in errors)
+    assert any("attestor.role: must be a string" in e for e in errors)

--- a/aragora-verify/tests/test_attestation_members.py
+++ b/aragora-verify/tests/test_attestation_members.py
@@ -56,3 +56,10 @@ def test_non_string_observed_fields_rejected() -> None:
     odr["attestation"]["observed"] = {"head_sha": 123}
     errors = validate_structure(odr)
     assert any("observed.head_sha: must be a string" in e for e in errors)
+
+
+def test_self_attested_block_rejected() -> None:
+    odr = _attested(valid_odr())
+    odr["attestation"]["execution_identity"] = {"id": "Scarmani"}
+    errors = validate_structure(odr)
+    assert any("must differ" in e for e in errors)

--- a/aragora-verify/tests/test_attestation_members.py
+++ b/aragora-verify/tests/test_attestation_members.py
@@ -1,0 +1,58 @@
+"""Dependency-free validator covers the oversight attestation members (#8230).
+
+The bundled JSON schema gained optional ``execution_identity`` / ``observed``
+/ ``mechanism`` attestation members; the default validator (used by installs
+without the optional ``jsonschema`` extra) must reject the same malformed
+shapes the schema rejects and accept well-formed blocks.
+"""
+
+from __future__ import annotations
+
+from aragora_verify.schema import validate_structure
+
+from _fixtures import valid_odr
+
+
+def _attested(odr: dict) -> dict:
+    odr = dict(odr)
+    odr["attestation"] = {
+        "disposition": "human_attested",
+        "attestor": {"id": "scarmani", "role": "oversight"},
+        "attested_at": "2026-07-17T12:00:00+00:00",
+        "execution_identity": {"id": "an0mium"},
+        "observed": {"head_sha": "b" * 40, "evidence_digest": "sha256:" + "a" * 64},
+        "mechanism": {
+            "type": "settlement_status",
+            "context": "aragora/human-settlement",
+            "ref": "https://api.github.com/repos/o/r/statuses/abc",
+        },
+    }
+    return odr
+
+
+def test_well_formed_oversight_block_accepted() -> None:
+    errors = validate_structure(_attested(valid_odr()))
+    assert errors == []
+
+
+def test_malformed_mechanism_rejected() -> None:
+    odr = _attested(valid_odr())
+    odr["attestation"]["mechanism"] = {"context": "missing-type"}
+    errors = validate_structure(odr)
+    assert any("mechanism.type" in e for e in errors)
+
+
+def test_non_object_members_rejected() -> None:
+    odr = _attested(valid_odr())
+    odr["attestation"]["observed"] = "not-an-object"
+    odr["attestation"]["execution_identity"] = 42
+    errors = validate_structure(odr)
+    assert any("observed: must be an object" in e for e in errors)
+    assert any("execution_identity: must be an object" in e for e in errors)
+
+
+def test_non_string_observed_fields_rejected() -> None:
+    odr = _attested(valid_odr())
+    odr["attestation"]["observed"] = {"head_sha": 123}
+    errors = validate_structure(odr)
+    assert any("observed.head_sha: must be a string" in e for e in errors)

--- a/aragora/cli/commands/compliance.py
+++ b/aragora/cli/commands/compliance.py
@@ -205,6 +205,54 @@ def add_compliance_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Output format (default: all)",
     )
 
+    # -- aragora compliance oversight-pack --
+    oversight_p = sub.add_parser(
+        "oversight-pack",
+        help="Generate an EU AI Act Article 14 human-oversight evidence pack",
+        description=(
+            "Assemble decision receipts and their human-oversight attestations "
+            "over a time window into an audit-ready EU AI Act Article 14 / "
+            "NIST evidence bundle. Dispositions are recorded, never implied: "
+            "receipts without a human attestation are counted as 'autonomous'. "
+            "Clause mapping documentation: docs/compliance/ART14_OVERSIGHT_PACK.md"
+        ),
+    )
+    oversight_p.add_argument(
+        "--window",
+        default="30d",
+        help="Rolling window, e.g. 30d, 12w, 720h, or a plain day count (default: 30d)",
+    )
+    oversight_p.add_argument(
+        "--receipts-dir",
+        dest="receipts_dirs",
+        action="append",
+        default=None,
+        help=(
+            "Directory scanned recursively for receipt JSON files (native "
+            "DecisionReceipt or ODR). Repeatable. Default: docs/receipts plus "
+            "~/.aragora/receipts when present."
+        ),
+    )
+    oversight_p.add_argument(
+        "--attestations",
+        default=None,
+        help=(
+            "JSON file mapping receipt_id -> attestation block (e.g. built "
+            "from settlement statuses via aragora.gauntlet.attestation)"
+        ),
+    )
+    oversight_p.add_argument(
+        "--output",
+        "-o",
+        default="./oversight-pack.json",
+        help="Output path for the JSON pack (default: ./oversight-pack.json)",
+    )
+    oversight_p.add_argument(
+        "--markdown",
+        default=None,
+        help="Optional output path for the Markdown report",
+    )
+
     # -- aragora compliance eu-ai-act generate --
     eu_p = sub.add_parser(
         "eu-ai-act",
@@ -303,6 +351,8 @@ def cmd_compliance(args: argparse.Namespace) -> None:
         cmd_compliance_export(args)
     elif command == "evidence":
         _cmd_evidence(args)
+    elif command == "oversight-pack":
+        _cmd_oversight_pack(args)
     elif command == "eu-ai-act":
         eu_command = getattr(args, "eu_ai_act_command", None)
         if eu_command == "generate":
@@ -331,6 +381,7 @@ def cmd_compliance(args: argparse.Namespace) -> None:
         print("    export     Export structured compliance bundle for a debate")
         print("    evidence   Generate data classification audit evidence bundle")
         print("    eu-ai-act  Generate compliance artifact bundles (Articles 9/12/13/14/15)")
+        print("    oversight-pack  Generate Article 14 human-oversight evidence pack")
         sys.exit(1)
 
 
@@ -568,6 +619,77 @@ def _cmd_evidence(args: argparse.Namespace) -> None:
     if output_format in ("markdown", "all"):
         print("    evidence_bundle.md     Human-readable report")
     print()
+
+
+def _parse_window_days(window: str) -> int:
+    """Parse a window spec like ``30d``, ``12w``, ``720h``, or ``30``."""
+    text = str(window).strip().lower()
+    try:
+        if text.endswith("d"):
+            return max(1, int(text[:-1]))
+        if text.endswith("w"):
+            return max(1, int(text[:-1]) * 7)
+        if text.endswith("h"):
+            return max(1, (int(text[:-1]) + 23) // 24)
+        return max(1, int(text))
+    except ValueError:
+        raise SystemExit(f"invalid --window value: {window!r} (expected e.g. 30d, 12w, 720h)")
+
+
+def _cmd_oversight_pack(args: argparse.Namespace) -> None:
+    """Generate the EU AI Act Article 14 human-oversight evidence pack."""
+    import json as _json
+    from pathlib import Path
+
+    from aragora.compliance.oversight_pack import (
+        build_oversight_pack,
+        load_receipts_from_dirs,
+        render_oversight_pack_markdown,
+    )
+
+    window_days = _parse_window_days(args.window)
+
+    directories = list(args.receipts_dirs or [])
+    if not directories:
+        directories = ["docs/receipts"]
+        default_store = Path.home() / ".aragora" / "receipts"
+        if default_store.is_dir():
+            directories.append(str(default_store))
+
+    attestations = None
+    if getattr(args, "attestations", None):
+        with open(args.attestations, encoding="utf-8") as fh:
+            attestations = _json.load(fh)
+        if not isinstance(attestations, dict):
+            raise SystemExit("--attestations file must be a JSON object of receipt_id -> block")
+
+    receipts = load_receipts_from_dirs(directories)
+    pack = build_oversight_pack(
+        receipts,
+        window_days=window_days,
+        attestations=attestations,
+    )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(_json.dumps(pack, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    if getattr(args, "markdown", None):
+        md_path = Path(args.markdown)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(render_oversight_pack_markdown(pack), encoding="utf-8")
+
+    summary = pack["summary"]
+    print(f"Oversight pack written: {output}")
+    if getattr(args, "markdown", None):
+        print(f"Markdown report: {args.markdown}")
+    print(
+        f"  window: {window_days}d | receipts: {summary['receipts_in_window']} "
+        f"(human-attested: {summary['human_attested']}, "
+        f"autonomous: {summary['autonomous']})"
+    )
+    print(f"  sources scanned: {', '.join(str(d) for d in directories)}")
+    print(f"  integrity: sha256/jcs {pack['integrity']['content_digest'][:16]}…")
 
 
 def _cmd_audit(args: argparse.Namespace) -> None:

--- a/aragora/cli/commands/compliance.py
+++ b/aragora/cli/commands/compliance.py
@@ -242,6 +242,20 @@ def add_compliance_parser(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     oversight_p.add_argument(
+        "--fetch-settlements",
+        action="store_true",
+        help=(
+            "Fetch human-settlement attestations from merged PRs' "
+            "aragora/human-settlement commit statuses via the gh CLI and "
+            "include them in the pack (network access required)"
+        ),
+    )
+    oversight_p.add_argument(
+        "--repo",
+        default=None,
+        help="owner/name for --fetch-settlements (default: resolved via gh from cwd)",
+    )
+    oversight_p.add_argument(
         "--output",
         "-o",
         default="./oversight-pack.json",
@@ -663,11 +677,31 @@ def _cmd_oversight_pack(args: argparse.Namespace) -> None:
         if not isinstance(attestations, dict):
             raise SystemExit("--attestations file must be a JSON object of receipt_id -> block")
 
+    settlement_attestations = None
+    settlements_skipped: list[dict] = []
+    if getattr(args, "fetch_settlements", False):
+        from aragora.compliance.oversight_fetch import fetch_settlement_attestations
+
+        fetched = fetch_settlement_attestations(
+            repo=getattr(args, "repo", None), window_days=window_days
+        )
+        settlement_attestations = fetched["attestations"]
+        settlements_skipped = fetched["skipped"]
+        print(
+            f"Fetched settlements from {fetched['repo']}: "
+            f"{len(settlement_attestations)} attested, "
+            f"{len(settlements_skipped)} skipped, "
+            f"{fetched['scanned_prs']} merged PRs scanned"
+        )
+        for skip in settlements_skipped:
+            print(f"  skipped PR #{skip.get('pr')}: {skip.get('reason')}")
+
     receipts = load_receipts_from_dirs(directories)
     pack = build_oversight_pack(
         receipts,
         window_days=window_days,
         attestations=attestations,
+        settlement_attestations=settlement_attestations,
     )
 
     output = Path(args.output)
@@ -686,7 +720,8 @@ def _cmd_oversight_pack(args: argparse.Namespace) -> None:
     print(
         f"  window: {window_days}d | receipts: {summary['receipts_in_window']} "
         f"(human-attested: {summary['human_attested']}, "
-        f"autonomous: {summary['autonomous']})"
+        f"autonomous: {summary['autonomous']}) | "
+        f"settlement attestations: {summary['settlement_attestations']}"
     )
     print(f"  sources scanned: {', '.join(str(d) for d in directories)}")
     print(f"  integrity: sha256/jcs {pack['integrity']['content_digest'][:16]}…")

--- a/aragora/cli/commands/compliance.py
+++ b/aragora/cli/commands/compliance.py
@@ -678,6 +678,7 @@ def _cmd_oversight_pack(args: argparse.Namespace) -> None:
             raise SystemExit("--attestations file must be a JSON object of receipt_id -> block")
 
     settlement_attestations = None
+    settlement_fetch_report = None
     settlements_skipped: list[dict] = []
     if getattr(args, "fetch_settlements", False):
         from aragora.compliance.oversight_fetch import fetch_settlement_attestations
@@ -687,6 +688,11 @@ def _cmd_oversight_pack(args: argparse.Namespace) -> None:
         )
         settlement_attestations = fetched["attestations"]
         settlements_skipped = fetched["skipped"]
+        # Persist fetch completeness in the artifact itself: skipped PRs and
+        # truncation are audit caveats, not console noise.
+        settlement_fetch_report = fetched
+        if fetched.get("truncated"):
+            print("WARNING: merged-PR scan truncated; settlements may be undercounted")
         print(
             f"Fetched settlements from {fetched['repo']}: "
             f"{len(settlement_attestations)} attested, "
@@ -702,6 +708,7 @@ def _cmd_oversight_pack(args: argparse.Namespace) -> None:
         window_days=window_days,
         attestations=attestations,
         settlement_attestations=settlement_attestations,
+        settlement_fetch_report=settlement_fetch_report,
     )
 
     output = Path(args.output)

--- a/aragora/compliance/oversight_fetch.py
+++ b/aragora/compliance/oversight_fetch.py
@@ -63,7 +63,7 @@ def fetch_settlement_attestations(
     *,
     repo: str | None = None,
     window_days: int = 30,
-    limit: int = 200,
+    limit: int = 500,
     now: datetime | None = None,
     gh_runner: GhRunner | None = None,
 ) -> dict[str, Any]:
@@ -72,7 +72,9 @@ def fetch_settlement_attestations(
     Args:
         repo: ``owner/name``; resolved from the current directory when omitted.
         window_days: Only settlements attested within this window are kept.
-        limit: Maximum merged PRs to scan (newest first).
+        limit: Maximum in-window merged PRs to scan. When the scan fills
+            this limit the result is flagged ``truncated`` (and a warning is
+            logged) instead of silently undercounting settlements.
         now: Window anchor (defaults to current UTC; injectable for tests).
         gh_runner: ``gh``-invocation override for tests.
 
@@ -91,6 +93,10 @@ def fetch_settlement_attestations(
     if not repo:
         raise ValueError("could not resolve repo; pass repo='owner/name'")
 
+    # Date-bounded search so `limit` only applies to in-window merges; a
+    # fixed recency limit alone silently omits older in-window PRs in
+    # high-churn repos. If the result still fills `limit`, the scan is
+    # truncated and reported as such — never silently.
     prs = (
         run(
             [
@@ -100,6 +106,8 @@ def fetch_settlement_attestations(
                 repo,
                 "--state",
                 "merged",
+                "--search",
+                f"merged:>={cutoff.date().isoformat()}",
                 "--limit",
                 str(limit),
                 "--json",
@@ -108,6 +116,7 @@ def fetch_settlement_attestations(
         )
         or []
     )
+    truncated = len(prs) >= limit
 
     attestations: list[dict[str, Any]] = []
     skipped: list[dict[str, Any]] = []
@@ -197,9 +206,16 @@ def fetch_settlement_attestations(
         len(attestations),
         len(skipped),
     )
+    if truncated:
+        logger.warning(
+            "oversight_fetch: merged-PR scan hit limit=%d and may be truncated; "
+            "raise limit= to cover the full window",
+            limit,
+        )
     return {
         "repo": repo,
         "scanned_prs": scanned,
         "attestations": attestations,
         "skipped": skipped,
+        "truncated": truncated,
     }

--- a/aragora/compliance/oversight_fetch.py
+++ b/aragora/compliance/oversight_fetch.py
@@ -141,6 +141,17 @@ def fetch_settlement_attestations(
             continue
         author = pr.get("author") or {}
         execution_id = str(author.get("login", "") or "") or None
+        if execution_id is None:
+            # Without a resolvable executing author the attestor≠execution
+            # separation check cannot run — unverifiable oversight is
+            # skipped with the reason, never assumed valid.
+            skipped.append(
+                {
+                    "pr": pr.get("number"),
+                    "reason": "PR author unresolvable; identity separation unverifiable",
+                }
+            )
+            continue
         try:
             attestation = attestation_from_settlement_status(
                 settlement,

--- a/aragora/compliance/oversight_fetch.py
+++ b/aragora/compliance/oversight_fetch.py
@@ -1,0 +1,177 @@
+"""Fetch human-settlement attestations from the GitHub trail (#8230 follow-up).
+
+Walks recently merged PRs and converts each head-bound
+``aragora/human-settlement`` commit status into an oversight attestation via
+:mod:`aragora.gauntlet.attestation` — automating the ``--attestations`` input
+of the Article 14 oversight pack with real, resolvable trail evidence.
+
+Honesty rules:
+
+- A settlement status whose creator equals the PR's executing author is NOT
+  independent oversight — the attestation builder refuses it (TET H2), and
+  the PR is reported in ``skipped`` with the reason, never silently dropped.
+- PRs with no human-settlement status are simply not attested (they remain
+  ``autonomous`` in the pack); only genuinely attested settlements appear.
+
+Requires the ``gh`` CLI (already the repo's sanctioned GitHub transport);
+inject ``gh_runner`` for tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from aragora.gauntlet.attestation import (
+    HUMAN_SETTLEMENT_CONTEXT,
+    attestation_from_settlement_status,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["fetch_settlement_attestations"]
+
+GhRunner = Callable[[list[str]], Any]
+
+
+def _run_gh(args: list[str]) -> Any:
+    """Run ``gh`` and parse its JSON stdout."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=True,
+    )
+    return json.loads(result.stdout) if result.stdout.strip() else None
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def fetch_settlement_attestations(
+    *,
+    repo: str | None = None,
+    window_days: int = 30,
+    limit: int = 200,
+    now: datetime | None = None,
+    gh_runner: GhRunner | None = None,
+) -> dict[str, Any]:
+    """Fetch attestations for human-settled merged PRs in the window.
+
+    Args:
+        repo: ``owner/name``; resolved from the current directory when omitted.
+        window_days: Only settlements attested within this window are kept.
+        limit: Maximum merged PRs to scan (newest first).
+        now: Window anchor (defaults to current UTC; injectable for tests).
+        gh_runner: ``gh``-invocation override for tests.
+
+    Returns:
+        ``{"attestations": [...], "skipped": [...], "scanned_prs": int,
+        "repo": str}`` where each attestation entry carries the PR reference
+        and the validated attestation block.
+    """
+    run = gh_runner or _run_gh
+    anchor = now or datetime.now(timezone.utc)
+    cutoff = anchor - timedelta(days=window_days)
+
+    if not repo:
+        view = run(["repo", "view", "--json", "nameWithOwner"]) or {}
+        repo = str(view.get("nameWithOwner", "") or "")
+    if not repo:
+        raise ValueError("could not resolve repo; pass repo='owner/name'")
+
+    prs = (
+        run(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "merged",
+                "--limit",
+                str(limit),
+                "--json",
+                "number,url,mergedAt,headRefOid,author",
+            ]
+        )
+        or []
+    )
+
+    attestations: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    scanned = 0
+    for pr in prs:
+        merged_at = _parse_iso(pr.get("mergedAt"))
+        if merged_at is None or merged_at < cutoff or merged_at > anchor:
+            continue
+        head_sha = str(pr.get("headRefOid", "") or "")
+        if not head_sha:
+            continue
+        scanned += 1
+        try:
+            statuses = run(["api", f"repos/{repo}/commits/{head_sha}/statuses"]) or []
+        except (subprocess.SubprocessError, OSError, ValueError) as exc:
+            skipped.append({"pr": pr.get("number"), "reason": f"statuses fetch failed: {exc}"})
+            continue
+        # Statuses API returns newest first; take the latest settlement status.
+        settlement = next(
+            (
+                s
+                for s in statuses
+                if s.get("context") == HUMAN_SETTLEMENT_CONTEXT and s.get("state") == "success"
+            ),
+            None,
+        )
+        if settlement is None:
+            continue
+        attested_at = _parse_iso(settlement.get("created_at"))
+        if attested_at is None or attested_at < cutoff or attested_at > anchor:
+            continue
+        author = pr.get("author") or {}
+        execution_id = str(author.get("login", "") or "") or None
+        try:
+            attestation = attestation_from_settlement_status(
+                settlement,
+                head_sha=head_sha,
+                execution_identity_id=execution_id,
+            )
+        except ValueError as exc:
+            # e.g. settlement recorded by the executing identity itself —
+            # refused as oversight (TET H2); reported, never silently kept.
+            skipped.append({"pr": pr.get("number"), "reason": str(exc)})
+            continue
+        attestations.append(
+            {
+                "pr": pr.get("number"),
+                "pr_url": pr.get("url"),
+                "merged_at": pr.get("mergedAt"),
+                "head_sha": head_sha,
+                "attestation": attestation.to_dict(),
+            }
+        )
+
+    logger.info(
+        "oversight_fetch repo=%s scanned=%d attested=%d skipped=%d",
+        repo,
+        scanned,
+        len(attestations),
+        len(skipped),
+    )
+    return {
+        "repo": repo,
+        "scanned_prs": scanned,
+        "attestations": attestations,
+        "skipped": skipped,
+    }

--- a/aragora/compliance/oversight_fetch.py
+++ b/aragora/compliance/oversight_fetch.py
@@ -121,7 +121,24 @@ def fetch_settlement_attestations(
             continue
         scanned += 1
         try:
-            statuses = run(["api", f"repos/{repo}/commits/{head_sha}/statuses"]) or []
+            # Busy heads can carry >100 statuses; paginate so an older
+            # settlement status is never missed (--slurp wraps pages in an
+            # outer array — flattened below; plain arrays also handled for
+            # older gh versions and test fakes).
+            raw = (
+                run(
+                    [
+                        "api",
+                        f"repos/{repo}/commits/{head_sha}/statuses?per_page=100",
+                        "--paginate",
+                        "--slurp",
+                    ]
+                )
+                or []
+            )
+            statuses = [
+                status for page in raw for status in (page if isinstance(page, list) else [page])
+            ]
         except (subprocess.SubprocessError, OSError, ValueError) as exc:
             skipped.append({"pr": pr.get("number"), "reason": f"statuses fetch failed: {exc}"})
             continue

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -254,7 +254,13 @@ def _receipt_entry(
     if is_odr:
         timestamp = receipt.get("issued_at")
         claim = receipt.get("claim") or {}
-        verdict = str(claim.get("decision", "") or "") if isinstance(claim, Mapping) else ""
+        # The ODR exporter/schema use claim.verdict; tolerate legacy
+        # claim.decision from third-party producers.
+        verdict = (
+            str(claim.get("verdict") or claim.get("decision") or "")
+            if isinstance(claim, Mapping)
+            else ""
+        )
         confidence_block = receipt.get("confidence") or {}
         confidence = (
             confidence_block.get("value") if isinstance(confidence_block, Mapping) else None
@@ -403,6 +409,7 @@ def build_oversight_pack(
 
     settlements: list[dict[str, Any]] = []
     settlements_invalid: list[dict[str, Any]] = []
+    settlements_out_of_window = 0
     for raw_settlement in settlement_attestations or []:
         settlement = dict(raw_settlement)
         block = settlement.get("attestation") or {}
@@ -410,8 +417,18 @@ def build_oversight_pack(
         # counted only when its attestation names who/when/how and satisfies
         # identity separation; malformed entries are reported, not counted.
         reason = _attestation_invalid_reason(block) if isinstance(block, Mapping) else "no block"
-        if reason:
-            settlements_invalid.append({**settlement, "invalid_reason": reason})
+        attested_at = _parse_timestamp(block.get("attested_at")) if not reason else None
+        if not reason and attested_at is None:
+            reason = "unparseable attested_at"
+        if reason or attested_at is None:
+            settlements_invalid.append(
+                {**settlement, "invalid_reason": reason or "unparseable attested_at"}
+            )
+            continue
+        # Window the settlement on its attestation time: an old externally
+        # supplied settlement must not satisfy a fresh pack's clauses.
+        if attested_at < cutoff or attested_at > anchor:
+            settlements_out_of_window += 1
             continue
         settlements.append(settlement)
         attestor = (block.get("attestor") or {}).get("id")
@@ -455,6 +472,7 @@ def build_oversight_pack(
             "mechanisms": dict(mechanisms),
             "settlement_attestations": len(settlements),
             "settlement_attestations_invalid": len(settlements_invalid),
+            "settlement_attestations_out_of_window": settlements_out_of_window,
             "excluded_no_timestamp": excluded_no_timestamp,
             "excluded_out_of_window": excluded_out_of_window,
         },

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -195,19 +195,30 @@ def _attestation_invalid_reason(block: Mapping[str, Any]) -> str | None:
     the block is countable.
     """
     attestor = block.get("attestor")
-    attestor_id = str(attestor.get("id", "") or "").strip() if isinstance(attestor, Mapping) else ""
+    raw_attestor_id = attestor.get("id") if isinstance(attestor, Mapping) else None
+    if raw_attestor_id is not None and not isinstance(raw_attestor_id, str):
+        # No str() coercion: the ODR schema types these as strings, and a
+        # coerced non-string must never become countable oversight evidence.
+        return "attestor.id must be a string"
+    attestor_id = (raw_attestor_id or "").strip()
     if not attestor_id:
         return "missing attestor.id"
-    if not str(block.get("attested_at", "") or "").strip():
+    raw_attested_at = block.get("attested_at")
+    if raw_attested_at is not None and not isinstance(raw_attested_at, str):
+        return "attested_at must be a string"
+    if not (raw_attested_at or "").strip():
         return "missing attested_at"
     mech = block.get("mechanism")
-    mech_type = str(mech.get("type", "") or "").strip() if isinstance(mech, Mapping) else ""
-    if not mech_type:
+    raw_mech_type = mech.get("type") if isinstance(mech, Mapping) else None
+    if raw_mech_type is not None and not isinstance(raw_mech_type, str):
+        return "mechanism.type must be a string"
+    if not (raw_mech_type or "").strip():
         return "missing mechanism.type"
     execution = block.get("execution_identity")
-    execution_id = (
-        str(execution.get("id", "") or "").strip() if isinstance(execution, Mapping) else ""
-    )
+    raw_execution_id = execution.get("id") if isinstance(execution, Mapping) else None
+    if raw_execution_id is not None and not isinstance(raw_execution_id, str):
+        return "execution_identity.id must be a string"
+    execution_id = (raw_execution_id or "").strip()
     if execution_id and execution_id.lower() == attestor_id.lower():
         return "attestor equals execution identity"
     return None

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -219,7 +219,11 @@ def _attestation_invalid_reason(block: Mapping[str, Any]) -> str | None:
     if raw_execution_id is not None and not isinstance(raw_execution_id, str):
         return "execution_identity.id must be a string"
     execution_id = (raw_execution_id or "").strip()
-    if execution_id and execution_id.lower() == attestor_id.lower():
+    if not execution_id:
+        # Without a named executor the attestor≠execution separation check
+        # cannot run — an unverifiable oversight claim never counts.
+        return "missing execution_identity.id (identity separation unverifiable)"
+    if execution_id.lower() == attestor_id.lower():
         return "attestor equals execution identity"
     return None
 
@@ -246,6 +250,15 @@ def _settlement_attestation_invalid_reason(block: Mapping[str, Any]) -> str | No
     )
     if not head_sha:
         return "missing observed.head_sha (settlement must be head-bound)"
+    digest = (
+        str(observed.get("evidence_digest", "") or "").strip()
+        if isinstance(observed, Mapping)
+        else ""
+    )
+    if not digest:
+        # The pack claims a status→receipt evidence binding; a settlement
+        # status that does not embed the receipt digest cannot provide it.
+        return "missing observed.evidence_digest (status-to-receipt binding absent)"
     return None
 
 

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -1,0 +1,453 @@
+"""EU AI Act Article 14 / NIST oversight evidence-pack generator (#8230).
+
+Assembles decision receipts and their human-oversight attestations over a
+time window into a single audit-ready bundle: per-receipt oversight
+dispositions, attestor identities, mechanisms, an Article 14 clause mapping,
+and a NIST AI RMF cross-reference — with an integrity digest over the
+canonicalized payload.
+
+Honesty rules (matching the ODR export's):
+
+- Dispositions are **recorded, never implied**: a receipt with no attestation
+  is counted as ``autonomous``, not skipped.
+- Receipts that cannot be windowed (no parseable timestamp) are excluded and
+  *counted as excluded*, not silently dropped.
+- Clause statuses are computed from the evidence actually present in the
+  window (``satisfied`` / ``partial``), never asserted unconditionally.
+
+CLI: ``aragora compliance oversight-pack --window 30d`` (see
+``aragora/cli/commands/compliance.py``). Clause mapping documentation:
+``docs/compliance/ART14_OVERSIGHT_PACK.md``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from aragora.gauntlet.attestation import (
+    AUTONOMOUS_DISPOSITION,
+    HUMAN_ATTESTED_DISPOSITION,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ARTICLE_14_CLAUSES",
+    "NIST_CROSS_REFERENCES",
+    "build_oversight_pack",
+    "load_receipts_from_dirs",
+    "render_oversight_pack_markdown",
+]
+
+PACK_ARTIFACT = "aragora.oversight_pack"
+PACK_VERSION = "0.1"
+
+# EU AI Act (Regulation (EU) 2024/1689) Article 14 clause map. Each entry
+# names the requirement and the receipt-level evidence the pack derives its
+# status from. Documented for auditors in docs/compliance/ART14_OVERSIGHT_PACK.md.
+ARTICLE_14_CLAUSES: list[dict[str, str]] = [
+    {
+        "clause": "14(1)",
+        "requirement": (
+            "High-risk AI systems shall be designed and developed such that "
+            "they can be effectively overseen by natural persons during use."
+        ),
+        "evidence_basis": (
+            "A dedicated oversight identity layer, credential-separated from "
+            "execution identities; receipts carry per-decision oversight "
+            "dispositions (human_attested / autonomous)."
+        ),
+    },
+    {
+        "clause": "14(2)",
+        "requirement": (
+            "Oversight shall aim at preventing or minimising risks to health, "
+            "safety or fundamental rights."
+        ),
+        "evidence_basis": (
+            "Adversarial multi-model review precedes decisions; receipts "
+            "record verdicts, confidence, and preserved dissent so overseers "
+            "act on risk signals rather than summaries."
+        ),
+    },
+    {
+        "clause": "14(3)",
+        "requirement": (
+            "Oversight measures shall be built into the system or identified "
+            "for implementation by the deployer."
+        ),
+        "evidence_basis": (
+            "The settlement mechanism (head-bound human-settlement status, "
+            "preapproval comments) is machine-checkable and cited per "
+            "attestation in this pack."
+        ),
+    },
+    {
+        "clause": "14(4)(a)",
+        "requirement": (
+            "Overseers can understand the capacities and limitations of the "
+            "system and monitor its operation."
+        ),
+        "evidence_basis": (
+            "Receipts expose agent responses, confidence, dissenting views, "
+            "and provenance chains for every windowed decision."
+        ),
+    },
+    {
+        "clause": "14(4)(b)",
+        "requirement": "Overseers remain aware of automation bias.",
+        "evidence_basis": (
+            "Heterogeneous-model dissent is preserved verbatim in receipts "
+            "rather than averaged away; hollow-consensus detection is part of "
+            "the debate protocol."
+        ),
+    },
+    {
+        "clause": "14(4)(c)",
+        "requirement": "Overseers can correctly interpret the system's output.",
+        "evidence_basis": (
+            "Receipts carry verdict reasoning and explainability blocks; "
+            "attestations record the exact evidence digest the overseer saw."
+        ),
+    },
+    {
+        "clause": "14(4)(d)",
+        "requirement": (
+            "Overseers can decide not to use the system or otherwise "
+            "disregard, override or reverse its output."
+        ),
+        "evidence_basis": (
+            "Human settlement is the merge/act gate for oversight-tier "
+            "decisions: absence of a human attestation withholds settlement; "
+            "dispositions record which decisions a human actually accepted."
+        ),
+    },
+    {
+        "clause": "14(4)(e)",
+        "requirement": (
+            "Overseers can intervene in the operation or interrupt the system "
+            "(stop button or similar)."
+        ),
+        "evidence_basis": (
+            "Operational kill-switches and halt files stop autonomous lanes; "
+            "interruption capability is procedural and referenced, not "
+            "evidenced per-receipt (status is at most 'partial' from receipts "
+            "alone)."
+        ),
+    },
+]
+
+# NIST AI RMF 1.0 cross-references for the same oversight evidence.
+NIST_CROSS_REFERENCES: list[dict[str, str]] = [
+    {
+        "function": "GOVERN 3.2",
+        "requirement": (
+            "Policies define human oversight roles and responsibilities for AI systems."
+        ),
+        "evidence_basis": "Oversight identity layer and per-decision attestor records.",
+    },
+    {
+        "function": "MANAGE 2.4",
+        "requirement": (
+            "Mechanisms are in place to supersede, disengage, or deactivate "
+            "AI systems that demonstrate performance or outcomes inconsistent "
+            "with intended use."
+        ),
+        "evidence_basis": "Human settlement gate; withheld attestation withholds action.",
+    },
+    {
+        "function": "MEASURE 2.10",
+        "requirement": "Human-AI configurations are evaluated (automation bias).",
+        "evidence_basis": "Preserved dissent and confidence in every windowed receipt.",
+    },
+]
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _receipt_entry(
+    receipt: Mapping[str, Any],
+    attestations: Mapping[str, Mapping[str, Any]],
+    source: str | None,
+) -> dict[str, Any]:
+    """Normalize a native DecisionReceipt dict or an ODR document."""
+    is_odr = "odr_version" in receipt
+    receipt_id = str(receipt.get("receipt_id", "") or "")
+
+    attestation: Mapping[str, Any] | None = None
+    if is_odr and isinstance(receipt.get("attestation"), Mapping):
+        attestation = receipt["attestation"]
+    if receipt_id and receipt_id in attestations:
+        attestation = attestations[receipt_id]
+
+    disposition = AUTONOMOUS_DISPOSITION
+    attestor_id: str | None = None
+    mechanism: str | None = None
+    observed: dict[str, Any] = {}
+    attested_at: str | None = None
+    if attestation:
+        disposition = str(attestation.get("disposition", HUMAN_ATTESTED_DISPOSITION))
+        attestor = attestation.get("attestor") or {}
+        attestor_id = str(attestor.get("id", "") or "") or None
+        mech = attestation.get("mechanism") or {}
+        mechanism = str(mech.get("type", "") or "") or None
+        if isinstance(attestation.get("observed"), Mapping):
+            observed = dict(attestation["observed"])
+        attested_at = str(attestation.get("attested_at", "") or "") or None
+
+    if is_odr:
+        timestamp = receipt.get("issued_at")
+        claim = receipt.get("claim") or {}
+        verdict = str(claim.get("decision", "") or "") if isinstance(claim, Mapping) else ""
+        confidence_block = receipt.get("confidence") or {}
+        confidence = (
+            confidence_block.get("value") if isinstance(confidence_block, Mapping) else None
+        )
+    else:
+        timestamp = receipt.get("timestamp") or receipt.get("produced_at")
+        verdict = str(receipt.get("verdict", "") or "")
+        confidence = receipt.get("confidence")
+
+    entry: dict[str, Any] = {
+        "receipt_id": receipt_id,
+        "format": "odr" if is_odr else "native",
+        "timestamp": timestamp,
+        "verdict": verdict,
+        "confidence": confidence,
+        "disposition": disposition,
+    }
+    if attestor_id:
+        entry["attestor"] = attestor_id
+    if mechanism:
+        entry["mechanism"] = mechanism
+    if attested_at:
+        entry["attested_at"] = attested_at
+    if observed:
+        entry["observed"] = observed
+    if source:
+        entry["source"] = source
+    return entry
+
+
+def _clause_status(clause: str, human_attested: int, total: int) -> tuple[str, str]:
+    """Honest per-clause status from windowed evidence."""
+    if clause == "14(4)(e)":
+        return (
+            "partial",
+            "interruption capability is procedural (kill-switches, halt files); "
+            "not evidenced per-receipt by this pack",
+        )
+    if total == 0:
+        return "partial", "no receipts in window"
+    if clause in ("14(1)", "14(3)", "14(4)(d)"):
+        # Identity-dependent clauses need at least one real human attestation.
+        if human_attested > 0:
+            return "satisfied", f"{human_attested}/{total} windowed decisions human-attested"
+        return (
+            "partial",
+            "oversight mechanism exists but no windowed decision carries a human attestation",
+        )
+    return "satisfied", f"evidence present on all {total} windowed receipts"
+
+
+def load_receipts_from_dirs(
+    directories: list[str | Path],
+) -> list[tuple[dict[str, Any], str]]:
+    """Load ``(receipt_dict, source_path)`` pairs from ``*.json`` files.
+
+    Files that are not JSON objects or carry no ``receipt_id`` are skipped
+    with a debug log — directories may hold unrelated JSON.
+    """
+    loaded: list[tuple[dict[str, Any], str]] = []
+    for directory in directories:
+        root = Path(directory).expanduser()
+        if not root.is_dir():
+            logger.debug("oversight_pack: skipping missing directory %s", root)
+            continue
+        for path in sorted(root.rglob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                logger.debug("oversight_pack: unreadable %s: %s", path, exc)
+                continue
+            if isinstance(data, dict) and data.get("receipt_id"):
+                loaded.append((data, str(path)))
+    return loaded
+
+
+def build_oversight_pack(
+    receipts: Sequence[tuple[Mapping[str, Any], str | None] | Mapping[str, Any]],
+    *,
+    window_days: int = 30,
+    now: datetime | None = None,
+    attestations: Mapping[str, Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the Article 14 / NIST oversight evidence pack.
+
+    Args:
+        receipts: Receipt dicts (native ``DecisionReceipt.to_dict()`` or ODR
+            documents), optionally paired with their source path.
+        window_days: Rolling window; receipts older than this are excluded.
+        now: Window anchor (defaults to current UTC; injectable for tests).
+        attestations: Optional ``receipt_id -> attestation block`` mapping,
+            overriding/supplying attestations for native receipts (e.g. built
+            with :mod:`aragora.gauntlet.attestation`).
+
+    Returns:
+        JSON-serializable pack dict with an integrity digest.
+    """
+    anchor = now or datetime.now(timezone.utc)
+    cutoff = anchor - timedelta(days=window_days)
+    attestation_map = dict(attestations or {})
+
+    entries: list[dict[str, Any]] = []
+    excluded_no_timestamp = 0
+    excluded_out_of_window = 0
+    for item in receipts:
+        if isinstance(item, tuple):
+            receipt, source = item
+        else:
+            receipt, source = item, None
+        entry = _receipt_entry(receipt, attestation_map, source)
+        parsed = _parse_timestamp(entry.get("timestamp"))
+        if parsed is None:
+            excluded_no_timestamp += 1
+            continue
+        if parsed < cutoff or parsed > anchor:
+            excluded_out_of_window += 1
+            continue
+        entries.append(entry)
+
+    entries.sort(key=lambda e: str(e.get("timestamp", "")))
+
+    dispositions = Counter(e["disposition"] for e in entries)
+    human_attested = dispositions.get(HUMAN_ATTESTED_DISPOSITION, 0)
+    attestors = sorted({e["attestor"] for e in entries if e.get("attestor")})
+    mechanisms = Counter(e["mechanism"] for e in entries if e.get("mechanism"))
+
+    article_14 = []
+    for clause_def in ARTICLE_14_CLAUSES:
+        status, basis = _clause_status(clause_def["clause"], human_attested, len(entries))
+        article_14.append({**clause_def, "status": status, "status_basis": basis})
+
+    pack: dict[str, Any] = {
+        "artifact": PACK_ARTIFACT,
+        "version": PACK_VERSION,
+        "framework": {
+            "eu_ai_act": "Regulation (EU) 2024/1689, Article 14 (Human Oversight)",
+            "nist": "NIST AI RMF 1.0 (cross-referenced functions)",
+        },
+        "generated_at": anchor.isoformat(),
+        "window": {
+            "days": window_days,
+            "start": cutoff.isoformat(),
+            "end": anchor.isoformat(),
+        },
+        "summary": {
+            "receipts_in_window": len(entries),
+            "human_attested": human_attested,
+            "autonomous": dispositions.get(AUTONOMOUS_DISPOSITION, 0),
+            "other_dispositions": {
+                k: v
+                for k, v in dispositions.items()
+                if k not in (HUMAN_ATTESTED_DISPOSITION, AUTONOMOUS_DISPOSITION)
+            },
+            "attestor_identities": attestors,
+            "mechanisms": dict(mechanisms),
+            "excluded_no_timestamp": excluded_no_timestamp,
+            "excluded_out_of_window": excluded_out_of_window,
+        },
+        "receipts": entries,
+        "article_14_mapping": article_14,
+        "nist_cross_references": list(NIST_CROSS_REFERENCES),
+    }
+
+    # Integrity digest over the canonical payload (RFC 8785 JCS, same basis
+    # as ODR content digests) so the bundle itself is tamper-evident.
+    from aragora.gauntlet.odr_export import jcs_canonicalize
+
+    pack["integrity"] = {
+        "algorithm": "sha256/jcs",
+        "content_digest": hashlib.sha256(jcs_canonicalize(pack)).hexdigest(),
+    }
+    return pack
+
+
+def render_oversight_pack_markdown(pack: Mapping[str, Any]) -> str:
+    """Render the pack as an auditor-readable Markdown report."""
+    summary = pack.get("summary", {})
+    window = pack.get("window", {})
+    lines = [
+        "# Human Oversight Evidence Pack (EU AI Act Article 14)",
+        "",
+        f"Generated: {pack.get('generated_at', '')}",
+        f"Window: {window.get('days', '?')} days "
+        f"({window.get('start', '')} → {window.get('end', '')})",
+        f"Integrity: `{pack.get('integrity', {}).get('content_digest', '')}` (sha256/jcs)",
+        "",
+        "## Summary",
+        "",
+        f"- Receipts in window: **{summary.get('receipts_in_window', 0)}**",
+        f"- Human-attested: **{summary.get('human_attested', 0)}**",
+        f"- Autonomous (explicitly recorded): **{summary.get('autonomous', 0)}**",
+        f"- Attestor identities: {', '.join(summary.get('attestor_identities', [])) or '(none)'}",
+        f"- Mechanisms: {json.dumps(summary.get('mechanisms', {}))}",
+        f"- Excluded (no timestamp): {summary.get('excluded_no_timestamp', 0)}; "
+        f"out of window: {summary.get('excluded_out_of_window', 0)}",
+        "",
+        "## Article 14 clause mapping",
+        "",
+        "| Clause | Status | Basis |",
+        "|---|---|---|",
+    ]
+    for clause in pack.get("article_14_mapping", []):
+        lines.append(
+            f"| {clause.get('clause', '')} | {clause.get('status', '')} | "
+            f"{clause.get('status_basis', '')} |"
+        )
+    lines += [
+        "",
+        "## NIST AI RMF cross-references",
+        "",
+        "| Function | Evidence basis |",
+        "|---|---|",
+    ]
+    for ref in pack.get("nist_cross_references", []):
+        lines.append(f"| {ref.get('function', '')} | {ref.get('evidence_basis', '')} |")
+    lines += [
+        "",
+        "## Receipts",
+        "",
+        "| Receipt | Timestamp | Verdict | Disposition | Attestor | Mechanism |",
+        "|---|---|---|---|---|---|",
+    ]
+    for entry in pack.get("receipts", []):
+        lines.append(
+            f"| `{str(entry.get('receipt_id', ''))[:16]}` | {entry.get('timestamp', '')} | "
+            f"{entry.get('verdict', '')} | {entry.get('disposition', '')} | "
+            f"{entry.get('attestor', '')} | {entry.get('mechanism', '')} |"
+        )
+    lines.append("")
+    lines.append(
+        "Clause requirement texts and evidence definitions: "
+        "`docs/compliance/ART14_OVERSIGHT_PACK.md`."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -253,6 +253,8 @@ def _receipt_entry(
     receipt: Mapping[str, Any],
     attestations: Mapping[str, Mapping[str, Any]],
     source: str | None,
+    cutoff: datetime | None = None,
+    anchor: datetime | None = None,
 ) -> dict[str, Any]:
     """Normalize a native DecisionReceipt dict or an ODR document."""
     is_odr = "odr_version" in receipt
@@ -287,6 +289,16 @@ def _receipt_entry(
         disposition = str(attestation.get("disposition", HUMAN_ATTESTED_DISPOSITION))
         if disposition == HUMAN_ATTESTED_DISPOSITION:
             invalid_reason = _attestation_invalid_reason(attestation)
+            if not invalid_reason:
+                # Same discipline as settlement entries: an attestation whose
+                # timestamp is unparseable or outside the pack window must not
+                # count as in-window human oversight (round-12 finding).
+                parsed_attested = _parse_timestamp(attestation.get("attested_at"))
+                if parsed_attested is None:
+                    invalid_reason = "unparseable attested_at"
+                elif cutoff is not None and anchor is not None:
+                    if parsed_attested < cutoff or parsed_attested > anchor:
+                        invalid_reason = "attested_at outside pack window"
         if invalid_reason:
             # Malformed oversight claims are recorded visibly, never counted
             # as human oversight and never silently dropped.
@@ -513,7 +525,7 @@ def build_oversight_pack(
             receipt, source = item
         else:
             receipt, source = item, None
-        entry = _receipt_entry(receipt, attestation_map, source)
+        entry = _receipt_entry(receipt, attestation_map, source, cutoff=cutoff, anchor=anchor)
         parsed = _parse_timestamp(entry.get("timestamp"))
         if parsed is None:
             excluded_no_timestamp += 1

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -213,6 +213,31 @@ def _attestation_invalid_reason(block: Mapping[str, Any]) -> str | None:
     return None
 
 
+def _settlement_attestation_invalid_reason(block: Mapping[str, Any]) -> str | None:
+    """Settlement entries face a stricter bar than receipt-level blocks.
+
+    A settlement attestation is trail evidence with no surrounding receipt to
+    back it, so beyond the core who/when/how it must be independently
+    checkable: a resolvable ``mechanism.ref`` and the ``observed.head_sha``
+    the oversight bound to. Without those, a synthetic block could satisfy
+    identity clauses with no verifiable trail.
+    """
+    reason = _attestation_invalid_reason(block)
+    if reason:
+        return reason
+    mech = block.get("mechanism")
+    ref = str(mech.get("ref", "") or "").strip() if isinstance(mech, Mapping) else ""
+    if not ref:
+        return "missing mechanism.ref (settlement evidence must be resolvable)"
+    observed = block.get("observed")
+    head_sha = (
+        str(observed.get("head_sha", "") or "").strip() if isinstance(observed, Mapping) else ""
+    )
+    if not head_sha:
+        return "missing observed.head_sha (settlement must be head-bound)"
+    return None
+
+
 def _receipt_entry(
     receipt: Mapping[str, Any],
     attestations: Mapping[str, Mapping[str, Any]],
@@ -416,7 +441,11 @@ def build_oversight_pack(
         # Same trust boundary as receipt-level blocks: a settlement entry is
         # counted only when its attestation names who/when/how and satisfies
         # identity separation; malformed entries are reported, not counted.
-        reason = _attestation_invalid_reason(block) if isinstance(block, Mapping) else "no block"
+        reason = (
+            _settlement_attestation_invalid_reason(block)
+            if isinstance(block, Mapping)
+            else "no block"
+        )
         attested_at = _parse_timestamp(block.get("attested_at")) if not reason else None
         if not reason and attested_at is None:
             reason = "unparseable attested_at"

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -280,7 +280,10 @@ def _receipt_entry(
             # Malformed oversight claims are recorded visibly, never counted
             # as human oversight and never silently dropped.
             disposition = INVALID_ATTESTATION_DISPOSITION
-        else:
+        elif disposition == HUMAN_ATTESTED_DISPOSITION:
+            # Oversight identity/mechanism fields belong only to validated
+            # human attestations — an autonomous block carrying stray
+            # attestor/mechanism data must not leak into the audit summary.
             attestor = attestation.get("attestor") or {}
             attestor_id = str(attestor.get("id", "") or "") or None
             mech = attestation.get("mechanism") or {}

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -182,6 +182,37 @@ def _parse_timestamp(value: Any) -> datetime | None:
     return parsed
 
 
+INVALID_ATTESTATION_DISPOSITION = "invalid_attestation"
+
+
+def _attestation_invalid_reason(block: Mapping[str, Any]) -> str | None:
+    """Why a ``human_attested`` block does NOT count as oversight evidence.
+
+    The pack never trusts a bare ``{"disposition": "human_attested"}``: to be
+    counted, a block must name who attested, when, and via what mechanism —
+    and must satisfy the same identity-separation rule the attestation
+    builder enforces (attestor != execution identity). Returns ``None`` when
+    the block is countable.
+    """
+    attestor = block.get("attestor")
+    attestor_id = str(attestor.get("id", "") or "").strip() if isinstance(attestor, Mapping) else ""
+    if not attestor_id:
+        return "missing attestor.id"
+    if not str(block.get("attested_at", "") or "").strip():
+        return "missing attested_at"
+    mech = block.get("mechanism")
+    mech_type = str(mech.get("type", "") or "").strip() if isinstance(mech, Mapping) else ""
+    if not mech_type:
+        return "missing mechanism.type"
+    execution = block.get("execution_identity")
+    execution_id = (
+        str(execution.get("id", "") or "").strip() if isinstance(execution, Mapping) else ""
+    )
+    if execution_id and execution_id.lower() == attestor_id.lower():
+        return "attestor equals execution identity"
+    return None
+
+
 def _receipt_entry(
     receipt: Mapping[str, Any],
     attestations: Mapping[str, Mapping[str, Any]],
@@ -202,15 +233,23 @@ def _receipt_entry(
     mechanism: str | None = None
     observed: dict[str, Any] = {}
     attested_at: str | None = None
+    invalid_reason: str | None = None
     if attestation:
         disposition = str(attestation.get("disposition", HUMAN_ATTESTED_DISPOSITION))
-        attestor = attestation.get("attestor") or {}
-        attestor_id = str(attestor.get("id", "") or "") or None
-        mech = attestation.get("mechanism") or {}
-        mechanism = str(mech.get("type", "") or "") or None
-        if isinstance(attestation.get("observed"), Mapping):
-            observed = dict(attestation["observed"])
-        attested_at = str(attestation.get("attested_at", "") or "") or None
+        if disposition == HUMAN_ATTESTED_DISPOSITION:
+            invalid_reason = _attestation_invalid_reason(attestation)
+        if invalid_reason:
+            # Malformed oversight claims are recorded visibly, never counted
+            # as human oversight and never silently dropped.
+            disposition = INVALID_ATTESTATION_DISPOSITION
+        else:
+            attestor = attestation.get("attestor") or {}
+            attestor_id = str(attestor.get("id", "") or "") or None
+            mech = attestation.get("mechanism") or {}
+            mechanism = str(mech.get("type", "") or "") or None
+            if isinstance(attestation.get("observed"), Mapping):
+                observed = dict(attestation["observed"])
+            attested_at = str(attestation.get("attested_at", "") or "") or None
 
     if is_odr:
         timestamp = receipt.get("issued_at")
@@ -241,6 +280,8 @@ def _receipt_entry(
         entry["attested_at"] = attested_at
     if observed:
         entry["observed"] = observed
+    if invalid_reason:
+        entry["attestation_invalid_reason"] = invalid_reason
     if source:
         entry["source"] = source
     return entry
@@ -360,9 +401,19 @@ def build_oversight_pack(
     attestors = sorted({e["attestor"] for e in entries if e.get("attestor")})
     mechanisms = Counter(e["mechanism"] for e in entries if e.get("mechanism"))
 
-    settlements = [dict(s) for s in (settlement_attestations or [])]
-    for settlement in settlements:
+    settlements: list[dict[str, Any]] = []
+    settlements_invalid: list[dict[str, Any]] = []
+    for raw_settlement in settlement_attestations or []:
+        settlement = dict(raw_settlement)
         block = settlement.get("attestation") or {}
+        # Same trust boundary as receipt-level blocks: a settlement entry is
+        # counted only when its attestation names who/when/how and satisfies
+        # identity separation; malformed entries are reported, not counted.
+        reason = _attestation_invalid_reason(block) if isinstance(block, Mapping) else "no block"
+        if reason:
+            settlements_invalid.append({**settlement, "invalid_reason": reason})
+            continue
+        settlements.append(settlement)
         attestor = (block.get("attestor") or {}).get("id")
         if attestor and attestor not in attestors:
             attestors.append(attestor)
@@ -403,11 +454,13 @@ def build_oversight_pack(
             "attestor_identities": attestors,
             "mechanisms": dict(mechanisms),
             "settlement_attestations": len(settlements),
+            "settlement_attestations_invalid": len(settlements_invalid),
             "excluded_no_timestamp": excluded_no_timestamp,
             "excluded_out_of_window": excluded_out_of_window,
         },
         "receipts": entries,
         "settlement_attestations": settlements,
+        "settlement_attestations_invalid": settlements_invalid,
         "article_14_mapping": article_14,
         "nist_cross_references": list(NIST_CROSS_REFERENCES),
     }

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -246,24 +246,36 @@ def _receipt_entry(
     return entry
 
 
-def _clause_status(clause: str, human_attested: int, total: int) -> tuple[str, str]:
-    """Honest per-clause status from windowed evidence."""
+def _clause_status(
+    clause: str, human_attested: int, total: int, settlements: int = 0
+) -> tuple[str, str]:
+    """Honest per-clause status from windowed evidence.
+
+    ``settlements`` counts human-settlement attestations fetched from the
+    repository trail (see :mod:`aragora.compliance.oversight_fetch`) — real
+    oversight events with resolvable refs, counted for the identity-dependent
+    clauses alongside receipt-level attestations.
+    """
+    human_evidence = human_attested + settlements
     if clause == "14(4)(e)":
         return (
             "partial",
             "interruption capability is procedural (kill-switches, halt files); "
             "not evidenced per-receipt by this pack",
         )
-    if total == 0:
-        return "partial", "no receipts in window"
     if clause in ("14(1)", "14(3)", "14(4)(d)"):
         # Identity-dependent clauses need at least one real human attestation.
-        if human_attested > 0:
-            return "satisfied", f"{human_attested}/{total} windowed decisions human-attested"
+        if human_evidence > 0:
+            basis = f"{human_attested}/{total} windowed decisions human-attested"
+            if settlements:
+                basis += f"; {settlements} human-settlement attestation(s) from the trail"
+            return "satisfied", basis
         return (
             "partial",
             "oversight mechanism exists but no windowed decision carries a human attestation",
         )
+    if total == 0:
+        return "partial", "no receipts in window"
     return "satisfied", f"evidence present on all {total} windowed receipts"
 
 
@@ -298,6 +310,7 @@ def build_oversight_pack(
     window_days: int = 30,
     now: datetime | None = None,
     attestations: Mapping[str, Mapping[str, Any]] | None = None,
+    settlement_attestations: Sequence[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the Article 14 / NIST oversight evidence pack.
 
@@ -309,6 +322,11 @@ def build_oversight_pack(
         attestations: Optional ``receipt_id -> attestation block`` mapping,
             overriding/supplying attestations for native receipts (e.g. built
             with :mod:`aragora.gauntlet.attestation`).
+        settlement_attestations: Optional human-settlement attestation entries
+            from the repository trail (the ``attestations`` list returned by
+            :func:`aragora.compliance.oversight_fetch.fetch_settlement_attestations`)
+            — real oversight events counted alongside receipt-level
+            attestations for the identity-dependent Article 14 clauses.
 
     Returns:
         JSON-serializable pack dict with an integrity digest.
@@ -342,9 +360,22 @@ def build_oversight_pack(
     attestors = sorted({e["attestor"] for e in entries if e.get("attestor")})
     mechanisms = Counter(e["mechanism"] for e in entries if e.get("mechanism"))
 
+    settlements = [dict(s) for s in (settlement_attestations or [])]
+    for settlement in settlements:
+        block = settlement.get("attestation") or {}
+        attestor = (block.get("attestor") or {}).get("id")
+        if attestor and attestor not in attestors:
+            attestors.append(attestor)
+        mech = (block.get("mechanism") or {}).get("type")
+        if mech:
+            mechanisms[mech] += 1
+    attestors.sort()
+
     article_14 = []
     for clause_def in ARTICLE_14_CLAUSES:
-        status, basis = _clause_status(clause_def["clause"], human_attested, len(entries))
+        status, basis = _clause_status(
+            clause_def["clause"], human_attested, len(entries), settlements=len(settlements)
+        )
         article_14.append({**clause_def, "status": status, "status_basis": basis})
 
     pack: dict[str, Any] = {
@@ -371,10 +402,12 @@ def build_oversight_pack(
             },
             "attestor_identities": attestors,
             "mechanisms": dict(mechanisms),
+            "settlement_attestations": len(settlements),
             "excluded_no_timestamp": excluded_no_timestamp,
             "excluded_out_of_window": excluded_out_of_window,
         },
         "receipts": entries,
+        "settlement_attestations": settlements,
         "article_14_mapping": article_14,
         "nist_cross_references": list(NIST_CROSS_REFERENCES),
     }
@@ -431,6 +464,26 @@ def render_oversight_pack_markdown(pack: Mapping[str, Any]) -> str:
     ]
     for ref in pack.get("nist_cross_references", []):
         lines.append(f"| {ref.get('function', '')} | {ref.get('evidence_basis', '')} |")
+    settlements = pack.get("settlement_attestations", [])
+    if settlements:
+        lines += [
+            "",
+            "## Human-settlement attestations (repository trail)",
+            "",
+            "| PR | Attestor | Attested at | Head SHA | Ref |",
+            "|---|---|---|---|---|",
+        ]
+        for settlement in settlements:
+            block = settlement.get("attestation", {})
+            attestor = (block.get("attestor") or {}).get("id", "")
+            observed = block.get("observed") or {}
+            mech = block.get("mechanism") or {}
+            lines.append(
+                f"| #{settlement.get('pr', '')} | {attestor} | "
+                f"{block.get('attested_at', '')} | "
+                f"`{str(observed.get('head_sha', ''))[:12]}` | "
+                f"{mech.get('ref', '')} |"
+            )
     lines += [
         "",
         "## Receipts",

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -461,6 +461,7 @@ def build_oversight_pack(
     now: datetime | None = None,
     attestations: Mapping[str, Mapping[str, Any]] | None = None,
     settlement_attestations: Sequence[Mapping[str, Any]] | None = None,
+    settlement_fetch_report: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the Article 14 / NIST oversight evidence pack.
 
@@ -472,6 +473,11 @@ def build_oversight_pack(
         attestations: Optional ``receipt_id -> attestation block`` mapping,
             overriding/supplying attestations for native receipts (e.g. built
             with :mod:`aragora.gauntlet.attestation`).
+        settlement_fetch_report: Optional fetch-completeness metadata from
+            :func:`aragora.compliance.oversight_fetch.fetch_settlement_attestations`
+            (repo, scanned_prs, skipped, truncated) — persisted in the pack so
+            the audit artifact itself carries the caveats, not just the CLI
+            output.
         settlement_attestations: Optional human-settlement attestation entries
             from the repository trail (the ``attestations`` list returned by
             :func:`aragora.compliance.oversight_fetch.fetch_settlement_attestations`)
@@ -595,6 +601,16 @@ def build_oversight_pack(
         "receipts": entries,
         "settlement_attestations": settlements,
         "settlement_attestations_invalid": settlements_invalid,
+        "settlement_fetch": (
+            {
+                "repo": settlement_fetch_report.get("repo"),
+                "scanned_prs": settlement_fetch_report.get("scanned_prs"),
+                "skipped": list(settlement_fetch_report.get("skipped") or []),
+                "truncated": bool(settlement_fetch_report.get("truncated")),
+            }
+            if settlement_fetch_report is not None
+            else None
+        ),
         "article_14_mapping": article_14,
         "nist_cross_references": list(NIST_CROSS_REFERENCES),
     }
@@ -651,6 +667,19 @@ def render_oversight_pack_markdown(pack: Mapping[str, Any]) -> str:
     ]
     for ref in pack.get("nist_cross_references", []):
         lines.append(f"| {ref.get('function', '')} | {ref.get('evidence_basis', '')} |")
+    fetch_report = pack.get("settlement_fetch")
+    if isinstance(fetch_report, dict):
+        lines += [
+            "",
+            "## Settlement fetch completeness",
+            "",
+            f"- Repo scanned: {fetch_report.get('repo', '')} "
+            f"({fetch_report.get('scanned_prs', 0)} merged PRs in window)",
+            f"- Truncated scan: **{'YES — settlements may be undercounted' if fetch_report.get('truncated') else 'no'}**",
+            f"- Skipped (unverifiable oversight): {len(fetch_report.get('skipped') or [])}",
+        ]
+        for skip in fetch_report.get("skipped") or []:
+            lines.append(f"  - PR #{skip.get('pr', '')}: {skip.get('reason', '')}")
     settlements = pack.get("settlement_attestations", [])
     if settlements:
         lines += [

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -387,7 +387,6 @@ def _clause_status(
     are computed from per-receipt evidence-field presence
     (``evidence_counts``), never from receipt presence alone.
     """
-    human_evidence = human_attested + settlements
     if clause == "14(4)(e)":
         return (
             "partial",
@@ -395,12 +394,23 @@ def _clause_status(
             "not evidenced per-receipt by this pack",
         )
     if clause in ("14(1)", "14(3)", "14(4)(d)"):
-        # Identity-dependent clauses need at least one real human attestation.
-        if human_evidence > 0:
+        # Identity-dependent clauses are satisfied only by human-attested
+        # receipts in the window: trail settlements demonstrate the
+        # mechanism operating but are not matched to the windowed decisions,
+        # so alone they cap the status at partial (never overstating
+        # per-decision oversight).
+        if human_attested > 0:
             basis = f"{human_attested}/{total} windowed decisions human-attested"
             if settlements:
                 basis += f"; {settlements} human-settlement attestation(s) from the trail"
             return "satisfied", basis
+        if settlements > 0:
+            return (
+                "partial",
+                f"{settlements} human-settlement attestation(s) demonstrate the "
+                "oversight mechanism operating in the window, but no windowed "
+                "receipt is itself human-attested",
+            )
         return (
             "partial",
             "oversight mechanism exists but no windowed decision carries a human attestation",

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -248,10 +248,20 @@ def _receipt_entry(
     receipt_id = str(receipt.get("receipt_id", "") or "")
 
     attestation: Mapping[str, Any] | None = None
-    if is_odr and isinstance(receipt.get("attestation"), Mapping):
-        attestation = receipt["attestation"]
+    malformed_attestation = False
+    if is_odr:
+        raw_odr_block = receipt.get("attestation")
+        if isinstance(raw_odr_block, Mapping):
+            attestation = raw_odr_block
     if receipt_id and receipt_id in attestations:
-        attestation = attestations[receipt_id]
+        candidate = attestations[receipt_id]
+        if isinstance(candidate, Mapping):
+            attestation = candidate
+        else:
+            # A non-object --attestations value is an invalid oversight
+            # claim, reported per-receipt instead of crashing the pack.
+            attestation = None
+            malformed_attestation = True
 
     disposition = AUTONOMOUS_DISPOSITION
     attestor_id: str | None = None
@@ -259,6 +269,9 @@ def _receipt_entry(
     observed: dict[str, Any] = {}
     attested_at: str | None = None
     invalid_reason: str | None = None
+    if malformed_attestation:
+        disposition = INVALID_ATTESTATION_DISPOSITION
+        invalid_reason = "attestation block is not an object"
     if attestation:
         disposition = str(attestation.get("disposition", HUMAN_ATTESTED_DISPOSITION))
         if disposition == HUMAN_ATTESTED_DISPOSITION:

--- a/aragora/compliance/oversight_pack.py
+++ b/aragora/compliance/oversight_pack.py
@@ -276,6 +276,12 @@ def _receipt_entry(
                 observed = dict(attestation["observed"])
             attested_at = str(attestation.get("attested_at", "") or "") or None
 
+    def _present_block(value: Any) -> bool:
+        # ODR blocks are honest: {"status": "absent", ...} markers don't count.
+        if isinstance(value, Mapping):
+            return value.get("status") != "absent" and bool(value)
+        return bool(value)
+
     if is_odr:
         timestamp = receipt.get("issued_at")
         claim = receipt.get("claim") or {}
@@ -290,10 +296,26 @@ def _receipt_entry(
         confidence = (
             confidence_block.get("value") if isinstance(confidence_block, Mapping) else None
         )
+        evidence = {
+            "has_confidence": bool(verdict) and confidence is not None,
+            "has_responses": _present_block(receipt.get("quorum")),
+            "has_dissent_record": _present_block(receipt.get("quorum")),
+            "has_reasoning": _present_block(receipt.get("reasoning")),
+        }
     else:
         timestamp = receipt.get("timestamp") or receipt.get("produced_at")
         verdict = str(receipt.get("verdict", "") or "")
         confidence = receipt.get("confidence")
+        evidence = {
+            "has_confidence": bool(verdict) and confidence is not None,
+            "has_responses": bool(
+                receipt.get("agent_responses") or receipt.get("provenance_chain")
+            ),
+            "has_dissent_record": "dissenting_views" in receipt,
+            "has_reasoning": bool(
+                receipt.get("verdict_reasoning") or receipt.get("explainability")
+            ),
+        }
 
     entry: dict[str, Any] = {
         "receipt_id": receipt_id,
@@ -302,6 +324,7 @@ def _receipt_entry(
         "verdict": verdict,
         "confidence": confidence,
         "disposition": disposition,
+        "evidence": evidence,
     }
     if attestor_id:
         entry["attestor"] = attestor_id
@@ -318,15 +341,38 @@ def _receipt_entry(
     return entry
 
 
+# Content-dependent clauses require the named evidence fields to actually be
+# present on receipts — mere receipt presence never satisfies them.
+_CLAUSE_EVIDENCE_FLAGS = {
+    "14(2)": "has_confidence",
+    "14(4)(a)": "has_responses",
+    "14(4)(b)": "has_dissent_record",
+    "14(4)(c)": "has_reasoning",
+}
+
+_EVIDENCE_FLAG_LABELS = {
+    "has_confidence": "verdict + confidence",
+    "has_responses": "agent responses / provenance",
+    "has_dissent_record": "recorded dissent field",
+    "has_reasoning": "verdict reasoning / explainability",
+}
+
+
 def _clause_status(
-    clause: str, human_attested: int, total: int, settlements: int = 0
+    clause: str,
+    human_attested: int,
+    total: int,
+    settlements: int = 0,
+    evidence_counts: Mapping[str, int] | None = None,
 ) -> tuple[str, str]:
     """Honest per-clause status from windowed evidence.
 
     ``settlements`` counts human-settlement attestations fetched from the
     repository trail (see :mod:`aragora.compliance.oversight_fetch`) — real
     oversight events with resolvable refs, counted for the identity-dependent
-    clauses alongside receipt-level attestations.
+    clauses alongside receipt-level attestations. Content-dependent clauses
+    are computed from per-receipt evidence-field presence
+    (``evidence_counts``), never from receipt presence alone.
     """
     human_evidence = human_attested + settlements
     if clause == "14(4)(e)":
@@ -348,7 +394,16 @@ def _clause_status(
         )
     if total == 0:
         return "partial", "no receipts in window"
-    return "satisfied", f"evidence present on all {total} windowed receipts"
+    flag = _CLAUSE_EVIDENCE_FLAGS[clause]
+    label = _EVIDENCE_FLAG_LABELS[flag]
+    carrying = (evidence_counts or {}).get(flag, 0)
+    if carrying >= total:
+        return "satisfied", f"all {total} windowed receipts carry {label}"
+    return (
+        "partial",
+        f"{carrying}/{total} windowed receipts carry {label}; "
+        "status requires the evidence on every windowed receipt",
+    )
 
 
 def load_receipts_from_dirs(
@@ -468,10 +523,19 @@ def build_oversight_pack(
             mechanisms[mech] += 1
     attestors.sort()
 
+    evidence_counts = {
+        flag: sum(1 for e in entries if (e.get("evidence") or {}).get(flag))
+        for flag in _EVIDENCE_FLAG_LABELS
+    }
+
     article_14 = []
     for clause_def in ARTICLE_14_CLAUSES:
         status, basis = _clause_status(
-            clause_def["clause"], human_attested, len(entries), settlements=len(settlements)
+            clause_def["clause"],
+            human_attested,
+            len(entries),
+            settlements=len(settlements),
+            evidence_counts=evidence_counts,
         )
         article_14.append({**clause_def, "status": status, "status_basis": basis})
 

--- a/aragora/gauntlet/attestation.py
+++ b/aragora/gauntlet/attestation.py
@@ -1,0 +1,222 @@
+"""Human-oversight attestation blocks for ODR receipts (ODR-6 / #8230).
+
+The machine-readable form of the human gate this repo already operates
+manually for Tier-4 settlements: **who** accepted the risk (an oversight
+identity, credential-separated from the execution identity), **what they
+saw** (head SHA, evidence digest), **when**, and **via what mechanism**
+(the ``aragora/human-settlement`` commit status, a preapproval comment).
+
+Design rules:
+
+- **Honesty by construction** — a decision without human oversight is
+  recorded with the explicit ``autonomous`` disposition (already the ODR
+  export default), never by silently omitting the block.
+- **Identity separation is enforced** — an attestation whose oversight
+  identity equals the execution identity is refused: self-attestation is
+  exactly what the oversight layer exists to prevent (see
+  ``docs/specs/TAMPER_EVIDENT_TRAIL.md`` H2, the #8169 precedent gap).
+
+Usage with the ODR export::
+
+    att = build_oversight_attestation(
+        attestor_id="scarmani",
+        attested_at="2026-07-17T12:00:00+00:00",
+        mechanism_type="settlement_status",
+        mechanism_context=HUMAN_SETTLEMENT_CONTEXT,
+        head_sha="abc123...",
+        evidence_digest="sha256:...",
+        execution_identity_id="an0mium",
+    )
+    odr = decision_receipt_to_odr(receipt, attestation=att.to_dict())
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+__all__ = [
+    "HUMAN_SETTLEMENT_CONTEXT",
+    "AUTONOMOUS_DISPOSITION",
+    "HUMAN_ATTESTED_DISPOSITION",
+    "OversightAttestation",
+    "attestation_from_preapproval_comment",
+    "attestation_from_settlement_status",
+    "build_oversight_attestation",
+]
+
+# Keep in sync with aragora/swarm/merge_quorum_io.py — the gate-trusted
+# commit-status context whose creator identity is the oversight signal.
+HUMAN_SETTLEMENT_CONTEXT = "aragora/human-settlement"
+
+AUTONOMOUS_DISPOSITION = "autonomous"
+HUMAN_ATTESTED_DISPOSITION = "human_attested"
+
+_SHA256_RE = re.compile(r"\b[0-9a-f]{64}\b")
+
+_MECHANISM_TYPES = frozenset({"settlement_status", "preapproval_comment", "manual"})
+
+
+@dataclass
+class OversightAttestation:
+    """A human-oversight attestation, serializable as the ODR attestation block.
+
+    ``to_dict()`` output is accepted directly by
+    :func:`aragora.gauntlet.odr_export.decision_receipt_to_odr` via its
+    ``attestation=`` parameter (which passes the block through and defaults
+    the disposition to ``human_attested``).
+    """
+
+    attestor_id: str
+    attested_at: str
+    mechanism_type: str
+    attestor_role: str = "oversight"
+    execution_identity_id: str | None = None
+    head_sha: str | None = None
+    evidence_digest: str | None = None
+    mechanism_context: str | None = None
+    mechanism_ref: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.attestor_id or not str(self.attestor_id).strip():
+            raise ValueError("attestor_id is required for a human attestation")
+        if not self.attested_at:
+            raise ValueError("attested_at is required for a human attestation")
+        if self.mechanism_type not in _MECHANISM_TYPES:
+            raise ValueError(
+                f"mechanism_type must be one of {sorted(_MECHANISM_TYPES)}, "
+                f"got {self.mechanism_type!r}"
+            )
+        # Credential separation: the identity accepting the risk must not be
+        # the identity that executed the decision (TET H2). Refusing here is
+        # fail-closed — a self-attested block is worse than an honest
+        # `autonomous` disposition.
+        if (
+            self.execution_identity_id
+            and str(self.attestor_id).strip().lower()
+            == str(self.execution_identity_id).strip().lower()
+        ):
+            raise ValueError(
+                "oversight identity must differ from execution identity "
+                f"(both are {self.attestor_id!r}); record the decision as "
+                "'autonomous' instead of self-attesting"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        block: dict[str, Any] = {
+            "disposition": HUMAN_ATTESTED_DISPOSITION,
+            "attestor": {"id": self.attestor_id, "role": self.attestor_role},
+            "attested_at": self.attested_at,
+            "mechanism": {"type": self.mechanism_type},
+        }
+        if self.execution_identity_id:
+            block["execution_identity"] = {"id": self.execution_identity_id}
+        observed: dict[str, Any] = {}
+        if self.head_sha:
+            observed["head_sha"] = self.head_sha
+        if self.evidence_digest:
+            observed["evidence_digest"] = self.evidence_digest
+        if observed:
+            block["observed"] = observed
+        if self.mechanism_context:
+            block["mechanism"]["context"] = self.mechanism_context
+        if self.mechanism_ref:
+            block["mechanism"]["ref"] = self.mechanism_ref
+        if self.extra:
+            block.update(dict(self.extra))
+        return block
+
+
+def build_oversight_attestation(
+    *,
+    attestor_id: str,
+    attested_at: str,
+    mechanism_type: str,
+    attestor_role: str = "oversight",
+    execution_identity_id: str | None = None,
+    head_sha: str | None = None,
+    evidence_digest: str | None = None,
+    mechanism_context: str | None = None,
+    mechanism_ref: str | None = None,
+) -> OversightAttestation:
+    """Build a validated :class:`OversightAttestation` (keyword-only)."""
+    return OversightAttestation(
+        attestor_id=attestor_id,
+        attested_at=attested_at,
+        mechanism_type=mechanism_type,
+        attestor_role=attestor_role,
+        execution_identity_id=execution_identity_id,
+        head_sha=head_sha,
+        evidence_digest=evidence_digest,
+        mechanism_context=mechanism_context,
+        mechanism_ref=mechanism_ref,
+    )
+
+
+def attestation_from_settlement_status(
+    status: Mapping[str, Any],
+    *,
+    head_sha: str,
+    execution_identity_id: str | None = None,
+) -> OversightAttestation:
+    """Build an attestation from a GitHub commit-status API object.
+
+    The ``aragora/human-settlement`` status is the repo's gate-trusted
+    oversight signal: its ``creator.login`` is the oversight identity, it is
+    head-bound (posted on ``head_sha``), and its description embeds the
+    settlement receipt's SHA-256 for the status→receipt evidence link (see
+    ``review_queue._post_human_settlement_status``).
+
+    Args:
+        status: The statuses API object (``creator``, ``created_at``,
+            ``context``, ``description``, ``url``).
+        head_sha: The commit SHA the status was posted on (the statuses API
+            object does not embed it; the caller queried by SHA).
+        execution_identity_id: The identity that executed/authored the
+            decision, for the separation check.
+    """
+    creator = status.get("creator") or {}
+    attestor_id = str(creator.get("login", "") or "")
+    description = str(status.get("description", "") or "")
+    digest_match = _SHA256_RE.search(description)
+    return OversightAttestation(
+        attestor_id=attestor_id,
+        attested_at=str(status.get("created_at", "") or ""),
+        mechanism_type="settlement_status",
+        execution_identity_id=execution_identity_id,
+        head_sha=head_sha,
+        evidence_digest=f"sha256:{digest_match.group(0)}" if digest_match else None,
+        mechanism_context=str(status.get("context", "") or HUMAN_SETTLEMENT_CONTEXT),
+        mechanism_ref=str(status.get("url", "") or "") or None,
+    )
+
+
+def attestation_from_preapproval_comment(
+    comment: Mapping[str, Any],
+    *,
+    head_sha: str | None = None,
+    evidence_digest: str | None = None,
+    execution_identity_id: str | None = None,
+) -> OversightAttestation:
+    """Build an attestation from a preapproval comment (Tier-4 flow).
+
+    Args:
+        comment: GitHub comment API object (``user.login``/``author``,
+            ``created_at``, ``html_url``).
+        head_sha: Head SHA the preapproval bound to, when recorded.
+        evidence_digest: Digest of the evidence packet the approver saw.
+        execution_identity_id: Executing identity, for the separation check.
+    """
+    user = comment.get("user") or comment.get("author") or {}
+    attestor_id = str(user.get("login", "") or "")
+    return OversightAttestation(
+        attestor_id=attestor_id,
+        attested_at=str(comment.get("created_at", "") or ""),
+        mechanism_type="preapproval_comment",
+        execution_identity_id=execution_identity_id,
+        head_sha=head_sha,
+        evidence_digest=evidence_digest,
+        mechanism_ref=str(comment.get("html_url", "") or "") or None,
+    )

--- a/aragora/gauntlet/attestation.py
+++ b/aragora/gauntlet/attestation.py
@@ -160,6 +160,7 @@ def attestation_from_settlement_status(
     *,
     head_sha: str,
     execution_identity_id: str | None = None,
+    expected_context: str = HUMAN_SETTLEMENT_CONTEXT,
 ) -> OversightAttestation:
     """Build an attestation from a GitHub commit-status API object.
 
@@ -177,6 +178,17 @@ def attestation_from_settlement_status(
         execution_identity_id: The identity that executed/authored the
             decision, for the separation check.
     """
+    # Only a successful status on the settlement context is oversight: this
+    # builder is public API, so it must refuse to convert an arbitrary CI
+    # status (or a failed settlement) into countable oversight evidence.
+    context = str(status.get("context", "") or "")
+    if context != expected_context:
+        raise ValueError(
+            f"status context {context!r} is not the settlement context {expected_context!r}"
+        )
+    state = str(status.get("state", "") or "")
+    if state != "success":
+        raise ValueError(f"settlement status state must be 'success', got {state!r}")
     creator = status.get("creator") or {}
     attestor_id = str(creator.get("login", "") or "")
     description = str(status.get("description", "") or "")

--- a/aragora/gauntlet/odr_schema.json
+++ b/aragora/gauntlet/odr_schema.json
@@ -242,7 +242,37 @@
           "additionalProperties": true
         },
         "attested_at": { "type": "string" },
-        "method": { "type": "string" }
+        "method": { "type": "string" },
+        "execution_identity": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "role": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "Identity that executed the decision, recorded distinct from the oversight attestor (ODR-6 / #8230)."
+        },
+        "observed": {
+          "type": "object",
+          "properties": {
+            "head_sha": { "type": "string" },
+            "evidence_digest": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "What the attestor saw when accepting the risk: head SHA and evidence digest."
+        },
+        "mechanism": {
+          "type": "object",
+          "required": ["type"],
+          "properties": {
+            "type": { "type": "string" },
+            "context": { "type": "string" },
+            "ref": { "type": "string" }
+          },
+          "additionalProperties": true,
+          "description": "How the attestation was recorded, e.g. settlement_status (aragora/human-settlement) or preapproval_comment, with a resolvable ref."
+        }
       },
       "if": {
         "properties": { "disposition": { "const": "human_attested" } }

--- a/aragora/gauntlet/odr_verify.py
+++ b/aragora/gauntlet/odr_verify.py
@@ -453,6 +453,22 @@ def _validate_attestation(errors: list[str], value: Any) -> None:
     elif isinstance(execution_identity, dict):
         for key in ("id", "name", "role"):
             _optional_string(errors, "attestation.execution_identity", execution_identity, key)
+        # Identity separation (TET H2): a human_attested receipt whose
+        # attestor IS the executing identity is self-attestation, refused at
+        # verify time too (beyond JSON Schema expressiveness).
+        attestor_id = attestor.get("id") if isinstance(attestor, dict) else None
+        execution_id = execution_identity.get("id")
+        if (
+            disposition == "human_attested"
+            and isinstance(attestor_id, str)
+            and isinstance(execution_id, str)
+            and attestor_id.strip()
+            and attestor_id.strip().lower() == execution_id.strip().lower()
+        ):
+            errors.append(
+                "attestation: attestor.id must differ from execution_identity.id "
+                "(self-attestation is not oversight)"
+            )
     observed = value.get("observed")
     if "observed" in value and not isinstance(observed, dict):
         errors.append("attestation.observed: must be an object")

--- a/aragora/gauntlet/odr_verify.py
+++ b/aragora/gauntlet/odr_verify.py
@@ -420,7 +420,17 @@ def _validate_attestation(errors: list[str], value: Any) -> None:
         errors,
         "attestation",
         value,
-        frozenset({"disposition", "attestor", "attested_at", "method"}),
+        frozenset(
+            {
+                "disposition",
+                "attestor",
+                "attested_at",
+                "method",
+                "execution_identity",
+                "observed",
+                "mechanism",
+            }
+        ),
     )
     disposition = value.get("disposition")
     if disposition not in ("human_attested", "autonomous"):
@@ -436,6 +446,27 @@ def _validate_attestation(errors: list[str], value: Any) -> None:
         errors.append("attestation.attestor: required object when disposition is human_attested")
     _optional_string(errors, "attestation", value, "attested_at")
     _optional_string(errors, "attestation", value, "method")
+    # Oversight extension members (ODR-6 / #8230); shapes mirror the schema.
+    execution_identity = value.get("execution_identity")
+    if "execution_identity" in value and not isinstance(execution_identity, dict):
+        errors.append("attestation.execution_identity: must be an object")
+    elif isinstance(execution_identity, dict):
+        for key in ("id", "name", "role"):
+            _optional_string(errors, "attestation.execution_identity", execution_identity, key)
+    observed = value.get("observed")
+    if "observed" in value and not isinstance(observed, dict):
+        errors.append("attestation.observed: must be an object")
+    elif isinstance(observed, dict):
+        for key in ("head_sha", "evidence_digest"):
+            _optional_string(errors, "attestation.observed", observed, key)
+    mechanism = value.get("mechanism")
+    if "mechanism" in value and not isinstance(mechanism, dict):
+        errors.append("attestation.mechanism: must be an object")
+    elif isinstance(mechanism, dict):
+        if not isinstance(mechanism.get("type"), str) or not mechanism.get("type"):
+            errors.append("attestation.mechanism.type: required non-empty string")
+        for key in ("context", "ref"):
+            _optional_string(errors, "attestation.mechanism", mechanism, key)
 
 
 def _validate_routing(errors: list[str], value: Any) -> None:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -58,7 +58,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
 | `coherence-scan` | - | DIC-26: scan a belief ledger for contradictions, evidence conflicts, and confidence rot | - |
-| `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
+| `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `oversight-pack`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
 | `connectors` | - | Connector management commands | `list`, `status`, `test` |

--- a/docs/compliance/ART14_OVERSIGHT_PACK.md
+++ b/docs/compliance/ART14_OVERSIGHT_PACK.md
@@ -1,0 +1,114 @@
+# Article 14 Human-Oversight Evidence Pack
+
+**Issue:** #8230 (ODR-6) · **Modules:** `aragora/gauntlet/attestation.py`,
+`aragora/compliance/oversight_pack.py` · **CLI:** `aragora compliance oversight-pack`
+
+Regulators increasingly require *proof of effective human oversight of
+agentic systems*. Aragora operates a credential-separated human gate in its
+own development flow (the `aragora/human-settlement` commit status, Tier-4
+preapprovals — see `docs/specs/TAMPER_EVIDENT_TRAIL.md`), and this pack
+converts that operating practice into a generatable, audit-ready artifact
+for the EU AI Act (Regulation (EU) 2024/1689) **Article 14** and the
+NIST AI RMF.
+
+## The attestation block
+
+Every decision receipt exported as an Open Decision Receipt (ODR) carries an
+`attestation` block with an explicit disposition — **absence is recorded,
+never implied**:
+
+```jsonc
+// Autonomous decision (the honest default — no human oversaw it)
+{ "disposition": "autonomous" }
+
+// Human-settled decision
+{
+  "disposition": "human_attested",
+  "attestor": { "id": "scarmani", "role": "oversight" },      // WHO accepted the risk
+  "execution_identity": { "id": "an0mium" },                   // distinct, enforced
+  "attested_at": "2026-07-17T12:00:00+00:00",                  // WHEN
+  "observed": {                                                // WHAT they saw
+    "head_sha": "…",
+    "evidence_digest": "sha256:…"
+  },
+  "mechanism": {                                               // VIA WHAT
+    "type": "settlement_status",
+    "context": "aragora/human-settlement",
+    "ref": "https://api.github.com/repos/…/statuses/…"
+  }
+}
+```
+
+Builders live in `aragora.gauntlet.attestation`:
+
+- `attestation_from_settlement_status(status, head_sha=…)` — from the
+  head-bound `aragora/human-settlement` commit status (creator login =
+  oversight identity; the status description embeds the settlement receipt's
+  SHA-256, giving the evidence digest).
+- `attestation_from_preapproval_comment(comment, …)` — from a Tier-4
+  preapproval comment.
+- `build_oversight_attestation(…)` — explicit construction.
+
+**Identity separation is enforced at construction**: an attestation whose
+oversight identity equals the execution identity raises — self-attestation
+is refused fail-closed, and the decision stays honestly `autonomous`.
+
+## Generating the pack
+
+```bash
+# 30-day window over the repo trail (docs/receipts) + local receipt store
+aragora compliance oversight-pack --window 30d \
+  --output oversight-pack.json --markdown oversight-pack.md
+
+# Explicit sources and externally built attestations
+aragora compliance oversight-pack --window 12w \
+  --receipts-dir docs/receipts --receipts-dir /path/to/odr/exports \
+  --attestations attestations.json
+```
+
+The pack contains: per-receipt entries (id, timestamp, verdict, disposition,
+attestor, mechanism, observed evidence), summary counts, the clause mapping
+below with **computed** statuses, NIST cross-references, and a
+tamper-evidence digest (SHA-256 over the RFC 8785/JCS canonical payload —
+the same basis as ODR content digests).
+
+Honesty rules: receipts without attestations count as `autonomous`;
+receipts without parseable timestamps are excluded *and counted as
+excluded*; clause statuses degrade to `partial` when the window lacks the
+evidence, they are never asserted unconditionally.
+
+## Article 14 clause mapping
+
+| Clause | Requirement (abridged) | Evidence in the pack | Status rule |
+|---|---|---|---|
+| 14(1) | System designed for effective oversight by natural persons | Oversight identity layer; per-decision dispositions | `satisfied` iff ≥1 human-attested receipt in window |
+| 14(2) | Oversight prevents/minimises risks | Adversarial review verdicts, confidence, preserved dissent | `satisfied` when receipts present |
+| 14(3) | Oversight measures built-in or identified | Settlement mechanism cited per attestation (status context / preapproval ref) | `satisfied` iff ≥1 human-attested receipt in window |
+| 14(4)(a) | Understand capacities/limitations, monitor operation | Agent responses, confidence, dissent, provenance chains per receipt | `satisfied` when receipts present |
+| 14(4)(b) | Awareness of automation bias | Heterogeneous-model dissent preserved verbatim; hollow-consensus detection | `satisfied` when receipts present |
+| 14(4)(c) | Correctly interpret output | Verdict reasoning, explainability, exact evidence digest seen | `satisfied` when receipts present |
+| 14(4)(d) | Can disregard/override/reverse output | Human settlement is the act gate; withheld attestation withholds action | `satisfied` iff ≥1 human-attested receipt in window |
+| 14(4)(e) | Can intervene or interrupt (stop) | Kill-switches / halt files are procedural, not per-receipt | at most `partial` from receipts alone (by design) |
+
+The 14(4)(e) ceiling is deliberate: this pack only claims what receipts can
+evidence. Interruption capability should be evidenced separately (runbooks,
+kill-switch drill records) in a fuller conformity bundle
+(`aragora compliance eu-ai-act generate`).
+
+## NIST AI RMF cross-references
+
+| Function | Mapping |
+|---|---|
+| GOVERN 3.2 | Oversight roles/responsibilities → oversight identity layer + attestor records |
+| MANAGE 2.4 | Mechanisms to supersede/disengage → human settlement gate |
+| MEASURE 2.10 | Human-AI configuration / automation bias → preserved dissent + confidence |
+
+## Relationship to other artifacts
+
+- `aragora compliance eu-ai-act generate` — full per-receipt Article 9/12/13/14/15
+  bundle; its `Article14Artifact` documents the oversight *design*. This pack
+  documents oversight *practice over a window*, across many receipts.
+- ODR export (`aragora/gauntlet/odr_export.py`) — carries the attestation
+  block per receipt; this pack aggregates them.
+- `docs/specs/TAMPER_EVIDENT_TRAIL.md` — the identity layers and the
+  settlement-creator pin (H2) this evidence chain builds on.

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -53,7 +53,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `codex` | - | Read-only inspector for Codex Desktop local state | `insights`, `sessions` |
 | `coherence-scan` | - | DIC-26: scan a belief ledger for contradictions, evidence conflicts, and confidence rot | - |
-| `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
+| `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `oversight-pack`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
 | `connectors` | - | Connector management commands | `list`, `status`, `test` |

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -215,9 +215,11 @@ class TestPackIntegration:
         assert pack["summary"]["mechanisms"]["settlement_status"] == 1
         assert pack["settlement_attestations"][0]["pr"] == 101
 
-    def test_settlements_satisfy_identity_clauses(self) -> None:
-        """Trail settlements are real oversight events: identity-dependent
-        clauses turn satisfied even when scanned receipts are all autonomous."""
+    def test_trail_settlements_alone_cap_identity_clauses_at_partial(self) -> None:
+        """Round-7 finding: trail settlements demonstrate the mechanism
+        operating but are not matched to windowed receipts, so alone they
+        never flip identity clauses to satisfied (no per-decision
+        overstatement). The basis names the settlements explicitly."""
         pack = build_oversight_pack(
             [
                 {
@@ -232,9 +234,37 @@ class TestPackIntegration:
             settlement_attestations=self._fetched(),
         )
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
-        assert by_clause["14(1)"]["status"] == "satisfied"
-        assert "human-settlement attestation" in by_clause["14(1)"]["status_basis"]
+        assert by_clause["14(1)"]["status"] == "partial"
+        assert (
+            "demonstrate the oversight mechanism operating" in (by_clause["14(1)"]["status_basis"])
+        )
         assert by_clause["14(4)(e)"]["status"] == "partial"
+
+    def test_receipt_attestation_plus_settlements_satisfied(self) -> None:
+        attested_odr = {
+            "odr_version": "0.1",
+            "receipt_id": "r-att",
+            "issued_at": "2026-07-10T00:00:00+00:00",
+            "claim": {"verdict": "PASS"},
+            "confidence": {"value": 0.8},
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer2"},
+                "attested_at": "2026-07-10T00:00:00+00:00",
+                "mechanism": {"type": "preapproval_comment"},
+            },
+        }
+        pack = build_oversight_pack(
+            [attested_odr],
+            window_days=30,
+            now=NOW,
+            settlement_attestations=self._fetched(),
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "satisfied"
+        assert (
+            "human-settlement attestation(s) from the trail" in (by_clause["14(1)"]["status_basis"])
+        )
 
     def test_without_settlements_behavior_unchanged(self) -> None:
         pack = build_oversight_pack([], window_days=30, now=NOW)

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -121,6 +121,39 @@ class TestFetcher:
         )
         assert ["repo", "view", "--json", "nameWithOwner"] not in calls
 
+    def test_unresolvable_author_skipped(self) -> None:
+        """Round-5 finding (claude P3): without a resolvable executing author
+        the separation check cannot run — skip with reason, never assume."""
+
+        def run(args):
+            if args[:2] == ["pr", "list"]:
+                return [
+                    {
+                        "number": 200,
+                        "url": "u",
+                        "mergedAt": "2026-07-16T10:00:00Z",
+                        "headRefOid": "f" * 40,
+                        "author": {},
+                    }
+                ]
+            return [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-07-16T11:00:00Z",
+                    "description": "settled",
+                    "url": "https://api.github.com/repos/acme/widgets/statuses/f",
+                }
+            ]
+
+        result = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run
+        )
+        assert result["attestations"] == []
+        assert result["skipped"][0]["pr"] == 200
+        assert "identity separation unverifiable" in result["skipped"][0]["reason"]
+
     def test_unresolvable_repo_raises(self) -> None:
         def run(args):
             return {} if args[:2] == ["repo", "view"] else []

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -301,6 +301,7 @@ class TestPackIntegration:
             "attestation": {
                 "disposition": "human_attested",
                 "attestor": {"id": "overseer2"},
+                "execution_identity": {"id": "agent-bot"},
                 "attested_at": "2026-07-10T00:00:00+00:00",
                 "mechanism": {"type": "preapproval_comment"},
             },

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -227,6 +227,29 @@ class TestFetcher:
             fetch_settlement_attestations(window_days=30, now=NOW, gh_runner=run)
 
 
+class TestFetchReportPersistence:
+    def test_fetch_report_persisted_in_pack_and_markdown(self) -> None:
+        """Round-9 finding: skipped/truncated fetch metadata must live in the
+        persisted artifact, not only the console output."""
+        report = {
+            "repo": "acme/widgets",
+            "scanned_prs": 7,
+            "skipped": [{"pr": 102, "reason": "oversight identity must differ"}],
+            "truncated": True,
+        }
+        pack = build_oversight_pack([], window_days=30, now=NOW, settlement_fetch_report=report)
+        assert pack["settlement_fetch"]["truncated"] is True
+        assert pack["settlement_fetch"]["skipped"][0]["pr"] == 102
+        md = render_oversight_pack_markdown(pack)
+        assert "Settlement fetch completeness" in md
+        assert "undercounted" in md
+        assert "#102" in md
+
+    def test_no_report_stays_none(self) -> None:
+        pack = build_oversight_pack([], window_days=30, now=NOW)
+        assert pack["settlement_fetch"] is None
+
+
 class TestPackIntegration:
     def _fetched(self) -> list[dict]:
         calls: list[list[str]] = []

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -1,0 +1,182 @@
+"""Settlement-attestation fetcher (#8230 follow-up).
+
+Walks merged PRs' ``aragora/human-settlement`` statuses into attestation
+blocks. Honesty: self-settled PRs (creator == executing author) are refused
+and reported in ``skipped``; unattested PRs simply don't appear.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from aragora.compliance.oversight_fetch import fetch_settlement_attestations
+from aragora.compliance.oversight_pack import (
+    build_oversight_pack,
+    render_oversight_pack_markdown,
+)
+
+NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+HEAD_A = "a" * 40
+HEAD_B = "b" * 40
+HEAD_C = "c" * 40
+
+
+def _gh_fixture(calls: list[list[str]]):
+    """A fake gh runner over a small merged-PR universe."""
+
+    def run(args: list[str]):
+        calls.append(args)
+        if args[:2] == ["repo", "view"]:
+            return {"nameWithOwner": "acme/widgets"}
+        if args[:2] == ["pr", "list"]:
+            return [
+                {  # human-settled by a distinct oversight identity
+                    "number": 101,
+                    "url": "https://github.com/acme/widgets/pull/101",
+                    "mergedAt": "2026-07-16T10:00:00Z",
+                    "headRefOid": HEAD_A,
+                    "author": {"login": "agent-bot"},
+                },
+                {  # self-settled: creator == author → must be skipped
+                    "number": 102,
+                    "url": "https://github.com/acme/widgets/pull/102",
+                    "mergedAt": "2026-07-15T10:00:00Z",
+                    "headRefOid": HEAD_B,
+                    "author": {"login": "overseer"},
+                },
+                {  # no settlement status → autonomous, not listed
+                    "number": 103,
+                    "url": "https://github.com/acme/widgets/pull/103",
+                    "mergedAt": "2026-07-14T10:00:00Z",
+                    "headRefOid": HEAD_C,
+                    "author": {"login": "agent-bot"},
+                },
+                {  # out of window
+                    "number": 90,
+                    "url": "https://github.com/acme/widgets/pull/90",
+                    "mergedAt": "2026-01-01T10:00:00Z",
+                    "headRefOid": "d" * 40,
+                    "author": {"login": "agent-bot"},
+                },
+            ]
+        if args[0] == "api" and HEAD_A in args[1]:
+            return [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-07-16T11:00:00Z",
+                    "description": "Settlement receipt " + "e" * 64 + " recorded for PR #101",
+                    "url": f"https://api.github.com/repos/acme/widgets/statuses/{HEAD_A}",
+                },
+                {"context": "ci/other", "state": "success"},
+            ]
+        if args[0] == "api" and HEAD_B in args[1]:
+            return [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-07-15T11:00:00Z",
+                    "description": "settled",
+                    "url": f"https://api.github.com/repos/acme/widgets/statuses/{HEAD_B}",
+                }
+            ]
+        if args[0] == "api" and HEAD_C in args[1]:
+            return [{"context": "ci/other", "state": "success"}]
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    return run
+
+
+class TestFetcher:
+    def test_fetches_attestations_and_skips_self_settled(self) -> None:
+        calls: list[list[str]] = []
+        result = fetch_settlement_attestations(
+            window_days=30, now=NOW, gh_runner=_gh_fixture(calls)
+        )
+        assert result["repo"] == "acme/widgets"
+        assert result["scanned_prs"] == 3  # out-of-window PR not scanned
+        assert len(result["attestations"]) == 1
+        entry = result["attestations"][0]
+        assert entry["pr"] == 101
+        block = entry["attestation"]
+        assert block["disposition"] == "human_attested"
+        assert block["attestor"]["id"] == "overseer"
+        assert block["execution_identity"]["id"] == "agent-bot"
+        assert block["observed"]["head_sha"] == HEAD_A
+        assert block["observed"]["evidence_digest"] == "sha256:" + "e" * 64
+        assert block["mechanism"]["type"] == "settlement_status"
+        # Self-settled PR reported, not silently dropped.
+        assert len(result["skipped"]) == 1
+        assert result["skipped"][0]["pr"] == 102
+        assert "must differ" in result["skipped"][0]["reason"]
+
+    def test_explicit_repo_skips_resolution(self) -> None:
+        calls: list[list[str]] = []
+        fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=_gh_fixture(calls)
+        )
+        assert ["repo", "view", "--json", "nameWithOwner"] not in calls
+
+    def test_unresolvable_repo_raises(self) -> None:
+        def run(args):
+            return {} if args[:2] == ["repo", "view"] else []
+
+        with pytest.raises(ValueError, match="could not resolve repo"):
+            fetch_settlement_attestations(window_days=30, now=NOW, gh_runner=run)
+
+
+class TestPackIntegration:
+    def _fetched(self) -> list[dict]:
+        calls: list[list[str]] = []
+        return fetch_settlement_attestations(window_days=30, now=NOW, gh_runner=_gh_fixture(calls))[
+            "attestations"
+        ]
+
+    def test_settlements_flow_into_pack(self) -> None:
+        pack = build_oversight_pack(
+            [], window_days=30, now=NOW, settlement_attestations=self._fetched()
+        )
+        assert pack["summary"]["settlement_attestations"] == 1
+        assert "overseer" in pack["summary"]["attestor_identities"]
+        assert pack["summary"]["mechanisms"]["settlement_status"] == 1
+        assert pack["settlement_attestations"][0]["pr"] == 101
+
+    def test_settlements_satisfy_identity_clauses(self) -> None:
+        """Trail settlements are real oversight events: identity-dependent
+        clauses turn satisfied even when scanned receipts are all autonomous."""
+        pack = build_oversight_pack(
+            [
+                {
+                    "receipt_id": "r1",
+                    "timestamp": "2026-07-10T00:00:00+00:00",
+                    "verdict": "PASS",
+                    "confidence": 0.9,
+                }
+            ],
+            window_days=30,
+            now=NOW,
+            settlement_attestations=self._fetched(),
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "satisfied"
+        assert "human-settlement attestation" in by_clause["14(1)"]["status_basis"]
+        assert by_clause["14(4)(e)"]["status"] == "partial"
+
+    def test_without_settlements_behavior_unchanged(self) -> None:
+        pack = build_oversight_pack([], window_days=30, now=NOW)
+        assert pack["summary"]["settlement_attestations"] == 0
+        assert pack["settlement_attestations"] == []
+        assert all(c["status"] == "partial" for c in pack["article_14_mapping"])
+
+    def test_markdown_lists_settlements(self) -> None:
+        pack = build_oversight_pack(
+            [], window_days=30, now=NOW, settlement_attestations=self._fetched()
+        )
+        md = render_oversight_pack_markdown(pack)
+        assert "Human-settlement attestations" in md
+        assert "#101" in md
+        assert "overseer" in md

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -121,6 +121,43 @@ class TestFetcher:
         )
         assert ["repo", "view", "--json", "nameWithOwner"] not in calls
 
+    def test_paginated_status_pages_flattened(self) -> None:
+        """Round-6 finding (openai P2): the settlement status must be found
+        even when it sits on a later status page (gh --paginate --slurp
+        returns an array of pages)."""
+
+        def run(args):
+            if args[:2] == ["pr", "list"]:
+                return [
+                    {
+                        "number": 300,
+                        "url": "u",
+                        "mergedAt": "2026-07-16T10:00:00Z",
+                        "headRefOid": "9" * 40,
+                        "author": {"login": "agent-bot"},
+                    }
+                ]
+            assert "--paginate" in args and "--slurp" in args
+            assert "per_page=100" in args[1]
+            page1 = [{"context": f"ci/noise-{i}", "state": "success"} for i in range(3)]
+            page2 = [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-07-16T11:00:00Z",
+                    "description": "settled",
+                    "url": "https://api.github.com/repos/acme/widgets/statuses/9",
+                }
+            ]
+            return [page1, page2]
+
+        result = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run
+        )
+        assert len(result["attestations"]) == 1
+        assert result["attestations"][0]["pr"] == 300
+
     def test_unresolvable_author_skipped(self) -> None:
         """Round-5 finding (claude P3): without a resolvable executing author
         the separation check cannot run — skip with reason, never assume."""

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -31,6 +31,7 @@ def _gh_fixture(calls: list[list[str]]):
         if args[:2] == ["repo", "view"]:
             return {"nameWithOwner": "acme/widgets"}
         if args[:2] == ["pr", "list"]:
+            assert "--search" in args and any(a.startswith("merged:>=") for a in args)
             return [
                 {  # human-settled by a distinct oversight identity
                     "number": 101,
@@ -120,6 +121,33 @@ class TestFetcher:
             repo="acme/widgets", window_days=30, now=NOW, gh_runner=_gh_fixture(calls)
         )
         assert ["repo", "view", "--json", "nameWithOwner"] not in calls
+
+    def test_truncated_scan_reported(self) -> None:
+        """Round-8 finding: filling the scan limit must be reported as
+        truncation, never a silent undercount."""
+
+        def run(args):
+            if args[:2] == ["pr", "list"]:
+                return [
+                    {
+                        "number": 400 + i,
+                        "url": "u",
+                        "mergedAt": "2026-07-16T10:00:00Z",
+                        "headRefOid": str(i) * 40,
+                        "author": {"login": "agent-bot"},
+                    }
+                    for i in range(2)
+                ]
+            return []
+
+        result = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run, limit=2
+        )
+        assert result["truncated"] is True
+        below_limit = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run, limit=5
+        )
+        assert below_limit["truncated"] is False
 
     def test_paginated_status_pages_flattened(self) -> None:
         """Round-6 finding (openai P2): the settlement status must be found

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -295,6 +295,25 @@ class TestBuildPack:
         assert pack["summary"]["attestor_identities"] == []
         assert pack["summary"]["mechanisms"] == {}
 
+    def test_non_string_attestation_fields_not_coerced(self) -> None:
+        """Round-11 finding: non-string attestor.id/attested_at/mechanism.type
+        must be rejected, never str()-coerced into countable evidence."""
+        for field_patch, reason in [
+            ({"attestor": {"id": 123}}, "attestor.id must be a string"),
+            ({"attested_at": 1234567890}, "attested_at must be a string"),
+            (
+                {"mechanism": {"type": ["settlement_status"]}},
+                "mechanism.type must be a string",
+            ),
+        ]:
+            doc = _odr("r-coerce", "2026-07-10T00:00:00+00:00", attested=True)
+            doc["attestation"].update(field_patch)
+            pack = build_oversight_pack([doc], window_days=30, now=NOW)
+            entry = pack["receipts"][0]
+            assert entry["disposition"] == "invalid_attestation", field_patch
+            assert entry["attestation_invalid_reason"] == reason
+            assert pack["summary"]["human_attested"] == 0
+
     def test_odr_verdict_field_normalized(self) -> None:
         """The ODR exporter/schema use claim.verdict (round-3 finding: reading
         claim.decision produced blank verdicts for real ODR inputs); legacy

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -233,7 +233,11 @@ class TestBuildPack:
             "missing attestor.id"
         )
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
-        assert by_clause["14(1)"]["status"] == "satisfied"
+        # Trail settlements alone cap identity clauses at partial (round 7).
+        assert by_clause["14(1)"]["status"] == "partial"
+        assert (
+            "demonstrate the oversight mechanism operating" in (by_clause["14(1)"]["status_basis"])
+        )
 
     def test_settlement_without_resolvable_trail_not_counted(self) -> None:
         """Settlement entries face a stricter bar than receipt blocks: without

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -112,6 +112,63 @@ class TestBuildPack:
         assert by_clause["14(4)(d)"]["status"] == "partial"
         assert by_clause["14(2)"]["status"] == "satisfied"
 
+    def test_bare_human_attested_block_not_trusted(self) -> None:
+        """A block claiming human_attested without attestor/when/mechanism is
+        recorded as invalid_attestation and never counts as oversight
+        (openai review round 2 on #9417)."""
+        doc = _odr("r-bare", "2026-07-10T00:00:00+00:00", attested=False)
+        doc["attestation"] = {"disposition": "human_attested"}
+        pack = build_oversight_pack([doc], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert entry["attestation_invalid_reason"] == "missing attestor.id"
+        assert pack["summary"]["human_attested"] == 0
+        assert pack["summary"]["other_dispositions"] == {"invalid_attestation": 1}
+        assert pack["summary"]["attestor_identities"] == []
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "partial"
+
+    def test_self_attested_block_not_trusted(self) -> None:
+        doc = _odr("r-self", "2026-07-10T00:00:00+00:00", attested=True)
+        doc["attestation"]["execution_identity"] = {"id": "scarmani"}
+        pack = build_oversight_pack([doc], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert entry["attestation_invalid_reason"] == "attestor equals execution identity"
+        assert pack["summary"]["human_attested"] == 0
+
+    def test_attestations_map_also_validated(self) -> None:
+        pack = build_oversight_pack(
+            [_native("r1", "2026-07-10T00:00:00+00:00")],
+            window_days=30,
+            now=NOW,
+            attestations={"r1": {"disposition": "human_attested"}},
+        )
+        assert pack["receipts"][0]["disposition"] == "invalid_attestation"
+        assert pack["summary"]["human_attested"] == 0
+
+    def test_invalid_settlement_attestations_reported_not_counted(self) -> None:
+        good = {
+            "pr": 1,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "attested_at": "2026-07-10T01:00:00+00:00",
+                "mechanism": {"type": "settlement_status"},
+            },
+        }
+        bad = {"pr": 2, "attestation": {"disposition": "human_attested"}}
+        pack = build_oversight_pack(
+            [], window_days=30, now=NOW, settlement_attestations=[good, bad]
+        )
+        assert pack["summary"]["settlement_attestations"] == 1
+        assert pack["summary"]["settlement_attestations_invalid"] == 1
+        assert pack["settlement_attestations_invalid"][0]["invalid_reason"] == (
+            "missing attestor.id"
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "satisfied"
+
     def test_empty_window_all_partial_or_honest(self) -> None:
         pack = build_oversight_pack([], window_days=30, now=NOW)
         assert pack["summary"]["receipts_in_window"] == 0

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -154,7 +154,11 @@ class TestBuildPack:
                 "disposition": "human_attested",
                 "attestor": {"id": "overseer"},
                 "attested_at": "2026-07-10T01:00:00+00:00",
-                "mechanism": {"type": "settlement_status"},
+                "mechanism": {
+                    "type": "settlement_status",
+                    "ref": "https://api.github.com/repos/o/r/statuses/abc",
+                },
+                "observed": {"head_sha": "b" * 40},
             },
         }
         bad = {"pr": 2, "attestation": {"disposition": "human_attested"}}
@@ -168,6 +172,45 @@ class TestBuildPack:
         )
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
         assert by_clause["14(1)"]["status"] == "satisfied"
+
+    def test_settlement_without_resolvable_trail_not_counted(self) -> None:
+        """Settlement entries face a stricter bar than receipt blocks: without
+        a resolvable mechanism.ref and observed.head_sha, a synthetic block
+        could satisfy identity clauses with no verifiable trail (round-4
+        finding)."""
+        no_ref = {
+            "pr": 5,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "attested_at": "2026-07-10T01:00:00+00:00",
+                "mechanism": {"type": "settlement_status"},
+                "observed": {"head_sha": "e" * 40},
+            },
+        }
+        no_head = {
+            "pr": 6,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "attested_at": "2026-07-10T01:00:00+00:00",
+                "mechanism": {
+                    "type": "settlement_status",
+                    "ref": "https://api.github.com/repos/o/r/statuses/y",
+                },
+            },
+        }
+        pack = build_oversight_pack(
+            [], window_days=30, now=NOW, settlement_attestations=[no_ref, no_head]
+        )
+        assert pack["summary"]["settlement_attestations"] == 0
+        reasons = {e["invalid_reason"] for e in pack["settlement_attestations_invalid"]}
+        assert reasons == {
+            "missing mechanism.ref (settlement evidence must be resolvable)",
+            "missing observed.head_sha (settlement must be head-bound)",
+        }
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "partial"
 
     def test_odr_verdict_field_normalized(self) -> None:
         """The ODR exporter/schema use claim.verdict (round-3 finding: reading
@@ -193,7 +236,11 @@ class TestBuildPack:
                 "disposition": "human_attested",
                 "attestor": {"id": "overseer"},
                 "attested_at": "2026-01-01T00:00:00+00:00",
-                "mechanism": {"type": "settlement_status"},
+                "mechanism": {
+                    "type": "settlement_status",
+                    "ref": "https://api.github.com/repos/o/r/statuses/old",
+                },
+                "observed": {"head_sha": "c" * 40},
             },
         }
         pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[stale])
@@ -209,7 +256,11 @@ class TestBuildPack:
                 "disposition": "human_attested",
                 "attestor": {"id": "overseer"},
                 "attested_at": "yesterday-ish",
-                "mechanism": {"type": "settlement_status"},
+                "mechanism": {
+                    "type": "settlement_status",
+                    "ref": "https://api.github.com/repos/o/r/statuses/x",
+                },
+                "observed": {"head_sha": "d" * 40},
             },
         }
         pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[bad])

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -46,6 +46,7 @@ def _odr(receipt_id: str, ts: str, attested: bool) -> dict:
         doc["attestation"] = {
             "disposition": "human_attested",
             "attestor": {"id": "scarmani", "role": "oversight"},
+            "execution_identity": {"id": "an0mium"},
             "attested_at": ts,
             "observed": {"head_sha": "b" * 40, "evidence_digest": "sha256:" + "a" * 64},
             "mechanism": {"type": "settlement_status", "context": "aragora/human-settlement"},
@@ -75,6 +76,7 @@ class TestBuildPack:
         att = {
             "disposition": "human_attested",
             "attestor": {"id": "scarmani"},
+            "execution_identity": {"id": "an0mium"},
             "attested_at": "2026-07-10T01:00:00+00:00",
             "mechanism": {"type": "preapproval_comment"},
         }
@@ -220,7 +222,8 @@ class TestBuildPack:
                     "type": "settlement_status",
                     "ref": "https://api.github.com/repos/o/r/statuses/abc",
                 },
-                "observed": {"head_sha": "b" * 40},
+                "execution_identity": {"id": "agent-bot"},
+                "observed": {"head_sha": "b" * 40, "evidence_digest": "sha256:" + "1" * 64},
             },
         }
         bad = {"pr": 2, "attestation": {"disposition": "human_attested"}}
@@ -251,7 +254,8 @@ class TestBuildPack:
                 "attestor": {"id": "overseer"},
                 "attested_at": "2026-07-10T01:00:00+00:00",
                 "mechanism": {"type": "settlement_status"},
-                "observed": {"head_sha": "e" * 40},
+                "execution_identity": {"id": "agent-bot"},
+                "observed": {"head_sha": "e" * 40, "evidence_digest": "sha256:" + "4" * 64},
             },
         }
         no_head = {
@@ -264,6 +268,8 @@ class TestBuildPack:
                     "type": "settlement_status",
                     "ref": "https://api.github.com/repos/o/r/statuses/y",
                 },
+                "execution_identity": {"id": "agent-bot"},
+                "observed": {"evidence_digest": "sha256:" + "5" * 64},
             },
         }
         pack = build_oversight_pack(
@@ -334,6 +340,43 @@ class TestBuildPack:
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
         assert by_clause["14(1)"]["status"] == "partial"
 
+    def test_missing_execution_identity_not_counted(self) -> None:
+        """Round-13 finding: without a named executor the separation check
+        cannot run, so the block never counts as oversight."""
+        doc = _odr("r-noexec", "2026-07-10T00:00:00+00:00", attested=True)
+        del doc["attestation"]["execution_identity"]
+        pack = build_oversight_pack([doc], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert "identity separation unverifiable" in entry["attestation_invalid_reason"]
+        assert pack["summary"]["human_attested"] == 0
+
+    def test_settlement_without_evidence_digest_not_counted(self) -> None:
+        """Round-13 finding: the pack claims status→receipt binding; a
+        settlement without the embedded receipt digest cannot provide it."""
+        no_digest = {
+            "pr": 7,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "execution_identity": {"id": "agent-bot"},
+                "attested_at": "2026-07-10T01:00:00+00:00",
+                "mechanism": {
+                    "type": "settlement_status",
+                    "ref": "https://api.github.com/repos/o/r/statuses/z",
+                },
+                "observed": {"head_sha": "f" * 40},
+            },
+        }
+        pack = build_oversight_pack(
+            [], window_days=30, now=NOW, settlement_attestations=[no_digest]
+        )
+        assert pack["summary"]["settlement_attestations"] == 0
+        assert (
+            "status-to-receipt binding absent"
+            in (pack["settlement_attestations_invalid"][0]["invalid_reason"])
+        )
+
     def test_odr_verdict_field_normalized(self) -> None:
         """The ODR exporter/schema use claim.verdict (round-3 finding: reading
         claim.decision produced blank verdicts for real ODR inputs); legacy
@@ -362,7 +405,8 @@ class TestBuildPack:
                     "type": "settlement_status",
                     "ref": "https://api.github.com/repos/o/r/statuses/old",
                 },
-                "observed": {"head_sha": "c" * 40},
+                "execution_identity": {"id": "agent-bot"},
+                "observed": {"head_sha": "c" * 40, "evidence_digest": "sha256:" + "2" * 64},
             },
         }
         pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[stale])
@@ -382,7 +426,8 @@ class TestBuildPack:
                     "type": "settlement_status",
                     "ref": "https://api.github.com/repos/o/r/statuses/x",
                 },
-                "observed": {"head_sha": "d" * 40},
+                "execution_identity": {"id": "agent-bot"},
+                "observed": {"head_sha": "d" * 40, "evidence_digest": "sha256:" + "3" * 64},
             },
         }
         pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[bad])

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -110,7 +110,55 @@ class TestBuildPack:
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
         assert by_clause["14(1)"]["status"] == "partial"
         assert by_clause["14(4)(d)"]["status"] == "partial"
+        # Content-dependent clauses need the evidence fields, not mere
+        # receipt presence: a bare native receipt carries verdict+confidence
+        # (14(2)) but no responses/dissent/reasoning.
         assert by_clause["14(2)"]["status"] == "satisfied"
+        assert by_clause["14(4)(a)"]["status"] == "partial"
+        assert by_clause["14(4)(b)"]["status"] == "partial"
+        assert by_clause["14(4)(c)"]["status"] == "partial"
+
+    def test_content_clauses_need_actual_evidence_fields(self) -> None:
+        """Round-5 finding (claude): clause presence must be computed from the
+        evidence fields the clause names, never from receipt presence."""
+        rich = {
+            "receipt_id": "r-rich",
+            "timestamp": "2026-07-10T00:00:00+00:00",
+            "verdict": "PASS",
+            "confidence": 0.9,
+            "dissenting_views": ["grok: latency risk"],
+            "agent_responses": [{"agent": "a", "response": "supported"}],
+            "verdict_reasoning": "Consensus reached with strong agreement",
+        }
+        pack = build_oversight_pack([rich], window_days=30, now=NOW)
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        for clause in ("14(2)", "14(4)(a)", "14(4)(b)", "14(4)(c)"):
+            assert by_clause[clause]["status"] == "satisfied", clause
+        entry = pack["receipts"][0]
+        assert entry["evidence"] == {
+            "has_confidence": True,
+            "has_responses": True,
+            "has_dissent_record": True,
+            "has_reasoning": True,
+        }
+        # Mixed evidence: one rich + one bare receipt -> partial with counts.
+        pack = build_oversight_pack(
+            [rich, _native("r-bare", "2026-07-11T00:00:00+00:00")],
+            window_days=30,
+            now=NOW,
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(4)(a)"]["status"] == "partial"
+        assert "1/2" in by_clause["14(4)(a)"]["status_basis"]
+
+    def test_odr_absent_blocks_do_not_count_as_evidence(self) -> None:
+        doc = _odr("r-abs", "2026-07-10T00:00:00+00:00", attested=False)
+        doc["reasoning"] = {"status": "absent", "reason": "none recorded"}
+        doc["quorum"] = {"status": "absent", "reason": "none recorded"}
+        pack = build_oversight_pack([doc], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["evidence"]["has_reasoning"] is False
+        assert entry["evidence"]["has_responses"] is False
 
     def test_bare_human_attested_block_not_trusted(self) -> None:
         """A block claiming human_attested without attestor/when/mechanism is

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -278,6 +278,23 @@ class TestBuildPack:
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
         assert by_clause["14(1)"]["status"] == "partial"
 
+    def test_autonomous_block_does_not_leak_oversight_fields(self) -> None:
+        """Round-10 finding: attestor/mechanism on a non-human disposition
+        must not enter the entry or the audit summary."""
+        doc = _odr("r-auto", "2026-07-10T00:00:00+00:00", attested=False)
+        doc["attestation"] = {
+            "disposition": "autonomous",
+            "attestor": {"id": "stray-identity"},
+            "mechanism": {"type": "settlement_status"},
+        }
+        pack = build_oversight_pack([doc], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "autonomous"
+        assert "attestor" not in entry
+        assert "mechanism" not in entry
+        assert pack["summary"]["attestor_identities"] == []
+        assert pack["summary"]["mechanisms"] == {}
+
     def test_odr_verdict_field_normalized(self) -> None:
         """The ODR exporter/schema use claim.verdict (round-3 finding: reading
         claim.decision produced blank verdicts for real ODR inputs); legacy

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -314,6 +314,26 @@ class TestBuildPack:
             assert entry["attestation_invalid_reason"] == reason
             assert pack["summary"]["human_attested"] == 0
 
+    def test_receipt_attestation_timestamp_windowed(self) -> None:
+        """Round-12 finding: receipt-level attestations get the same
+        parse/window discipline as settlement entries."""
+        unparseable = _odr("r-when", "2026-07-10T00:00:00+00:00", attested=True)
+        unparseable["attestation"]["attested_at"] = "yesterday-ish"
+        pack = build_oversight_pack([unparseable], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert entry["attestation_invalid_reason"] == "unparseable attested_at"
+        assert pack["summary"]["human_attested"] == 0
+
+        stale = _odr("r-old", "2026-07-10T00:00:00+00:00", attested=True)
+        stale["attestation"]["attested_at"] = "2026-01-01T00:00:00+00:00"
+        pack = build_oversight_pack([stale], window_days=30, now=NOW)
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert entry["attestation_invalid_reason"] == "attested_at outside pack window"
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "partial"
+
     def test_odr_verdict_field_normalized(self) -> None:
         """The ODR exporter/schema use claim.verdict (round-3 finding: reading
         claim.decision produced blank verdicts for real ODR inputs); legacy

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -1,0 +1,215 @@
+"""Article 14 oversight evidence pack (#8230).
+
+Acceptance: the pack cites real receipts (native or ODR) over a window with
+per-receipt dispositions, honest exclusions, computed clause statuses, and a
+tamper-evidence digest; the CLI command produces JSON + Markdown.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from aragora.compliance.oversight_pack import (
+    ARTICLE_14_CLAUSES,
+    build_oversight_pack,
+    load_receipts_from_dirs,
+    render_oversight_pack_markdown,
+)
+
+NOW = datetime(2026, 7, 17, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _native(receipt_id: str, ts: str, verdict: str = "PASS") -> dict:
+    return {
+        "receipt_id": receipt_id,
+        "timestamp": ts,
+        "verdict": verdict,
+        "confidence": 0.9,
+    }
+
+
+def _odr(receipt_id: str, ts: str, attested: bool) -> dict:
+    doc = {
+        "odr_version": "0.1",
+        "receipt_id": receipt_id,
+        "issued_at": ts,
+        "claim": {"decision": "PASS"},
+        "confidence": {"value": 0.8},
+        "attestation": {"disposition": "autonomous"},
+    }
+    if attested:
+        doc["attestation"] = {
+            "disposition": "human_attested",
+            "attestor": {"id": "scarmani", "role": "oversight"},
+            "attested_at": ts,
+            "observed": {"head_sha": "b" * 40, "evidence_digest": "sha256:" + "a" * 64},
+            "mechanism": {"type": "settlement_status", "context": "aragora/human-settlement"},
+        }
+    return doc
+
+
+class TestBuildPack:
+    def test_windowing_and_dispositions(self) -> None:
+        receipts = [
+            _native("in-window-auto", "2026-07-10T00:00:00+00:00"),
+            _odr("in-window-attested", "2026-07-12T00:00:00+00:00", attested=True),
+            _native("too-old", "2026-05-01T00:00:00+00:00"),
+            _native("no-timestamp", ""),
+        ]
+        pack = build_oversight_pack(receipts, window_days=30, now=NOW)
+        summary = pack["summary"]
+        assert summary["receipts_in_window"] == 2
+        assert summary["human_attested"] == 1
+        assert summary["autonomous"] == 1
+        assert summary["excluded_out_of_window"] == 1
+        assert summary["excluded_no_timestamp"] == 1
+        assert summary["attestor_identities"] == ["scarmani"]
+        assert summary["mechanisms"] == {"settlement_status": 1}
+
+    def test_attestations_map_upgrades_native_receipt(self) -> None:
+        att = {
+            "disposition": "human_attested",
+            "attestor": {"id": "scarmani"},
+            "attested_at": "2026-07-10T01:00:00+00:00",
+            "mechanism": {"type": "preapproval_comment"},
+        }
+        pack = build_oversight_pack(
+            [_native("r1", "2026-07-10T00:00:00+00:00")],
+            window_days=30,
+            now=NOW,
+            attestations={"r1": att},
+        )
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "human_attested"
+        assert entry["attestor"] == "scarmani"
+        assert entry["mechanism"] == "preapproval_comment"
+
+    def test_clause_statuses_with_attestation(self) -> None:
+        pack = build_oversight_pack(
+            [_odr("r1", "2026-07-10T00:00:00+00:00", attested=True)],
+            window_days=30,
+            now=NOW,
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert len(by_clause) == len(ARTICLE_14_CLAUSES)
+        assert by_clause["14(1)"]["status"] == "satisfied"
+        assert by_clause["14(4)(d)"]["status"] == "satisfied"
+        # 14(4)(e) is capped at partial by design: receipts alone cannot
+        # evidence interruption capability.
+        assert by_clause["14(4)(e)"]["status"] == "partial"
+
+    def test_clause_statuses_without_attestation_are_honest(self) -> None:
+        pack = build_oversight_pack(
+            [_native("r1", "2026-07-10T00:00:00+00:00")], window_days=30, now=NOW
+        )
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "partial"
+        assert by_clause["14(4)(d)"]["status"] == "partial"
+        assert by_clause["14(2)"]["status"] == "satisfied"
+
+    def test_empty_window_all_partial_or_honest(self) -> None:
+        pack = build_oversight_pack([], window_days=30, now=NOW)
+        assert pack["summary"]["receipts_in_window"] == 0
+        assert all(c["status"] == "partial" for c in pack["article_14_mapping"])
+
+    def test_integrity_digest_stable_and_tamper_evident(self) -> None:
+        receipts = [_odr("r1", "2026-07-10T00:00:00+00:00", attested=True)]
+        pack1 = build_oversight_pack(receipts, window_days=30, now=NOW)
+        pack2 = build_oversight_pack(receipts, window_days=30, now=NOW)
+        assert pack1["integrity"]["content_digest"] == pack2["integrity"]["content_digest"]
+        pack3 = build_oversight_pack(
+            [_odr("r1", "2026-07-10T00:00:00+00:00", attested=False)],
+            window_days=30,
+            now=NOW,
+        )
+        assert pack1["integrity"]["content_digest"] != pack3["integrity"]["content_digest"]
+
+    def test_pack_is_json_serializable(self) -> None:
+        pack = build_oversight_pack(
+            [_odr("r1", "2026-07-10T00:00:00+00:00", attested=True)],
+            window_days=30,
+            now=NOW,
+        )
+        json.dumps(pack)
+
+    def test_source_paths_carried(self) -> None:
+        pack = build_oversight_pack(
+            [(_native("r1", "2026-07-10T00:00:00+00:00"), "docs/receipts/r1.json")],
+            window_days=30,
+            now=NOW,
+        )
+        assert pack["receipts"][0]["source"] == "docs/receipts/r1.json"
+
+
+class TestMarkdown:
+    def test_render_contains_clauses_and_receipts(self) -> None:
+        pack = build_oversight_pack(
+            [_odr("receipt-abc", "2026-07-10T00:00:00+00:00", attested=True)],
+            window_days=30,
+            now=NOW,
+        )
+        md = render_oversight_pack_markdown(pack)
+        assert "Article 14" in md
+        assert "14(4)(e)" in md
+        assert "receipt-abc"[:16] in md
+        assert "scarmani" in md
+        assert pack["integrity"]["content_digest"] in md
+
+
+class TestLoader:
+    def test_loads_receipts_and_skips_junk(self, tmp_path: Path) -> None:
+        (tmp_path / "a.json").write_text(
+            json.dumps(_native("r1", "2026-07-10T00:00:00+00:00")), encoding="utf-8"
+        )
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "b.json").write_text(
+            json.dumps(_odr("r2", "2026-07-11T00:00:00+00:00", attested=True)),
+            encoding="utf-8",
+        )
+        (tmp_path / "junk.json").write_text("[1,2,3]", encoding="utf-8")
+        (tmp_path / "broken.json").write_text("{not json", encoding="utf-8")
+        loaded = load_receipts_from_dirs([tmp_path, tmp_path / "missing"])
+        ids = sorted(receipt["receipt_id"] for receipt, _ in loaded)
+        assert ids == ["r1", "r2"]
+        assert all(str(tmp_path) in source for _, source in loaded)
+
+
+class TestCli:
+    def test_cli_writes_json_and_markdown(self, tmp_path: Path) -> None:
+        from aragora.cli.commands.compliance import _cmd_oversight_pack
+
+        receipts_dir = tmp_path / "receipts"
+        receipts_dir.mkdir()
+        recent = datetime.now(timezone.utc).isoformat()
+        (receipts_dir / "r1.json").write_text(
+            json.dumps(_odr("r-cli-1", recent, attested=True)), encoding="utf-8"
+        )
+        out_json = tmp_path / "pack.json"
+        out_md = tmp_path / "pack.md"
+        args = argparse.Namespace(
+            window="30d",
+            receipts_dirs=[str(receipts_dir)],
+            attestations=None,
+            output=str(out_json),
+            markdown=str(out_md),
+        )
+        _cmd_oversight_pack(args)
+        pack = json.loads(out_json.read_text(encoding="utf-8"))
+        assert pack["summary"]["receipts_in_window"] == 1
+        assert pack["summary"]["human_attested"] == 1
+        assert "Article 14" in out_md.read_text(encoding="utf-8")
+
+    def test_cli_invalid_window_exits(self, tmp_path: Path) -> None:
+        from aragora.cli.commands.compliance import _parse_window_days
+
+        assert _parse_window_days("30d") == 30
+        assert _parse_window_days("12w") == 84
+        assert _parse_window_days("720h") == 30
+        assert _parse_window_days("45") == 45
+        with pytest.raises(SystemExit):
+            _parse_window_days("soon")

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -38,7 +38,7 @@ def _odr(receipt_id: str, ts: str, attested: bool) -> dict:
         "odr_version": "0.1",
         "receipt_id": receipt_id,
         "issued_at": ts,
-        "claim": {"decision": "PASS"},
+        "claim": {"verdict": "PASS"},
         "confidence": {"value": 0.8},
         "attestation": {"disposition": "autonomous"},
     }
@@ -168,6 +168,55 @@ class TestBuildPack:
         )
         by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
         assert by_clause["14(1)"]["status"] == "satisfied"
+
+    def test_odr_verdict_field_normalized(self) -> None:
+        """The ODR exporter/schema use claim.verdict (round-3 finding: reading
+        claim.decision produced blank verdicts for real ODR inputs); legacy
+        claim.decision still tolerated."""
+        pack = build_oversight_pack(
+            [_odr("r-v", "2026-07-10T00:00:00+00:00", attested=False)],
+            window_days=30,
+            now=NOW,
+        )
+        assert pack["receipts"][0]["verdict"] == "PASS"
+        legacy = _odr("r-d", "2026-07-10T00:00:00+00:00", attested=False)
+        legacy["claim"] = {"decision": "FAIL"}
+        pack = build_oversight_pack([legacy], window_days=30, now=NOW)
+        assert pack["receipts"][0]["verdict"] == "FAIL"
+
+    def test_out_of_window_settlement_not_counted(self) -> None:
+        """An old externally supplied settlement must not satisfy a fresh
+        pack's identity clauses (round-3 finding)."""
+        stale = {
+            "pr": 3,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "attested_at": "2026-01-01T00:00:00+00:00",
+                "mechanism": {"type": "settlement_status"},
+            },
+        }
+        pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[stale])
+        assert pack["summary"]["settlement_attestations"] == 0
+        assert pack["summary"]["settlement_attestations_out_of_window"] == 1
+        by_clause = {c["clause"]: c for c in pack["article_14_mapping"]}
+        assert by_clause["14(1)"]["status"] == "partial"
+
+    def test_unparseable_attested_at_settlement_invalid(self) -> None:
+        bad = {
+            "pr": 4,
+            "attestation": {
+                "disposition": "human_attested",
+                "attestor": {"id": "overseer"},
+                "attested_at": "yesterday-ish",
+                "mechanism": {"type": "settlement_status"},
+            },
+        }
+        pack = build_oversight_pack([], window_days=30, now=NOW, settlement_attestations=[bad])
+        assert pack["summary"]["settlement_attestations"] == 0
+        assert pack["settlement_attestations_invalid"][0]["invalid_reason"] == (
+            "unparseable attested_at"
+        )
 
     def test_empty_window_all_partial_or_honest(self) -> None:
         pack = build_oversight_pack([], window_days=30, now=NOW)

--- a/tests/compliance/test_oversight_pack.py
+++ b/tests/compliance/test_oversight_pack.py
@@ -195,6 +195,20 @@ class TestBuildPack:
         assert pack["receipts"][0]["disposition"] == "invalid_attestation"
         assert pack["summary"]["human_attested"] == 0
 
+    def test_non_object_attestations_value_reported_not_crash(self) -> None:
+        """Round-6 finding (openai P3): a non-object --attestations value must
+        be reported as an invalid attestation, not crash the pack."""
+        pack = build_oversight_pack(
+            [_native("r1", "2026-07-10T00:00:00+00:00")],
+            window_days=30,
+            now=NOW,
+            attestations={"r1": "human_attested"},
+        )
+        entry = pack["receipts"][0]
+        assert entry["disposition"] == "invalid_attestation"
+        assert entry["attestation_invalid_reason"] == "attestation block is not an object"
+        assert pack["summary"]["human_attested"] == 0
+
     def test_invalid_settlement_attestations_reported_not_counted(self) -> None:
         good = {
             "pr": 1,

--- a/tests/gauntlet/test_attestation.py
+++ b/tests/gauntlet/test_attestation.py
@@ -231,6 +231,23 @@ class TestOdrIntegration:
         assert not result.ok
         assert any("mechanism.type" in str(c.detail) for c in result.checks)
 
+    def test_verifier_rejects_self_attested_odr(self) -> None:
+        """Round-10 finding: a hand-crafted ODR with attestor == execution
+        identity must fail verification, not just builder construction."""
+        from aragora.gauntlet.odr_verify import verify_odr_document
+
+        odr = decision_receipt_to_odr(_receipt())
+        odr["attestation"] = {
+            "disposition": "human_attested",
+            "attestor": {"id": "an0mium"},
+            "execution_identity": {"id": "An0mium"},
+            "attested_at": "2026-07-17T12:00:00+00:00",
+            "mechanism": {"type": "settlement_status"},
+        }
+        result = verify_odr_document(odr)
+        assert not result.ok
+        assert any("must differ" in str(c.detail) for c in result.checks)
+
     def test_odr_schema_validates_attested_receipt(self) -> None:
         import json
         from pathlib import Path

--- a/tests/gauntlet/test_attestation.py
+++ b/tests/gauntlet/test_attestation.py
@@ -183,6 +183,38 @@ class TestOdrIntegration:
         odr = decision_receipt_to_odr(_receipt())
         assert odr["attestation"] == {"disposition": "autonomous"}
 
+    def test_hand_rolled_verifier_accepts_attested_receipt(self) -> None:
+        """The dependency-free verifier must accept the oversight members
+        (openai review round 1 on #9417: schema was extended but the
+        odr_verify allowlist was not)."""
+        from aragora.gauntlet.odr_verify import verify_odr_document
+
+        att = build_oversight_attestation(
+            attestor_id="scarmani",
+            attested_at="2026-07-17T12:34:56+00:00",
+            mechanism_type="settlement_status",
+            mechanism_context=HUMAN_SETTLEMENT_CONTEXT,
+            head_sha=HEAD_SHA,
+            evidence_digest=f"sha256:{RECEIPT_SHA}",
+            execution_identity_id="an0mium",
+        )
+        odr = decision_receipt_to_odr(_receipt(), attestation=att.to_dict())
+        result = verify_odr_document(odr)
+        assert result.ok, [c for c in result.checks if c.status == "fail"]
+
+    def test_hand_rolled_verifier_rejects_malformed_mechanism(self) -> None:
+        from aragora.gauntlet.odr_verify import verify_odr_document
+
+        odr = decision_receipt_to_odr(_receipt())
+        odr["attestation"] = {
+            "disposition": "human_attested",
+            "attestor": {"id": "scarmani"},
+            "mechanism": {"context": "missing-type"},
+        }
+        result = verify_odr_document(odr)
+        assert not result.ok
+        assert any("mechanism.type" in str(c.detail) for c in result.checks)
+
     def test_odr_schema_validates_attested_receipt(self) -> None:
         import json
         from pathlib import Path

--- a/tests/gauntlet/test_attestation.py
+++ b/tests/gauntlet/test_attestation.py
@@ -1,0 +1,203 @@
+"""Human-oversight attestation blocks (ODR-6 / #8230).
+
+Acceptance: ODR receipts for human-settled decisions carry the attestation
+block (who/what/when/mechanism); autonomous receipts carry the explicit
+``autonomous`` disposition; self-attestation (oversight identity ==
+execution identity) is refused fail-closed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.gauntlet.attestation import (
+    HUMAN_SETTLEMENT_CONTEXT,
+    OversightAttestation,
+    attestation_from_preapproval_comment,
+    attestation_from_settlement_status,
+    build_oversight_attestation,
+)
+from aragora.gauntlet.odr_export import decision_receipt_to_odr
+from aragora.gauntlet.receipt_models import DecisionReceipt
+
+RECEIPT_SHA = "a" * 64
+HEAD_SHA = "b" * 40
+
+
+def _receipt() -> DecisionReceipt:
+    return DecisionReceipt(
+        receipt_id="r-att-1",
+        gauntlet_id="g-att-1",
+        timestamp="2026-07-17T12:00:00+00:00",
+        input_summary="Should we merge PR #9999?",
+        input_hash="c" * 64,
+        risk_summary={"total": 0},
+        attacks_attempted=0,
+        attacks_successful=0,
+        probes_run=1,
+        vulnerabilities_found=0,
+        verdict="PASS",
+        confidence=0.9,
+        robustness_score=0.8,
+    )
+
+
+class TestBuilder:
+    def test_full_block_shape(self) -> None:
+        att = build_oversight_attestation(
+            attestor_id="scarmani",
+            attested_at="2026-07-17T12:34:56+00:00",
+            mechanism_type="settlement_status",
+            mechanism_context=HUMAN_SETTLEMENT_CONTEXT,
+            mechanism_ref="https://api.github.com/repos/o/r/statuses/abc",
+            head_sha=HEAD_SHA,
+            evidence_digest=f"sha256:{RECEIPT_SHA}",
+            execution_identity_id="an0mium",
+        )
+        block = att.to_dict()
+        assert block["disposition"] == "human_attested"
+        assert block["attestor"] == {"id": "scarmani", "role": "oversight"}
+        assert block["execution_identity"] == {"id": "an0mium"}
+        assert block["attested_at"] == "2026-07-17T12:34:56+00:00"
+        assert block["observed"]["head_sha"] == HEAD_SHA
+        assert block["observed"]["evidence_digest"] == f"sha256:{RECEIPT_SHA}"
+        assert block["mechanism"]["type"] == "settlement_status"
+        assert block["mechanism"]["context"] == HUMAN_SETTLEMENT_CONTEXT
+
+    def test_self_attestation_refused(self) -> None:
+        """Oversight identity == execution identity must fail closed (TET H2)."""
+        with pytest.raises(ValueError, match="must differ"):
+            build_oversight_attestation(
+                attestor_id="an0mium",
+                attested_at="2026-07-17T12:00:00+00:00",
+                mechanism_type="settlement_status",
+                execution_identity_id="an0mium",
+            )
+
+    def test_self_attestation_refused_case_insensitive(self) -> None:
+        with pytest.raises(ValueError, match="must differ"):
+            build_oversight_attestation(
+                attestor_id="Scarmani",
+                attested_at="2026-07-17T12:00:00+00:00",
+                mechanism_type="manual",
+                execution_identity_id="scarmani",
+            )
+
+    def test_missing_attestor_refused(self) -> None:
+        with pytest.raises(ValueError, match="attestor_id"):
+            OversightAttestation(
+                attestor_id="  ",
+                attested_at="2026-07-17T12:00:00+00:00",
+                mechanism_type="manual",
+            )
+
+    def test_missing_timestamp_refused(self) -> None:
+        with pytest.raises(ValueError, match="attested_at"):
+            OversightAttestation(attestor_id="scarmani", attested_at="", mechanism_type="manual")
+
+    def test_unknown_mechanism_refused(self) -> None:
+        with pytest.raises(ValueError, match="mechanism_type"):
+            OversightAttestation(
+                attestor_id="scarmani",
+                attested_at="2026-07-17T12:00:00+00:00",
+                mechanism_type="vibes",
+            )
+
+
+class TestFromSettlementStatus:
+    def _status(self) -> dict:
+        return {
+            "creator": {"login": "scarmani"},
+            "created_at": "2026-07-17T13:00:00Z",
+            "context": HUMAN_SETTLEMENT_CONTEXT,
+            "description": f"Settlement receipt {RECEIPT_SHA} recorded for PR #9999",
+            "url": "https://api.github.com/repos/o/r/statuses/xyz",
+        }
+
+    def test_maps_status_fields(self) -> None:
+        att = attestation_from_settlement_status(
+            self._status(), head_sha=HEAD_SHA, execution_identity_id="an0mium"
+        )
+        block = att.to_dict()
+        assert block["attestor"]["id"] == "scarmani"
+        assert block["attested_at"] == "2026-07-17T13:00:00Z"
+        assert block["observed"]["head_sha"] == HEAD_SHA
+        assert block["observed"]["evidence_digest"] == f"sha256:{RECEIPT_SHA}"
+        assert block["mechanism"]["context"] == HUMAN_SETTLEMENT_CONTEXT
+        assert block["mechanism"]["ref"].endswith("/statuses/xyz")
+
+    def test_status_by_execution_identity_refused(self) -> None:
+        """The #8169 precedent gap: a settlement status created by the
+        executing identity is not human oversight."""
+        status = self._status()
+        status["creator"] = {"login": "an0mium"}
+        with pytest.raises(ValueError, match="must differ"):
+            attestation_from_settlement_status(
+                status, head_sha=HEAD_SHA, execution_identity_id="an0mium"
+            )
+
+    def test_description_without_digest(self) -> None:
+        status = self._status()
+        status["description"] = "settled"
+        att = attestation_from_settlement_status(status, head_sha=HEAD_SHA)
+        assert "evidence_digest" not in att.to_dict().get("observed", {})
+
+
+class TestFromPreapprovalComment:
+    def test_maps_comment_fields(self) -> None:
+        att = attestation_from_preapproval_comment(
+            {
+                "user": {"login": "scarmani"},
+                "created_at": "2026-07-17T14:00:00Z",
+                "html_url": "https://github.com/o/r/pull/1#issuecomment-5",
+            },
+            head_sha=HEAD_SHA,
+            evidence_digest=f"sha256:{RECEIPT_SHA}",
+            execution_identity_id="an0mium",
+        )
+        block = att.to_dict()
+        assert block["mechanism"]["type"] == "preapproval_comment"
+        assert block["mechanism"]["ref"].endswith("#issuecomment-5")
+        assert block["attestor"]["id"] == "scarmani"
+
+
+class TestOdrIntegration:
+    def test_human_settled_odr_carries_attestation(self) -> None:
+        att = attestation_from_settlement_status(
+            {
+                "creator": {"login": "scarmani"},
+                "created_at": "2026-07-17T13:00:00Z",
+                "context": HUMAN_SETTLEMENT_CONTEXT,
+                "description": f"Settlement receipt {RECEIPT_SHA} recorded for PR #9999",
+                "url": "https://api.github.com/repos/o/r/statuses/xyz",
+            },
+            head_sha=HEAD_SHA,
+            execution_identity_id="an0mium",
+        )
+        odr = decision_receipt_to_odr(_receipt(), attestation=att.to_dict())
+        assert odr["attestation"]["disposition"] == "human_attested"
+        assert odr["attestation"]["attestor"]["id"] == "scarmani"
+        assert odr["attestation"]["observed"]["head_sha"] == HEAD_SHA
+
+    def test_autonomous_disposition_is_explicit(self) -> None:
+        odr = decision_receipt_to_odr(_receipt())
+        assert odr["attestation"] == {"disposition": "autonomous"}
+
+    def test_odr_schema_validates_attested_receipt(self) -> None:
+        import json
+        from pathlib import Path
+
+        import jsonschema
+
+        schema = json.loads(Path("aragora/gauntlet/odr_schema.json").read_text(encoding="utf-8"))
+        att = build_oversight_attestation(
+            attestor_id="scarmani",
+            attested_at="2026-07-17T12:34:56+00:00",
+            mechanism_type="settlement_status",
+            mechanism_context=HUMAN_SETTLEMENT_CONTEXT,
+            head_sha=HEAD_SHA,
+            evidence_digest=f"sha256:{RECEIPT_SHA}",
+            execution_identity_id="an0mium",
+        )
+        odr = decision_receipt_to_odr(_receipt(), attestation=att.to_dict())
+        jsonschema.validate(odr, schema)

--- a/tests/gauntlet/test_attestation.py
+++ b/tests/gauntlet/test_attestation.py
@@ -110,6 +110,7 @@ class TestFromSettlementStatus:
             "creator": {"login": "scarmani"},
             "created_at": "2026-07-17T13:00:00Z",
             "context": HUMAN_SETTLEMENT_CONTEXT,
+            "state": "success",
             "description": f"Settlement receipt {RECEIPT_SHA} recorded for PR #9999",
             "url": "https://api.github.com/repos/o/r/statuses/xyz",
         }
@@ -135,6 +136,20 @@ class TestFromSettlementStatus:
             attestation_from_settlement_status(
                 status, head_sha=HEAD_SHA, execution_identity_id="an0mium"
             )
+
+    def test_non_settlement_context_refused(self) -> None:
+        """Public-API hardening (round-7 finding): an arbitrary CI status can
+        never be converted into countable oversight evidence."""
+        status = self._status()
+        status["context"] = "ci/build"
+        with pytest.raises(ValueError, match="settlement context"):
+            attestation_from_settlement_status(status, head_sha=HEAD_SHA)
+
+    def test_non_success_state_refused(self) -> None:
+        status = self._status()
+        status["state"] = "failure"
+        with pytest.raises(ValueError, match="must be 'success'"):
+            attestation_from_settlement_status(status, head_sha=HEAD_SHA)
 
     def test_description_without_digest(self) -> None:
         status = self._status()
@@ -168,6 +183,7 @@ class TestOdrIntegration:
                 "creator": {"login": "scarmani"},
                 "created_at": "2026-07-17T13:00:00Z",
                 "context": HUMAN_SETTLEMENT_CONTEXT,
+                "state": "success",
                 "description": f"Settlement receipt {RECEIPT_SHA} recorded for PR #9999",
                 "url": "https://api.github.com/repos/o/r/statuses/xyz",
             },


### PR DESCRIPTION
## Summary

Implements [#8230](https://github.com/synaptent/aragora/issues/8230) (ODR-6): the machine-readable human-oversight attestation block + the `aragora compliance oversight-pack` evidence-bundle generator — converting this repo's own credential-separated human gate into the sellable Art. 14 artifact ahead of the **Aug 2, 2026** EU AI Act deadline. W2→W3 critical path of the 30-day external-proof plan (the W3 bundle builds on this).

### 1. Attestation block (`aragora/gauntlet/attestation.py`)

The machine-readable form of what this repo already does manually for Tier-4: **who** accepted the risk (oversight identity), **what they saw** (head SHA, evidence digest), **when**, **via what mechanism** (settlement status creator / preapproval comment ref).

- **Identity separation enforced at construction**: attestor == execution identity raises — self-attestation is refused fail-closed. This mechanically closes the #8169 precedent gap named in TET H2 (a settlement status recorded by the executing identity is not oversight).
- Builders: `attestation_from_settlement_status` (the head-bound `aragora/human-settlement` status; creator login = oversight identity, description's embedded receipt SHA-256 = evidence digest) and `attestation_from_preapproval_comment`.
- `to_dict()` feeds `decision_receipt_to_odr(attestation=...)` unchanged; autonomous receipts keep the existing explicit `{"disposition": "autonomous"}` (absence recorded, never implied).
- `odr_schema.json` (both copies, byte-identical): **additive optional** attestation properties `execution_identity` / `observed` / `mechanism` — pre-existing receipts validate unchanged.

### 2. Evidence pack (`aragora/compliance/oversight_pack.py` + CLI)

`aragora compliance oversight-pack --window 30d [--receipts-dir ...] [--attestations map.json] --output pack.json [--markdown pack.md]`

- Per-receipt dispositions over the window (native DecisionReceipt and ODR inputs), attestor identities, mechanisms, honest exclusion counts (unparseable timestamps are counted, not dropped).
- **Art. 14 clause mapping with computed statuses** — `satisfied`/`partial` derived from windowed evidence; 14(4)(e) (stop capability) is capped at `partial` by design because receipts alone cannot evidence interruption. Documented for auditors in [docs/compliance/ART14_OVERSIGHT_PACK.md](https://github.com/synaptent/aragora/blob/feat/art14-oversight-8230/docs/compliance/ART14_OVERSIGHT_PACK.md).
- NIST AI RMF cross-references (GOVERN 3.2, MANAGE 2.4, MEASURE 2.10).
- Tamper-evidence: sha256 over the RFC 8785/JCS canonical payload (same basis as ODR content digests).

## Acceptance (from #8230)

- ✅ Human-settled ODR receipts carry the attestation block; autonomous receipts carry the explicit `autonomous` disposition (tested, incl. jsonschema validation)
- ✅ `oversight-pack` cites real receipts from this repo's trail — dogfood run: 30d window over `docs/receipts` + local store = **50 real receipts** (honestly all `autonomous` — the human settlements live as GitHub statuses, supplied via `--attestations`); the attestation builder was verified against **today's real Tier-4 settlement status on #9343** (creator `scarmani`, head-bound, resolvable ref)
- ✅ Documented Art. 14 clause mapping
- ✅ Tier 2-3 scope only: artifact generation; no settlement-verification touch points

## Test plan

- 25 new tests (`tests/gauntlet/test_attestation.py`, `tests/compliance/test_oversight_pack.py`): block shape, self-attestation refusal (incl. case-insensitive + the #8169 scenario), settlement-status/preapproval mapping, ODR integration + schema validation, windowing, disposition counting, honest clause statuses, digest stability/tamper-evidence, markdown render, loader robustness, CLI end-to-end
- Full gauntlet + compliance suites: 2,635 pass; repo mypy clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)