### PR TITLE
fix(tests): reap VibeProxy executor threads to stop cross-file pollution

### DIFF
--- a/tests/agents/api_agents/conftest.py
+++ b/tests/agents/api_agents/conftest.py
@@ -557,27 +557,6 @@ def _restore_create_client_session():
 
 
 @pytest.fixture(autouse=True)
-def _fresh_vibeproxy_executor(monkeypatch):
-    """Give each test a private VibeProxy executor and reap its threads.
-
-    The module-level ``_PROXY_EXECUTOR`` in ``api_agents.openai`` keeps its
-    worker threads alive for the rest of the process once a test routes a
-    request through VibeProxy.  Lingering threads flip
-    ``threading.active_count() > 1`` checks elsewhere in the suite — notably
-    ``quorum_evidence._reviewer_process_context()``, which then selects a
-    forkserver context and fails to pickle locally defined reviewer runners.
-    """
-    from concurrent.futures import ThreadPoolExecutor
-
-    from aragora.agents.api_agents import openai as openai_module
-
-    executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="vibeproxy-openai-test")
-    monkeypatch.setattr(openai_module, "_PROXY_EXECUTOR", executor)
-    yield
-    executor.shutdown(wait=True, cancel_futures=True)
-
-
-@pytest.fixture(autouse=True)
 def _allow_localhost_for_api_agents(monkeypatch):
     """Ensure localhost is allowed for API agent tests.
 
@@ -589,3 +568,40 @@ def _allow_localhost_for_api_agents(monkeypatch):
     This fixture ensures ARAGORA_ENV doesn't block localhost access for these tests.
     """
     monkeypatch.delenv("ARAGORA_ENV", raising=False)
+
+
+# Defined last so it is set up last and torn down FIRST: the executor must be
+# reaped while sibling autouse patches (ARAGORA_ENV, create_client_session)
+# are still in place, or an abandoned proxy leg could finish against
+# unpatched globals during teardown.
+@pytest.fixture(autouse=True)
+def _fresh_vibeproxy_executor(monkeypatch):
+    """Give each test a private VibeProxy executor and reap its threads.
+
+    The module-level ``_PROXY_EXECUTOR`` in ``api_agents.openai`` keeps its
+    worker threads alive for the rest of the process once a test routes a
+    request through VibeProxy.  Lingering threads flip
+    ``threading.active_count() > 1`` checks elsewhere in the suite — notably
+    ``quorum_evidence._reviewer_process_context()``, which then selects a
+    forkserver context and fails to pickle locally defined reviewer runners.
+
+    The teardown join is bounded: tests that deliberately abandon a wedged
+    proxy leg must release it themselves (block on an event, not a bare
+    sleep) — a worker still alive after the grace period fails loudly here
+    rather than hanging the suite or silently leaking the thread.
+    """
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+    from aragora.agents.api_agents import openai as openai_module
+
+    executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="vibeproxy-openai-test")
+    monkeypatch.setattr(openai_module, "_PROXY_EXECUTOR", executor)
+    yield
+    executor.shutdown(wait=False, cancel_futures=True)
+    deadline = time.monotonic() + 10.0
+    for thread in list(executor._threads):
+        thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    stuck = sorted(t.name for t in executor._threads if t.is_alive())
+    if stuck:
+        pytest.fail(f"VibeProxy executor threads did not exit within 10s: {stuck}")

--- a/tests/agents/api_agents/conftest.py
+++ b/tests/agents/api_agents/conftest.py
@@ -557,6 +557,27 @@ def _restore_create_client_session():
 
 
 @pytest.fixture(autouse=True)
+def _fresh_vibeproxy_executor(monkeypatch):
+    """Give each test a private VibeProxy executor and reap its threads.
+
+    The module-level ``_PROXY_EXECUTOR`` in ``api_agents.openai`` keeps its
+    worker threads alive for the rest of the process once a test routes a
+    request through VibeProxy.  Lingering threads flip
+    ``threading.active_count() > 1`` checks elsewhere in the suite — notably
+    ``quorum_evidence._reviewer_process_context()``, which then selects a
+    forkserver context and fails to pickle locally defined reviewer runners.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    from aragora.agents.api_agents import openai as openai_module
+
+    executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="vibeproxy-openai-test")
+    monkeypatch.setattr(openai_module, "_PROXY_EXECUTOR", executor)
+    yield
+    executor.shutdown(wait=True, cancel_futures=True)
+
+
+@pytest.fixture(autouse=True)
 def _allow_localhost_for_api_agents(monkeypatch):
     """Ensure localhost is allowed for API agent tests.
 

