### PR TITLE
fix(dev): align compose Node runtime

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -124,7 +124,7 @@ services:
   # Frontend Dev Server
   # ==========================================================================
   frontend-dev:
-    image: node:18.19-alpine
+    image: node:20.11-alpine
     container_name: aragora-frontend-dev
     working_dir: /app
     ports:


### PR DESCRIPTION
## Summary

- update the `frontend-dev` image in `docker-compose.dev.yml` from `node:18.19-alpine` to `node:20.11-alpine`
- keep the follow-up isolated to the development Compose file
- leave Next.js, package dependencies, `aragora/live/Dockerfile`, and PR #9484 untouched

## Risk

Low and development-only. The same `node:20.11-alpine` tag is already used by `deploy/Dockerfile.frontend`; this change aligns the Compose frontend runtime without changing application dependencies.

## Validation

- `docker compose -f docker-compose.dev.yml config --quiet`
- `docker compose -f docker-compose.dev.yml --profile knowledge config --quiet`
- rendered Compose image equals `node:20.11-alpine`
- `pre-commit run --files docker-compose.dev.yml`
- commit and push hooks passed
- exact diff scope: one file, one insertion, one deletion

## Context

Separate follow-up to #9484. This PR is intentionally draft and should proceed through the normal review and settlement gates.