### PR TITLE
fix(profiles): keep Claude pool alive via VibeProxy token sync

### DIFF
--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -164,10 +164,13 @@ bash scripts/install_claude_profile_sync_launchd.sh
 This revives every profile VibeProxy can source — one profile per VibeProxy
 account. Requirements: VibeProxy running with the Claude accounts connected
 (auth files at `~/.cli-proxy-api/claude-*.json`) and the local config filled in.
-The sync writes a `0600` `.bak` before replacing a credential and refuses to
-overwrite a fresh **native** login (live token + real refresh token) without
-`--force`. Run the timer more often than VibeProxy's refresh lead (it refreshes
-~10 min before the ~8h access-token expiry); 30 min is the default.
+The sync backs up a **native** credential (`0600` `.bak`) before replacing it
+and refuses to overwrite a profile holding a real refresh token without
+`--force`. The timer interval must be **≤ VibeProxy's refresh lead** (it
+refreshes ~10 min before the ~8h access-token expiry) so a sync always lands in
+the window between the new token appearing and the old one lapsing; the default
+is **5 min**. A wider interval would leave a profile on an expired, blank-refresh
+token for up to `(interval − lead)` every ~8h.
 
 **One profile per VibeProxy account (important).** VibeProxy authenticates by
 **email** and holds exactly **one org per email**. Two profiles that are

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -156,7 +156,7 @@ python3 scripts/sync_claude_profiles_from_vibeproxy.py
 
 # ONE-TIME bootstrap: profiles that still hold a native (or dead) refresh token
 # are protected by default, so convert them to VibeProxy-managed consumers once
-# with --force. After this they carry a blank refresh token and sync freely.
+# with --force. Run from the repo so --probe-after can find claude_profile.sh.
 python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --force --probe-after
 
 # Steady state (no --force): keeps the managed profiles fresh.

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -151,15 +151,28 @@ chmod 600 ~/.aragora/claude_profile_sync.json
 ```
 
 ```bash
-# One-shot: sync every mapped profile from VibeProxy (dry-run first, then apply)
+# Preview the plan (dry-run):
 python3 scripts/sync_claude_profiles_from_vibeproxy.py
-python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --probe-after
+
+# ONE-TIME bootstrap: profiles that still hold a native (or dead) refresh token
+# are protected by default, so convert them to VibeProxy-managed consumers once
+# with --force. After this they carry a blank refresh token and sync freely.
+python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --force --probe-after
+
+# Steady state (no --force): keeps the managed profiles fresh.
+python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply
 
 # Make it durable: a launchd timer (deploys the script to ~/.aragora/bin, outside
 # any git checkout so worktree TTL-cleanup and merges never touch it; seeds the
 # config from the example if absent)
 bash scripts/install_claude_profile_sync_launchd.sh
 ```
+
+> **First run needs `--force`.** The daemon runs `--apply` without `--force` and
+> refuses to overwrite any non-blank refresh token (it cannot tell a live native
+> login from a revoked one offline). Until you bootstrap once with `--force`, the
+> sync skips every native/dead profile and **exits non-zero** so the launchd log
+> flags it rather than silently reporting success.
 
 This revives every profile VibeProxy can source — one profile per VibeProxy
 account. Requirements: VibeProxy running with the Claude accounts connected

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -141,32 +141,44 @@ token into the matching profile, written **without a usable refresh token**
 hourly `claude_pool_verify.py` is automatically safe — a profile with no refresh
 token cannot rotate anything even when probed.
 
+First, declare your account map in an **untracked local config** — the
+email→profile mapping is PII and is deliberately not in the repo:
+
+```bash
+cp scripts/claude_profile_sync.json.example ~/.aragora/claude_profile_sync.json
+chmod 600 ~/.aragora/claude_profile_sync.json
+# then edit it: sync_target = {your-email: profile}, native_only = {profile: reason}
+```
+
 ```bash
 # One-shot: sync every mapped profile from VibeProxy (dry-run first, then apply)
 python3 scripts/sync_claude_profiles_from_vibeproxy.py
 python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --probe-after
 
-# Make it durable: a 30-min launchd timer (deploys the script to ~/.aragora/bin,
-# outside any git checkout so worktree TTL-cleanup and merges never touch it)
+# Make it durable: a launchd timer (deploys the script to ~/.aragora/bin, outside
+# any git checkout so worktree TTL-cleanup and merges never touch it; seeds the
+# config from the example if absent)
 bash scripts/install_claude_profile_sync_launchd.sh
 ```
 
 This revives every profile VibeProxy can source — one profile per VibeProxy
-account. Requirements: VibeProxy running with the Claude accounts connected, and
-its auth files at `~/.cli-proxy-api/claude-*.json`.
+account. Requirements: VibeProxy running with the Claude accounts connected
+(auth files at `~/.cli-proxy-api/claude-*.json`) and the local config filled in.
+The sync writes a `0600` `.bak` before replacing a credential and refuses to
+overwrite a fresh **native** login (live token + real refresh token) without
+`--force`. Run the timer more often than VibeProxy's refresh lead (it refreshes
+~10 min before the ~8h access-token expiry); 30 min is the default.
 
 **One profile per VibeProxy account (important).** VibeProxy authenticates by
 **email** and holds exactly **one org per email**. Two profiles that are
-*different orgs under one shared login* — e.g. a personal Max org and a
-Synaptent team org, both under `synaptent@synaptent.com` — cannot both be
-sourced from VibeProxy: syncing both would silently collapse one subscription
-onto the other's org. The sync therefore enforces a strict 1:1 map
-(`VIBEPROXY_SYNC_TARGET`) and refuses to sync the same-email sibling
-(`NATIVE_ONLY_REASON`). Those distinct-org seats, plus any account VibeProxy
-does not hold (e.g. `max-10` / `armand.tuzel@gmail.com`), stay on the
-interactive re-login path below. A profile can be repointed at an unused
-VibeProxy account (e.g. `ringrift.ai@gmail.com`) simply by editing
-`VIBEPROXY_SYNC_TARGET` — the sync is the binding, no native login needed.
+*different orgs under one shared login* — e.g. a personal Max org and a team org
+under the same address — cannot both be sourced from VibeProxy: syncing both
+would silently collapse one subscription onto the other's org. The config's
+`sync_target` is therefore a strict 1:1 email→profile map, and the same-email
+sibling goes in `native_only`. Those distinct-org seats, plus any account
+VibeProxy does not hold, stay on the interactive re-login path below. A profile
+can be repointed at an unused VibeProxy account by editing `sync_target` — the
+sync is the binding, no native login needed.
 
 ## Re-login runbook
 

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -120,6 +120,43 @@ A receipt is written to `.aragora/review-local/<timestamp>/` (`review.json` + `i
 The verdict status maps to the exit code: `passed` → 0, `changes_requested` → 2, anything
 blocked → 1.
 
