### PR TITLE
feat(review): support VibeProxy Claude quorum collection

### DIFF
--- a/aragora/agents/transports/claude_vibeproxy.py
+++ b/aragora/agents/transports/claude_vibeproxy.py
@@ -1,0 +1,143 @@
+"""Bounded Claude text generation through the explicit VibeProxy policy."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+
+from aragora.agents.transports.vibeproxy import (
+    ModelTransportPolicy,
+    TransportMode,
+    VibeProxyConfigurationError,
+    VibeProxyTimeoutError,
+    VibeProxyUnavailableError,
+)
+
+DEFAULT_CLAUDE_MODEL = "claude-opus-4-8"
+VIBEPROXY_HARNESS = "local VibeProxy Anthropic Messages transport"
+VIBEPROXY_TIMEOUT_ENV = "ARAGORA_COLLECT_EVIDENCE_VIBEPROXY_TIMEOUT_SECONDS"
+DEFAULT_VIBEPROXY_TIMEOUT_SECONDS = 120.0
+
+
+@dataclass(frozen=True)
+class ClaudeVibeProxyAttempt:
+    """Result of the optional VibeProxy leg before a direct Claude fallback."""
+
+    attempted: bool
+    required: bool
+    ok: bool
+    text: str = ""
+    error: str = ""
+    harness: str = ""
+    timeout_seconds: float = 0.0
+
+
+def _attempt_timeout(reviewer_timeout: float, mode: TransportMode) -> float:
+    raw = os.environ.get(VIBEPROXY_TIMEOUT_ENV, "").strip()
+    if raw:
+        try:
+            configured = float(raw)
+        except ValueError as exc:
+            raise VibeProxyConfigurationError(
+                f"{VIBEPROXY_TIMEOUT_ENV} must be a positive finite number"
+            ) from exc
+        if not math.isfinite(configured) or configured <= 0:
+            raise VibeProxyConfigurationError(
+                f"{VIBEPROXY_TIMEOUT_ENV} must be a positive finite number"
+            )
+    else:
+        configured = DEFAULT_VIBEPROXY_TIMEOUT_SECONDS
+
+    # Prefer mode must leave time for the direct reviewer path. Required mode
+    # can consume the full reviewer budget because fallback is prohibited.
+    budget = reviewer_timeout if mode is TransportMode.REQUIRED else reviewer_timeout / 2
+    return min(configured, budget)
+
+
+def run_claude_vibeproxy(
+    prompt: str,
+    *,
+    reviewer_timeout: float,
+    model: str = DEFAULT_CLAUDE_MODEL,
+    policy: ModelTransportPolicy | None = None,
+) -> ClaudeVibeProxyAttempt:
+    """Run one exact-model Claude attempt when VibeProxy is explicitly selected.
+
+    Direct mode returns ``attempted=False`` without touching the proxy. Invalid
+    configuration fails closed. In prefer mode an unavailable proxy returns a
+    non-required failure so the caller may use its existing direct path.
+    """
+
+    try:
+        resolved_policy = policy or ModelTransportPolicy.from_env()
+    except VibeProxyConfigurationError as exc:
+        return ClaudeVibeProxyAttempt(
+            attempted=True,
+            required=True,
+            ok=False,
+            error=f"VibeProxy configuration error: {exc}",
+        )
+
+    if resolved_policy.mode is TransportMode.DIRECT:
+        return ClaudeVibeProxyAttempt(attempted=False, required=False, ok=False)
+
+    required = resolved_policy.mode is TransportMode.REQUIRED
+    timeout = 0.0
+    try:
+        timeout = _attempt_timeout(reviewer_timeout, resolved_policy.mode)
+        route = resolved_policy.resolve("anthropic", model, capabilities=("chat",))
+        if route.transport != "vibeproxy" or resolved_policy.client is None:
+            return ClaudeVibeProxyAttempt(
+                attempted=True,
+                required=required,
+                ok=False,
+                error=route.fallback_reason or "VibeProxy route unavailable",
+                timeout_seconds=timeout,
+            )
+        text = resolved_policy.client.anthropic_message(
+            model=route.resolved_model,
+            prompt=prompt,
+            timeout=timeout,
+        )
+    except VibeProxyTimeoutError as exc:
+        return ClaudeVibeProxyAttempt(
+            attempted=True,
+            required=required,
+            ok=False,
+            error=str(exc),
+            timeout_seconds=timeout,
+        )
+    except VibeProxyConfigurationError as exc:
+        return ClaudeVibeProxyAttempt(
+            attempted=True,
+            required=True,
+            ok=False,
+            error=str(exc),
+            timeout_seconds=timeout,
+        )
+    except VibeProxyUnavailableError as exc:
+        return ClaudeVibeProxyAttempt(
+            attempted=True,
+            required=required,
+            ok=False,
+            error=str(exc),
+            timeout_seconds=timeout,
+        )
+    return ClaudeVibeProxyAttempt(
+        attempted=True,
+        required=required,
+        ok=True,
+        text=text,
+        harness=f"{VIBEPROXY_HARNESS} (model: {route.resolved_model})",
+        timeout_seconds=timeout,
+    )
+
+
+__all__ = [
+    "ClaudeVibeProxyAttempt",
+    "DEFAULT_CLAUDE_MODEL",
+    "VIBEPROXY_HARNESS",
+    "VIBEPROXY_TIMEOUT_ENV",
+    "run_claude_vibeproxy",
+]

--- a/aragora/swarm/quorum_evidence.py
+++ b/aragora/swarm/quorum_evidence.py
@@ -59,6 +59,7 @@ from aragora.cli.commands.review_queue_transport import (
     GITHUB_TRANSPORT_BLOCKED_STATUS,
     _is_github_transport_error,
 )
+from aragora.agents.transports.claude_vibeproxy import run_claude_vibeproxy
 from aragora.swarm import merge_quorum_io
 
 logger = logging.getLogger(__name__)
@@ -472,6 +473,7 @@ class ReviewerResult:
     ok: bool
     error: str = ""
     harness: str = ""
+    allow_transport_fallback: bool = True
 
 
 @dataclass
@@ -1335,7 +1337,8 @@ def build_review_prompt(
 def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     """Run a genuine reviewer, preferring subscription CLIs over metered APIs.
 
