### PR TITLE
fix(conductor): preserve merge-packet transport failures

### DIFF
--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -1085,6 +1085,13 @@ def _merge_ready_prompt_blocker(merge_packet: Any, *, pr: int | None = None) -> 
     if merge_packet.get("error"):
         detail = _prompt_one_line(merge_packet.get("error")) or "command failed without details"
         return f"merge-packet is unavailable: {detail}"
+    if "returncode" in merge_packet:
+        try:
+            returncode = int(merge_packet["returncode"])
+        except (TypeError, ValueError):
+            return "merge-packet has an invalid command return code"
+        if returncode != 0:
+            return f"merge-packet command failed with return code {returncode}"
     entry = _select_merge_ready_entry(merge_packet, pr=pr)
     if not entry:
         target = f"PR #{pr}" if pr is not None else "admin_squash_order"

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -157,8 +157,10 @@ def _json_or_empty(result: subprocess.CompletedProcess[str]) -> Any:
                 # Overwrite (not setdefault): a child that exits nonzero must not
                 # mask the failure via a stale "returncode": 0 in its own stdout.
                 payload["returncode"] = result.returncode
-                if not payload.get("error") and result.stderr.strip():
-                    payload["error"] = result.stderr.strip()
+                if not payload.get("error"):
+                    payload["error"] = result.stderr.strip() or (
+                        f"command failed with return code {result.returncode}"
+                    )
             return payload
     if result.returncode != 0:
         return {"error": result.stderr.strip(), "returncode": result.returncode}

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -147,7 +147,9 @@ def _json_or_empty(result: subprocess.CompletedProcess[str]) -> Any:
         else:
             if result.returncode != 0 and isinstance(payload, dict):
                 payload = dict(payload)
-                payload.setdefault("returncode", result.returncode)
+                # Overwrite (not setdefault): a child that exits nonzero must not
+                # mask the failure via a stale "returncode": 0 in its own stdout.
+                payload["returncode"] = result.returncode
             return payload
     if result.returncode != 0:
         return {"error": result.stderr.strip(), "returncode": result.returncode}

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -137,15 +137,21 @@ def _repo_runner(repo_root: Path) -> CommandRunner:
 
 
 def _json_or_empty(result: subprocess.CompletedProcess[str]) -> Any:
+    text = (result.stdout or "").strip()
+    if text:
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            if result.returncode == 0:
+                return {"raw": text}
+        else:
+            if result.returncode != 0 and isinstance(payload, dict):
+                payload = dict(payload)
+                payload.setdefault("returncode", result.returncode)
+            return payload
     if result.returncode != 0:
         return {"error": result.stderr.strip(), "returncode": result.returncode}
-    text = (result.stdout or "").strip()
-    if not text:
-        return {}
-    try:
-        return json.loads(text)
-    except json.JSONDecodeError:
-        return {"raw": text}
+    return {}
 
 
 def _run_json(command: list[str], command_runner: CommandRunner) -> Any:
@@ -1071,6 +1077,14 @@ def _live_pr_metadata_blocker(
 def _merge_ready_prompt_blocker(merge_packet: Any, *, pr: int | None = None) -> str:
     if not isinstance(merge_packet, dict) or not merge_packet:
         return "merge-packet is missing or malformed"
+    if merge_packet.get("transport_blocked") or merge_packet.get("status") == "transport_blocked":
+        kind = _prompt_one_line(merge_packet.get("error_kind")) or "unknown transport"
+        detail = _prompt_one_line(merge_packet.get("error")) or "live GitHub transport unavailable"
+        preserve = "; preserve_no_mutate=true" if merge_packet.get("preserve_no_mutate") else ""
+        return f"merge-packet transport blocked ({kind}): {detail}{preserve}"
+    if merge_packet.get("error"):
+        detail = _prompt_one_line(merge_packet.get("error")) or "command failed without details"
+        return f"merge-packet is unavailable: {detail}"
     entry = _select_merge_ready_entry(merge_packet, pr=pr)
     if not entry:
         target = f"PR #{pr}" if pr is not None else "admin_squash_order"

--- a/scripts/build_next_prompt.py
+++ b/scripts/build_next_prompt.py
@@ -145,11 +145,20 @@ def _json_or_empty(result: subprocess.CompletedProcess[str]) -> Any:
             if result.returncode == 0:
                 return {"raw": text}
         else:
-            if result.returncode != 0 and isinstance(payload, dict):
+            if result.returncode != 0:
+                if not isinstance(payload, dict):
+                    return {
+                        "error": result.stderr.strip()
+                        or f"command failed with return code {result.returncode}",
+                        "returncode": result.returncode,
+                        "payload": payload,
+                    }
                 payload = dict(payload)
                 # Overwrite (not setdefault): a child that exits nonzero must not
                 # mask the failure via a stale "returncode": 0 in its own stdout.
                 payload["returncode"] = result.returncode
+                if not payload.get("error") and result.stderr.strip():
+                    payload["error"] = result.stderr.strip()
             return payload
     if result.returncode != 0:
         return {"error": result.stderr.strip(), "returncode": result.returncode}

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -1024,6 +1024,34 @@ def test_merge_ready_packet_preserves_structured_transport_failure(tmp_path: Pat
     assert packet["returncode"] == 1
 
 
+def test_json_or_empty_wraps_non_dict_json_from_failed_command() -> None:
+    payload = [{"name": "lint", "state": "SUCCESS"}]
+    result = subprocess.CompletedProcess(
+        ["gh", "pr", "checks"],
+        1,
+        json.dumps(payload),
+        "HTTP 502: Bad Gateway",
+    )
+
+    assert prompt_builder._json_or_empty(result) == {
+        "error": "HTTP 502: Bad Gateway",
+        "returncode": 1,
+        "payload": payload,
+    }
+
+
+def test_json_or_empty_preserves_non_dict_json_from_successful_command() -> None:
+    payload = [{"name": "lint", "state": "SUCCESS"}]
+    result = subprocess.CompletedProcess(
+        ["gh", "pr", "checks"],
+        0,
+        json.dumps(payload),
+        "",
+    )
+
+    assert prompt_builder._json_or_empty(result) == payload
+
+
 def test_merge_ready_prompt_reports_transport_failure_before_candidate_parsing(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -1047,6 +1047,19 @@ def test_merge_ready_prompt_reports_transport_failure_before_candidate_parsing(
     assert "I authorize normal protected squash merge" not in prompt
 
 
+def test_merge_ready_prompt_rejects_authorized_packet_from_failed_command(
+    tmp_path: Path,
+) -> None:
+    packet = _merge_ready_packet()
+    packet["live_pr"] = _merge_ready_live_pr()
+    packet["returncode"] = 1
+
+    prompt = prompt_builder.build_merge_ready_prompt(packet, repo_root=tmp_path)
+
+    assert "merge-packet command failed with return code 1" in prompt
+    assert "I authorize normal protected squash merge" not in prompt
+
+
 def test_packet_authorizes_blocks_string_not_ready_pr() -> None:
     packet = {
         "entries": [

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -1169,6 +1169,34 @@ def test_merge_ready_packet_adds_live_metadata_for_selected_pr(tmp_path: Path) -
     ] in calls
 
 
+def test_merge_ready_packet_rejects_failed_live_metadata_with_json_stdout(
+    tmp_path: Path,
+) -> None:
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if "merge-packet" in command:
+            return subprocess.CompletedProcess(command, 0, json.dumps(_merge_ready_packet()), "")
+        if command[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                json.dumps(_merge_ready_live_pr()),
+                "",
+            )
+        return subprocess.CompletedProcess(command, 1, "", "unexpected")
+
+    packet = prompt_builder.build_merge_ready_packet(
+        repo_root=tmp_path,
+        pr=7828,
+        command_runner=fake_runner,
+    )
+    prompt = prompt_builder.build_merge_ready_prompt(packet, repo_root=tmp_path, pr=7828)
+
+    assert packet["live_pr"]["returncode"] == 1
+    assert packet["live_pr"]["error"] == "command failed with return code 1"
+    assert "live PR metadata for PR #7828 is unavailable" in prompt
+    assert "I authorize normal protected squash merge" not in prompt
+
+
 def test_decision_packet_detects_merged_pr_with_active_tmux_evidence_lane(
     tmp_path: Path,
 ) -> None:

--- a/tests/scripts/test_build_next_prompt.py
+++ b/tests/scripts/test_build_next_prompt.py
@@ -998,6 +998,55 @@ def test_merge_ready_prompt_fails_closed_for_string_not_ready_entry(tmp_path: Pa
     assert "I authorize normal protected squash merge" not in prompt
 
 
+def test_merge_ready_packet_preserves_structured_transport_failure(tmp_path: Path) -> None:
+    transport_failure = {
+        "status": "transport_blocked",
+        "transport_blocked": True,
+        "preserve_no_mutate": True,
+        "error_kind": "github_transport",
+        "error": "gh pr list failed: HTTP 504: Gateway Timeout",
+        "admin_squash_order": [],
+        "entries": [],
+    }
+
+    def fake_runner(command: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 1, json.dumps(transport_failure), "")
+
+    packet = prompt_builder.build_merge_ready_packet(
+        repo_root=tmp_path,
+        limit=40,
+        command_runner=fake_runner,
+    )
+
+    assert packet["status"] == "transport_blocked"
+    assert packet["error_kind"] == "github_transport"
+    assert packet["preserve_no_mutate"] is True
+    assert packet["returncode"] == 1
+
+
+def test_merge_ready_prompt_reports_transport_failure_before_candidate_parsing(
+    tmp_path: Path,
+) -> None:
+    packet = {
+        "status": "transport_blocked",
+        "transport_blocked": True,
+        "preserve_no_mutate": True,
+        "error_kind": "github_transport",
+        "error": "gh pr list failed: HTTP 504: Gateway Timeout",
+        "admin_squash_order": [],
+        "entries": [],
+        "returncode": 1,
+    }
+
+    prompt = prompt_builder.build_merge_ready_prompt(packet, repo_root=tmp_path)
+
+    assert "merge-packet transport blocked (github_transport)" in prompt
+    assert "HTTP 504: Gateway Timeout" in prompt
+    assert "preserve_no_mutate=true" in prompt
+    assert "missing a parseable pr_number" not in prompt
+    assert "I authorize normal protected squash merge" not in prompt
+
+
 def test_packet_authorizes_blocks_string_not_ready_pr() -> None:
     packet = {
         "entries": [


### PR DESCRIPTION
Program: #9039

## Summary
- preserve structured merge-packet JSON when the helper exits nonzero
- report GitHub transport failures and preserve/no-mutate state before candidate parsing
- keep exact-head, tier, settlement, and merge authorization gates unchanged

## Reproduction
Before this repair, a queue-wide GraphQL 504 produced: `merge-packet ready entry is missing a parseable pr_number`.

After this repair, the same live failure reports `merge-packet transport blocked (github_transport)` with the HTTP 504 detail and `preserve_no_mutate=true`.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/scripts/test_build_next_prompt.py -p no:rerunfailures -p no:cacheprovider` (52 passed)
- `python3 -m ruff check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py`
- `python3 -m ruff format --check scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py`
- `python3 -m py_compile scripts/build_next_prompt.py tests/scripts/test_build_next_prompt.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

Draft only. No CI rerun, evidence posting, settlement, or merge was performed.