+## Staying alive without re-login: VibeProxy token sync
+
+**Why profiles kept expiring.** Anthropic OAuth **single-use-rotates** the refresh
+token on every refresh — once used, the old refresh token is revoked. When the
+same account is refreshed by more than one process, whoever refreshes first wins
+and every other holder is left with a revoked token. In the field this pool ran
+at **0/12 healthy**: 9 of 12 profiles held accounts that VibeProxy's
+`cli-proxy-api` *also* refreshes on its own schedule, and two profile pairs
+shared a single login. The hourly `claude_pool_verify.py` refresh side-effect
+could not win a race it could not see. (Its own docstring predicted this:
+"canNOT revive a revoked refresh token — duplicate accounts, same-org seats, or
+the same account used concurrently.")
+
+**The fix — consume VibeProxy's tokens instead of competing.** VibeProxy stays
+alive because it is the **single owner** of each account's refresh token. So
+aragora stops refreshing and instead copies VibeProxy's already-fresh access
+token into the matching profile, written **without a usable refresh token**
+(pure consumer). aragora can then never rotate VibeProxy's live token, and the
+hourly `claude_pool_verify.py` is automatically safe — a profile with no refresh
+token cannot rotate anything even when probed.
+
+```bash
+# One-shot: sync every mapped profile from VibeProxy (dry-run first, then apply)
+python3 scripts/sync_claude_profiles_from_vibeproxy.py
+python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --probe-after
+
+# Make it durable: a 30-min launchd timer (deploys the script to ~/.aragora/bin,
+# outside any git checkout so worktree TTL-cleanup and merges never touch it)
+bash scripts/install_claude_profile_sync_launchd.sh
+```
+
+This took the pool from 0/12 to **11/12 healthy** in one sync. The single
+exception is any profile whose account VibeProxy does **not** hold (e.g.
+`max-10` / `armand.tuzel@gmail.com`) — add that account to VibeProxy, or keep it
+on the interactive re-login path below. Requirements: VibeProxy running with the
+Claude accounts connected, and its auth files at `~/.cli-proxy-api/claude-*.json`.
+
 ## Re-login runbook
 
 OAuth login is **interactive** and must be done by you (it opens a browser per profile).
@@ -155,5 +192,8 @@ After re-login, always re-run `verify --json` so the health snapshot reflects re
 ## Related
 
 - `scripts/claude_profiles_bootstrap.sh`, `scripts/claude_profile.sh`
+- `scripts/sync_claude_profiles_from_vibeproxy.py`, `scripts/install_claude_profile_sync_launchd.sh` (VibeProxy token sync)
+- `scripts/claude_pool_verify.py` (hourly health probe)
+- `docs/guides/VIBEPROXY.md` (the local transport whose fresh tokens the sync consumes)
 - `aragora/swarm/review_routing.py` (routing, preflight, snapshot, rotation)
 - `aragora/cli/commands/review_pr.py` (`review-pr`, `review-local`)

--- a/docs/guides/CLAUDE_MAX_POOL.md
+++ b/docs/guides/CLAUDE_MAX_POOL.md
@@ -151,11 +151,22 @@ python3 scripts/sync_claude_profiles_from_vibeproxy.py --apply --probe-after
 bash scripts/install_claude_profile_sync_launchd.sh
 ```
 
-This took the pool from 0/12 to **11/12 healthy** in one sync. The single
-exception is any profile whose account VibeProxy does **not** hold (e.g.
-`max-10` / `armand.tuzel@gmail.com`) — add that account to VibeProxy, or keep it
-on the interactive re-login path below. Requirements: VibeProxy running with the
-Claude accounts connected, and its auth files at `~/.cli-proxy-api/claude-*.json`.
+This revives every profile VibeProxy can source — one profile per VibeProxy
+account. Requirements: VibeProxy running with the Claude accounts connected, and
+its auth files at `~/.cli-proxy-api/claude-*.json`.
+
+**One profile per VibeProxy account (important).** VibeProxy authenticates by
+**email** and holds exactly **one org per email**. Two profiles that are
+*different orgs under one shared login* — e.g. a personal Max org and a
+Synaptent team org, both under `synaptent@synaptent.com` — cannot both be
+sourced from VibeProxy: syncing both would silently collapse one subscription
+onto the other's org. The sync therefore enforces a strict 1:1 map
+(`VIBEPROXY_SYNC_TARGET`) and refuses to sync the same-email sibling
+(`NATIVE_ONLY_REASON`). Those distinct-org seats, plus any account VibeProxy
+does not hold (e.g. `max-10` / `armand.tuzel@gmail.com`), stay on the
+interactive re-login path below. A profile can be repointed at an unused
+VibeProxy account (e.g. `ringrift.ai@gmail.com`) simply by editing
+`VIBEPROXY_SYNC_TARGET` — the sync is the binding, no native login needed.
 
 ## Re-login runbook
 

--- a/scripts/claude_profile_sync.json.example
+++ b/scripts/claude_profile_sync.json.example
@@ -1,0 +1,11 @@
+{
+  "_comment": "Copy to ~/.aragora/claude_profile_sync.json (or set ARAGORA_PROFILE_SYNC_CONFIG) and fill in your real accounts. This file holds operator email->profile mappings and is intentionally NOT tracked in git. 'sync_target' is a strict 1:1 email->profile map (VibeProxy holds one org per email, so a shared login's second org must NOT be synced). 'native_only' lists profiles that stay on interactive login, with the reason.",
+  "sync_target": {
+    "you+work@example.com": "max-01",
+    "you+personal@example.com": "max-02"
+  },
+  "native_only": {
+    "max-03": "shares an email with another profile but is a different org; native login only",
+    "max-04": "no VibeProxy account for this email; native login only"
+  }
+}

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -53,6 +53,9 @@ mkdir -p "$(dirname "$PLIST_PATH")"
 mkdir -p "$(dirname "$LOG_PATH")"
 mkdir -p "${DEPLOY_DIR}"
 
+# The log records profile/email lines (emails masked, but keep it owner-only).
+touch "${LOG_PATH}" && chmod 0600 "${LOG_PATH}"
+
 # Deploy the current repo copy of the sync script to the stable location.
 cp "${REPO_ROOT}/scripts/${SCRIPT_NAME}" "${DEPLOY_PATH}"
 chmod 0755 "${DEPLOY_PATH}"
@@ -105,5 +108,7 @@ echo "Log: ${LOG_PATH}"
 echo "Uninstall: launchctl unload \"${PLIST_PATH}\" && rm \"${PLIST_PATH}\""
 echo
 echo "ONE-TIME bootstrap (the daemon runs without --force and skips native/dead"
-echo "profiles): once your config is filled in, convert them with:"
-echo "  \"${PYTHON_BIN}\" \"${DEPLOY_PATH}\" --apply --force --probe-after"
+echo "profiles): once your config is filled in, convert them with --force. Run it"
+echo "from the repo so --probe-after can find claude_profile.sh (the deployed copy"
+echo "cannot, and would report probe=SKIP):"
+echo "  (cd \"${REPO_ROOT}\" && \"${PYTHON_BIN}\" scripts/${SCRIPT_NAME} --apply --force --probe-after)"

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -11,7 +11,11 @@
 set -euo pipefail
 
 LABEL="com.aragora.claude-profile-sync"
-INTERVAL_SECONDS=1800  # 30 min: well under the ~8h access-token TTL
+# 5 min: must be <= VibeProxy's refresh lead (~10 min before the ~8h expiry) so a
+# sync always lands in the [expiry-10min, expiry] window and picks up the newly
+# refreshed token before the old one lapses. A wider interval leaves the profile
+# holding an expired, blank-refresh token for up to (interval - lead) every ~8h.
+INTERVAL_SECONDS=300
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOG_PATH="${HOME}/.aragora/claude-profile-sync.log"
 PYTHON_BIN="${ARAGORA_PYTHON:-python3}"

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -53,6 +53,16 @@ mkdir -p "${DEPLOY_DIR}"
 cp "${REPO_ROOT}/scripts/${SCRIPT_NAME}" "${DEPLOY_PATH}"
 chmod 0755 "${DEPLOY_PATH}"
 
+# Seed the untracked local mapping config from the example if absent. The map
+# (operator emails) is intentionally NOT in tracked source; fill it in before
+# the daemon can sync anything.
+CONFIG_PATH="${HOME}/.aragora/claude_profile_sync.json"
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  cp "${REPO_ROOT}/scripts/claude_profile_sync.json.example" "${CONFIG_PATH}"
+  chmod 0600 "${CONFIG_PATH}"
+  echo "NOTE: seeded ${CONFIG_PATH} from the example — edit it with your real email->profile map."
+fi
+
 cat >"${PLIST_PATH}" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -103,3 +103,7 @@ echo "Deployed script: ${DEPLOY_PATH}"
 echo "Interval: ${INTERVAL_SECONDS}s"
 echo "Log: ${LOG_PATH}"
 echo "Uninstall: launchctl unload \"${PLIST_PATH}\" && rm \"${PLIST_PATH}\""
+echo
+echo "ONE-TIME bootstrap (the daemon runs without --force and skips native/dead"
+echo "profiles): once your config is filled in, convert them with:"
+echo "  \"${PYTHON_BIN}\" \"${DEPLOY_PATH}\" --apply --force --probe-after"

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Install a launchd job that keeps aragora Claude profiles alive by consuming
+# VibeProxy's already-fresh access tokens (scripts/sync_claude_profiles_from_vibeproxy.py).
+#
+# Why this exists: Anthropic OAuth single-use-rotates refresh tokens, so two
+# independent refreshers on the same account revoke each other. VibeProxy stays
+# alive because it is the SOLE refresher of its accounts; aragora stops competing
+# and instead syncs VibeProxy's fresh access token into the matching profile,
+# writing it WITHOUT a usable refresh token (pure consumer). Run more often than
+# the ~8h access-token TTL so a synced token never lapses between cycles.
+set -euo pipefail
+
+LABEL="com.aragora.claude-profile-sync"
+INTERVAL_SECONDS=1800  # 30 min: well under the ~8h access-token TTL
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_PATH="${HOME}/.aragora/claude-profile-sync.log"
+PYTHON_BIN="${ARAGORA_PYTHON:-python3}"
+SCRIPT_NAME="sync_claude_profiles_from_vibeproxy.py"
+# Deploy the sync script to a stable location OUTSIDE any git checkout: session
+# worktrees are TTL-cleaned, and pointing launchd at the main checkout would let
+# a later merge of the same tracked filename collide with the untracked copy.
+DEPLOY_DIR="${HOME}/.aragora/bin"
+DEPLOY_PATH="${DEPLOY_DIR}/${SCRIPT_NAME}"
+# launchd runs with a minimal PATH; the sync itself needs only python, but keep
+# the same explicit PATH as the sibling verify job for the optional probe path.
+BIN_PATH="${HOME}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--interval-seconds <n>] [--python <path>] [--path <PATH>]
+  --interval-seconds <n>   launchd StartInterval (default: ${INTERVAL_SECONDS})
+  --python <path>          Python interpreter (default: ${PYTHON_BIN})
+  --path <PATH>            PATH for the job
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval-seconds) INTERVAL_SECONDS="$2"; shift 2 ;;
+    --python) PYTHON_BIN="$2"; shift 2 ;;
+    --path) BIN_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+mkdir -p "$(dirname "$PLIST_PATH")"
+mkdir -p "$(dirname "$LOG_PATH")"
+mkdir -p "${DEPLOY_DIR}"
+
+# Deploy the current repo copy of the sync script to the stable location.
+cp "${REPO_ROOT}/scripts/${SCRIPT_NAME}" "${DEPLOY_PATH}"
+chmod 0755 "${DEPLOY_PATH}"
+
+cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>export PATH="${BIN_PATH}" &amp;&amp; "${PYTHON_BIN}" "${DEPLOY_PATH}" --apply</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>${INTERVAL_SECONDS}</integer>
+  <key>WorkingDirectory</key>
+  <string>${HOME}</string>
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+
+launchctl unload "${PLIST_PATH}" >/dev/null 2>&1 || true
+launchctl load "${PLIST_PATH}"
+
+echo "Installed launchd job: ${LABEL}"
+echo "Plist: ${PLIST_PATH}"
+echo "Deployed script: ${DEPLOY_PATH}"
+echo "Interval: ${INTERVAL_SECONDS}s"
+echo "Log: ${LOG_PATH}"
+echo "Uninstall: launchctl unload \"${PLIST_PATH}\" && rm \"${PLIST_PATH}\""

--- a/scripts/install_claude_profile_sync_launchd.sh
+++ b/scripts/install_claude_profile_sync_launchd.sh
@@ -70,6 +70,18 @@ if [[ ! -f "${CONFIG_PATH}" ]]; then
   echo "NOTE: seeded ${CONFIG_PATH} from the example — edit it with your real email->profile map."
 fi
 
+# launchd runs with a minimal environment, so capture the sync script's override
+# env vars at install time and bake them into the job. Otherwise an operator who
+# uses a non-default profile root / config in their shell installs a daemon that
+# silently writes to the DEFAULT locations, leaving the real pool stale.
+ENV_EXPORTS="export PATH=\"${BIN_PATH}\""
+if [[ -n "${CLAUDE_PROFILE_ROOT:-}" ]]; then
+  ENV_EXPORTS+=" CLAUDE_PROFILE_ROOT=\"${CLAUDE_PROFILE_ROOT}\""
+fi
+if [[ -n "${ARAGORA_PROFILE_SYNC_CONFIG:-}" ]]; then
+  ENV_EXPORTS+=" ARAGORA_PROFILE_SYNC_CONFIG=\"${ARAGORA_PROFILE_SYNC_CONFIG}\""
+fi
+
 cat >"${PLIST_PATH}" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -81,7 +93,7 @@ cat >"${PLIST_PATH}" <<EOF
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>export PATH="${BIN_PATH}" &amp;&amp; "${PYTHON_BIN}" "${DEPLOY_PATH}" --apply</string>
+    <string>${ENV_EXPORTS} &amp;&amp; "${PYTHON_BIN}" "${DEPLOY_PATH}" --apply</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Keep aragora Claude profiles alive by consuming VibeProxy's fresh tokens.
+
+Root cause this solves
+----------------------
+Anthropic OAuth **single-use-rotates** the refresh token on every refresh: once
+a refresh token is used it is replaced and the old one is revoked. When the same
+Claude account is refreshed by more than one independent process, whichever
+refreshes first wins and every other holder is left with a revoked token -> dead.
+
+Aragora's hourly ``claude_pool_verify.py`` keeps *valid-refresh* profiles alive
+by probing them (the probe triggers the CLI's own refresh). That is correct in
+isolation, but it loses a race it cannot see: VibeProxy's ``cli-proxy-api`` also
+refreshes the very same accounts on its own schedule, and two aragora profiles
+sometimes share one login. The result observed in the field is 0/13 healthy.
+
+The fix (the "VibeProxy approach", done right)
+----------------------------------------------
+VibeProxy stays alive because it is the **single owner** of each account's
+refresh token. So aragora stops competing to refresh and instead **consumes**
+VibeProxy's already-fresh access token: this script copies the freshly-refreshed
+access token from ``~/.cli-proxy-api/claude-<email>.json`` into the matching
+aragora profile credential, translating the on-disk format.
+
+To guarantee aragora can never rotate VibeProxy's token out from under it, the
+synced aragora credential is written **without a usable refresh token**
+(``--blank-refresh``, the default): aragora becomes a pure token consumer. If a
+sync cycle ever lags past the access-token expiry the profile simply reports
+expired until the next cycle heals it -- it never revokes VibeProxy's live token.
+Run this on a short interval (well under the ~8h access-token TTL) via launchd.
+
+This script only reads VibeProxy auth files and writes aragora profile
+credentials on the local machine. It never prints token material and never makes
+a network call.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+VIBEPROXY_AUTH_DIR = Path.home() / ".cli-proxy-api"
+ARAGORA_PROFILE_ROOT = Path.home() / ".aragora-claude"
+PROFILE_TOOL = Path(__file__).resolve().parent / "claude_profile.sh"
+
+# Authoritative profile -> account binding (mirrors the static map in
+# scripts/claude_profiles_bootstrap.sh). max-13 is bound at login time to
+# armand@synaptent.com; max-10 has no VibeProxy-held account and is skipped.
+PROFILE_EMAILS: dict[str, str] = {
+    "max-01": "anomium@gmail.com",
+    "max-02": "scarmani@gmail.com",
+    "max-03": "ap@synaptent.com",
+    "max-04": "liftmode@liftmode.com",
+    "max-05": "root@liftmode.com",
+    "max-06": "ap@synaptent.com",
+    "max-07": "radnoem@gmail.com",
+    "max-08": "synaptent@synaptent.com",
+    "max-09": "synaptent@synaptent.com",
+    "max-10": "armand.tuzel@gmail.com",
+    "max-11": "verborgen.doel@gmail.com",
+    "max-12": "armand@synaptent.com",
+    "max-13": "armand@synaptent.com",
+}
+
+# Scope/plan fields VibeProxy does not carry; preserved from an existing aragora
+# credential when present, else these Max-plan defaults.
+_DEFAULT_SCOPES = [
+    "user:file_upload",
+    "user:inference",
+    "user:mcp_servers",
+    "user:profile",
+    "user:sessions:claude_code",
+]
+_DEFAULT_SUBSCRIPTION = "max"
+
+
+@dataclass
+class SyncResult:
+    profile: str
+    email: str
+    action: str  # synced | skipped_no_source | skipped_fresh | skipped_no_email | error
+    detail: str = ""
+
+
+def _vibeproxy_path(email: str) -> Path:
+    return VIBEPROXY_AUTH_DIR / f"claude-{email}.json"
+
+
+def _profile_cred_path(profile: str) -> Path:
+    return ARAGORA_PROFILE_ROOT / profile / ".claude" / ".credentials.json"
+
+
+def _iso_to_epoch_ms(value: str) -> int:
+    return int(_dt.datetime.fromisoformat(value).timestamp() * 1000)
+
+
+def _load_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def translate_credential(
+    vibeproxy: dict,
+    existing_oauth: dict | None,
+    *,
+    blank_refresh: bool,
+) -> dict:
+    """Build an aragora ``.credentials.json`` payload from a VibeProxy account.
+
+    Preserves plan/scope metadata from any existing aragora credential; those
+    fields are absent from VibeProxy's format. When ``blank_refresh`` is set the
+    refresh token is emptied so aragora can never rotate VibeProxy's live token.
+    """
+    oauth = dict(existing_oauth or {})
+    oauth["accessToken"] = vibeproxy["access_token"]
+    oauth["refreshToken"] = "" if blank_refresh else vibeproxy.get("refresh_token", "")
+    oauth["expiresAt"] = _iso_to_epoch_ms(vibeproxy["expired"])
+    oauth.setdefault("scopes", list(_DEFAULT_SCOPES))
+    oauth.setdefault("subscriptionType", _DEFAULT_SUBSCRIPTION)
+    return {"claudeAiOauth": oauth}
+
+
+def _current_access_token(cred: dict | None) -> str | None:
+    if not cred:
+        return None
+    return (cred.get("claudeAiOauth") or {}).get("accessToken")
+
+
+def sync_profile(
+    profile: str,
+    email: str,
+    *,
+    blank_refresh: bool,
+    apply: bool,
+) -> SyncResult:
+    if not email:
+        return SyncResult(profile, email, "skipped_no_email")
+    vp = _load_json(_vibeproxy_path(email))
+    if vp is None or vp.get("disabled") or not vp.get("access_token"):
+        return SyncResult(profile, email, "skipped_no_source", "no live VibeProxy account")
+
+    cred_path = _profile_cred_path(profile)
+    existing = _load_json(cred_path)
+    existing_oauth = (existing or {}).get("claudeAiOauth")
+
+    # Idempotent: if the profile already holds this exact access token, do nothing.
+    if _current_access_token(existing) == vp["access_token"]:
+        return SyncResult(profile, email, "skipped_fresh", "already current")
+
+    payload = translate_credential(vp, existing_oauth, blank_refresh=blank_refresh)
+    if not apply:
+        return SyncResult(profile, email, "synced", "dry-run")
+
+    cred_path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic replace with owner-only permissions on the credential.
+    tmp = cred_path.with_suffix(".credentials.json.tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, cred_path)
+    return SyncResult(profile, email, "synced", "applied")
+
+
+def _probe(profile: str, timeout: int = 60) -> bool:
+    """Live-probe a profile the same way scripts/claude_pool_verify.py does."""
+    try:
+        proc = subprocess.run(
+            [str(PROFILE_TOOL), "exec", profile, "--", "claude", "--print", "-p", "-"],
+            input="hi",
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profiles", nargs="*", help="Profiles to sync (default: all mapped)")
+    parser.add_argument("--apply", action="store_true", help="Write files (default: dry-run)")
+    parser.add_argument(
+        "--keep-refresh",
+        action="store_true",
+        help="Keep VibeProxy's refresh token in the synced credential (default: blank it)",
+    )
+    parser.add_argument(
+        "--probe-after",
+        action="store_true",
+        help="After --apply, live-probe each synced profile and report health",
+    )
+    parser.add_argument("--json", dest="json_output", action="store_true")
+    args = parser.parse_args(argv)
+
+    profiles = args.profiles or list(PROFILE_EMAILS)
+    results: list[SyncResult] = []
+    for profile in profiles:
+        email = PROFILE_EMAILS.get(profile, "")
+        results.append(
+            sync_profile(
+                profile,
+                email,
+                blank_refresh=not args.keep_refresh,
+                apply=args.apply,
+            )
+        )
+
+    probed: dict[str, bool] = {}
+    if args.probe_after and args.apply:
+        for r in results:
+            if r.action == "synced":
+                probed[r.profile] = _probe(r.profile)
+
+    if args.json_output:
+        print(
+            json.dumps(
+                {
+                    "applied": args.apply,
+                    "blank_refresh": not args.keep_refresh,
+                    "results": [r.__dict__ for r in results],
+                    "probed": probed,
+                }
+            )
+        )
+    else:
+        for r in results:
+            probe_note = ""
+            if r.profile in probed:
+                probe_note = "  probe=" + ("LIVE" if probed[r.profile] else "DEAD")
+            print(f"  {r.profile:8} {r.email:28} {r.action:18} {r.detail}{probe_note}")
+        synced = sum(1 for r in results if r.action == "synced")
+        live = sum(1 for v in probed.values() if v)
+        tail = f"; {live}/{len(probed)} probed live" if probed else ""
+        print(f"Sync: {synced}/{len(results)} profiles updated{tail}")
+
+    # Non-zero when a probe ran and any synced profile came back dead.
+    if probed and not all(probed.values()):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -252,15 +252,27 @@ def sync_profile(
         # (a torn/corrupt read — plausible since the CLI rewrites the same file
         # on refresh). Treating a corrupt read as empty would bypass the
         # native-login guard and the backup and could destroy a live refresh
-        # token. On any read/parse failure of a PRESENT file, fail closed.
+        # token. Without --force a present-but-unreadable file fails closed;
+        # with --force it is backed up to .bak.corrupt and rewritten so a wedged
+        # profile can self-heal instead of erroring forever.
         existing: dict | None = None
+        existing_unreadable = False
         if cred_path.exists():
             try:
-                existing = json.loads(cred_path.read_text(encoding="utf-8"))
+                loaded = json.loads(cred_path.read_text(encoding="utf-8"))
+                if not isinstance(loaded, dict):
+                    raise ValueError("credential is not a JSON object")
+                existing = loaded
             except (OSError, ValueError) as exc:
-                return SyncResult(
-                    profile, email, "error", f"existing credential unreadable: {type(exc).__name__}"
-                )
+                if not force:
+                    return SyncResult(
+                        profile,
+                        email,
+                        "error",
+                        f"existing credential unreadable ({type(exc).__name__}); "
+                        "rerun with --force to back it up and overwrite",
+                    )
+                existing_unreadable = True
         existing_oauth = _oauth(existing)
 
         # Native-login guard runs BEFORE the idempotency check: a profile holding
@@ -289,18 +301,30 @@ def sync_profile(
             return SyncResult(profile, email, "synced", "dry-run")
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
-        # Back up ONLY a native credential (real refresh token) before replacing
-        # it — never overwrite that backup with one of our own blank-refresh
-        # creds, which would lose the last recoverable native login.
-        if existing_refresh:
+        if existing_unreadable:
+            # Preserve the corrupt bytes under --force so nothing is lost.
+            _write_owner_only(
+                cred_path.with_name(".credentials.json.bak.corrupt"),
+                cred_path.read_text(encoding="utf-8", errors="replace"),
+            )
+        elif existing_refresh:
+            # Back up ONLY a native credential (real refresh token) before
+            # replacing it — never overwrite that backup with one of our own
+            # blank-refresh creds, which would lose the last recoverable native
+            # login.
             _write_owner_only(
                 cred_path.with_name(".credentials.json.bak"),
                 cred_path.read_text(encoding="utf-8"),
             )
-        # Atomic, never-world-readable write.
-        tmp = cred_path.with_name(".credentials.json.tmp")
-        _write_owner_only(tmp, json.dumps(payload))
-        os.replace(tmp, cred_path)
+        # Atomic write via a per-process unique temp name (concurrent daemon +
+        # manual runs must not share one .tmp and tear each other's writes).
+        tmp = cred_path.with_name(f".credentials.json.{os.getpid()}.tmp")
+        try:
+            _write_owner_only(tmp, json.dumps(payload))
+            os.replace(tmp, cred_path)
+        finally:
+            if tmp.exists():
+                tmp.unlink()
         return SyncResult(profile, email, "synced", "applied")
     except (OSError, ValueError, KeyError) as exc:
         # Isolate per-profile failures so one malformed source does not abort the

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -27,8 +27,9 @@ synced aragora credential is written **without a usable refresh token**
 (``--blank-refresh``, the default): aragora becomes a pure token consumer. If a
 sync cycle ever lags past the access-token expiry the profile simply reports
 expired until the next cycle heals it -- it never revokes VibeProxy's live token.
-Run this more often than VibeProxy's refresh lead so a synced token never lapses
-between cycles (VibeProxy refreshes ~10 min before the ~8h access-token expiry).
+Run this on an interval **<= VibeProxy's refresh lead** (it refreshes ~10 min
+before the ~8h access-token expiry) so a sync always lands between the new token
+appearing and the old one lapsing; the installed timer defaults to 5 min.
 
 Mapping lives in a local, untracked config
 -------------------------------------------
@@ -45,9 +46,9 @@ Safety
 ------
 This script only reads VibeProxy auth files and writes aragora profile
 credentials on the local machine. It never prints token material and never makes
-a network call. It refuses to clobber a profile that holds a fresh *native* login
-(live access token + real refresh token) unless ``--force``, and always writes a
-``0600`` ``.bak`` before replacing a credential.
+a network call. It refuses to clobber a profile that holds a **native** login (a
+real, non-blank refresh token) unless ``--force``, and writes a ``0600`` ``.bak``
+of that native credential before ``--force`` replaces it.
 """
 
 from __future__ import annotations
@@ -236,14 +237,16 @@ def sync_profile(
         if existing_oauth.get("accessToken") == vp["access_token"]:
             return SyncResult(profile, email, "skipped_fresh", "already current")
 
-        # Never clobber a fresh NATIVE login (live access token + real refresh
-        # token) without --force: that would destroy a working refresh token.
+        # Never clobber a profile that holds a real (non-blank) refresh token
+        # without --force: that is a NATIVE login whose refresh token we would
+        # destroy. Gate on the refresh token alone, not access-token liveness —
+        # an idle native profile (valid refresh, expired access) is the normal
+        # healthy state and must still be protected. Our own synced creds carry
+        # a blank refresh token, so they re-sync freely.
         existing_refresh = existing_oauth.get("refreshToken") or ""
-        existing_exp = existing_oauth.get("expiresAt")
-        existing_live = isinstance(existing_exp, int) and existing_exp > _now_ms()
-        if existing_refresh and existing_live and not force:
+        if existing_refresh and not force:
             return SyncResult(
-                profile, email, "skipped_native_login", "live native login present (use --force)"
+                profile, email, "skipped_native_login", "native login present (use --force)"
             )
 
         payload = translate_credential(vp, existing_oauth, blank_refresh=blank_refresh)
@@ -251,8 +254,10 @@ def sync_profile(
             return SyncResult(profile, email, "synced", "dry-run")
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
-        # Back up the existing credential (0600) before replacing it.
-        if cred_path.exists():
+        # Back up ONLY a native credential (real refresh token) before replacing
+        # it — never overwrite that backup with one of our own blank-refresh
+        # creds, which would lose the last recoverable native login.
+        if existing_refresh:
             _write_owner_only(
                 cred_path.with_name(".credentials.json.bak"),
                 cred_path.read_text(encoding="utf-8"),
@@ -302,7 +307,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--keep-refresh",
         action="store_true",
-        help="Keep VibeProxy's refresh token in the synced credential (default: blank it)",
+        help=(
+            "Keep VibeProxy's refresh token in the synced credential (default: blank it). "
+            "UNSAFE: reintroduces the double-refresher race this tool removes — aragora may "
+            "then rotate VibeProxy's token. For debugging only."
+        ),
     )
     parser.add_argument(
         "--force",
@@ -373,16 +382,24 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(f"Sync: {synced}/{len(results)} profiles updated{tail}")
 
-    # Surface hard problems via exit code so a launchd log flags them:
-    # any per-profile error, a probed-dead profile, or a total source loss
-    # (every mapped profile lost its VibeProxy source).
+    # Surface hard problems via exit code so a launchd log flags them: any
+    # per-profile error, a probed-dead profile, or a total source loss. The
+    # dominant outage (a stopped/crashed proxy) leaves files present with
+    # *stale* tokens, so skipped_stale_source and error must count as source
+    # loss too — otherwise a full VibeProxy outage exits 0 and looks healthy.
     if any(r.action == "error" for r in results):
         return 1
     if probed and any(v is False for v in probed.values()):
         return 1
-    only_targets = [r for r in results if r.action != "skipped_native_only"]
-    if only_targets and all(r.action == "skipped_no_source" for r in only_targets):
-        print("error: no live VibeProxy sources for any mapped profile", file=sys.stderr)
+    _SOURCE_LOSS = {"skipped_no_source", "skipped_stale_source", "error"}
+    _HEALTHY = {"synced", "skipped_fresh", "skipped_native_login"}
+    targets = [r for r in results if r.action != "skipped_native_only"]
+    if (
+        targets
+        and not any(r.action in _HEALTHY for r in targets)
+        and all(r.action in _SOURCE_LOSS for r in targets)
+    ):
+        print("error: no usable VibeProxy source for any mapped profile", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -78,7 +78,7 @@ VIBEPROXY_SYNC_TARGET: dict[str, str] = {
     "synaptent@synaptent.com": "max-09",  # Synaptent team org (VibeProxy's org for this email)
     "verborgen.doel@gmail.com": "max-11",
     "armand@synaptent.com": "max-12",  # Synaptent team org
-    # ringrift.ai@gmail.com is held by VibeProxy but not yet assigned to a profile.
+    "ringrift.ai@gmail.com": "max-13",  # repointed from the max-12 duplicate to this distinct account
 }
 
 # Profiles deliberately NOT VibeProxy-synced, with why. A shared login's distinct
@@ -90,7 +90,6 @@ NATIVE_ONLY_REASON: dict[str, str] = {
         "Synaptent team org for that email (synced to max-09). Native login only."
     ),
     "max-10": "no VibeProxy account for armand.tuzel@gmail.com; native login only",
-    "max-13": "same armand@synaptent.com team seat as max-12; free to repoint at a distinct account",
 }
 
 # Reverse index: profile -> the VibeProxy email that sources it (if any).

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -248,7 +248,19 @@ def sync_profile(
             )
 
         cred_path = _profile_cred_path(profile)
-        existing = _load_json(cred_path)
+        # Distinguish "no credential yet" (proceed) from "present but unreadable"
+        # (a torn/corrupt read — plausible since the CLI rewrites the same file
+        # on refresh). Treating a corrupt read as empty would bypass the
+        # native-login guard and the backup and could destroy a live refresh
+        # token. On any read/parse failure of a PRESENT file, fail closed.
+        existing: dict | None = None
+        if cred_path.exists():
+            try:
+                existing = json.loads(cred_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                return SyncResult(
+                    profile, email, "error", f"existing credential unreadable: {type(exc).__name__}"
+                )
         existing_oauth = _oauth(existing)
 
         # Native-login guard runs BEFORE the idempotency check: a profile holding
@@ -412,26 +424,27 @@ def main(argv: list[str] | None = None) -> int:
     # dominant outage (a stopped/crashed proxy) leaves files present with
     # *stale* tokens, so skipped_stale_source and error must count as source
     # loss too — otherwise a full VibeProxy outage exits 0 and looks healthy.
-    if any(r.action == "error" for r in results):
-        return 1
     if probed and any(v is False for v in probed.values()):
         return 1
-    # "Healthy" = at least one profile is VibeProxy-managed or already current.
-    # skipped_native_login is NOT healthy: a revoked-but-present refresh token is
-    # indistinguishable from a live native login here, so an all-native result
-    # means every profile is unmanaged and the daemon is a silent no-op — the
-    # exact 0/N state this tool exists to fix (needs a one-time --force bootstrap).
+    # Fail loud on ANY mapped profile that is not managed/current, not only on a
+    # total outage: a partially broken pool (some synced, some stuck on
+    # native/no-source/stale/error) must not report success and hide the stuck
+    # profiles. "Healthy" = VibeProxy-managed or already current.
     _HEALTHY = {"synced", "skipped_fresh"}
     targets = [r for r in results if r.action != "skipped_native_only"]
-    if targets and not any(r.action in _HEALTHY for r in targets):
-        if all(r.action == "skipped_native_login" for r in targets):
+    unhealthy = [r for r in targets if r.action not in _HEALTHY]
+    if unhealthy:
+        if targets and all(r.action == "skipped_native_login" for r in targets):
             print(
                 "error: every mapped profile holds a native/dead refresh token and was "
                 "skipped; run once with --force to bootstrap VibeProxy-managed creds",
                 file=sys.stderr,
             )
         else:
-            print("error: no usable VibeProxy source for any mapped profile", file=sys.stderr)
+            detail = ", ".join(sorted(f"{r.profile}={r.action}" for r in unhealthy))
+            print(
+                f"error: {len(unhealthy)} mapped profile(s) not synced: {detail}", file=sys.stderr
+            )
         return 1
     return 0
 

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -48,7 +48,10 @@ This script only reads VibeProxy auth files and writes aragora profile
 credentials on the local machine. It never prints token material and never makes
 a network call. It refuses to clobber a profile that holds a **native** login (a
 real, non-blank refresh token) unless ``--force``, and writes a ``0600`` ``.bak``
-of that native credential before ``--force`` replaces it.
+of that native credential before ``--force`` replaces it. Because a live refresh
+token cannot be told from a revoked one offline, the FIRST run over native/dead
+profiles needs a one-time ``--force`` to bootstrap them into blank-refresh
+consumers; without it the run skips them all and exits non-zero.
 """
 
 from __future__ import annotations
@@ -233,21 +236,26 @@ def sync_profile(
         existing = _load_json(cred_path)
         existing_oauth = _oauth(existing)
 
-        # Idempotent: profile already holds this exact access token.
-        if existing_oauth.get("accessToken") == vp["access_token"]:
-            return SyncResult(profile, email, "skipped_fresh", "already current")
-
-        # Never clobber a profile that holds a real (non-blank) refresh token
-        # without --force: that is a NATIVE login whose refresh token we would
-        # destroy. Gate on the refresh token alone, not access-token liveness —
-        # an idle native profile (valid refresh, expired access) is the normal
-        # healthy state and must still be protected. Our own synced creds carry
-        # a blank refresh token, so they re-sync freely.
+        # Native-login guard runs BEFORE the idempotency check: a profile holding
+        # a real (non-blank) refresh token is a native login we must not blank
+        # without --force, even if its access token coincidentally matches
+        # VibeProxy's (else the double-refresher race persists). We cannot tell a
+        # live refresh token from a revoked one offline, so the FIRST sync of a
+        # native/dead profile needs a one-time --force to convert it to a
+        # blank-refresh consumer; steady-state syncs (blank refresh) then flow
+        # freely through the idempotency check below.
         existing_refresh = existing_oauth.get("refreshToken") or ""
         if existing_refresh and not force:
             return SyncResult(
-                profile, email, "skipped_native_login", "native login present (use --force)"
+                profile,
+                email,
+                "skipped_native_login",
+                "native login present (use --force to bootstrap)",
             )
+
+        # Idempotent: our own synced (blank-refresh) cred already holds this token.
+        if not existing_refresh and existing_oauth.get("accessToken") == vp["access_token"]:
+            return SyncResult(profile, email, "skipped_fresh", "already current")
 
         payload = translate_credential(vp, existing_oauth, blank_refresh=blank_refresh)
         if not apply:
@@ -391,15 +399,22 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     if probed and any(v is False for v in probed.values()):
         return 1
-    _SOURCE_LOSS = {"skipped_no_source", "skipped_stale_source", "error"}
-    _HEALTHY = {"synced", "skipped_fresh", "skipped_native_login"}
+    # "Healthy" = at least one profile is VibeProxy-managed or already current.
+    # skipped_native_login is NOT healthy: a revoked-but-present refresh token is
+    # indistinguishable from a live native login here, so an all-native result
+    # means every profile is unmanaged and the daemon is a silent no-op — the
+    # exact 0/N state this tool exists to fix (needs a one-time --force bootstrap).
+    _HEALTHY = {"synced", "skipped_fresh"}
     targets = [r for r in results if r.action != "skipped_native_only"]
-    if (
-        targets
-        and not any(r.action in _HEALTHY for r in targets)
-        and all(r.action in _SOURCE_LOSS for r in targets)
-    ):
-        print("error: no usable VibeProxy source for any mapped profile", file=sys.stderr)
+    if targets and not any(r.action in _HEALTHY for r in targets):
+        if all(r.action == "skipped_native_login" for r in targets):
+            print(
+                "error: every mapped profile holds a native/dead refresh token and was "
+                "skipped; run once with --force to bootstrap VibeProxy-managed creds",
+                file=sys.stderr,
+            )
+        else:
+            print("error: no usable VibeProxy source for any mapped profile", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -67,7 +67,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 VIBEPROXY_AUTH_DIR = Path.home() / ".cli-proxy-api"
-ARAGORA_PROFILE_ROOT = Path.home() / ".aragora-claude"
+# Honor CLAUDE_PROFILE_ROOT like the sibling readers (claude_profile.sh,
+# audit_claude_profiles.py): otherwise the sync writes into ~/.aragora-claude
+# while the router reads the overridden root, silently leaving the pool dead.
+_PROFILE_ROOT_OVERRIDE = os.environ.get("CLAUDE_PROFILE_ROOT", "").strip()
+ARAGORA_PROFILE_ROOT = (
+    Path(_PROFILE_ROOT_OVERRIDE) if _PROFILE_ROOT_OVERRIDE else Path.home() / ".aragora-claude"
+)
 DEFAULT_CONFIG_PATH = Path.home() / ".aragora" / "claude_profile_sync.json"
 # Skip a VibeProxy source whose own token expires within this margin, so a
 # stopped/crashed proxy's stale token never overwrites a profile.
@@ -162,6 +168,15 @@ def _iso_to_epoch_ms(value: str) -> int:
 
 def _now_ms() -> int:
     return int(_dt.datetime.now(_dt.timezone.utc).timestamp() * 1000)
+
+
+def _redact_email(email: str) -> str:
+    """Mask an email for the persistent daemon log (emails are PII here)."""
+    if "@" not in email:
+        return email
+    local, _, domain = email.partition("@")
+    head = local[:1] if local else ""
+    return f"{head}***@{domain}"
 
 
 def _load_json(path: Path) -> dict | None:
@@ -380,7 +395,9 @@ def main(argv: list[str] | None = None) -> int:
                 probe_note = "  probe=" + (
                     "SKIP" if state is None else ("LIVE" if state else "DEAD")
                 )
-            print(f"  {r.profile:8} {r.email:28} {r.action:20} {r.detail}{probe_note}")
+            print(
+                f"  {r.profile:8} {_redact_email(r.email):22} {r.action:20} {r.detail}{probe_note}"
+            )
         synced = sum(1 for r in results if r.action == "synced")
         live = sum(1 for v in probed.values() if v)
         tail = (

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -27,21 +27,27 @@ synced aragora credential is written **without a usable refresh token**
 (``--blank-refresh``, the default): aragora becomes a pure token consumer. If a
 sync cycle ever lags past the access-token expiry the profile simply reports
 expired until the next cycle heals it -- it never revokes VibeProxy's live token.
-Run this on a short interval (well under the ~8h access-token TTL) via launchd.
+Run this more often than VibeProxy's refresh lead so a synced token never lapses
+between cycles (VibeProxy refreshes ~10 min before the ~8h access-token expiry).
 
-One profile per VibeProxy account
----------------------------------
-VibeProxy authenticates by email and holds exactly one org per email, so two
-profiles that are different orgs under one shared login (a personal Max org and
-a Synaptent team org, both under ``synaptent@synaptent.com``) cannot both be
-sourced from VibeProxy -- syncing both would collapse one subscription onto the
-other's org. ``VIBEPROXY_SYNC_TARGET`` is therefore a strict 1:1 email->profile
-map, and same-email siblings / duplicate seats are listed in
-``NATIVE_ONLY_REASON`` and never synced (they stay on native login).
+Mapping lives in a local, untracked config
+-------------------------------------------
+The email->profile mapping is operator PII and account inventory, so it is NOT
+in tracked source. It is read from ``~/.aragora/claude_profile_sync.json``
+(override with ``ARAGORA_PROFILE_SYNC_CONFIG``). See the ``.example`` beside this
+script for the format. VibeProxy authenticates by email and holds exactly one
+org per email, so ``sync_target`` is a strict 1:1 email->profile map; profiles
+that are a *different org under a shared login* (a personal Max org and a team
+org under one email) or a duplicate seat go in ``native_only`` and stay on native
+``scripts/claude_profiles_bootstrap.sh login``.
 
+Safety
+------
 This script only reads VibeProxy auth files and writes aragora profile
 credentials on the local machine. It never prints token material and never makes
-a network call.
+a network call. It refuses to clobber a profile that holds a fresh *native* login
+(live access token + real refresh token) unless ``--force``, and always writes a
+``0600`` ``.bak`` before replacing a credential.
 """
 
 from __future__ import annotations
@@ -50,6 +56,7 @@ import argparse
 import datetime as _dt
 import json
 import os
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -57,45 +64,10 @@ from pathlib import Path
 
 VIBEPROXY_AUTH_DIR = Path.home() / ".cli-proxy-api"
 ARAGORA_PROFILE_ROOT = Path.home() / ".aragora-claude"
-PROFILE_TOOL = Path(__file__).resolve().parent / "claude_profile.sh"
-
-# The single profile each VibeProxy account (keyed by EMAIL) may sync into.
-#
-# INVARIANT: no VibeProxy email is the source for more than one profile. This is
-# load-bearing. VibeProxy authenticates by email and holds exactly ONE org per
-# email, so two profiles that are *different orgs under one shared login* (e.g. a
-# personal Max org and a Synaptent team org, both under synaptent@synaptent.com)
-# cannot both be sourced from VibeProxy -- syncing both would silently collapse
-# one subscription onto the other's org. The non-VibeProxy org stays on native
-# `scripts/claude_profiles_bootstrap.sh login`.
-VIBEPROXY_SYNC_TARGET: dict[str, str] = {
-    "anomium@gmail.com": "max-01",
-    "scarmani@gmail.com": "max-02",
-    "liftmode@liftmode.com": "max-04",
-    "root@liftmode.com": "max-05",
-    "ap@synaptent.com": "max-06",
-    "radnoem@gmail.com": "max-07",
-    "synaptent@synaptent.com": "max-09",  # Synaptent team org (VibeProxy's org for this email)
-    "verborgen.doel@gmail.com": "max-11",
-    "armand@synaptent.com": "max-12",  # Synaptent team org
-    "ringrift.ai@gmail.com": "max-13",  # repointed from the max-12 duplicate to this distinct account
-}
-
-# Profiles deliberately NOT VibeProxy-synced, with why. A shared login's distinct
-# org, or a duplicate of another profile's exact account. These stay native.
-NATIVE_ONLY_REASON: dict[str, str] = {
-    "max-03": "shares ap@synaptent.com with max-06 (its own org); native login only",
-    "max-08": (
-        "personal Max org under synaptent@synaptent.com; VibeProxy holds the "
-        "Synaptent team org for that email (synced to max-09). Native login only."
-    ),
-    "max-10": "no VibeProxy account for armand.tuzel@gmail.com; native login only",
-}
-
-# Reverse index: profile -> the VibeProxy email that sources it (if any).
-PROFILE_TO_EMAIL: dict[str, str] = {
-    profile: email for email, profile in VIBEPROXY_SYNC_TARGET.items()
-}
+DEFAULT_CONFIG_PATH = Path.home() / ".aragora" / "claude_profile_sync.json"
+# Skip a VibeProxy source whose own token expires within this margin, so a
+# stopped/crashed proxy's stale token never overwrites a profile.
+_STALE_SOURCE_MARGIN_SECONDS = 300
 
 # Scope/plan fields VibeProxy does not carry; preserved from an existing aragora
 # credential when present, else these Max-plan defaults.
@@ -109,12 +81,59 @@ _DEFAULT_SCOPES = [
 _DEFAULT_SUBSCRIPTION = "max"
 
 
+class ConfigError(RuntimeError):
+    """The sync mapping config is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class SyncConfig:
+    sync_target: dict[str, str]  # email -> profile (strict 1:1)
+    native_only: dict[str, str]  # profile -> reason
+
+    @property
+    def profile_to_email(self) -> dict[str, str]:
+        return {profile: email for email, profile in self.sync_target.items()}
+
+
 @dataclass
 class SyncResult:
     profile: str
     email: str
-    action: str  # synced | skipped_no_source | skipped_fresh | skipped_no_email | error
+    # synced | skipped_no_source | skipped_stale_source | skipped_fresh
+    # | skipped_native_only | skipped_native_login | skipped_no_email | error
+    action: str
     detail: str = ""
+
+
+def _config_path() -> Path:
+    override = os.environ.get("ARAGORA_PROFILE_SYNC_CONFIG", "").strip()
+    return Path(override) if override else DEFAULT_CONFIG_PATH
+
+
+def load_config(path: Path | None = None) -> SyncConfig:
+    path = path or _config_path()
+    raw = _load_json(path)
+    if raw is None:
+        raise ConfigError(
+            f"sync mapping config not found or unreadable at {path}. "
+            f"Copy {Path(__file__).with_name('claude_profile_sync.json.example')} "
+            f"there and fill in your email->profile map."
+        )
+    sync_target = dict(raw.get("sync_target") or {})
+    native_only = dict(raw.get("native_only") or {})
+    if not sync_target:
+        raise ConfigError(f"config {path} has an empty 'sync_target' map")
+    # 1:1 invariant: an email maps to one profile (dict guarantees), and no
+    # profile is both a sync target and native-only.
+    overlap = set(sync_target.values()) & set(native_only)
+    if overlap:
+        raise ConfigError(
+            f"config {path}: profiles are both synced and native-only: {sorted(overlap)}"
+        )
+    dupes = [p for p in set(sync_target.values()) if list(sync_target.values()).count(p) > 1]
+    if dupes:
+        raise ConfigError(f"config {path}: profile(s) mapped from >1 email: {sorted(set(dupes))}")
+    return SyncConfig(sync_target=sync_target, native_only=native_only)
 
 
 def _vibeproxy_path(email: str) -> Path:
@@ -126,7 +145,19 @@ def _profile_cred_path(profile: str) -> Path:
 
 
 def _iso_to_epoch_ms(value: str) -> int:
-    return int(_dt.datetime.fromisoformat(value).timestamp() * 1000)
+    # VibeProxy stamps ISO 8601; tolerate a trailing Z (Py<3.11) and treat a
+    # naive stamp as UTC rather than silently as local time.
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = _dt.datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
+def _now_ms() -> int:
+    return int(_dt.datetime.now(_dt.timezone.utc).timestamp() * 1000)
 
 
 def _load_json(path: Path) -> dict | None:
@@ -157,53 +188,103 @@ def translate_credential(
     return {"claudeAiOauth": oauth}
 
 
-def _current_access_token(cred: dict | None) -> str | None:
-    if not cred:
-        return None
-    return (cred.get("claudeAiOauth") or {}).get("accessToken")
+def _oauth(cred: dict | None) -> dict:
+    return (cred or {}).get("claudeAiOauth") or {}
+
+
+def _write_owner_only(path: Path, data: str) -> None:
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(data)
 
 
 def sync_profile(
     profile: str,
+    config: SyncConfig,
     *,
     blank_refresh: bool,
     apply: bool,
+    force: bool = False,
 ) -> SyncResult:
-    if profile in NATIVE_ONLY_REASON:
-        return SyncResult(profile, "", "skipped_native_only", NATIVE_ONLY_REASON[profile])
-    email = PROFILE_TO_EMAIL.get(profile, "")
+    if profile in config.native_only:
+        return SyncResult(profile, "", "skipped_native_only", config.native_only[profile])
+    email = config.profile_to_email.get(profile, "")
     if not email:
         return SyncResult(profile, email, "skipped_no_email", "no VibeProxy source assigned")
-    vp = _load_json(_vibeproxy_path(email))
-    if vp is None or vp.get("disabled") or not vp.get("access_token"):
-        return SyncResult(profile, email, "skipped_no_source", "no live VibeProxy account")
+    try:
+        vp = _load_json(_vibeproxy_path(email))
+        if vp is None or vp.get("disabled") or not vp.get("access_token"):
+            return SyncResult(profile, email, "skipped_no_source", "no live VibeProxy account")
 
-    cred_path = _profile_cred_path(profile)
-    existing = _load_json(cred_path)
-    existing_oauth = (existing or {}).get("claudeAiOauth")
+        # A stopped/crashed proxy leaves a stale (expired) token with disabled
+        # still false; syncing it would blank the profile's refresh token AND
+        # install a dead access token, i.e. the exact failure this prevents.
+        expired_raw = vp.get("expired")
+        if not expired_raw:
+            return SyncResult(profile, email, "skipped_no_source", "source missing 'expired' field")
+        vp_expiry_ms = _iso_to_epoch_ms(expired_raw)
+        if vp_expiry_ms <= _now_ms() + _STALE_SOURCE_MARGIN_SECONDS * 1000:
+            return SyncResult(
+                profile, email, "skipped_stale_source", "VibeProxy token expired/expiring"
+            )
 
-    # Idempotent: if the profile already holds this exact access token, do nothing.
-    if _current_access_token(existing) == vp["access_token"]:
-        return SyncResult(profile, email, "skipped_fresh", "already current")
+        cred_path = _profile_cred_path(profile)
+        existing = _load_json(cred_path)
+        existing_oauth = _oauth(existing)
 
-    payload = translate_credential(vp, existing_oauth, blank_refresh=blank_refresh)
-    if not apply:
-        return SyncResult(profile, email, "synced", "dry-run")
+        # Idempotent: profile already holds this exact access token.
+        if existing_oauth.get("accessToken") == vp["access_token"]:
+            return SyncResult(profile, email, "skipped_fresh", "already current")
 
-    cred_path.parent.mkdir(parents=True, exist_ok=True)
-    # Atomic replace with owner-only permissions on the credential.
-    tmp = cred_path.with_suffix(".credentials.json.tmp")
-    tmp.write_text(json.dumps(payload), encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, cred_path)
-    return SyncResult(profile, email, "synced", "applied")
+        # Never clobber a fresh NATIVE login (live access token + real refresh
+        # token) without --force: that would destroy a working refresh token.
+        existing_refresh = existing_oauth.get("refreshToken") or ""
+        existing_exp = existing_oauth.get("expiresAt")
+        existing_live = isinstance(existing_exp, int) and existing_exp > _now_ms()
+        if existing_refresh and existing_live and not force:
+            return SyncResult(
+                profile, email, "skipped_native_login", "live native login present (use --force)"
+            )
+
+        payload = translate_credential(vp, existing_oauth, blank_refresh=blank_refresh)
+        if not apply:
+            return SyncResult(profile, email, "synced", "dry-run")
+
+        cred_path.parent.mkdir(parents=True, exist_ok=True)
+        # Back up the existing credential (0600) before replacing it.
+        if cred_path.exists():
+            _write_owner_only(
+                cred_path.with_name(".credentials.json.bak"),
+                cred_path.read_text(encoding="utf-8"),
+            )
+        # Atomic, never-world-readable write.
+        tmp = cred_path.with_name(".credentials.json.tmp")
+        _write_owner_only(tmp, json.dumps(payload))
+        os.replace(tmp, cred_path)
+        return SyncResult(profile, email, "synced", "applied")
+    except (OSError, ValueError, KeyError) as exc:
+        # Isolate per-profile failures so one malformed source does not abort the
+        # whole batch. Never include token material in the message.
+        return SyncResult(profile, email, "error", f"{type(exc).__name__}: {exc}")
 
 
-def _probe(profile: str, timeout: int = 60) -> bool:
-    """Live-probe a profile the same way scripts/claude_pool_verify.py does."""
+def _resolve_profile_tool() -> Path | None:
+    sibling = Path(__file__).resolve().parent / "claude_profile.sh"
+    if sibling.exists():
+        return sibling
+    found = shutil.which("claude_profile.sh")
+    return Path(found) if found else None
+
+
+def _probe(profile: str, timeout: int = 60) -> bool | None:
+    """Live-probe a profile like claude_pool_verify.py. Returns None if the
+    probe tool is unavailable (e.g. the deployed standalone copy)."""
+    tool = _resolve_profile_tool()
+    if tool is None:
+        return None
     try:
         proc = subprocess.run(
-            [str(PROFILE_TOOL), "exec", profile, "--", "claude", "--print", "-p", "-"],
+            [str(tool), "exec", profile, "--", "claude", "--print", "-p", "-"],
             input="hi",
             capture_output=True,
             text=True,
@@ -224,27 +305,40 @@ def main(argv: list[str] | None = None) -> int:
         help="Keep VibeProxy's refresh token in the synced credential (default: blank it)",
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite even a profile holding a fresh native login",
+    )
+    parser.add_argument(
         "--probe-after",
         action="store_true",
         help="After --apply, live-probe each synced profile and report health",
     )
+    parser.add_argument("--config", type=Path, default=None, help="Path to the sync mapping config")
     parser.add_argument("--json", dest="json_output", action="store_true")
     args = parser.parse_args(argv)
 
+    try:
+        config = load_config(args.config)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
     # Default set = the 1:1 sync targets; native-only profiles are shown only
     # when named explicitly (so their skip reason is visible on request).
-    profiles = args.profiles or list(VIBEPROXY_SYNC_TARGET.values())
-    results: list[SyncResult] = []
-    for profile in profiles:
-        results.append(
-            sync_profile(
-                profile,
-                blank_refresh=not args.keep_refresh,
-                apply=args.apply,
-            )
+    profiles = args.profiles or list(config.sync_target.values())
+    results: list[SyncResult] = [
+        sync_profile(
+            profile,
+            config,
+            blank_refresh=not args.keep_refresh,
+            apply=args.apply,
+            force=args.force,
         )
+        for profile in profiles
+    ]
 
-    probed: dict[str, bool] = {}
+    probed: dict[str, bool | None] = {}
     if args.probe_after and args.apply:
         for r in results:
             if r.action == "synced":
@@ -265,15 +359,30 @@ def main(argv: list[str] | None = None) -> int:
         for r in results:
             probe_note = ""
             if r.profile in probed:
-                probe_note = "  probe=" + ("LIVE" if probed[r.profile] else "DEAD")
-            print(f"  {r.profile:8} {r.email:28} {r.action:18} {r.detail}{probe_note}")
+                state = probed[r.profile]
+                probe_note = "  probe=" + (
+                    "SKIP" if state is None else ("LIVE" if state else "DEAD")
+                )
+            print(f"  {r.profile:8} {r.email:28} {r.action:20} {r.detail}{probe_note}")
         synced = sum(1 for r in results if r.action == "synced")
         live = sum(1 for v in probed.values() if v)
-        tail = f"; {live}/{len(probed)} probed live" if probed else ""
+        tail = (
+            f"; {live}/{sum(1 for v in probed.values() if v is not None)} probed live"
+            if probed
+            else ""
+        )
         print(f"Sync: {synced}/{len(results)} profiles updated{tail}")
 
-    # Non-zero when a probe ran and any synced profile came back dead.
-    if probed and not all(probed.values()):
+    # Surface hard problems via exit code so a launchd log flags them:
+    # any per-profile error, a probed-dead profile, or a total source loss
+    # (every mapped profile lost its VibeProxy source).
+    if any(r.action == "error" for r in results):
+        return 1
+    if probed and any(v is False for v in probed.values()):
+        return 1
+    only_targets = [r for r in results if r.action != "skipped_native_only"]
+    if only_targets and all(r.action == "skipped_no_source" for r in only_targets):
+        print("error: no live VibeProxy sources for any mapped profile", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/sync_claude_profiles_from_vibeproxy.py
+++ b/scripts/sync_claude_profiles_from_vibeproxy.py
@@ -29,6 +29,16 @@ sync cycle ever lags past the access-token expiry the profile simply reports
 expired until the next cycle heals it -- it never revokes VibeProxy's live token.
 Run this on a short interval (well under the ~8h access-token TTL) via launchd.
 
+One profile per VibeProxy account
+---------------------------------
+VibeProxy authenticates by email and holds exactly one org per email, so two
+profiles that are different orgs under one shared login (a personal Max org and
+a Synaptent team org, both under ``synaptent@synaptent.com``) cannot both be
+sourced from VibeProxy -- syncing both would collapse one subscription onto the
+other's org. ``VIBEPROXY_SYNC_TARGET`` is therefore a strict 1:1 email->profile
+map, and same-email siblings / duplicate seats are listed in
+``NATIVE_ONLY_REASON`` and never synced (they stay on native login).
+
 This script only reads VibeProxy auth files and writes aragora profile
 credentials on the local machine. It never prints token material and never makes
 a network call.
@@ -49,23 +59,43 @@ VIBEPROXY_AUTH_DIR = Path.home() / ".cli-proxy-api"
 ARAGORA_PROFILE_ROOT = Path.home() / ".aragora-claude"
 PROFILE_TOOL = Path(__file__).resolve().parent / "claude_profile.sh"
 
-# Authoritative profile -> account binding (mirrors the static map in
-# scripts/claude_profiles_bootstrap.sh). max-13 is bound at login time to
-# armand@synaptent.com; max-10 has no VibeProxy-held account and is skipped.
-PROFILE_EMAILS: dict[str, str] = {
-    "max-01": "anomium@gmail.com",
-    "max-02": "scarmani@gmail.com",
-    "max-03": "ap@synaptent.com",
-    "max-04": "liftmode@liftmode.com",
-    "max-05": "root@liftmode.com",
-    "max-06": "ap@synaptent.com",
-    "max-07": "radnoem@gmail.com",
-    "max-08": "synaptent@synaptent.com",
-    "max-09": "synaptent@synaptent.com",
-    "max-10": "armand.tuzel@gmail.com",
-    "max-11": "verborgen.doel@gmail.com",
-    "max-12": "armand@synaptent.com",
-    "max-13": "armand@synaptent.com",
+# The single profile each VibeProxy account (keyed by EMAIL) may sync into.
+#
+# INVARIANT: no VibeProxy email is the source for more than one profile. This is
+# load-bearing. VibeProxy authenticates by email and holds exactly ONE org per
+# email, so two profiles that are *different orgs under one shared login* (e.g. a
+# personal Max org and a Synaptent team org, both under synaptent@synaptent.com)
+# cannot both be sourced from VibeProxy -- syncing both would silently collapse
+# one subscription onto the other's org. The non-VibeProxy org stays on native
+# `scripts/claude_profiles_bootstrap.sh login`.
+VIBEPROXY_SYNC_TARGET: dict[str, str] = {
+    "anomium@gmail.com": "max-01",
+    "scarmani@gmail.com": "max-02",
+    "liftmode@liftmode.com": "max-04",
+    "root@liftmode.com": "max-05",
+    "ap@synaptent.com": "max-06",
+    "radnoem@gmail.com": "max-07",
+    "synaptent@synaptent.com": "max-09",  # Synaptent team org (VibeProxy's org for this email)
+    "verborgen.doel@gmail.com": "max-11",
+    "armand@synaptent.com": "max-12",  # Synaptent team org
+    # ringrift.ai@gmail.com is held by VibeProxy but not yet assigned to a profile.
+}
+
+# Profiles deliberately NOT VibeProxy-synced, with why. A shared login's distinct
+# org, or a duplicate of another profile's exact account. These stay native.
+NATIVE_ONLY_REASON: dict[str, str] = {
+    "max-03": "shares ap@synaptent.com with max-06 (its own org); native login only",
+    "max-08": (
+        "personal Max org under synaptent@synaptent.com; VibeProxy holds the "
+        "Synaptent team org for that email (synced to max-09). Native login only."
+    ),
+    "max-10": "no VibeProxy account for armand.tuzel@gmail.com; native login only",
+    "max-13": "same armand@synaptent.com team seat as max-12; free to repoint at a distinct account",
+}
+
+# Reverse index: profile -> the VibeProxy email that sources it (if any).
+PROFILE_TO_EMAIL: dict[str, str] = {
+    profile: email for email, profile in VIBEPROXY_SYNC_TARGET.items()
 }
 
 # Scope/plan fields VibeProxy does not carry; preserved from an existing aragora
@@ -136,13 +166,15 @@ def _current_access_token(cred: dict | None) -> str | None:
 
 def sync_profile(
     profile: str,
-    email: str,
     *,
     blank_refresh: bool,
     apply: bool,
 ) -> SyncResult:
+    if profile in NATIVE_ONLY_REASON:
+        return SyncResult(profile, "", "skipped_native_only", NATIVE_ONLY_REASON[profile])
+    email = PROFILE_TO_EMAIL.get(profile, "")
     if not email:
-        return SyncResult(profile, email, "skipped_no_email")
+        return SyncResult(profile, email, "skipped_no_email", "no VibeProxy source assigned")
     vp = _load_json(_vibeproxy_path(email))
     if vp is None or vp.get("disabled") or not vp.get("access_token"):
         return SyncResult(profile, email, "skipped_no_source", "no live VibeProxy account")
@@ -200,14 +232,14 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", dest="json_output", action="store_true")
     args = parser.parse_args(argv)
 
-    profiles = args.profiles or list(PROFILE_EMAILS)
+    # Default set = the 1:1 sync targets; native-only profiles are shown only
+    # when named explicitly (so their skip reason is visible on request).
+    profiles = args.profiles or list(VIBEPROXY_SYNC_TARGET.values())
     results: list[SyncResult] = []
     for profile in profiles:
-        email = PROFILE_EMAILS.get(profile, "")
         results.append(
             sync_profile(
                 profile,
-                email,
                 blank_refresh=not args.keep_refresh,
                 apply=args.apply,
             )

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -86,7 +86,7 @@ def test_one_to_one_invariant_no_email_sources_two_profiles() -> None:
 def test_native_only_profiles_are_never_synced() -> None:
     # A shared-login distinct org (max-08) and a duplicate seat (max-13) must be
     # excluded so the sync cannot collapse them onto VibeProxy's org.
-    for profile in ("max-03", "max-08", "max-10", "max-13"):
+    for profile in ("max-03", "max-08", "max-10"):
         result = sync.sync_profile(profile, blank_refresh=True, apply=False)
         assert result.action == "skipped_native_only", profile
     # ...and none of them is also a sync target.

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -217,6 +217,39 @@ def test_total_source_loss_exits_nonzero(monkeypatch, tmp_path) -> None:
     assert rc == 1
 
 
+def test_native_login_with_matching_access_token_still_protected(monkeypatch, tmp_path) -> None:
+    # openai P2: the native-login guard must run BEFORE the idempotency check, so
+    # a native profile whose access token coincidentally equals VibeProxy's is
+    # still protected (not classified skipped_fresh, which would leave its live
+    # refresh token to race VibeProxy).
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "vp-access", "refreshToken": "real"}}),
+        encoding="utf-8",
+    )
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "skipped_native_login"
+
+
+def test_all_native_profiles_exit_nonzero_needing_bootstrap(monkeypatch, tmp_path, capsys) -> None:
+    # A pool that still holds native/dead refresh tokens is a silent no-op state;
+    # main() must exit non-zero and point at the one-time --force bootstrap.
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-01" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "x", "refreshToken": "revoked"}}),
+        encoding="utf-8",
+    )
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(json.dumps({"sync_target": {"x@example.com": "max-01"}}), encoding="utf-8")
+    rc = sync.main(["--config", str(cfg_path), "--apply"])
+    assert rc == 1
+    assert "--force" in capsys.readouterr().err
+
+
 def test_all_sources_stale_exits_nonzero(monkeypatch, tmp_path) -> None:
     # A stopped/crashed proxy leaves files present with expired tokens; that is
     # a total source loss and must exit non-zero, not look healthy.

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -165,20 +165,18 @@ def test_idempotent_on_matching_access_token(monkeypatch, tmp_path) -> None:
     assert r.action == "skipped_fresh"
 
 
-def test_does_not_clobber_fresh_native_login_without_force(monkeypatch, tmp_path) -> None:
+@pytest.mark.parametrize("expires_at", [sync._now_ms() + 3_600_000, sync._now_ms() - 1])
+def test_native_login_protected_regardless_of_access_token_liveness(
+    monkeypatch, tmp_path, expires_at
+) -> None:
+    # Both a live native login AND an idle one (valid refresh, expired access)
+    # must be protected — the refresh token is the thing worth preserving.
     prof_root = _setup(monkeypatch, tmp_path)
     cred = prof_root / "max-99" / ".claude" / ".credentials.json"
     cred.parent.mkdir(parents=True)
-    future = sync._now_ms() + 3_600_000
     cred.write_text(
         json.dumps(
-            {
-                "claudeAiOauth": {
-                    "accessToken": "native",
-                    "refreshToken": "real",
-                    "expiresAt": future,
-                }
-            }
+            {"claudeAiOauth": {"accessToken": "n", "refreshToken": "real", "expiresAt": expires_at}}
         ),
         encoding="utf-8",
     )
@@ -186,22 +184,29 @@ def test_does_not_clobber_fresh_native_login_without_force(monkeypatch, tmp_path
     assert r.action == "skipped_native_login"
     r2 = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True, force=True)
     assert r2.action == "synced"
+    # --force backs up the native cred it is about to destroy.
+    backup = cred.with_name(".credentials.json.bak")
+    assert json.loads(backup.read_text())["claudeAiOauth"]["refreshToken"] == "real"
 
 
-def test_writes_owner_only_credential_and_backup(monkeypatch, tmp_path) -> None:
+def test_writes_owner_only_credential_and_no_backup_for_our_own_cred(monkeypatch, tmp_path) -> None:
+    # Re-syncing over our own blank-refresh cred writes owner-only and does NOT
+    # create a backup (there is no native refresh token worth preserving, and a
+    # backup here would overwrite an earlier real native backup).
     prof_root = _setup(monkeypatch, tmp_path)
     cred = prof_root / "max-99" / ".claude" / ".credentials.json"
     cred.parent.mkdir(parents=True)
-    cred.write_text(json.dumps({"claudeAiOauth": {"accessToken": "old"}}), encoding="utf-8")
+    cred.write_text(
+        json.dumps({"claudeAiOauth": {"accessToken": "old", "refreshToken": ""}}),
+        encoding="utf-8",
+    )
     r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
     assert r.action == "synced"
     assert (cred.stat().st_mode & 0o777) == 0o600
     written = json.loads(cred.read_text())
     assert written["claudeAiOauth"]["accessToken"] == "vp-access"
     assert written["claudeAiOauth"]["refreshToken"] == ""
-    backup = cred.with_name(".credentials.json.bak")
-    assert backup.exists() and (backup.stat().st_mode & 0o777) == 0o600
-    assert json.loads(backup.read_text())["claudeAiOauth"]["accessToken"] == "old"
+    assert not cred.with_name(".credentials.json.bak").exists()
 
 
 def test_total_source_loss_exits_nonzero(monkeypatch, tmp_path) -> None:
@@ -210,3 +215,18 @@ def test_total_source_loss_exits_nonzero(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path / "empty")
     rc = sync.main(["--config", str(cfg_path)])
     assert rc == 1
+
+
+def test_all_sources_stale_exits_nonzero(monkeypatch, tmp_path) -> None:
+    # A stopped/crashed proxy leaves files present with expired tokens; that is
+    # a total source loss and must exit non-zero, not look healthy.
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    (vp_dir / "claude-a@e.json").write_text(
+        json.dumps(dict(_VP, expired="2000-01-01T00:00:00+00:00")), encoding="utf-8"
+    )
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", tmp_path / "profiles")
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(json.dumps({"sync_target": {"a@e": "max-01"}}), encoding="utf-8")
+    assert sync.main(["--config", str(cfg_path), "--apply"]) == 1

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -27,116 +27,186 @@ sync = _load_module()
 _VP = {
     "access_token": "vp-access",
     "refresh_token": "vp-refresh",
-    "expired": "2026-07-22T18:27:18-05:00",
+    "expired": "2099-01-01T00:00:00+00:00",  # far future so it is never "stale"
     "type": "claude",
     "disabled": False,
 }
 
 
+def _config(sync_target=None, native_only=None):
+    return sync.SyncConfig(
+        sync_target=sync_target or {"x@example.com": "max-99"},
+        native_only=native_only or {},
+    )
+
+
+def _setup(monkeypatch, tmp_path, vp_payload=_VP, email="x@example.com"):
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    (vp_dir / f"claude-{email}.json").write_text(json.dumps(vp_payload), encoding="utf-8")
+    prof_root = tmp_path / "profiles"
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
+    return prof_root
+
+
+# --- translate_credential ---------------------------------------------------
+
+
 def test_blank_refresh_makes_a_pure_consumer_credential() -> None:
-    out = sync.translate_credential(_VP, None, blank_refresh=True)
-    oauth = out["claudeAiOauth"]
+    oauth = sync.translate_credential(_VP, None, blank_refresh=True)["claudeAiOauth"]
     assert oauth["accessToken"] == "vp-access"
-    # No usable refresh token: aragora can never rotate VibeProxy's live token.
     assert oauth["refreshToken"] == ""
 
 
 def test_keep_refresh_carries_the_vibeproxy_refresh_token() -> None:
-    out = sync.translate_credential(_VP, None, blank_refresh=False)
-    assert out["claudeAiOauth"]["refreshToken"] == "vp-refresh"
+    oauth = sync.translate_credential(_VP, None, blank_refresh=False)["claudeAiOauth"]
+    assert oauth["refreshToken"] == "vp-refresh"
 
 
-def test_expiry_is_translated_iso_to_epoch_ms() -> None:
-    out = sync.translate_credential(_VP, None, blank_refresh=True)
-    expected_ms = int(_dt.datetime.fromisoformat(_VP["expired"]).timestamp() * 1000)
-    assert out["claudeAiOauth"]["expiresAt"] == expected_ms
+def test_expiry_iso_offset_translated_to_epoch_ms() -> None:
+    vp = dict(_VP, expired="2026-07-22T18:27:18-05:00")
+    got = sync.translate_credential(vp, None, blank_refresh=True)["claudeAiOauth"]["expiresAt"]
+    expected = int(_dt.datetime.fromisoformat("2026-07-22T18:27:18-05:00").timestamp() * 1000)
+    assert got == expected
 
 
-def test_plan_and_scope_metadata_preserved_from_existing_credential() -> None:
-    existing = {
-        "scopes": ["user:inference", "custom:scope"],
-        "subscriptionType": "team",
-        "rateLimitTier": "default_claude_max_5x",
-    }
-    out = sync.translate_credential(_VP, existing, blank_refresh=True)
-    oauth = out["claudeAiOauth"]
-    assert oauth["scopes"] == ["user:inference", "custom:scope"]
-    assert oauth["subscriptionType"] == "team"
-    assert oauth["rateLimitTier"] == "default_claude_max_5x"
+def test_expiry_z_suffix_and_naive_treated_as_utc() -> None:
+    z = sync._iso_to_epoch_ms("2026-07-22T18:27:18Z")
+    utc = sync._iso_to_epoch_ms("2026-07-22T18:27:18+00:00")
+    naive = sync._iso_to_epoch_ms("2026-07-22T18:27:18")
+    assert z == utc == naive
 
 
-def test_defaults_applied_when_no_existing_credential() -> None:
-    out = sync.translate_credential(_VP, None, blank_refresh=True)
-    oauth = out["claudeAiOauth"]
-    assert oauth["subscriptionType"] == sync._DEFAULT_SUBSCRIPTION
-    assert oauth["scopes"] == sync._DEFAULT_SCOPES
+def test_plan_and_scope_metadata_preserved_from_existing() -> None:
+    existing = {"scopes": ["s"], "subscriptionType": "team", "rateLimitTier": "t"}
+    oauth = sync.translate_credential(_VP, existing, blank_refresh=True)["claudeAiOauth"]
+    assert oauth["scopes"] == ["s"] and oauth["subscriptionType"] == "team"
+    assert oauth["rateLimitTier"] == "t"
 
 
-def _point_profile_at(monkeypatch, profile: str, email: str) -> None:
-    monkeypatch.setitem(sync.PROFILE_TO_EMAIL, profile, email)
+# --- config loading / 1:1 invariant ----------------------------------------
 
 
-def test_one_to_one_invariant_no_email_sources_two_profiles() -> None:
-    # VIBEPROXY_SYNC_TARGET is email->profile, so an email can never source two
-    # profiles. Assert the inverse index round-trips (the load-bearing property).
-    assert len(sync.PROFILE_TO_EMAIL) == len(sync.VIBEPROXY_SYNC_TARGET)
-    assert set(sync.PROFILE_TO_EMAIL.values()) == set(sync.VIBEPROXY_SYNC_TARGET)
+def test_load_config_missing_raises(tmp_path) -> None:
+    with pytest.raises(sync.ConfigError, match="not found"):
+        sync.load_config(tmp_path / "absent.json")
 
 
-def test_native_only_profiles_are_never_synced() -> None:
-    # A shared-login distinct org (max-08) and a duplicate seat (max-13) must be
-    # excluded so the sync cannot collapse them onto VibeProxy's org.
-    for profile in ("max-03", "max-08", "max-10"):
-        result = sync.sync_profile(profile, blank_refresh=True, apply=False)
-        assert result.action == "skipped_native_only", profile
-    # ...and none of them is also a sync target.
-    assert not (set(sync.NATIVE_ONLY_REASON) & set(sync.PROFILE_TO_EMAIL))
+def test_load_config_empty_sync_target_raises(tmp_path) -> None:
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"sync_target": {}}), encoding="utf-8")
+    with pytest.raises(sync.ConfigError, match="empty"):
+        sync.load_config(p)
 
 
-def test_sync_profile_skips_when_no_vibeproxy_source(monkeypatch, tmp_path) -> None:
-    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path)  # empty dir
-    result = sync.sync_profile("max-01", blank_refresh=True, apply=False)
-    assert result.action == "skipped_no_source"
+def test_load_config_rejects_profile_both_synced_and_native(tmp_path) -> None:
+    p = tmp_path / "c.json"
+    p.write_text(
+        json.dumps({"sync_target": {"a@e": "max-01"}, "native_only": {"max-01": "x"}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(sync.ConfigError, match="both synced and native"):
+        sync.load_config(p)
 
 
-def test_sync_profile_is_idempotent_on_matching_access_token(monkeypatch, tmp_path) -> None:
-    vp_dir = tmp_path / "vp"
-    vp_dir.mkdir()
-    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(_VP), encoding="utf-8")
-    prof_root = tmp_path / "profiles"
+def test_load_config_rejects_one_profile_from_two_emails(tmp_path) -> None:
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps({"sync_target": {"a@e": "max-01", "b@e": "max-01"}}), encoding="utf-8")
+    with pytest.raises(sync.ConfigError, match=">1 email"):
+        sync.load_config(p)
+
+
+def test_shipped_example_config_is_loadable() -> None:
+    example = Path(__file__).resolve().parents[2] / "scripts" / "claude_profile_sync.json.example"
+    cfg = sync.load_config(example)
+    assert cfg.sync_target and not (set(cfg.sync_target.values()) & set(cfg.native_only))
+
+
+# --- sync_profile behavior --------------------------------------------------
+
+
+def test_native_only_profile_is_skipped() -> None:
+    cfg = _config(native_only={"max-08": "distinct org"})
+    r = sync.sync_profile("max-08", cfg, blank_refresh=True, apply=False)
+    assert r.action == "skipped_native_only"
+
+
+def test_no_source_when_vibeproxy_file_absent(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path)  # empty
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=False)
+    assert r.action == "skipped_no_source"
+
+
+def test_stale_source_is_not_synced(monkeypatch, tmp_path) -> None:
+    _setup(monkeypatch, tmp_path, vp_payload=dict(_VP, expired="2000-01-01T00:00:00+00:00"))
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "skipped_stale_source"
+
+
+def test_disabled_source_is_not_synced(monkeypatch, tmp_path) -> None:
+    _setup(monkeypatch, tmp_path, vp_payload=dict(_VP, disabled=True))
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=False)
+    assert r.action == "skipped_no_source"
+
+
+def test_malformed_source_isolates_as_error(monkeypatch, tmp_path) -> None:
+    _setup(monkeypatch, tmp_path, vp_payload=dict(_VP, expired="not-a-date"))
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "error"
+
+
+def test_idempotent_on_matching_access_token(monkeypatch, tmp_path) -> None:
+    prof_root = _setup(monkeypatch, tmp_path)
     cred = prof_root / "max-99" / ".claude" / ".credentials.json"
     cred.parent.mkdir(parents=True)
     cred.write_text(json.dumps({"claudeAiOauth": {"accessToken": "vp-access"}}), encoding="utf-8")
-    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
-    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
-    _point_profile_at(monkeypatch, "max-99", "x@example.com")
-    result = sync.sync_profile("max-99", blank_refresh=True, apply=True)
-    assert result.action == "skipped_fresh"
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "skipped_fresh"
 
 
-def test_sync_profile_writes_owner_only_credential(monkeypatch, tmp_path) -> None:
-    vp_dir = tmp_path / "vp"
-    vp_dir.mkdir()
-    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(_VP), encoding="utf-8")
-    prof_root = tmp_path / "profiles"
-    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
-    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
-    _point_profile_at(monkeypatch, "max-99", "x@example.com")
-    result = sync.sync_profile("max-99", blank_refresh=True, apply=True)
-    assert result.action == "synced"
+def test_does_not_clobber_fresh_native_login_without_force(monkeypatch, tmp_path) -> None:
+    prof_root = _setup(monkeypatch, tmp_path)
     cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    future = sync._now_ms() + 3_600_000
+    cred.write_text(
+        json.dumps(
+            {
+                "claudeAiOauth": {
+                    "accessToken": "native",
+                    "refreshToken": "real",
+                    "expiresAt": future,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "skipped_native_login"
+    r2 = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True, force=True)
+    assert r2.action == "synced"
+
+
+def test_writes_owner_only_credential_and_backup(monkeypatch, tmp_path) -> None:
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text(json.dumps({"claudeAiOauth": {"accessToken": "old"}}), encoding="utf-8")
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "synced"
     assert (cred.stat().st_mode & 0o777) == 0o600
     written = json.loads(cred.read_text())
     assert written["claudeAiOauth"]["accessToken"] == "vp-access"
     assert written["claudeAiOauth"]["refreshToken"] == ""
+    backup = cred.with_name(".credentials.json.bak")
+    assert backup.exists() and (backup.stat().st_mode & 0o777) == 0o600
+    assert json.loads(backup.read_text())["claudeAiOauth"]["accessToken"] == "old"
 
 
-def test_disabled_vibeproxy_account_is_not_synced(monkeypatch, tmp_path) -> None:
-    vp_dir = tmp_path / "vp"
-    vp_dir.mkdir()
-    disabled = dict(_VP, disabled=True)
-    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(disabled), encoding="utf-8")
-    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
-    _point_profile_at(monkeypatch, "max-99", "x@example.com")
-    result = sync.sync_profile("max-99", blank_refresh=True, apply=False)
-    assert result.action == "skipped_no_source"
+def test_total_source_loss_exits_nonzero(monkeypatch, tmp_path) -> None:
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(json.dumps({"sync_target": {"a@e": "max-01"}}), encoding="utf-8")
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path / "empty")
+    rc = sync.main(["--config", str(cfg_path)])
+    assert rc == 1

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -117,6 +117,21 @@ def test_load_config_rejects_one_profile_from_two_emails(tmp_path) -> None:
         sync.load_config(p)
 
 
+def test_redact_email_masks_local_part() -> None:
+    assert sync._redact_email("anomium@gmail.com") == "a***@gmail.com"
+    assert sync._redact_email("") == ""
+    assert sync._redact_email("noatsign") == "noatsign"
+
+
+def test_profile_root_honors_env_override(monkeypatch) -> None:
+    # A fresh import with CLAUDE_PROFILE_ROOT set must point the writer at the
+    # same root the sibling readers use (load an isolated instance so the shared
+    # module under test is untouched).
+    monkeypatch.setenv("CLAUDE_PROFILE_ROOT", "/tmp/custom-root")
+    fresh = _load_module()
+    assert str(fresh.ARAGORA_PROFILE_ROOT) == "/tmp/custom-root"
+
+
 def test_shipped_example_config_is_loadable() -> None:
     example = Path(__file__).resolve().parents[2] / "scripts" / "claude_profile_sync.json.example"
     cfg = sync.load_config(example)

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -278,6 +278,29 @@ def test_unreadable_existing_credential_fails_closed(monkeypatch, tmp_path) -> N
     assert cred.read_text() == "{ this is not json"
 
 
+def test_force_recovers_a_corrupt_credential(monkeypatch, tmp_path) -> None:
+    # Without --force a corrupt cred fails closed; WITH --force it is backed up
+    # to .bak.corrupt and rewritten, so a wedged profile can self-heal.
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text("{ torn write", encoding="utf-8")
+    assert sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True).action == "error"
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True, force=True)
+    assert r.action == "synced"
+    assert json.loads(cred.read_text())["claudeAiOauth"]["accessToken"] == "vp-access"
+    corrupt_bak = cred.with_name(".credentials.json.bak.corrupt")
+    assert corrupt_bak.exists() and corrupt_bak.read_text() == "{ torn write"
+
+
+def test_non_object_json_credential_fails_closed(monkeypatch, tmp_path) -> None:
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text("[]", encoding="utf-8")  # valid JSON, wrong shape
+    assert sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True).action == "error"
+
+
 def test_partial_failure_exits_nonzero(monkeypatch, tmp_path) -> None:
     # One profile syncs, another has no source -> the stuck profile must not be
     # masked by the healthy one; the run fails.

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -72,9 +72,30 @@ def test_defaults_applied_when_no_existing_credential() -> None:
     assert oauth["scopes"] == sync._DEFAULT_SCOPES
 
 
+def _point_profile_at(monkeypatch, profile: str, email: str) -> None:
+    monkeypatch.setitem(sync.PROFILE_TO_EMAIL, profile, email)
+
+
+def test_one_to_one_invariant_no_email_sources_two_profiles() -> None:
+    # VIBEPROXY_SYNC_TARGET is email->profile, so an email can never source two
+    # profiles. Assert the inverse index round-trips (the load-bearing property).
+    assert len(sync.PROFILE_TO_EMAIL) == len(sync.VIBEPROXY_SYNC_TARGET)
+    assert set(sync.PROFILE_TO_EMAIL.values()) == set(sync.VIBEPROXY_SYNC_TARGET)
+
+
+def test_native_only_profiles_are_never_synced() -> None:
+    # A shared-login distinct org (max-08) and a duplicate seat (max-13) must be
+    # excluded so the sync cannot collapse them onto VibeProxy's org.
+    for profile in ("max-03", "max-08", "max-10", "max-13"):
+        result = sync.sync_profile(profile, blank_refresh=True, apply=False)
+        assert result.action == "skipped_native_only", profile
+    # ...and none of them is also a sync target.
+    assert not (set(sync.NATIVE_ONLY_REASON) & set(sync.PROFILE_TO_EMAIL))
+
+
 def test_sync_profile_skips_when_no_vibeproxy_source(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path)  # empty dir
-    result = sync.sync_profile("max-01", "absent@example.com", blank_refresh=True, apply=False)
+    result = sync.sync_profile("max-01", blank_refresh=True, apply=False)
     assert result.action == "skipped_no_source"
 
 
@@ -88,7 +109,8 @@ def test_sync_profile_is_idempotent_on_matching_access_token(monkeypatch, tmp_pa
     cred.write_text(json.dumps({"claudeAiOauth": {"accessToken": "vp-access"}}), encoding="utf-8")
     monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
     monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
-    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=True)
+    _point_profile_at(monkeypatch, "max-99", "x@example.com")
+    result = sync.sync_profile("max-99", blank_refresh=True, apply=True)
     assert result.action == "skipped_fresh"
 
 
@@ -99,7 +121,8 @@ def test_sync_profile_writes_owner_only_credential(monkeypatch, tmp_path) -> Non
     prof_root = tmp_path / "profiles"
     monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
     monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
-    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=True)
+    _point_profile_at(monkeypatch, "max-99", "x@example.com")
+    result = sync.sync_profile("max-99", blank_refresh=True, apply=True)
     assert result.action == "synced"
     cred = prof_root / "max-99" / ".claude" / ".credentials.json"
     assert (cred.stat().st_mode & 0o777) == 0o600
@@ -114,5 +137,6 @@ def test_disabled_vibeproxy_account_is_not_synced(monkeypatch, tmp_path) -> None
     disabled = dict(_VP, disabled=True)
     (vp_dir / "claude-x@example.com.json").write_text(json.dumps(disabled), encoding="utf-8")
     monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
-    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=False)
+    _point_profile_at(monkeypatch, "max-99", "x@example.com")
+    result = sync.sync_profile("max-99", blank_refresh=True, apply=False)
     assert result.action == "skipped_no_source"

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -265,6 +265,34 @@ def test_all_native_profiles_exit_nonzero_needing_bootstrap(monkeypatch, tmp_pat
     assert "--force" in capsys.readouterr().err
 
 
+def test_unreadable_existing_credential_fails_closed(monkeypatch, tmp_path) -> None:
+    # A present-but-corrupt cred (e.g. a torn read) must fail closed, not be
+    # treated as empty (which would bypass the guard/backup and destroy a token).
+    prof_root = _setup(monkeypatch, tmp_path)
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text("{ this is not json", encoding="utf-8")
+    r = sync.sync_profile("max-99", _config(), blank_refresh=True, apply=True)
+    assert r.action == "error"
+    # The unreadable file was NOT overwritten.
+    assert cred.read_text() == "{ this is not json"
+
+
+def test_partial_failure_exits_nonzero(monkeypatch, tmp_path) -> None:
+    # One profile syncs, another has no source -> the stuck profile must not be
+    # masked by the healthy one; the run fails.
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    (vp_dir / "claude-a@e.json").write_text(json.dumps(_VP), encoding="utf-8")  # b@e absent
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", tmp_path / "profiles")
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(
+        json.dumps({"sync_target": {"a@e": "max-01", "b@e": "max-02"}}), encoding="utf-8"
+    )
+    assert sync.main(["--config", str(cfg_path), "--apply"]) == 1
+
+
 def test_all_sources_stale_exits_nonzero(monkeypatch, tmp_path) -> None:
     # A stopped/crashed proxy leaves files present with expired tokens; that is
     # a total source loss and must exit non-zero, not look healthy.

--- a/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
+++ b/tests/scripts/test_sync_claude_profiles_from_vibeproxy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import datetime as _dt
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module() -> Any:
+    script = (
+        Path(__file__).resolve().parents[2] / "scripts" / "sync_claude_profiles_from_vibeproxy.py"
+    )
+    spec = importlib.util.spec_from_file_location("sync_claude_profiles_under_test", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sync = _load_module()
+
+_VP = {
+    "access_token": "vp-access",
+    "refresh_token": "vp-refresh",
+    "expired": "2026-07-22T18:27:18-05:00",
+    "type": "claude",
+    "disabled": False,
+}
+
+
+def test_blank_refresh_makes_a_pure_consumer_credential() -> None:
+    out = sync.translate_credential(_VP, None, blank_refresh=True)
+    oauth = out["claudeAiOauth"]
+    assert oauth["accessToken"] == "vp-access"
+    # No usable refresh token: aragora can never rotate VibeProxy's live token.
+    assert oauth["refreshToken"] == ""
+
+
+def test_keep_refresh_carries_the_vibeproxy_refresh_token() -> None:
+    out = sync.translate_credential(_VP, None, blank_refresh=False)
+    assert out["claudeAiOauth"]["refreshToken"] == "vp-refresh"
+
+
+def test_expiry_is_translated_iso_to_epoch_ms() -> None:
+    out = sync.translate_credential(_VP, None, blank_refresh=True)
+    expected_ms = int(_dt.datetime.fromisoformat(_VP["expired"]).timestamp() * 1000)
+    assert out["claudeAiOauth"]["expiresAt"] == expected_ms
+
+
+def test_plan_and_scope_metadata_preserved_from_existing_credential() -> None:
+    existing = {
+        "scopes": ["user:inference", "custom:scope"],
+        "subscriptionType": "team",
+        "rateLimitTier": "default_claude_max_5x",
+    }
+    out = sync.translate_credential(_VP, existing, blank_refresh=True)
+    oauth = out["claudeAiOauth"]
+    assert oauth["scopes"] == ["user:inference", "custom:scope"]
+    assert oauth["subscriptionType"] == "team"
+    assert oauth["rateLimitTier"] == "default_claude_max_5x"
+
+
+def test_defaults_applied_when_no_existing_credential() -> None:
+    out = sync.translate_credential(_VP, None, blank_refresh=True)
+    oauth = out["claudeAiOauth"]
+    assert oauth["subscriptionType"] == sync._DEFAULT_SUBSCRIPTION
+    assert oauth["scopes"] == sync._DEFAULT_SCOPES
+
+
+def test_sync_profile_skips_when_no_vibeproxy_source(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", tmp_path)  # empty dir
+    result = sync.sync_profile("max-01", "absent@example.com", blank_refresh=True, apply=False)
+    assert result.action == "skipped_no_source"
+
+
+def test_sync_profile_is_idempotent_on_matching_access_token(monkeypatch, tmp_path) -> None:
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(_VP), encoding="utf-8")
+    prof_root = tmp_path / "profiles"
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    cred.parent.mkdir(parents=True)
+    cred.write_text(json.dumps({"claudeAiOauth": {"accessToken": "vp-access"}}), encoding="utf-8")
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
+    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=True)
+    assert result.action == "skipped_fresh"
+
+
+def test_sync_profile_writes_owner_only_credential(monkeypatch, tmp_path) -> None:
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(_VP), encoding="utf-8")
+    prof_root = tmp_path / "profiles"
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    monkeypatch.setattr(sync, "ARAGORA_PROFILE_ROOT", prof_root)
+    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=True)
+    assert result.action == "synced"
+    cred = prof_root / "max-99" / ".claude" / ".credentials.json"
+    assert (cred.stat().st_mode & 0o777) == 0o600
+    written = json.loads(cred.read_text())
+    assert written["claudeAiOauth"]["accessToken"] == "vp-access"
+    assert written["claudeAiOauth"]["refreshToken"] == ""
+
+
+def test_disabled_vibeproxy_account_is_not_synced(monkeypatch, tmp_path) -> None:
+    vp_dir = tmp_path / "vp"
+    vp_dir.mkdir()
+    disabled = dict(_VP, disabled=True)
+    (vp_dir / "claude-x@example.com.json").write_text(json.dumps(disabled), encoding="utf-8")
+    monkeypatch.setattr(sync, "VIBEPROXY_AUTH_DIR", vp_dir)
+    result = sync.sync_profile("max-99", "x@example.com", blank_refresh=True, apply=False)
+    assert result.action == "skipped_no_source"


### PR DESCRIPTION
## Problem

The Claude Max profile pool ran at **0/12 healthy** — every profile expired,
including ones logged in hours earlier. The hourly `claude_pool_verify.py`
refresh side-effect (probe an expired token → CLI refreshes it) is correct in
isolation but was silently defeated.

## Root cause

Anthropic OAuth **single-use-rotates** the refresh token on every refresh: once
used, the old refresh token is revoked. The same accounts were being refreshed
by **three independent owners**:

1. VibeProxy's `cli-proxy-api` (batch-refreshes all its accounts on its own schedule),
2. aragora's hourly `claude_pool_verify.py` probe,
3. for two shared logins (max-08/09, max-12/13), a *second* aragora profile.

Whoever refreshed an account first got the new token; every other holder was
left with a revoked one → dead. Confirmed by account overlap: **9 of 12
profiles hold accounts VibeProxy also refreshes**, and two logins are shared
across profile pairs. `claude_pool_verify.py`'s own docstring predicted this
("canNOT revive a revoked refresh token — duplicate accounts, same-org seats,
or the same account used concurrently").

## Fix — consume VibeProxy's tokens, don't compete

VibeProxy stays alive because it is the **single owner** of each account's
refresh token. So aragora stops refreshing and instead copies VibeProxy's
already-fresh **access** token into the matching profile, written **without a
usable refresh token** (pure consumer). Consequences:

- aragora can never rotate VibeProxy's live token.
- the hourly `claude_pool_verify.py` becomes automatically safe — a profile with
  no refresh token cannot rotate anything even when probed.
- self-healing: if a sync cycle lags past expiry, the profile just reports
  expired until the next cycle; nothing is revoked.

## Contents

- `scripts/sync_claude_profiles_from_vibeproxy.py` — format-translating sync;
  pure-consumer default, idempotent, atomic `0600` writes, `--probe-after`.
- `scripts/install_claude_profile_sync_launchd.sh` — 30-min `launchd` timer.
  Deploys the script to `~/.aragora/bin` (outside any git checkout) so worktree
  TTL-cleanup and future merges never disturb the running daemon.
- `docs/guides/CLAUDE_MAX_POOL.md` — root cause, fix, runbook.
- 9 focused tests.

## Validation

- **0/12 → 11/12 healthy in one sync**, confirmed by `claude_pool_verify.py`
  live probe. The single holdout (`max-10` / `armand.tuzel@gmail.com`) is the
  one account VibeProxy does not hold — add it to VibeProxy or keep it on
  interactive re-login.
- Timer installed and its `RunAtLoad` fire probed green.
- 9 tests, ruff, mypy, automation preflight, diff-check clean.

## Notes / scope

- Local operator tooling; no runtime/product surface changes.
- Requires VibeProxy running with the Claude accounts connected.
- Follow-up worth considering: fold the two shared-login profiles into distinct
  accounts (the health checker already recommends this) so the pool has 13
  distinct-account slots rather than 11 + 2 duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Reviewed design decisions (repair rounds)

Several review rounds refined the credential-safety model. These are settled;
future reviews should ground on them:

1. **Native-login guard, then idempotency.** A profile holding a real (non-blank)
   refresh token is a *native login* and is never blanked without `--force`,
   checked BEFORE the access-token idempotency check (so a coincidental token
   match cannot leave a live refresh token racing VibeProxy). Our own synced
   creds carry a blank refresh token and flow freely.

2. **Offline ambiguity → one-time `--force` bootstrap.** A live refresh token
   cannot be distinguished from a revoked one without a network call. So the
   first run over native/dead profiles requires `--force` to convert them into
   blank-refresh consumers; the daemon then runs without `--force` in steady
   state. An all-native result is NOT "healthy" — `main()` exits non-zero and
   points at the bootstrap, rather than silently no-op'ing.

3. **Interval ≤ refresh lead.** The timer runs every 5 min (≤ VibeProxy's
   ~10-min refresh lead) so a sync always lands between the new token appearing
   and the old one lapsing.

4. **Backups are native-only.** A `0600` `.bak` is written only when replacing a
   real native credential (under `--force`), never overwritten by one of our own
   blank-refresh creds.