--- a/tests/agents/api_agents/test_openai.py
+++ b/tests/agents/api_agents/test_openai.py
@@ -780,17 +780,24 @@ class TestOpenAIVibeProxyRouting:
     ) -> None:
         """A stuck discovery leg (queue wait or socket) must not delay
         PREFER-mode fallback beyond the wall-clock discovery cap."""
+        import threading
         import time as time_module
 
         from aragora.agents.api_agents import openai as openai_module
         from aragora.agents.api_agents.openai import OpenAIAPIAgent
         from aragora.agents.transports.vibeproxy import ModelTransportPolicy, TransportMode
 
+        # The abandoned discovery leg keeps running in the executor after the
+        # wall-clock cap fires; block on an event (released in the finally)
+        # instead of a bare sleep so executor teardown does not re-serialize
+        # the full wedge duration.
+        release_wedge = threading.Event()
+
         class WedgedClient:
             base_url = "http://127.0.0.1:8318/v1"
 
             def catalog(self, *, timeout: float | None = None):
-                time_module.sleep(5.0)
+                release_wedge.wait(5.0)
                 return SimpleNamespace(models=frozenset({"gpt-5.5"}))
 
             def openai_request(self, **kwargs):
@@ -804,16 +811,19 @@ class TestOpenAIVibeProxyRouting:
             client=WedgedClient(),  # type: ignore[arg-type]
         )
 
-        started = time_module.perf_counter()
-        with patch(
-            "aragora.agents.api_agents.openai_compatible.create_client_session",
-            return_value=self._direct_session(mock_openai_response),
-        ):
-            result = await agent.generate("hello")
-        elapsed = time_module.perf_counter() - started
+        try:
+            started = time_module.perf_counter()
+            with patch(
+                "aragora.agents.api_agents.openai_compatible.create_client_session",
+                return_value=self._direct_session(mock_openai_response),
+            ):
+                result = await agent.generate("hello")
+            elapsed = time_module.perf_counter() - started
 
-        assert "test response from GPT" in result
-        assert elapsed < 3.0
+            assert "test response from GPT" in result
+            assert elapsed < 3.0
+        finally:
+            release_wedge.set()
 
     @pytest.mark.asyncio
     async def test_proxy_success_records_latency(self, mock_env_with_api_keys) -> None:


### PR DESCRIPTION
## Summary
Fixes pre-existing test pollution on main: running `tests/agents/api_agents/test_openai.py` before `tests/swarm/test_quorum_evidence.py` in one process failed `test_collect_overall_timeout_does_not_wait_for_stuck_reviewer` and `test_collect_overall_timeout_fails_closed_and_ignores_late_results`, while each file passed alone.

## Root cause
The VibeProxy routing tests (#9477) submit work to the module-level `_PROXY_EXECUTOR` `ThreadPoolExecutor` in `aragora/agents/api_agents/openai.py`. Its worker threads (`vibeproxy-openai_*`) persist for the rest of the process. `quorum_evidence._reviewer_process_context()` then sees `threading.active_count() > 1` and — correctly, for fork safety in a threaded parent — selects a **forkserver** context instead of **fork**. Forkserver must pickle the worker target, and the quorum tests' locally defined `runner` closures are not picklable:

```
AttributeError: Can't pickle local object 'test_collect_overall_timeout_...<locals>.runner'
```

The production fork-safety check is legitimate; the pollution is the leaked test threads.

## Fix
Autouse fixture in `tests/agents/api_agents/conftest.py` (alongside the existing pollution-guard fixtures there) that monkeypatches a fresh per-test executor and shuts it down with `cancel_futures=True` at teardown, reaping its threads and restoring the pristine (thread-less) module executor.

## Verification
- `pytest tests/agents/api_agents/test_openai.py tests/swarm/test_quorum_evidence.py`: 310 passed (previously 2 failed)
- Thread probe after `test_openai.py`: `threading.active_count() == 1` (previously 3 with two `vibeproxy-openai_*` threads)
- Full `tests/agents/api_agents/`: 811 passed

## Reviewed design tradeoffs
- Test-side fixture over production change: the forkserver selection in `_reviewer_process_context()` is deliberate fork-safety behavior and must not be weakened; the leak is purely a test-process artifact.
- Per-test (function-scoped) swap over module-scoped teardown: threads spawn lazily, so a fresh executor is free, and each test starts from a clean thread state regardless of ordering within the directory.
- `cancel_futures=True` on shutdown so a test that leaves queued work behind cannot hang teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)