-    ``claude`` -> claude CLI (or Anthropic API if ANTHROPIC_API_KEY);
+    ``claude`` -> explicitly selected VibeProxy, then Claude CLI (or Anthropic
+    API if ANTHROPIC_API_KEY);
     ``openai`` -> Codex CLI (or API if OPENAI_API_KEY);
     ``grok`` -> Grok Build CLI when installed (else API); ``gemini`` -> Antigravity
     CLI when installed (else API); everything else -> API agent. The CLI-first
@@ -1362,7 +1365,7 @@ def default_reviewer_runner(family: str, prompt: str) -> ReviewerResult:
     # explicitly enabled, review via OpenRouter using a same-tier model for the SAME
     # family. Keeps the heterogeneous-family invariant (same family, different
     # transport) so one provider's outage/quota can't stall the quorum.
-    if not result.ok:
+    if not result.ok and result.allow_transport_fallback:
         fallback = _run_openrouter_reviewer(fam, prompt)
         if fallback.ok:
             return fallback
@@ -1483,8 +1486,9 @@ def _cli_liveness_probe(family: str, argv: list[str]) -> str | None:
     return None
 
 
-def _run_claude_cli(prompt: str) -> ReviewerResult:
-    timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
+def _run_claude_cli(prompt: str, *, timeout: float | None = None) -> ReviewerResult:
+    if timeout is None:
+        timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
     try:
         with _claude_empty_mcp_config_file() as mcp_config_path:
             argv = _claude_reviewer_command(mcp_config_path)
@@ -1521,17 +1525,34 @@ def _run_claude_cli(prompt: str) -> ReviewerResult:
 
 
 def _run_claude_reviewer(prompt: str) -> ReviewerResult:
