### PR TITLE
test(governance): prove CDG prerequisite regressions

### DIFF
--- a/tests/governance/test_contract_drift_measurement_authority_tier.py
+++ b/tests/governance/test_contract_drift_measurement_authority_tier.py
@@ -1,4 +1,10 @@
-"""Focused guards for the Contract Drift measurement-authority Tier-4 constants."""
+"""Focused guards for the Contract Drift measurement-authority Tier-4 constants.
+
+The historical PR-scope regressions intentionally require a full Git checkout.
+Their purpose is to authenticate immutable before/head/squash objects, so missing
+objects are a failed proof rather than a reason to skip a maintained exact-name
+governance test.
+"""
 
 from __future__ import annotations
 
@@ -180,7 +186,10 @@ def _git_text(repo_root: Path, *args: str) -> str:
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 0, (
+        "immutable-history governance proof requires the repository's full Git objects: "
+        f"git {' '.join(args)} failed with {result.stderr.strip()!r}"
+    )
     return result.stdout
 
 

--- a/tests/governance/test_contract_drift_measurement_authority_tier.py
+++ b/tests/governance/test_contract_drift_measurement_authority_tier.py
@@ -1,9 +1,9 @@
 """Focused guards for the Contract Drift measurement-authority Tier-4 constants.
 
-The historical PR-scope regressions intentionally require a full Git checkout.
-Their purpose is to authenticate immutable before/head/squash objects, so missing
-objects are a failed proof rather than a reason to skip a maintained exact-name
-governance test.
+The historical PR-scope regressions intentionally require a full Git checkout of
+the default-branch history. Their purpose is to authenticate immutable
+before/squash objects, so missing objects are a failed proof rather than a reason
+to skip a maintained exact-name governance test.
 """
 
 from __future__ import annotations
