### PR TITLE
docs(site): sync independent verifier guide mirror

### DIFF
--- a/docs-site/docs/specs/independent-verifier-guide.md
+++ b/docs-site/docs/specs/independent-verifier-guide.md
@@ -151,17 +151,21 @@ have to trust, or even install, the rest of Aragora to check a receipt. The
 `[schema]` extra (`jsonschema`) and `[dev]` extra (`pytest`) are optional and
 not required to verify a receipt.
 
-**Cryptography version-floor risk.** `aragora-verify/pyproject.toml` pins
-`cryptography>=41.0`. The root `aragora` distribution's `[tool.uv]
-constraint-dependencies` floors `cryptography>=48.0.1` (fixing
-[GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf)).
-Because `aragora-verify` is installed standalone, its *own* floor — not the
-root project's — governs what an isolated `pip install aragora-verify`
-resolves to: an environment that already pins an older `cryptography`
-(41.0–47.x) elsewhere can satisfy `aragora-verify`'s declared floor while
-staying on a version with a known, fixed advisory. Raising the floor to
-match is a packaging change to `aragora-verify/pyproject.toml`, not a docs
-change, and is not made by this guide.
+**Cryptography version-floor risk.** Because `aragora-verify` is installed
+standalone, its *own* dependency floor — not the root project's — governs what
+an isolated `pip install aragora-verify` resolves to. The source package now
+declares `cryptography>=48.0.1`, matching the root `aragora` distribution's
+`[tool.uv] constraint-dependencies` floor for
+[GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf).
+The verifier's public API uses stable Ed25519 verification and PEM loading, but
+the packaged wheel still brings in `cryptography`'s OpenSSL-backed distribution;
+the raised floor keeps isolated installs off affected wheels even when Aragora's
+root lockfile is absent. If you are auditing the currently published `0.1.1`
+PyPI line before a `0.1.2` release exists, verify the installed wheel's
+metadata directly or run from this checkout so the raised floor is part of the
+package under test. The local metadata guard test covers the source tree; making
+that guard a required PR workflow is intentionally separate from this packaging
+repair and needs the normal workflow-change approval path.
 
 ## Running from a checkout (no PyPI install)
 


### PR DESCRIPTION
## Summary

Synchronize the generated docs-site mirror of `docs/specs/INDEPENDENT_VERIFIER_GUIDE.md` after the verifier cryptography-floor repair landed on main.

This is the one-file net-negative docs repair identified while advancing #9199. The same drift reproduces on clean `origin/main` at `e14fdaa2e5998eb6f1f8b486538b4befb9fd88ff`, where Build Documentation fails during `Ensure docs are synced`. No open PR owned either the source or mirror path before this branch was claimed.

Part of #9039. Unblocks #9199 and other docs-triggering PRs without folding ambient generated drift into their branches.

## Scope

- `docs-site/docs/specs/independent-verifier-guide.md` only
- no source-doc, workflow, required-context, or policy changes

## Validation

- `python3 scripts/doc_stats.py --write`
- `node docs-site/scripts/sync-docs.js`
- second generator run produced the identical diff digest
- `python3 scripts/check_capability_matrix_sync.py`
- `python3 scripts/check_legacy_entrypoints.py`
- `python3 scripts/generate_cli_reference.py --check`
- `python3 scripts/check_docs_consistency.py`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build` in `docs-site/`
- changed-file pre-commit hooks
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

The Docusaurus build completed successfully with the repository's existing advisory broken-link warnings.
