### PR TITLE
fix(dev): mount local TypeScript SDK in Compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -136,10 +136,17 @@ services:
       - WATCHPACK_POLLING=true
     volumes:
       - ./aragora/live:/app
+      # The frontend's file:../../sdk/typescript dependency resolves here from /app.
       - ./sdk/typescript:/sdk/typescript:ro
+      - /sdk/typescript/node_modules
+      - /sdk/typescript/dist
       - /app/node_modules  # Exclude node_modules from mount
       - /app/.next         # Exclude .next from mount
-    command: sh -c "npm install && npm run dev"
+    command: >
+      sh -c "npm --prefix /sdk/typescript ci --legacy-peer-deps &&
+      npm --prefix /sdk/typescript run build &&
+      npm install --legacy-peer-deps &&
+      npm run dev"
     depends_on:
       - aragora-dev
     restart: unless-stopped

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -124,7 +124,7 @@ services:
   # Frontend Dev Server
   # ==========================================================================
   frontend-dev:
-    image: node:20.11-alpine
+    image: node:20.19-alpine
     container_name: aragora-frontend-dev
     working_dir: /app
     ports:
@@ -137,15 +137,19 @@ services:
     volumes:
       - ./aragora/live:/app
       # The frontend's file:../../sdk/typescript dependency resolves here from /app.
-      - ./sdk/typescript:/sdk/typescript:ro
-      - /sdk/typescript/node_modules
-      - /sdk/typescript/dist
+      - typescript-sdk-dev:/sdk/typescript
+      - ./sdk/typescript/.npmrc:/sdk/typescript/.npmrc:ro
+      - ./sdk/typescript/package.json:/sdk/typescript/package.json:ro
+      - ./sdk/typescript/package-lock.json:/sdk/typescript/package-lock.json:ro
+      - ./sdk/typescript/tsconfig.json:/sdk/typescript/tsconfig.json:ro
+      - ./sdk/typescript/src:/sdk/typescript/src:ro
+      - frontend-dev-npm-cache:/root/.npm
       - /app/node_modules  # Exclude node_modules from mount
       - /app/.next         # Exclude .next from mount
     command: >
       sh -c "npm --prefix /sdk/typescript ci --legacy-peer-deps &&
       npm --prefix /sdk/typescript run build &&
-      npm install --legacy-peer-deps &&
+      npm install &&
       npm run dev"
     depends_on:
       - aragora-dev
@@ -272,6 +276,8 @@ services:
 volumes:
   aragora-dev-data:
   aragora-dev-nomic:
+  typescript-sdk-dev:
+  frontend-dev-npm-cache:
   redis-dev-data:
   postgres-dev-data:
   weaviate-dev-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -136,6 +136,7 @@ services:
       - WATCHPACK_POLLING=true
     volumes:
       - ./aragora/live:/app
+      - ./sdk/typescript:/sdk/typescript:ro
       - /app/node_modules  # Exclude node_modules from mount
       - /app/.next         # Exclude .next from mount
     command: sh -c "npm install && npm run dev"