@@ -46,11 +46,11 @@ UNRELATED_SIBLING_PATHS = (
 FILE_ROOT_SUFFIXES = (".bak", ".old", ".pyx", "/child", "x")
 
 CLASSIFIER_BASE = "bf4e49c60b357b80f2bee5956f84570d0f9b140a"
-CLASSIFIER_HEAD = "1286508b40ea0d8c7ae8ea6071bd2b65b7065976"
 CLASSIFIER_MERGE = "ee686e9d116c704ede146a6ec69dfe013b6c32be"
+CLASSIFIER_TREE = "0d50965a26df2b88b8cb9bc29b70156e2d9ce006"
 MATCHER_BASE = "6137552e4419862b895b096eef1ae36ff8ad210a"
-MATCHER_HEAD = "0c817337b4bf1b4d07332614de7eb5235f02ee9d"
 MATCHER_MERGE = "e8a0d165242737d3226b6d3360aa9e8ec014fd75"
+MATCHER_TREE = "65c567a51ed4d19d411b9f874163e8a39675d396"
 STAGE1_MERGE = "9482fc2dffdb6425d2405389c13f46d5954ac467"
 
 
@@ -334,7 +334,7 @@ def test_classifier_pr_changes_are_constants_only() -> None:
     review_queue_path = "aragora/cli/commands/review_queue.py"
     merge_train_path = "scripts/tier4_merge_train.py"
 
-    assert _changed_files(repo_root, CLASSIFIER_BASE, CLASSIFIER_HEAD) == {
+    assert _changed_files(repo_root, CLASSIFIER_BASE, CLASSIFIER_MERGE) == {
         review_queue_path,
         merge_train_path,
         "tests/governance/test_contract_drift_measurement_authority_tier.py",
@@ -344,18 +344,18 @@ def test_classifier_pr_changes_are_constants_only() -> None:
         "merge-base",
         "--is-ancestor",
         CLASSIFIER_BASE,
-        CLASSIFIER_HEAD,
+        CLASSIFIER_MERGE,
     )
     assert (
         _git_text(repo_root, "show", "-s", "--format=%P", CLASSIFIER_MERGE).strip()
         == CLASSIFIER_BASE
     )
-    assert _git_text(repo_root, "rev-parse", f"{CLASSIFIER_HEAD}^{{tree}}") == _git_text(
-        repo_root, "rev-parse", f"{CLASSIFIER_MERGE}^{{tree}}"
+    assert (
+        _git_text(repo_root, "rev-parse", f"{CLASSIFIER_MERGE}^{{tree}}").strip() == CLASSIFIER_TREE
     )
 
     review_base = _source_at_ref(repo_root, CLASSIFIER_BASE, review_queue_path)
-    review_head = _source_at_ref(repo_root, CLASSIFIER_HEAD, review_queue_path)
+    review_head = _source_at_ref(repo_root, CLASSIFIER_MERGE, review_queue_path)
     _assert_only_assignments_changed(
         review_base,
         review_head,
@@ -372,7 +372,7 @@ def test_classifier_pr_changes_are_constants_only() -> None:
     )
 
     train_base = _source_at_ref(repo_root, CLASSIFIER_BASE, merge_train_path)
-    train_head = _source_at_ref(repo_root, CLASSIFIER_HEAD, merge_train_path)
+    train_head = _source_at_ref(repo_root, CLASSIFIER_MERGE, merge_train_path)
     _assert_only_assignments_changed(
         train_base,
         train_head,
@@ -397,14 +397,12 @@ def test_matcher_repair_preserves_eight_constants_and_single_line_authority_tupl
         "aragora/cli/commands/review_queue.py",
         "scripts/tier4_merge_train.py",
     )
-    refs = (MATCHER_BASE, MATCHER_HEAD, MATCHER_MERGE, STAGE1_MERGE)
+    refs = (MATCHER_BASE, MATCHER_MERGE, STAGE1_MERGE)
 
     _git_text(repo_root, "merge-base", "--is-ancestor", CLASSIFIER_MERGE, MATCHER_BASE)
     _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_MERGE, STAGE1_MERGE)
     assert _git_text(repo_root, "show", "-s", "--format=%P", MATCHER_MERGE).strip() == MATCHER_BASE
-    assert _git_text(repo_root, "rev-parse", f"{MATCHER_HEAD}^{{tree}}") == _git_text(
-        repo_root, "rev-parse", f"{MATCHER_MERGE}^{{tree}}"
-    )
+    assert _git_text(repo_root, "rev-parse", f"{MATCHER_MERGE}^{{tree}}").strip() == MATCHER_TREE
 
     for path in paths:
         sources = {ref: _source_at_ref(repo_root, ref, path) for ref in refs}
@@ -438,17 +436,19 @@ def test_matcher_repair_has_no_parser_dispatch_handler_or_settlement_scope() -> 
     merge_train_path = "scripts/tier4_merge_train.py"
     parser_path = "aragora/cli/parser.py"
 
-    assert _changed_files(repo_root, MATCHER_BASE, MATCHER_HEAD) == {
+    assert _changed_files(repo_root, MATCHER_BASE, MATCHER_MERGE) == {
         review_queue_path,
         "tests/governance/test_contract_drift_measurement_authority_tier.py",
         "tests/scripts/test_tier4_merge_train.py",
     }
-    _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_BASE, MATCHER_HEAD)
+    _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_BASE, MATCHER_MERGE)
     _git_text(repo_root, "merge-base", "--is-ancestor", CLASSIFIER_MERGE, MATCHER_BASE)
     _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_MERGE, STAGE1_MERGE)
+    assert _git_text(repo_root, "show", "-s", "--format=%P", MATCHER_MERGE).strip() == MATCHER_BASE
+    assert _git_text(repo_root, "rev-parse", f"{MATCHER_MERGE}^{{tree}}").strip() == MATCHER_TREE
 
     review_base = _source_at_ref(repo_root, MATCHER_BASE, review_queue_path)
-    review_head = _source_at_ref(repo_root, MATCHER_HEAD, review_queue_path)
+    review_head = _source_at_ref(repo_root, MATCHER_MERGE, review_queue_path)
     assert _without_top_level_functions(
         review_base, {"_matches_prefix"}
     ) == _without_top_level_functions(review_head, {"_matches_prefix"})
