### PR TITLE
test(swarm): make overall-timeout reviewer runners picklable under forkserver

### DIFF
--- a/tests/swarm/test_quorum_evidence.py
+++ b/tests/swarm/test_quorum_evidence.py
@@ -12,6 +12,7 @@ The compose helper is checked against the *real* evidence parser
 from __future__ import annotations
 
 import asyncio
+import functools
 import json
 import multiprocessing
 import os
@@ -1040,23 +1041,34 @@ def test_collect_runs_reviewers_concurrently() -> None:
     assert outcome.failures == []
 
 
+def _claude_passes_others_stall_runner(family: str, prompt: str, delay: float) -> ReviewerResult:
+    """Module-level so it stays picklable under forkserver/spawn contexts.
+
+    ``_reviewer_process_context`` deliberately avoids fork whenever the parent
+    has extra threads (e.g. leaked by an earlier test file), and forkserver and
+    spawn must pickle the runner. A local closure would fail with
+    ``AttributeError: Can't pickle local object``. Parametrize the stall via
+    ``functools.partial`` — partials of module-level functions pickle fine.
+    """
+    if family == "claude":
+        return ReviewerResult(family, "Verdict: PASS from claude", True)
+    time.sleep(delay)
+    return ReviewerResult(family, f"Verdict: PASS from {family}", True)
+
+
 def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None:
     fakes, posted = _fakes(tier=0)
-
-    def runner(family: str, prompt: str) -> ReviewerResult:
-        if family == "claude":
-            return ReviewerResult(family, "Verdict: PASS from claude", True)
-        time.sleep(1.5)
-        return ReviewerResult(family, "Verdict: PASS from grok", True)
-
-    fakes["reviewer_runner"] = runner
+    # Deadline must leave room for forkserver/spawn worker boot (fork starts in
+    # ~ms, forkserver re-imports this module in the child) while staying well
+    # under grok's stall so only grok times out.
+    fakes["reviewer_runner"] = functools.partial(_claude_passes_others_stall_runner, delay=3.0)
     outcome = collect_evidence(
         repo="o/r",
         pr=1,
         families=["claude", "grok"],
         author="me",
         apply=True,
-        overall_timeout_seconds=0.2,
+        overall_timeout_seconds=0.75,
         **fakes,
     )
 
@@ -1070,17 +1082,12 @@ def test_collect_overall_timeout_fails_closed_and_ignores_late_results() -> None
 
 
 def test_collect_overall_timeout_does_not_wait_for_stuck_reviewer() -> None:
-    if "fork" not in multiprocessing.get_all_start_methods():
-        pytest.skip("process-supervised timeout regression requires fork context")
+    # Verified under fork and forkserver (macOS); spawn-only platforms boot a
+    # fresh interpreter per worker, which the tight deadline cannot absorb.
+    if not {"fork", "forkserver"} & set(multiprocessing.get_all_start_methods()):
+        pytest.skip("process-supervised timeout regression needs fork or forkserver")
     fakes, posted = _fakes(tier=0)
-
-    def runner(family: str, prompt: str) -> ReviewerResult:
-        if family == "claude":
-            return ReviewerResult(family, "Verdict: PASS from claude", True)
-        time.sleep(10)
-        return ReviewerResult(family, "Verdict: PASS from grok", True)
-
-    fakes["reviewer_runner"] = runner
+    fakes["reviewer_runner"] = functools.partial(_claude_passes_others_stall_runner, delay=10)
     started_at = time.monotonic()
     outcome = collect_evidence(
         repo="o/r",
@@ -1088,12 +1095,13 @@ def test_collect_overall_timeout_does_not_wait_for_stuck_reviewer() -> None:
         families=["claude", "grok"],
         author="me",
         apply=True,
-        overall_timeout_seconds=0.05,
+        overall_timeout_seconds=1.0,
         **fakes,
     )
     elapsed = time.monotonic() - started_at
 
-    assert elapsed < 1.0
+    # Far below grok's 10s stall: proves the deadline reaps stuck workers.
+    assert elapsed < 5.0
     assert outcome.orchestration_timeout is True
     assert outcome.timed_out_families == ["grok"]
     assert outcome.action == "prepare"


### PR DESCRIPTION
## Summary

Hardens the two `collect_evidence` overall-timeout tests in `tests/swarm/test_quorum_evidence.py` against leaked threads from earlier test files:

- `test_collect_overall_timeout_does_not_wait_for_stuck_reviewer`
- `test_collect_overall_timeout_fails_closed_and_ignores_late_results`

`_reviewer_process_context()` in `aragora/swarm/quorum_evidence.py` deliberately selects forkserver/spawn instead of fork whenever `threading.active_count() > 1` (fork-safety in threaded parents — intentionally untouched here). Those start methods must pickle the worker target and its args. The two tests defined their `reviewer_runner` callables as local closures, which are unpicklable, so any lingering thread from a neighboring test file flipped them onto the forkserver path and they failed with `AttributeError: Can't pickle local object '...<locals>.runner'`.

Companion to #9493, which reaps the known leaked-thread source (module-level `_PROXY_EXECUTOR` in `aragora/agents/api_agents/openai.py`). This PR is the complementary fix: the tests are now robust regardless of what neighbors leak.

## Changes

- Replaced the local-closure runners with one module-level runner (`_claude_passes_others_stall_runner`) parametrized via `functools.partial` — partials of module-level functions pickle fine under forkserver and spawn.
- Widened deadlines/margins just enough to absorb forkserver child boot (the child re-imports the test module, ~0.1–0.3s, vs ~ms for fork): stuck test `overall_timeout_seconds` 0.05→1.0 and elapsed bound 1.0→5.0; fails-closed test deadline 0.2→0.75 with the stall raised 1.5→3.0 to keep margin on both sides. Semantics are unchanged: the fast reviewer's result is kept, only the stalled reviewer times out, and orchestration provably never waits out the 10s stall.
- Relaxed the stuck test's skip guard from fork-only to fork-or-forkserver (verified under both on macOS). Spawn-only platforms still skip: a fresh interpreter per worker cannot absorb the tight deadline. Note the old guard never protected against the leaked-thread flip anyway — `"fork" in get_all_start_methods()` is true on macOS/Linux even when forkserver ends up being used.

## Verification

1. `python3 -m pytest tests/swarm/test_quorum_evidence.py -q` — 259 passed alone (fork path).
2. Leaked-thread reproduction: a probe test file that starts a `ThreadPoolExecutor`, submits a no-op, and never shuts down (leaving a worker thread alive) run first in the same pytest process, forcing the forkserver path. Both timeout tests pass, cold and warm (previously: the pickle `AttributeError`; after the pickle fix alone, the 0.05s deadline still swept the fast reviewer into `timed_out_families` under forkserver — hence the margin widening).
3. Probe + full file: 260 passed, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)