--- a/tests/ci/test_docker_compose_dev.py
+++ b/tests/ci/test_docker_compose_dev.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _frontend_dev_service() -> dict[str, object]:
+    compose = yaml.safe_load((ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8"))
+    return compose["services"]["frontend-dev"]
+
+
+def test_frontend_dev_builds_local_sdk_before_starting() -> None:
+    service = _frontend_dev_service()
+    volumes = service["volumes"]
+    command = service["command"]
+
+    assert "./sdk/typescript:/sdk/typescript:ro" in volumes
+    assert "/sdk/typescript/node_modules" in volumes
+    assert "/sdk/typescript/dist" in volumes
+
+    steps = (
+        "npm --prefix /sdk/typescript ci --legacy-peer-deps",
+        "npm --prefix /sdk/typescript run build",
+        "npm install --legacy-peer-deps",
+        "npm run dev",
+    )
+    positions = [command.index(step) for step in steps]
+    assert positions == sorted(positions)

--- a/tests/ci/test_docker_compose_dev.py
+++ b/tests/ci/test_docker_compose_dev.py
@@ -1,3 +1,5 @@
+import json
+import posixpath
 from pathlib import Path
 
 import yaml
@@ -6,25 +8,40 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _frontend_dev_service() -> dict[str, object]:
-    compose = yaml.safe_load((ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8"))
-    return compose["services"]["frontend-dev"]
+def _compose() -> dict[str, object]:
+    return yaml.safe_load((ROOT / "docker-compose.dev.yml").read_text(encoding="utf-8"))
 
 
 def test_frontend_dev_builds_local_sdk_before_starting() -> None:
-    service = _frontend_dev_service()
+    compose = _compose()
+    service = compose["services"]["frontend-dev"]
     volumes = service["volumes"]
-    command = service["command"]
+    command = " ".join(service["command"].split())
 
-    assert "./sdk/typescript:/sdk/typescript:ro" in volumes
-    assert "/sdk/typescript/node_modules" in volumes
-    assert "/sdk/typescript/dist" in volumes
+    assert service["image"] == "node:20.19-alpine"
+    assert "typescript-sdk-dev:/sdk/typescript" in volumes
+    assert "frontend-dev-npm-cache:/root/.npm" in volumes
+    assert {
+        "./sdk/typescript/.npmrc:/sdk/typescript/.npmrc:ro",
+        "./sdk/typescript/package.json:/sdk/typescript/package.json:ro",
+        "./sdk/typescript/package-lock.json:/sdk/typescript/package-lock.json:ro",
+        "./sdk/typescript/tsconfig.json:/sdk/typescript/tsconfig.json:ro",
+        "./sdk/typescript/src:/sdk/typescript/src:ro",
+    }.issubset(volumes)
+    assert "typescript-sdk-dev" in compose["volumes"]
+    assert "frontend-dev-npm-cache" in compose["volumes"]
 
-    steps = (
-        "npm --prefix /sdk/typescript ci --legacy-peer-deps",
-        "npm --prefix /sdk/typescript run build",
-        "npm install --legacy-peer-deps",
-        "npm run dev",
+    assert command == (
+        'sh -c "npm --prefix /sdk/typescript ci --legacy-peer-deps && '
+        'npm --prefix /sdk/typescript run build && npm install && npm run dev"'
     )
-    positions = [command.index(step) for step in steps]
-    assert positions == sorted(positions)
+
+
+def test_frontend_sdk_dependency_resolves_to_compose_mount() -> None:
+    package = json.loads((ROOT / "aragora/live/package.json").read_text(encoding="utf-8"))
+    specifier = package["dependencies"]["@aragora/sdk"]
+
+    assert specifier.startswith("file:")
+    assert posixpath.normpath(posixpath.join("/app", specifier.removeprefix("file:"))) == (
+        "/sdk/typescript"
+    )


### PR DESCRIPTION
## Summary

- mount a writable Compose-managed SDK workspace at `/sdk/typescript`
- overlay only tracked SDK inputs as read-only bind mounts
- build the SDK before installing and starting the frontend
- cache npm downloads without exposing host `node_modules` or generated output
- raise the development image to Node 20.19 and add focused policy coverage

## Problem reproduced

The original one-line source mount fixed the dangling
`file:../../sdk/typescript` path, but it still failed on a clean clone. The SDK
exports only `dist/*`; `dist` is ignored and absent from Git. A read-only parent
bind also cannot safely create missing nested mount targets on every Docker
implementation.

## Review findings addressed

Claude's P2 at `90c0a70af4b1549f71a2a1b019ea7317f025ae93` is resolved by building the
SDK before the frontend install.

Claude's follow-up P2 at `c423f3ff4b2484bbd3931350c494564db651ef8e` is resolved by replacing the
read-only parent bind with a writable named SDK workspace. The tracked `.npmrc`,
manifests, TypeScript config, and source tree are overlaid read-only; `npm ci`
and `tsup --clean` can create `node_modules` and `dist` inside the named volume.
The command is an explicit `&&` chain, so frontend installation never runs after
an SDK install or build failure.

The same repair addresses the related advisory findings by:

- pinning Node 20.19 for the current development-tool engine floor;
- asserting that `/app/../../sdk/typescript` resolves to `/sdk/typescript`;
- retaining the frontend's existing `npm install` behavior rather than adding a
  new lock-policy exception; and
- keeping npm's download cache in a Compose-managed volume.

## Validation

- `pytest -q tests/ci/test_docker_compose_dev.py` - 2 passed
- `ruff check tests/ci/test_docker_compose_dev.py` - passed
- `ruff format --check tests/ci/test_docker_compose_dev.py` - passed
- `docker compose -f docker-compose.dev.yml config --quiet` - passed
- `pre-commit run --files docker-compose.dev.yml tests/ci/test_docker_compose_dev.py` - passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - passed
- `git diff --check origin/main...HEAD` - passed
- clean temporary filesystem simulation - SDK `npm ci`, SDK build, frontend
  install, and `require.resolve("@aragora/sdk")` passed; resolution ended at
  the generated SDK `dist/index.js`

The local Docker CLI is available, but its daemon was stopped during the repair
cycle, so a real container launch could not be claimed. Normal CI was triggered
by the push; no workflow was manually rerun.

## Risk

Low and development-only. Frontend container startup now performs an SDK
dependency install and build before the existing frontend install. Generated
output and SDK dependencies stay inside Compose-managed volumes; no host
manifest, lockfile, workflow, production Dockerfile, public API, or runtime
service behavior changes.

## Context

Separate follow-up to #9500. The PR remains on the normal required-check,
independent-review, quorum, and protected merge path.