-    """Run Claude evidence via the subscription CLI, then the direct Anthropic API.
+    """Run Claude evidence through explicit VibeProxy policy, CLI, then API.
 
-    The claude subscription CLI is preferred (no metered cost). When it is
-    unavailable or fails — e.g. CI runners and other keyless-CLI environments —
-    fall back to the direct Anthropic API if ``ANTHROPIC_API_KEY`` is set, so the
-    merge gate can still form a western-family quorum from API keys alone rather
-    than depending solely on OpenRouter. If neither path works the original CLI
-    failure is returned, so the generic OpenRouter fallback in
-    :func:`default_reviewer_runner` still applies.
+    VibeProxy is attempted only when ``ARAGORA_MODEL_TRANSPORT`` explicitly
+    selects ``vibeproxy-prefer`` or ``vibeproxy-required``. It remains the Claude
+    family and exact model; the proxy client rejects response-model substitution.
+    Direct mode preserves the existing subscription CLI/API order. Required mode
+    fails closed instead of using a direct or OpenRouter fallback.
     """
-    result = _run_claude_cli(prompt)
+    timeout = _timeout_seconds(_CLAUDE_TIMEOUT_ENV, _CLAUDE_TIMEOUT)
+    vibeproxy = run_claude_vibeproxy(prompt, reviewer_timeout=timeout)
+    if vibeproxy.ok:
+        return ReviewerResult(
+            "claude",
+            _cap_text(vibeproxy.text),
+            True,
+            harness=vibeproxy.harness,
+        )
+    if vibeproxy.required:
+        return ReviewerResult(
+            "claude",
+            "",
+            False,
+            vibeproxy.error,
+            allow_transport_fallback=False,
+        )
+
+    direct_timeout = timeout - vibeproxy.timeout_seconds
+    result = _run_claude_cli(prompt, timeout=direct_timeout)
     if result.ok:
         return result
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
@@ -1540,6 +1561,14 @@ def _run_claude_reviewer(prompt: str) -> ReviewerResult:
         api = _run_api_agent("anthropic-api", prompt)
         if api.ok:
             return replace(api, family="claude")
+    if vibeproxy.attempted and vibeproxy.error:
+        return replace(
+            result,
+            error=(
+                f"VibeProxy prefer attempt failed: {vibeproxy.error}; "
+                f"direct Claude path failed: {result.error}"
+            ),
+        )
     return result
 
 

--- a/docs/guides/VIBEPROXY.md
+++ b/docs/guides/VIBEPROXY.md
@@ -7,11 +7,11 @@ additional review signal.
 
 ## Current Scope
 
-- Supported now: bounded Fable/Claude advisory consults through the Anthropic
-  Messages protocol. Consults use the direct CLI path unless VibeProxy is
-  explicitly selected.
+- Supported now: bounded Fable/Claude advisory consults and Claude-family
+  merge-quorum review collection through the Anthropic Messages protocol.
+  Both paths remain direct unless VibeProxy is explicitly selected.
 - Direct by default: normal agents, CI, production servers, credential checks,
-  public gateways, and merge-quorum evidence collection.
+  public gateways, and every unconfigured merge-quorum evidence collection.
 - Deferred until contract-tested: web search, tools, embeddings, image, audio,
   and other media capabilities.
 
@@ -113,6 +113,21 @@ ARAGORA_MODEL_TRANSPORT=vibeproxy-prefer \
 ARAGORA_MODEL_TRANSPORT=vibeproxy-required \
   python3 scripts/consult_claude.py --json "Reply with exactly PROXY_ONLY"
 ```
+
+For an exact-head Claude quorum dry-run, select the transport explicitly:
+
+```bash
+ARAGORA_MODEL_TRANSPORT=vibeproxy-required \
+  python3 scripts/collect_quorum_evidence.py \
+    --repo synaptent/aragora --pr <PR> --reviewers claude --json
+```
+
+The resulting evidence still identifies the logical family as Claude and
+discloses the VibeProxy Anthropic Messages harness. Transport selection does
+not grant evidence-posting, settlement, or merge authority. The normal
+exact-head lint, dissent, tier, and human-settlement gates remain unchanged.
+`ARAGORA_COLLECT_EVIDENCE_VIBEPROXY_TIMEOUT_SECONDS` bounds the proxy leg;
+prefer mode also reserves half of the reviewer timeout for the direct fallback.
 
 ## Fallback Rules
 

--- a/scripts/inference_site_allowlist.json
+++ b/scripts/inference_site_allowlist.json
@@ -2,7 +2,10 @@
   "generated_by": "scripts/check_inference_site_allowlist.py --emit-template",
   "policy_note": "Template output defaults to direct-only; preserve reviewed classifications and rationales.",
   "schema_version": 1,
-  "transport_policy_consumers": ["scripts/consult_claude.py"],
+  "transport_policy_consumers": [
+    "aragora/agents/transports/claude_vibeproxy.py",
+    "scripts/consult_claude.py"
+  ],
   "sites": [
     {"anchor":"AnthropicAPIAgent.__init__","classification":"direct-only","detectors":{"endpoint-literal":1},"path":"aragora/agents/api_agents/anthropic.py","protocol":"base","provider":"anthropic","rationale":"not yet routed through the central exact-match transport policy"},
     {"anchor":"AnthropicAPIAgent.generate","classification":"direct-only","detectors":{"http-inference-call":1},"path":"aragora/agents/api_agents/anthropic.py","protocol":"messages","provider":"anthropic","rationale":"not yet routed through the central exact-match transport policy"},

--- a/tests/agents/transports/test_claude_vibeproxy.py
+++ b/tests/agents/transports/test_claude_vibeproxy.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from aragora.agents.transports.claude_vibeproxy import (
+    VIBEPROXY_HARNESS,
+    VIBEPROXY_TIMEOUT_ENV,
+    run_claude_vibeproxy,
+)
+from aragora.agents.transports.vibeproxy import (
+    ModelTransportPolicy,
+    TransportMode,
+    VibeProxyCatalog,
+)
+
+
+@dataclass
+class FakeClient:
+    models: frozenset[str] = frozenset({"claude-opus-4-8"})
+    base_url: str = "http://127.0.0.1:8318/v1"
+    calls: list[dict[str, object]] = field(default_factory=list)
+
+    def catalog(self) -> VibeProxyCatalog:
+        return VibeProxyCatalog(models=self.models, fetched_at=0.0)
+
+    def anthropic_message(self, **kwargs: object) -> str:
+        self.calls.append(dict(kwargs))
+        return "Verdict: PASS"
+
+
+def test_direct_mode_does_not_touch_vibeproxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VIBEPROXY_TIMEOUT_ENV, "invalid-but-unused")
+    client = FakeClient()
+    policy = ModelTransportPolicy(TransportMode.DIRECT, client=client)
+
+    result = run_claude_vibeproxy("prompt", reviewer_timeout=600, policy=policy)
+
+    assert result.attempted is False
+    assert result.ok is False
+    assert client.calls == []
+
+
+def test_prefer_mode_runs_exact_model_and_discloses_harness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(VIBEPROXY_TIMEOUT_ENV, "30")
+    client = FakeClient()
+    policy = ModelTransportPolicy(TransportMode.PREFER, client=client)
+
+    result = run_claude_vibeproxy("review prompt", reviewer_timeout=600, policy=policy)
+
+    assert result.ok is True
+    assert result.required is False
+    assert result.text == "Verdict: PASS"
+    assert result.harness == f"{VIBEPROXY_HARNESS} (model: claude-opus-4-8)"
+    assert result.timeout_seconds == 30.0
+    assert client.calls == [
+        {
+            "model": "claude-opus-4-8",
+            "prompt": "review prompt",
+            "timeout": 30.0,
+        }
+    ]
+
+
+def test_prefer_mode_reserves_half_the_reviewer_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(VIBEPROXY_TIMEOUT_ENV, "500")
+    client = FakeClient()
+    policy = ModelTransportPolicy(TransportMode.PREFER, client=client)
+
+    result = run_claude_vibeproxy("prompt", reviewer_timeout=80, policy=policy)
+
+    assert result.ok is True
+    assert result.timeout_seconds == 40.0
+    assert client.calls[0]["timeout"] == 40.0
+
+
+def test_prefer_mode_allows_direct_fallback_when_model_is_unavailable() -> None:
+    policy = ModelTransportPolicy(
+        TransportMode.PREFER,
+        client=FakeClient(models=frozenset()),
+    )
+
+    result = run_claude_vibeproxy("prompt", reviewer_timeout=600, policy=policy)
+
+    assert result.attempted is True
+    assert result.required is False
+    assert result.ok is False
+    assert result.error == "model not in VibeProxy catalog: claude-opus-4-8"
+
+
+def test_required_mode_fails_closed_when_model_is_unavailable() -> None:
+    policy = ModelTransportPolicy(
+        TransportMode.REQUIRED,
+        client=FakeClient(models=frozenset()),
+    )
+
+    result = run_claude_vibeproxy("prompt", reviewer_timeout=600, policy=policy)
+
+    assert result.attempted is True
+    assert result.required is True
+    assert result.ok is False
+    assert result.error == "model not in VibeProxy catalog: claude-opus-4-8"
+
+
+def test_invalid_timeout_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VIBEPROXY_TIMEOUT_ENV, "not-a-number")
+    policy = ModelTransportPolicy(TransportMode.PREFER, client=FakeClient())
+
+    result = run_claude_vibeproxy("prompt", reviewer_timeout=600, policy=policy)
+
+    assert result.attempted is True
+    assert result.required is True
+    assert result.ok is False
+    assert VIBEPROXY_TIMEOUT_ENV in result.error

--- a/tests/scripts/test_check_inference_site_allowlist.py
+++ b/tests/scripts/test_check_inference_site_allowlist.py
@@ -25,7 +25,16 @@ checker = _load_module()
 def test_repository_manifest_matches_current_tree() -> None:
     result = checker.check_allowlist()
     payload = json.loads(checker.DEFAULT_MANIFEST.read_text(encoding="utf-8"))
-    assert result.ok is True and result.policy_consumers == ("scripts/consult_claude.py",) and [(site["path"], site["anchor"]) for site in payload["sites"] if site["classification"] == "proxy-eligible"] == [("scripts/consult_claude.py", "_run_vibeproxy")], result  # fmt: skip
+    assert result.ok is True, result
+    assert result.policy_consumers == (
+        "aragora/agents/transports/claude_vibeproxy.py",
+        "scripts/consult_claude.py",
+    )
+    assert [
+        (site["path"], site["anchor"])
+        for site in payload["sites"]
+        if site["classification"] == "proxy-eligible"
+    ] == [("scripts/consult_claude.py", "_run_vibeproxy")]
 
 
 def _write_source(root: Path, relative: str, source: str) -> Path:

--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -369,6 +369,127 @@ def test_claude_reviewer_command_disables_mcp() -> None:
     assert "--strict-mcp-config" in cmd
 
 
+def test_claude_reviewer_uses_successful_vibeproxy_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        qe,
+        "run_claude_vibeproxy",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            attempted=True,
+            required=False,
+            ok=True,
+            text="Verdict: PASS",
+            error="",
+            harness="local VibeProxy Anthropic Messages transport",
+            timeout_seconds=30.0,
+        ),
+    )
+    monkeypatch.setattr(
+        qe,
+        "_run_claude_cli",
+        lambda _prompt: pytest.fail("direct CLI must not run after proxy success"),
+    )
+
+    result = qe._run_claude_reviewer("review prompt")
+
+    assert result == ReviewerResult(
+        "claude",
+        "Verdict: PASS",
+        True,
+        harness="local VibeProxy Anthropic Messages transport",
+    )
+
+
+def test_claude_reviewer_prefer_failure_uses_direct_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        qe,
+        "run_claude_vibeproxy",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            attempted=True,
+            required=False,
+            ok=False,
+            text="",
+            error="proxy unavailable",
+            harness="",
+            timeout_seconds=120.0,
+        ),
+    )
+    direct_timeouts: list[float] = []
+    monkeypatch.setattr(
+        qe,
+        "_run_claude_cli",
+        lambda _prompt, *, timeout: direct_timeouts.append(timeout)
+        or ReviewerResult("claude", "Verdict: PASS", True),
+    )
+
+    assert qe._run_claude_reviewer("prompt") == ReviewerResult("claude", "Verdict: PASS", True)
+    assert direct_timeouts == [480.0]
+
+
+def test_claude_reviewer_required_failure_never_runs_direct_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        qe,
+        "run_claude_vibeproxy",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            attempted=True,
+            required=True,
+            ok=False,
+            text="",
+            error="proxy required but unavailable",
+            harness="",
+            timeout_seconds=600.0,
+        ),
+    )
+    monkeypatch.setattr(
+        qe,
+        "_run_claude_cli",
+        lambda _prompt: pytest.fail("required mode must not use direct CLI"),
+    )
+
+    assert qe._run_claude_reviewer("prompt") == ReviewerResult(
+        "claude",
+        "",
+        False,
+        "proxy required but unavailable",
+        allow_transport_fallback=False,
+    )
+
+
+def test_default_reviewer_required_proxy_failure_never_uses_openrouter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        qe,
+        "run_claude_vibeproxy",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            attempted=True,
+            required=True,
+            ok=False,
+            text="",
+            error="proxy required but unavailable",
+            harness="",
+            timeout_seconds=600.0,
+        ),
+    )
+    monkeypatch.setattr(
+        qe,
+        "_run_openrouter_reviewer",
+        lambda *_args, **_kwargs: pytest.fail(
+            "required VibeProxy mode must suppress OpenRouter fallback"
+        ),
+    )
+
+    result = qe.default_reviewer_runner("claude", "prompt")
+
+    assert result.allow_transport_fallback is False
+    assert result.error == "proxy required but unavailable"
+
+
 # --- OpenAI reviewer fallback ----------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- add explicit `vibeproxy-prefer` / `vibeproxy-required` routing for Claude-family quorum collection
- preserve the logical Claude family and exact response-model validation while disclosing the VibeProxy harness and resolved model
- keep direct collection as the default; required mode fails closed and suppresses direct/OpenRouter fallback
- bound prefer-mode proxy and direct-reviewer time within the existing reviewer budget
- register the new transport-policy consumer without making protected evidence paths proxy-eligible

Depends on #9439 and is intentionally stacked on `codex/vibeproxy-inference-allowlist-9409`.
Refs #9409.

## Validation

- `python3 -m pytest tests/scripts/test_check_inference_site_allowlist.py tests/agents/transports/test_claude_vibeproxy.py tests/swarm/test_quorum_evidence.py -q` (295 passed)
- `python3 scripts/check_inference_site_allowlist.py --json` (`ok=true`, no drift/unclassified/forbidden ports)
- `python3 scripts/report_code_quality.py --check`
- focused Ruff checks
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/codex/vibeproxy-inference-allowlist-9409 HEAD`

## Safety / rollout

- Claude only; OpenAI quorum transport remains unchanged.
- No evidence-posting, settlement, merge, or authority behavior is changed.
- This is Tier 4 countable-review transport scope. Keep draft until #9439 lands and the issue #9409 shadow/burn-in requirements are satisfied, then require exact-head human settlement.
- A live VibeProxy catalog probe confirmed local loopback health and the exact `claude-opus-4-8` model. After ONE-CLAUDE cleared, a non-posting `default_reviewer_runner("claude", ...)` smoke in `vibeproxy-required` mode returned `VIBEPROXY_QUORUM_READY` with the Claude family and exact-model VibeProxy harness disclosed.
