### PR TITLE
fix(preflight): allow canonical rescue proof artifacts (#6598)

### DIFF
--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -31,7 +31,7 @@ Checks:
   - branch has a non-empty diff versus the base
   - diff has no whitespace errors
   - session/log/coordination artifacts are not committed
-  - rescue productization publish artifacts are not committed
+  - non-canonical rescue productization publish artifacts are not committed
   - synthetic preflight validation commits/scratch diffs are not published
   - source changes without test changes are called out for operator review
 EOF
@@ -185,8 +185,9 @@ if [[ -n "${forbidden_files}" ]]; then
     exit 1
 fi
 
-rescue_publish_regex='(^|/)rescue-productization-[0-9]{8}T[0-9]{6}Z\.json$|(^|/)(rescue_productization|rescue-productization)(/.*)?/(latest\.json|rescue-productization-[0-9]{8}T[0-9]{6}Z\.json)$'
-rescue_publish_files="$(printf '%s\n' "${changed_files}" | grep -E "${rescue_publish_regex}" || true)"
+rescue_publish_regex='(^|/)rescue-productization-[^/]*\.json$|(^|/)(rescue_productization|rescue-productization)(/.*)?/(latest\.json|rescue-productization-[^/]*\.json)$|^docs/status/generated/rescue_productization/.*$'
+canonical_rescue_status_regex='^docs/status/generated/rescue_productization/(latest\.json|rescue-productization-[0-9]{8}T[0-9]{6}Z\.json)$'
+rescue_publish_files="$(printf '%s\n' "${changed_files}" | grep -E "${rescue_publish_regex}" | grep -Ev "${canonical_rescue_status_regex}" || true)"
 if [[ -n "${rescue_publish_files}" ]]; then
     if [[ "${JSON_MODE}" == "true" ]]; then
         fail_preflight 1 "rescue productization publish artifacts must not be committed"

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -279,6 +279,39 @@ def test_automation_pr_preflight_rejects_rescue_publish_artifacts(
     )
 
 
+def test_automation_pr_preflight_allows_canonical_rescue_status_artifacts(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/tw03-proof-surface"], cwd=repo)
+    generated_dir = repo / "docs" / "status" / "generated" / "rescue_productization"
+    latest = generated_dir / "latest.json"
+    timestamped = generated_dir / "rescue-productization-20260721T184000Z.json"
+    generated_dir.mkdir(parents=True)
+    latest.write_text('{"generated_at": "2026-07-21T18:40:00Z"}\n', encoding="utf-8")
+    timestamped.write_text(
+        '{"generated_at": "2026-07-21T18:40:00Z"}\n',
+        encoding="utf-8",
+    )
+    _run(
+        [
+            "git",
+            "add",
+            "docs/status/generated/rescue_productization/latest.json",
+            "docs/status/generated/rescue_productization/rescue-productization-20260721T184000Z.json",
+        ],
+        cwd=repo,
+    )
+    _run(["git", "commit", "-m", "docs: refresh tw03 proof surface"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "ok"
+    assert payload["rescue_publish_files"] == []
+
+
 def test_automation_pr_preflight_rejects_reports_rescue_publish_artifacts(
     tmp_path: Path,
 ) -> None:
@@ -359,6 +392,33 @@ def test_automation_pr_preflight_rejects_nested_rescue_publish_pointers(
     assert "rescue productization publish artifacts" in proc.stderr
     assert "published/rescue-productization-20260516T162243Z.json" in proc.stderr
     assert "published/rescue_productization/snapshots/latest.json" in proc.stderr
+
+
+def test_automation_pr_preflight_rejects_noncanonical_rescue_status_artifacts(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/bad-tw03-proof-surface"], cwd=repo)
+    paths = [
+        "docs/status/generated/rescue_productization/rescue-productization-latest.json",
+        "docs/status/generated/rescue_productization/snapshots/latest.json",
+        "rescue-productization-20260721T184000Z.json",
+        "scratch/rescue_productization/latest.json",
+    ]
+    for path in paths:
+        artifact = repo / path
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("{}\n", encoding="utf-8")
+    _run(["git", "add", *paths], cwd=repo)
+    _run(["git", "commit", "-m", "bad: commit noncanonical rescue artifacts"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "--json", "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 1
+    payload = json.loads(proc.stdout)
+    assert payload["status"] == "failed"
+    assert payload["error"] == "rescue productization publish artifacts must not be committed"
+    assert payload["rescue_publish_files"] == paths
 
 
 def test_automation_pr_preflight_accepts_unrelated_latest_json(


### PR DESCRIPTION
## Summary

- admit only the two canonical repo-tracked TW-03 rescue-productization artifact forms:
  - `docs/status/generated/rescue_productization/latest.json`
  - `docs/status/generated/rescue_productization/rescue-productization-<YYYYMMDDTHHMMSSZ>.json`
- keep root-level, scratch, nested, malformed, and other rescue publication artifacts fail-closed
- add focused executable coverage for both canonical paths and the rejected lookalikes

This is the bounded Tier-4 implementation authorized on #6598 at exact base `a4371df1cb041f34d97ecbeecfe8f44be5d4647d`. It unblocks the recurring proof publication represented by #9464 without changing that PR or its generated output.

Authorization: https://github.com/synaptent/aragora/issues/6598#issuecomment-5037699650

## Risk

The preflight is automated-development admission policy, so this remains Tier 4. The allowlist is exact-path and exact-filename-shape; malformed or relocated equivalents remain rejected.

## Validation

- `python3 -m pytest -q tests/scripts/test_automation_pr_preflight.py` - 21 passed
- focused canonical/root/scratch fixture subset - 3 passed
- `bash -n scripts/automation_pr_preflight.sh` - passed
- `python3 -m ruff check tests/scripts/test_automation_pr_preflight.py` - passed
- `python3 -m ruff format --check tests/scripts/test_automation_pr_preflight.py` - passed
- `pre-commit run --files scripts/automation_pr_preflight.sh tests/scripts/test_automation_pr_preflight.py` - passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - passed
- `git diff --check origin/main...HEAD` - passed
- normal push hooks, including changed-surface mypy and portability - passed

## Scope

Only `scripts/automation_pr_preflight.sh` and `tests/scripts/test_automation_pr_preflight.py` changed. Workflows, generated proof outputs, #9464, required contexts, branch protection, evidence, settlement, and merge behavior are intentionally unchanged.

Refs #6598. Unblocks #9464.
