### PR TITLE
test(compliance): oversight_fetch coverage + --fetch-settlements docs (#8230 follow-up)

### DIFF
--- a/docs/compliance/ART14_OVERSIGHT_PACK.md
+++ b/docs/compliance/ART14_OVERSIGHT_PACK.md
@@ -64,7 +64,37 @@ aragora compliance oversight-pack --window 30d \
 aragora compliance oversight-pack --window 12w \
   --receipts-dir docs/receipts --receipts-dir /path/to/odr/exports \
   --attestations attestations.json
+
+# Auto-fetch human-settlement attestations from the GitHub trail
+# (walks merged PRs' aragora/human-settlement commit statuses via gh)
+aragora compliance oversight-pack --window 30d --fetch-settlements \
+  --repo owner/name   # --repo optional; resolved from cwd via gh
 ```
+
+### Auto-fetched settlement attestations (`--fetch-settlements`)
+
+`aragora/compliance/oversight_fetch.py` automates the `--attestations`
+input from the trail itself: it lists merged PRs in the window, reads each
+head's commit statuses, and converts every successful head-bound
+`aragora/human-settlement` status into an attestation via
+`attestation_from_settlement_status` (status `creator.login` = oversight
+identity, PR author = execution identity). The same honesty rules apply
+end-to-end:
+
+- **Self-settled PRs are refused** — a settlement whose status creator
+  equals the PR's executing author fails the builder's identity-separation
+  check and lands in the pack's `settlement_fetch.skipped` list with the
+  reason, never silently kept *or* dropped.
+- **Windowing is double-checked** — both the PR merge time and the status
+  `created_at` must fall inside the window.
+- **Completeness is persisted** — a scan that fills the PR limit is flagged
+  `truncated`, and per-PR fetch failures are recorded in `skipped`; both
+  live in the pack's `settlement_fetch` section (and the Markdown report),
+  not just console output.
+- Trail settlements are aggregated in the pack's `settlement_attestations`
+  section and count toward the identity-dependent clauses (14(1), 14(3),
+  14(4)(d)) as *mechanism-operating* evidence; alone (unmatched to windowed
+  receipts) they cap those clauses at `partial`, never `satisfied`.
 
 The pack contains: per-receipt entries (id, timestamp, verdict, disposition,
 attestor, mechanism, observed evidence), summary counts, the clause mapping

--- a/tests/compliance/test_oversight_fetch.py
+++ b/tests/compliance/test_oversight_fetch.py
@@ -226,6 +226,83 @@ class TestFetcher:
         with pytest.raises(ValueError, match="could not resolve repo"):
             fetch_settlement_attestations(window_days=30, now=NOW, gh_runner=run)
 
+    def test_statuses_fetch_failure_skipped_with_reason(self) -> None:
+        """A malformed statuses payload (json.loads ValueError in the real
+        gh path) must skip that PR with the reason — never abort the scan or
+        silently drop the PR."""
+
+        def run(args):
+            if args[:2] == ["pr", "list"]:
+                return [
+                    {
+                        "number": 500,
+                        "url": "u",
+                        "mergedAt": "2026-07-16T10:00:00Z",
+                        "headRefOid": "a" * 40,
+                        "author": {"login": "agent-bot"},
+                    },
+                    {
+                        "number": 501,
+                        "url": "u",
+                        "mergedAt": "2026-07-15T10:00:00Z",
+                        "headRefOid": "b" * 40,
+                        "author": {"login": "agent-bot"},
+                    },
+                ]
+            if "a" * 40 in args[1]:
+                raise ValueError("Expecting value: line 1 column 1 (char 0)")
+            return [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-07-15T11:00:00Z",
+                    "description": "settled",
+                    "url": "https://api.github.com/repos/acme/widgets/statuses/b",
+                }
+            ]
+
+        result = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run
+        )
+        # The healthy PR is still attested; the broken one is reported.
+        assert [e["pr"] for e in result["attestations"]] == [501]
+        assert result["skipped"][0]["pr"] == 500
+        assert "statuses fetch failed" in result["skipped"][0]["reason"]
+
+    def test_settlement_attested_outside_window_not_counted(self) -> None:
+        """A settlement status attested before the window cutoff (e.g. an old
+        settlement on a recently re-merged head) must not be counted as
+        in-window oversight."""
+
+        def run(args):
+            if args[:2] == ["pr", "list"]:
+                return [
+                    {
+                        "number": 600,
+                        "url": "u",
+                        "mergedAt": "2026-07-16T10:00:00Z",
+                        "headRefOid": "c" * 40,
+                        "author": {"login": "agent-bot"},
+                    }
+                ]
+            return [
+                {
+                    "context": "aragora/human-settlement",
+                    "state": "success",
+                    "creator": {"login": "overseer"},
+                    "created_at": "2026-01-01T11:00:00Z",  # far before cutoff
+                    "description": "settled",
+                    "url": "https://api.github.com/repos/acme/widgets/statuses/c",
+                }
+            ]
+
+        result = fetch_settlement_attestations(
+            repo="acme/widgets", window_days=30, now=NOW, gh_runner=run
+        )
+        assert result["attestations"] == []
+        assert result["scanned_prs"] == 1
+
 
 class TestFetchReportPersistence:
     def test_fetch_report_persisted_in_pack_and_markdown(self) -> None:


### PR DESCRIPTION
## Summary

The #8230 follow-up ("a fetcher that walks recent settled PRs and builds the `--attestations` map from GitHub statuses automatically") turned out to be **already implemented and merged** — it was added inside PR #9417's final squash (`28afef6f2c`, second squashed commit: *settlement-attestations fetcher for the oversight pack*): `aragora/compliance/oversight_fetch.py`, CLI `aragora compliance oversight-pack --fetch-settlements [--repo owner/name]`, pack `settlement_attestations`/`settlement_fetch` sections, 13 tests.

This PR closes the residual gaps instead of duplicating that work:

- **Tests (2 new, written first, red-branch verified against implementation lines):**
  - a statuses-fetch failure (the malformed-JSON `ValueError` path in `_run_gh`) skips that PR with the recorded `statuses fetch failed` reason while the rest of the scan still attests — never aborts, never silently drops;
  - a `aragora/human-settlement` status attested **before the window cutoff** (old settlement on a recently merged head) is not counted as in-window oversight.
- **Docs:** `docs/compliance/ART14_OVERSIGHT_PACK.md` only documented the manual `--attestations` map; it now documents `--fetch-settlements` — creator-login = oversight identity, PR author = execution identity, fail-closed self-attestation refusal (reported in `settlement_fetch.skipped`), double windowing (merge time AND `created_at`), persisted truncation/completeness, and the partial-cap rule for trail-only settlements on 14(1)/14(3)/14(4)(d).

## Risk

Tier surface: compliance/gauntlet-adjacent, but **no production code changes** — test file + one markdown doc. The oversight-pack behavior, CLI flags, and the fail-closed identity-separation rule are untouched. Generated `docs/reference/CLI_REFERENCE.md` verified up to date (regeneration produced no diff). `docs/METRICS.md` drift observed during regeneration predates this branch and is deliberately not bundled here.

## Validation

- `pytest tests/compliance/test_oversight_fetch.py tests/compliance/test_oversight_pack.py tests/gauntlet/test_attestation.py` — 61 passed
- `ruff check` + `ruff format --check` — clean
- `mypy tests/compliance/test_oversight_fetch.py` (.venv mypy) — no issues
- `node docs-site/scripts/sync-docs.js` — ART14 doc is not in the sync map; no docs-site changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)