@@ -456,10 +456,10 @@ def test_matcher_repair_has_no_parser_dispatch_handler_or_settlement_scope() -> 
         review_head, "_matches_prefix"
     )
     assert _source_at_ref(repo_root, MATCHER_BASE, merge_train_path) == _source_at_ref(
-        repo_root, MATCHER_HEAD, merge_train_path
+        repo_root, MATCHER_MERGE, merge_train_path
     )
     assert _source_at_ref(repo_root, MATCHER_BASE, parser_path) == _source_at_ref(
-        repo_root, MATCHER_HEAD, parser_path
+        repo_root, MATCHER_MERGE, parser_path
     )
 
 

--- a/tests/governance/test_contract_drift_measurement_authority_tier.py
+++ b/tests/governance/test_contract_drift_measurement_authority_tier.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -38,35 +39,157 @@ UNRELATED_SIBLING_PATHS = (
 
 FILE_ROOT_SUFFIXES = (".bak", ".old", ".pyx", "/child", "x")
 
+CLASSIFIER_BASE = "bf4e49c60b357b80f2bee5956f84570d0f9b140a"
+CLASSIFIER_HEAD = "1286508b40ea0d8c7ae8ea6071bd2b65b7065976"
+CLASSIFIER_MERGE = "ee686e9d116c704ede146a6ec69dfe013b6c32be"
+MATCHER_BASE = "6137552e4419862b895b096eef1ae36ff8ad210a"
+MATCHER_HEAD = "0c817337b4bf1b4d07332614de7eb5235f02ee9d"
+MATCHER_MERGE = "e8a0d165242737d3226b6d3360aa9e8ec014fd75"
+STAGE1_MERGE = "9482fc2dffdb6425d2405389c13f46d5954ac467"
+
+
+def _assignment_node(source: str, assignment_name: str) -> ast.Assign | ast.AnnAssign:
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == assignment_name:
+                return node
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == assignment_name
+        ):
+            return node
+    raise AssertionError(f"{assignment_name} assignment not found")
+
 
 def _assigned_string_literals(source_path: Path, assignment_name: str) -> tuple[str, ...]:
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    for node in tree.body:
-        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
-            continue
-        if node.target.id != assignment_name:
-            continue
-        if not isinstance(node.value, ast.Tuple):
-            raise AssertionError(f"{assignment_name} must be a literal tuple")
-        values = tuple(
-            element.value
-            for element in node.value.elts
-            if isinstance(element, ast.Constant) and isinstance(element.value, str)
-        )
-        if len(values) != len(node.value.elts):
-            raise AssertionError(f"{assignment_name} must contain only string literals")
-        return values
-    raise AssertionError(f"{assignment_name} assignment not found in {source_path}")
+    source = source_path.read_text(encoding="utf-8")
+    return _assigned_string_literals_from_source(source, assignment_name)
+
+
+def _assigned_string_literals_from_source(source: str, assignment_name: str) -> tuple[str, ...]:
+    node = _assignment_node(source, assignment_name)
+    if not isinstance(node.value, ast.Tuple):
+        raise AssertionError(f"{assignment_name} must be a literal tuple")
+    values = tuple(
+        element.value
+        for element in node.value.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    )
+    if len(values) != len(node.value.elts):
+        raise AssertionError(f"{assignment_name} must contain only string literals")
+    return values
 
 
 def _assignment_line_span(source_path: Path, assignment_name: str) -> int:
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    source = source_path.read_text(encoding="utf-8")
+    return _assignment_line_span_from_source(source, assignment_name)
+
+
+def _assignment_line_span_from_source(source: str, assignment_name: str) -> int:
+    node = _assignment_node(source, assignment_name)
+    assert node.end_lineno is not None
+    return node.end_lineno - node.lineno
+
+
+def _assignment_source(source: str, assignment_name: str) -> str:
+    node = _assignment_node(source, assignment_name)
+    segment = ast.get_source_segment(source, node)
+    if segment is None:
+        raise AssertionError(f"{assignment_name} source segment unavailable")
+    return segment
+
+
+def _top_level_assignment_name(node: ast.stmt) -> str | None:
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return node.target.id
+    if (
+        isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+    ):
+        return node.targets[0].id
+    return None
+
+
+def _assert_only_assignments_changed(
+    base_source: str,
+    head_source: str,
+    expected_changed_assignments: set[str],
+) -> None:
+    base_tree = ast.parse(base_source)
+    head_tree = ast.parse(head_source)
+    base_assignments = {
+        name: ast.dump(node, include_attributes=False)
+        for node in base_tree.body
+        if (name := _top_level_assignment_name(node)) is not None
+    }
+    head_assignments = {
+        name: ast.dump(node, include_attributes=False)
+        for node in head_tree.body
+        if (name := _top_level_assignment_name(node)) is not None
+    }
+    changed_assignments = {
+        name
+        for name in base_assignments.keys() | head_assignments.keys()
+        if base_assignments.get(name) != head_assignments.get(name)
+    }
+    assert changed_assignments == expected_changed_assignments
+
+    base_tree.body = [
+        node
+        for node in base_tree.body
+        if _top_level_assignment_name(node) not in expected_changed_assignments
+    ]
+    head_tree.body = [
+        node
+        for node in head_tree.body
+        if _top_level_assignment_name(node) not in expected_changed_assignments
+    ]
+    assert ast.dump(base_tree, include_attributes=False) == ast.dump(
+        head_tree, include_attributes=False
+    )
+
+
+def _without_top_level_functions(source: str, function_names: set[str]) -> str:
+    tree = ast.parse(source)
+    tree.body = [
+        node
+        for node in tree.body
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        or node.name not in function_names
+    ]
+    return ast.dump(tree, include_attributes=False)
+
+
+def _function_dump(source: str, function_name: str) -> str:
+    tree = ast.parse(source)
     for node in tree.body:
-        if not isinstance(node, ast.AnnAssign) or not isinstance(node.target, ast.Name):
-            continue
-        if node.target.id == assignment_name:
-            return node.end_lineno - node.lineno
-    raise AssertionError(f"{assignment_name} assignment not found in {source_path}")
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function_name:
+            return ast.dump(node, include_attributes=False)
+    raise AssertionError(f"{function_name} function not found")
+
+
+def _git_text(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _source_at_ref(repo_root: Path, ref: str, path: str) -> str:
+    return _git_text(repo_root, "show", f"{ref}:{path}")
+
+
+def _changed_files(repo_root: Path, base: str, head: str) -> set[str]:
+    return set(_git_text(repo_root, "diff", "--name-only", base, head).splitlines())
 
 
 def _canonical_matched_rule(path: str) -> str | None:
@@ -195,6 +318,140 @@ def test_authority_constants_and_tuple_shape_remain_exact() -> None:
         == EXPECTED_AUTHORITY_PREFIXES
     )
     assert _assignment_line_span(review_queue_path, "CONTRACT_DRIFT_AUTHORITY_PREFIXES") == 0
+
+
+def test_classifier_pr_changes_are_constants_only() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    review_queue_path = "aragora/cli/commands/review_queue.py"
+    merge_train_path = "scripts/tier4_merge_train.py"
+
+    assert _changed_files(repo_root, CLASSIFIER_BASE, CLASSIFIER_HEAD) == {
+        review_queue_path,
+        merge_train_path,
+        "tests/governance/test_contract_drift_measurement_authority_tier.py",
+    }
+    _git_text(
+        repo_root,
+        "merge-base",
+        "--is-ancestor",
+        CLASSIFIER_BASE,
+        CLASSIFIER_HEAD,
+    )
+    assert (
+        _git_text(repo_root, "show", "-s", "--format=%P", CLASSIFIER_MERGE).strip()
+        == CLASSIFIER_BASE
+    )
+    assert _git_text(repo_root, "rev-parse", f"{CLASSIFIER_HEAD}^{{tree}}") == _git_text(
+        repo_root, "rev-parse", f"{CLASSIFIER_MERGE}^{{tree}}"
+    )
+
+    review_base = _source_at_ref(repo_root, CLASSIFIER_BASE, review_queue_path)
+    review_head = _source_at_ref(repo_root, CLASSIFIER_HEAD, review_queue_path)
+    _assert_only_assignments_changed(
+        review_base,
+        review_head,
+        {
+            "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+            "CONTRACT_DRIFT_AUTHORITY_TIER",
+            "CONTRACT_DRIFT_AUTHORITY_PREFIXES",
+            "TIER_4_PREFIXES",
+        },
+    )
+    assert (
+        _assigned_string_literals_from_source(review_head, "CONTRACT_DRIFT_AUTHORITY_PREFIXES")
+        == EXPECTED_AUTHORITY_PREFIXES
+    )
+
+    train_base = _source_at_ref(repo_root, CLASSIFIER_BASE, merge_train_path)
+    train_head = _source_at_ref(repo_root, CLASSIFIER_HEAD, merge_train_path)
+    _assert_only_assignments_changed(
+        train_base,
+        train_head,
+        {
+            "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+            "CONTRACT_DRIFT_AUTHORITY_TIER",
+            "CONTRACT_DRIFT_AUTHORITY_CANONICAL_SOURCE",
+            "CONTRACT_DRIFT_AUTHORITY_PREFIXES",
+            "SERIALIZED_TIER4_PREFIXES",
+        },
+    )
+    assert (
+        _assigned_string_literals_from_source(train_head, "CONTRACT_DRIFT_AUTHORITY_PREFIXES")
+        == EXPECTED_AUTHORITY_PREFIXES
+    )
+
+
+def test_matcher_repair_preserves_eight_constants_and_single_line_authority_tuple() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    authority_assignment = "CONTRACT_DRIFT_AUTHORITY_PREFIXES"
+    paths = (
+        "aragora/cli/commands/review_queue.py",
+        "scripts/tier4_merge_train.py",
+    )
+    refs = (MATCHER_BASE, MATCHER_HEAD, MATCHER_MERGE, STAGE1_MERGE)
+
+    _git_text(repo_root, "merge-base", "--is-ancestor", CLASSIFIER_MERGE, MATCHER_BASE)
+    _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_MERGE, STAGE1_MERGE)
+    assert _git_text(repo_root, "show", "-s", "--format=%P", MATCHER_MERGE).strip() == MATCHER_BASE
+    assert _git_text(repo_root, "rev-parse", f"{MATCHER_HEAD}^{{tree}}") == _git_text(
+        repo_root, "rev-parse", f"{MATCHER_MERGE}^{{tree}}"
+    )
+
+    for path in paths:
+        sources = {ref: _source_at_ref(repo_root, ref, path) for ref in refs}
+        assignments = {
+            ref: _assignment_source(source, authority_assignment) for ref, source in sources.items()
+        }
+        assert len(set(assignments.values())) == 1
+        for source in sources.values():
+            assert (
+                _assigned_string_literals_from_source(source, authority_assignment)
+                == EXPECTED_AUTHORITY_PREFIXES
+            )
+
+    canonical_sources = {
+        ref: _source_at_ref(
+            repo_root,
+            ref,
+            "aragora/cli/commands/review_queue.py",
+        )
+        for ref in refs
+    }
+    assert all(
+        _assignment_line_span_from_source(source, authority_assignment) == 0
+        for source in canonical_sources.values()
+    )
+
+
+def test_matcher_repair_has_no_parser_dispatch_handler_or_settlement_scope() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    review_queue_path = "aragora/cli/commands/review_queue.py"
+    merge_train_path = "scripts/tier4_merge_train.py"
+    parser_path = "aragora/cli/parser.py"
+
+    assert _changed_files(repo_root, MATCHER_BASE, MATCHER_HEAD) == {
+        review_queue_path,
+        "tests/governance/test_contract_drift_measurement_authority_tier.py",
+        "tests/scripts/test_tier4_merge_train.py",
+    }
+    _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_BASE, MATCHER_HEAD)
+    _git_text(repo_root, "merge-base", "--is-ancestor", CLASSIFIER_MERGE, MATCHER_BASE)
+    _git_text(repo_root, "merge-base", "--is-ancestor", MATCHER_MERGE, STAGE1_MERGE)
+
+    review_base = _source_at_ref(repo_root, MATCHER_BASE, review_queue_path)
+    review_head = _source_at_ref(repo_root, MATCHER_HEAD, review_queue_path)
+    assert _without_top_level_functions(
+        review_base, {"_matches_prefix"}
+    ) == _without_top_level_functions(review_head, {"_matches_prefix"})
+    assert _function_dump(review_base, "_matches_prefix") != _function_dump(
+        review_head, "_matches_prefix"
+    )
+    assert _source_at_ref(repo_root, MATCHER_BASE, merge_train_path) == _source_at_ref(
+        repo_root, MATCHER_HEAD, merge_train_path
+    )
+    assert _source_at_ref(repo_root, MATCHER_BASE, parser_path) == _source_at_ref(
+        repo_root, MATCHER_HEAD, parser_path
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/scripts/test_tier4_merge_train.py
+++ b/tests/scripts/test_tier4_merge_train.py
@@ -31,6 +31,8 @@ def _load_module() -> Any:
 
 train = _load_module()
 
+HOSTILE_EXACT_FILE_VARIANTS = (".bak", ".old", ".pyx", "/child", "x")
+
 
 def _pr(number: int, files: list[str], *, created: str = "", title: str = "") -> dict[str, Any]:
     return {
@@ -57,6 +59,52 @@ def test_matches_directory_prefix_surface() -> None:
         train.matches_serialized_path(".github/workflows/aragora-merge-quorum.yml")
         == ".github/workflows/"
     )
+
+
+def test_every_slash_directory_root_matches_descendant_files_at_two_depths() -> None:
+    review_queue = importlib.import_module("aragora.cli.commands.review_queue")
+    directory_roots = tuple(rule for rule in train.SERIALIZED_TIER4_PREFIXES if rule.endswith("/"))
+    assert directory_roots
+    assert directory_roots == tuple(
+        rule for rule in review_queue.TIER_4_PREFIXES if rule.endswith("/")
+    )
+
+    for index, root in enumerate(directory_roots, start=1):
+        shallow = f"{root}stage1_probe.txt"
+        deep = f"{root}stage1/nested_probe.txt"
+        occupying_pr = 9_000 + index
+
+        for path in (shallow, deep):
+            canonical_rule = next(
+                (
+                    rule
+                    for rule in review_queue.TIER_4_PREFIXES
+                    if review_queue._matches_prefix(path, (rule,))
+                ),
+                None,
+            )
+            tier, name, _reason = review_queue._classify_model_review_tier([path])
+            assert canonical_rule == root
+            assert (tier, name) == (4, "tier_4_preapproval_required")
+            assert train.matches_serialized_path(path) == root
+            assert train.serialized_paths_for([path]) == {root}
+
+            allowed = train.evaluate_merge_train([path], open_prs=[], cap=1)
+            assert allowed["decision"] == train.ALLOW
+            assert allowed["candidate_surfaces"] == [root]
+
+        queued = train.evaluate_merge_train(
+            [deep],
+            open_prs=[_pr(occupying_pr, [shallow])],
+            cap=1,
+        )
+        assert queued["decision"] == train.QUEUE
+        assert queued["blocking_prs"] == [occupying_pr]
+        assert queued["contended_surfaces"][root] == {
+            "open_pr_numbers": [occupying_pr],
+            "head_pr": occupying_pr,
+            "lane_full": True,
+        }
 
 
 def test_non_serialized_path_returns_none() -> None:
@@ -119,6 +167,72 @@ def test_cap_one_contention_is_deterministic_for_exact_authority_file() -> None:
         "head_pr": 9410,
         "lane_full": True,
     }
