### PR TITLE
[codex] align local required typecheck parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ ci: lint typecheck test-fast
 ci-required:
 	@echo "Running required GitHub checks locally..."
 	ruff check aragora/ tests/ scripts/
-	mypy aragora/ --ignore-missing-imports
+	bash scripts/test_tiers.sh typecheck
 	python scripts/check_version_alignment.py
 	python scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json
 	python scripts/check_sdk_namespace_parity.py --strict --baseline scripts/baselines/check_sdk_namespace_parity.json

--- a/tests/scripts/test_ci_required_typecheck_contract.py
+++ b/tests/scripts/test_ci_required_typecheck_contract.py
@@ -1,0 +1,49 @@
+"""Keep the local required-check target aligned with the CI typecheck path."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TYPECHECK_COMMAND = "bash scripts/test_tiers.sh typecheck"
+
+
+def _make_target_commands(target: str) -> list[str]:
+    lines = (ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    start = lines.index(f"{target}:")
+    commands: list[str] = []
+
+    for line in lines[start + 1 :]:
+        if line.startswith("\t"):
+            commands.append(line.removeprefix("\t").strip())
+            continue
+        if line and not line.lstrip().startswith("#"):
+            break
+
+    return commands
+
+
+def _workflow_full_typecheck_command() -> str:
+    workflow = yaml.safe_load((ROOT / ".github/workflows/lint.yml").read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["typecheck-run"]["steps"]
+    step = next(item for item in steps if item.get("name") == "Run full typecheck tier")
+    return str(step["run"])
+
+
+def test_ci_required_uses_the_workflow_typecheck_command() -> None:
+    commands = _make_target_commands("ci-required")
+    workflow_command = _workflow_full_typecheck_command()
+
+    assert commands.count(TYPECHECK_COMMAND) == 1
+    assert TYPECHECK_COMMAND in workflow_command
+
+
+def test_ci_required_does_not_bypass_the_typecheck_tier() -> None:
+    commands = _make_target_commands("ci-required")
+    direct_mypy = re.compile(r"(^|\s)(?:python\s+-m\s+)?mypy(?:\s|$)")
+
+    assert not any(direct_mypy.search(command) for command in commands)


### PR DESCRIPTION
## Summary

Align the local `ci-required` target with the authoritative typecheck path used by the lint workflow.

## Problem

`make ci-required` invoked raw full-repository mypy directly. On current main that reports 1,966 findings, while the repository's required typecheck tier passes with its governed baseline. This made pristine-main health report a local main-red result that did not represent the required workflow contract.

## Fix

- delegate the `ci-required` typecheck step to `bash scripts/test_tiers.sh typecheck`;
- add a contract test that parses both `Makefile` and `.github/workflows/lint.yml` and requires the same authoritative command;
- reject any future direct mypy invocation inside the `ci-required` target.

This is a narrow recut of the local-health parity portion of #8939. It does not modify that PR, workflows, `.mypy-baseline`, `pyproject.toml`, `uv.lock`, or production source files.

## Validation

- `python -m pytest tests/scripts/test_ci_required_typecheck_contract.py -q` (`2 passed`)
- `bash scripts/test_tiers.sh typecheck` (`0 errors`)
- `ruff check tests/scripts/test_ci_required_typecheck_contract.py`
- `ruff format --check tests/scripts/test_ci_required_typecheck_contract.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- commit and push hooks passed