+
+
+def test_every_exact_file_root_serializes_and_contends_with_occupying_pr_and_hostile_variants_join_no_lane() -> (
+    None
+):
+    review_queue = importlib.import_module("aragora.cli.commands.review_queue")
+    exact_roots = tuple(rule for rule in train.SERIALIZED_TIER4_PREFIXES if not rule.endswith("/"))
+    assert exact_roots
+    assert exact_roots == tuple(
+        rule for rule in review_queue.TIER_4_PREFIXES if not rule.endswith("/")
+    )
+
+    for index, root in enumerate(exact_roots, start=1):
+        occupying_pr = 10_000 + index
+        assert train.matches_serialized_path(root) == root
+        assert train.serialized_paths_for([root]) == {root}
+        tier, name, _reason = review_queue._classify_model_review_tier([root])
+        assert (tier, name) == (4, "tier_4_preapproval_required")
+
+        allowed = train.evaluate_merge_train([root], open_prs=[], cap=1)
+        assert allowed["decision"] == train.ALLOW
+        assert allowed["candidate_surfaces"] == [root]
+        assert allowed["blocking_prs"] == []
+
+        queued = train.evaluate_merge_train(
+            [root],
+            open_prs=[_pr(occupying_pr, [root])],
+            cap=1,
+        )
+        assert queued["decision"] == train.QUEUE
+        assert queued["blocking_prs"] == [occupying_pr]
+        assert queued["contended_surfaces"][root] == {
+            "open_pr_numbers": [occupying_pr],
+            "head_pr": occupying_pr,
+            "lane_full": True,
+        }
+
+        for suffix in HOSTILE_EXACT_FILE_VARIANTS:
+            variant = f"{root}{suffix}"
+            canonical_rule = next(
+                (
+                    rule
+                    for rule in review_queue.TIER_4_PREFIXES
+                    if review_queue._matches_prefix(variant, (rule,))
+                ),
+                None,
+            )
+            variant_tier, _variant_name, _variant_reason = review_queue._classify_model_review_tier(
+                [variant]
+            )
+            assert canonical_rule is None
+            assert variant_tier < 4
+            assert train.matches_serialized_path(variant) is None
+            assert train.serialized_paths_for([variant]) == set()
+            assert train.build_train([_pr(occupying_pr, [variant])]) == {}
+
+            variant_decision = train.evaluate_merge_train(
+                [variant],
+                open_prs=[_pr(occupying_pr, [root])],
+                cap=1,
+            )
+            assert variant_decision["decision"] == train.ALLOW
+            assert variant_decision["candidate_surfaces"] == []
+            assert variant_decision["contended_surfaces"] == {}
+            assert variant_decision["blocking_prs"] == []
+            assert "no serialized Tier-4 surface" in variant_decision["reason"]
 
 
 def test_cap_two_allows_second_pr() -> None:

--- a/tests/scripts/test_tier4_merge_train.py
+++ b/tests/scripts/test_tier4_merge_train.py
@@ -4,7 +4,10 @@ Pure-core, fixture-driven: the lane decision is exercised against explicit
 open-PR lists, so no ``gh`` subprocess is ever invoked. A drift guard asserts
 the vendored serialized-surface list stays in sync with the canonical
 ``review_queue.TIER_4_PREFIXES`` (skipped when that import's heavy dependency
-closure is unavailable, e.g. in a minimal sandbox).
+closure is unavailable, e.g. in a minimal sandbox). The maintained exact-name
+Stage-1 regressions additionally exercise canonical classification directly;
+those proofs intentionally fail rather than skip when the canonical classifier
+cannot be imported.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Source

Feature `cdg-tier4-prerequisite-regression-proof`, operator-authorized VAL-CDG-001 exact-name prerequisite maintenance.

## Summary

- add the five maintained exact-name Stage-1 prerequisite regressions as direct tests
- authenticate the immutable classifier and matcher base/head/squash chronology and exact changed-file/semantic scope
- prove every exact Tier-4 file rule allows an empty lane, queues behind its exact occupying PR, and rejects hostile suffix/child variants from all lanes
- prove every slash-terminated Tier-4 directory rule classifies and serializes descendants at two depths, including cap-one contention
- change tests only, leave production code and PR #9449 untouched, and claim no VAL-CDG assertion

## Validation

- focused five names: `5 passed`
- complete Stage-1 matrix: `864 passed`
- maintained selector over PR #9449 head `3bb618d87b6561721f6b37b758644b463abc8c52` plus this overlay: `45 names`, `43 present`, `765 collected cases`; only the two PR #9449-owned canonical cohort/provenance names remain absent
- `make lint`: passed
- `ruff format --check aragora/ tests/ scripts/`: `10763 files already formatted`
- mission differential typecheck: `new=96 <= recorded env drift=108`
- scoped changed-file mypy with skipped import traversal: no issues in the two edited files
- import smoke: passed
- smoke tier: `138 passed`, `232544 deselected`
- automation preflight: exactly the two authorized test files

## Scope and risk

The immutable historical PR head objects must remain available to the test checkout. The production matcher, exact eight authority roots, parser, dispatch, handlers, settlement surfaces, and PR #9449 branch are unchanged.