### PR TITLE
feat(cli): expose crux cards via --crux-cards flag

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -868,7 +868,7 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         from datetime import datetime, timezone
         from pathlib import Path
 
-        from aragora.gauntlet.receipt_models import DecisionReceipt
+        from aragora.gauntlet.receipt_models import DecisionReceipt, crux_cards_from_metadata
 
         receipts_dir = Path.home() / ".aragora" / "receipts"
         receipts_dir.mkdir(parents=True, exist_ok=True)
@@ -990,11 +990,11 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
             receipt["model_comparison"] = model_comparison
 
         # Crux cards (#8227): attached by the consensus phase when the debate
-        # ran with enable_crux_cards (--crux-cards). Only carried when items
-        # exist so flag-off receipts stay byte-identical.
-        crux_cards = metadata.get("crux_cards") if isinstance(metadata, dict) else None
-        if isinstance(crux_cards, dict) and crux_cards.get("items"):
-            receipt["cruxes"] = crux_cards
+        # ran with enable_crux_cards (--crux-cards). Shared helper enforces
+        # the "only carry non-empty blocks" invariant with from_debate_result.
+        cruxes = crux_cards_from_metadata(metadata)
+        if cruxes is not None:
+            receipt["cruxes"] = cruxes
 
         receipt["artifact_hash"] = DecisionReceipt.from_dict(receipt).artifact_hash
         receipt["checksum"] = receipt["artifact_hash"]
@@ -1689,6 +1689,25 @@ def cmd_ask(args: argparse.Namespace) -> None:
                 "This task was interpreted from an ambiguous input and requires confirmation."
             )
 
+    # Crux cards (#8227): only the local run_debate path honors
+    # enable_crux_cards. Reject statically invalid explicit API/graph/matrix
+    # combinations up front — before context engineering burns LLM work or
+    # ARAGORA_OFFLINE is mutated — and otherwise force local execution below
+    # (mirroring how --demo forces local).
+    crux_cards_requested = bool(getattr(args, "crux_cards", False))
+    if crux_cards_requested and (
+        getattr(args, "api", False)
+        or getattr(args, "graph", False)
+        or getattr(args, "matrix", False)
+    ):
+        print(
+            "--crux-cards currently requires local execution; API/graph/matrix "
+            "debates do not honor it. Remove --api/--graph/--matrix (local is "
+            "used automatically), or drop --crux-cards.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     explicit_codebase_context = bool(getattr(args, "codebase_context", False))
     mode_name = str(getattr(args, "mode", "") or "").strip().lower()
     inferred_codebase_context = mode_name == "orchestrator" or _looks_like_self_improvement_task(
@@ -1817,7 +1836,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
         protocol_overrides["enable_evidence_weighting"] = False
     if not getattr(args, "trending", True):
         protocol_overrides["enable_trending_injection"] = False
-    if getattr(args, "crux_cards", False):
+    if crux_cards_requested:
         # Crux cards (#8227): attach load-bearing disagreements to the debate
         # result metadata so the decision receipt carries a cruxes block.
         protocol_overrides["enable_crux_cards"] = True
@@ -1877,6 +1896,11 @@ def cmd_ask(args: argparse.Namespace) -> None:
 
     requested_api = getattr(args, "api", False)
     requested_local = getattr(args, "local", False)
+    if crux_cards_requested:
+        # Explicit API/graph/matrix requests were rejected above; force the
+        # local path (like --demo does) so enable_crux_cards is honored even
+        # when a trusted API server would otherwise be auto-selected.
+        requested_local = True
     graph_mode = getattr(args, "graph", False)
     matrix_mode = getattr(args, "matrix", False)
     decision_integrity = bool(getattr(args, "decision_integrity", False))
@@ -2119,18 +2143,6 @@ def cmd_ask(args: argparse.Namespace) -> None:
     use_api = requested_api
     if not requested_api and not requested_local:
         use_api = _trusted_server_available(server_url, flag_passed=api_url_flag_passed)
-
-    # Crux cards (#8227): the flag is only plumbed through the local
-    # protocol_overrides path. Fail closed on API/graph/matrix dispatch
-    # instead of silently dropping the promised cruxes block.
-    if getattr(args, "crux_cards", False) and (use_api or graph_mode or matrix_mode):
-        print(
-            "--crux-cards currently requires local execution; API/graph/matrix "
-            "debates do not honor it. Add --local (and remove --api/--graph/--matrix), "
-            "or drop --crux-cards.",
-            file=sys.stderr,
-        )
-        raise SystemExit(2)
 
     if use_api:
         try:

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -2120,6 +2120,18 @@ def cmd_ask(args: argparse.Namespace) -> None:
     if not requested_api and not requested_local:
         use_api = _trusted_server_available(server_url, flag_passed=api_url_flag_passed)
 
+    # Crux cards (#8227): the flag is only plumbed through the local
+    # protocol_overrides path. Fail closed on API/graph/matrix dispatch
+    # instead of silently dropping the promised cruxes block.
+    if getattr(args, "crux_cards", False) and (use_api or graph_mode or matrix_mode):
+        print(
+            "--crux-cards currently requires local execution; API/graph/matrix "
+            "debates do not honor it. Add --local (and remove --api/--graph/--matrix), "
+            "or drop --crux-cards.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     if use_api:
         try:
             if graph_mode:

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -989,6 +989,13 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         if isinstance(model_comparison, dict):
             receipt["model_comparison"] = model_comparison
 
+        # Crux cards (#8227): attached by the consensus phase when the debate
+        # ran with enable_crux_cards (--crux-cards). Only carried when items
+        # exist so flag-off receipts stay byte-identical.
+        crux_cards = metadata.get("crux_cards") if isinstance(metadata, dict) else None
+        if isinstance(crux_cards, dict) and crux_cards.get("items"):
+            receipt["cruxes"] = crux_cards
+
         receipt["artifact_hash"] = DecisionReceipt.from_dict(receipt).artifact_hash
         receipt["checksum"] = receipt["artifact_hash"]
         content_hash = hashlib.sha256(
@@ -1810,6 +1817,10 @@ def cmd_ask(args: argparse.Namespace) -> None:
         protocol_overrides["enable_evidence_weighting"] = False
     if not getattr(args, "trending", True):
         protocol_overrides["enable_trending_injection"] = False
+    if getattr(args, "crux_cards", False):
+        # Crux cards (#8227): attach load-bearing disagreements to the debate
+        # result metadata so the decision receipt carries a cruxes block.
+        protocol_overrides["enable_crux_cards"] = True
     # Note: ELO weighting is controlled via WeightCalculatorConfig, passed via protocol
 
     # Demo mode forces local execution

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -868,7 +868,11 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         from datetime import datetime, timezone
         from pathlib import Path
 
-        from aragora.gauntlet.receipt_models import DecisionReceipt, crux_cards_from_metadata
+        from aragora.gauntlet.receipt_models import (
+            DecisionReceipt,
+            crux_cards_from_metadata,
+            receipt_schema_version,
+        )
 
         receipts_dir = Path.home() / ".aragora" / "receipts"
         receipts_dir.mkdir(parents=True, exist_ok=True)
@@ -983,18 +987,19 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
                     "evidence_hash": input_hash,
                 }
             ],
-            "schema_version": "1.1",
         }
         model_comparison = metadata.get("model_comparison") if isinstance(metadata, dict) else None
         if isinstance(model_comparison, dict):
             receipt["model_comparison"] = model_comparison
 
         # Crux cards (#8227): attached by the consensus phase when the debate
-        # ran with enable_crux_cards (--crux-cards). Shared helper enforces
-        # the "only carry non-empty blocks" invariant with from_debate_result.
+        # ran with enable_crux_cards (--crux-cards). Shared helpers enforce
+        # the "only carry non-empty blocks" invariant and the schema-version
+        # bump (1.2 when cruxes bind into the hash) with from_debate_result.
         cruxes = crux_cards_from_metadata(metadata)
         if cruxes is not None:
             receipt["cruxes"] = cruxes
+        receipt["schema_version"] = receipt_schema_version(cruxes)
 
         receipt["artifact_hash"] = DecisionReceipt.from_dict(receipt).artifact_hash
         receipt["checksum"] = receipt["artifact_hash"]
@@ -1690,23 +1695,36 @@ def cmd_ask(args: argparse.Namespace) -> None:
             )
 
     # Crux cards (#8227): only the local run_debate path honors
-    # enable_crux_cards. Reject statically invalid explicit API/graph/matrix
-    # combinations up front — before context engineering burns LLM work or
-    # ARAGORA_OFFLINE is mutated — and otherwise force local execution below
-    # (mirroring how --demo forces local).
+    # enable_crux_cards, so the flag uniformly requires local execution.
+    # Any explicit API configuration (--api, --api-url, ARAGORA_API_URL,
+    # --graph, --matrix) is rejected up front — before context engineering
+    # burns LLM work or ARAGORA_OFFLINE is mutated. Otherwise local execution
+    # is forced below (mirroring --demo), with a Note so the auto-discovery
+    # path is never silent.
     crux_cards_requested = bool(getattr(args, "crux_cards", False))
-    if crux_cards_requested and (
-        getattr(args, "api", False)
-        or getattr(args, "graph", False)
-        or getattr(args, "matrix", False)
-    ):
-        print(
-            "--crux-cards currently requires local execution; API/graph/matrix "
-            "debates do not honor it. Remove --api/--graph/--matrix (local is "
-            "used automatically), or drop --crux-cards.",
-            file=sys.stderr,
-        )
-        raise SystemExit(2)
+    if crux_cards_requested:
+        crux_api_url = getattr(args, "api_url", None)
+        if (
+            getattr(args, "api", False)
+            or getattr(args, "graph", False)
+            or getattr(args, "matrix", False)
+            or _is_explicitly_configured_api_url(
+                crux_api_url or DEFAULT_API_URL, flag_passed=crux_api_url is not None
+            )
+        ):
+            print(
+                "--crux-cards currently requires local execution; API/graph/matrix "
+                "debates do not honor it. Remove --api/--api-url/--graph/--matrix "
+                "and unset ARAGORA_API_URL, or drop --crux-cards.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        if not getattr(args, "local", False):
+            print(
+                "Note: --crux-cards is only honored by local execution; "
+                "running the debate locally.",
+                file=sys.stderr,
+            )
 
     explicit_codebase_context = bool(getattr(args, "codebase_context", False))
     mode_name = str(getattr(args, "mode", "") or "").strip().lower()
@@ -1897,9 +1915,9 @@ def cmd_ask(args: argparse.Namespace) -> None:
     requested_api = getattr(args, "api", False)
     requested_local = getattr(args, "local", False)
     if crux_cards_requested:
-        # Explicit API/graph/matrix requests were rejected above; force the
-        # local path (like --demo does) so enable_crux_cards is honored even
-        # when a trusted API server would otherwise be auto-selected.
+        # Explicit API configuration was rejected above; force the local path
+        # (like --demo does) so enable_crux_cards is honored even when a
+        # trusted API server would otherwise be auto-selected.
         requested_local = True
     graph_mode = getattr(args, "graph", False)
     matrix_mode = getattr(args, "matrix", False)

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -1696,26 +1696,40 @@ def cmd_ask(args: argparse.Namespace) -> None:
 
     # Crux cards (#8227): only the local run_debate path honors
     # enable_crux_cards, so the flag uniformly requires local execution.
-    # Any explicit API configuration (--api, --api-url, ARAGORA_API_URL,
-    # --graph, --matrix) is rejected up front — before context engineering
-    # burns LLM work or ARAGORA_OFFLINE is mutated. Otherwise local execution
-    # is forced below (mirroring --demo), with a Note so the auto-discovery
-    # path is never silent.
+    # Graph/matrix are rejected unconditionally (they conflict with local
+    # execution below anyway). Explicit API configuration (--api, --api-url,
+    # ARAGORA_API_URL) is rejected only when the run is not already local
+    # (--local/--demo/ARAGORA_OFFLINE) — a merely-exported ARAGORA_API_URL
+    # must not reject a run that could never dispatch to it. Checked up
+    # front, before context engineering burns LLM work or ARAGORA_OFFLINE is
+    # mutated. Otherwise local execution is forced below (mirroring --demo),
+    # with a Note so the auto-discovery path is never silent.
     crux_cards_requested = bool(getattr(args, "crux_cards", False))
     if crux_cards_requested:
+        from aragora.utils.env import is_offline_mode as _crux_is_offline
+
+        if getattr(args, "graph", False) or getattr(args, "matrix", False):
+            print(
+                "--crux-cards currently requires local execution; graph/matrix "
+                "debates do not honor it. Remove --graph/--matrix or drop "
+                "--crux-cards.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        already_local = (
+            getattr(args, "local", False) or getattr(args, "demo", False) or _crux_is_offline()
+        )
         crux_api_url = getattr(args, "api_url", None)
-        if (
+        if not already_local and (
             getattr(args, "api", False)
-            or getattr(args, "graph", False)
-            or getattr(args, "matrix", False)
             or _is_explicitly_configured_api_url(
                 crux_api_url or DEFAULT_API_URL, flag_passed=crux_api_url is not None
             )
         ):
             print(
-                "--crux-cards currently requires local execution; API/graph/matrix "
-                "debates do not honor it. Remove --api/--api-url/--graph/--matrix "
-                "and unset ARAGORA_API_URL, or drop --crux-cards.",
+                "--crux-cards currently requires local execution; API debates do "
+                "not honor it. Add --local, remove --api/--api-url and unset "
+                "ARAGORA_API_URL, or drop --crux-cards.",
                 file=sys.stderr,
             )
             raise SystemExit(2)

--- a/aragora/cli/commands/verify.py
+++ b/aragora/cli/commands/verify.py
@@ -11,11 +11,13 @@ Runs the following checks on a decision receipt JSON file:
   dual-field receipts cannot hide a mismatched proof. This hash covers the
   *decision-integrity fields* --
   ``receipt_id``, ``gauntlet_id``, ``input_hash``, ``risk_summary``, ``verdict``,
-  and ``confidence`` -- so tampering with any of those is detected. It does **not**
-  cover presentational/metadata fields such as ``timestamp`` or ``schema_version``;
-  for full-payload tamper-evidence, sign the receipt and use the signature check
-  (or ``aragora receipt verify``). The reported coverage is scoped accordingly so
-  the command does not overclaim.
+  and ``confidence`` -- so tampering with any of those is detected. Crux receipts
+  (schema >= 1.2) additionally bind ``cruxes`` and ``schema_version`` into the
+  hash, so a 1.2 -> 1.1 downgrade is detected as tampering. The hash does **not**
+  cover presentational/metadata fields such as ``timestamp`` (or
+  ``schema_version`` on pre-crux receipts); for full-payload tamper-evidence,
+  sign the receipt and use the signature check (or ``aragora receipt verify``).
+  The reported coverage is scoped accordingly so the command does not overclaim.
 - **Presence/format checks** (non-integrity): confirms ``schema_version`` is
   present, ``verdict`` is a recognised Verdict enum value, and ``timestamp`` is
   valid ISO 8601. These validate well-formedness, not tamper-evidence.
@@ -46,10 +48,11 @@ def create_verify_parser(subparsers: argparse._SubParsersAction) -> None:
             "Validate a decision receipt JSON file. Recomputes the SHA-256 "
             "decision-integrity hash (artifact_hash, plus legacy checksum fallback; "
             "both are checked when both are present) to detect tampering of the decision-integrity fields (receipt_id, "
-            "gauntlet_id, input_hash, risk_summary, verdict, confidence); also checks "
+            "gauntlet_id, input_hash, risk_summary, verdict, confidence; crux receipts "
+            "additionally bind cruxes and schema_version); also checks "
             "schema_version presence, that the verdict is a valid enum value, and "
             "timestamp format. Note: the integrity hash does not cover presentational "
-            "fields like timestamp/schema_version -- for full-payload tamper-evidence "
+            "fields like timestamp -- for full-payload tamper-evidence "
             "the receipt must be cryptographically signed (the signature is verified "
             "when present)."
         ),
@@ -122,7 +125,9 @@ def _is_valid_iso_timestamp(value: str) -> bool:
 # (mirrors ``DecisionReceipt._calculate_hash``). These -- and ONLY these -- are the
 # fields whose tampering this command's integrity check detects. Reported to the
 # user via the ``covers`` key so the command does not overclaim coverage of
-# presentational fields (timestamp, schema_version, ...) the hash does not include.
+# presentational fields (timestamp, ...) the hash does not include. Crux
+# receipts (schema >= 1.2) additionally bind ``cruxes`` and ``schema_version``
+# (downgrade-tamper protection) -- see ``_integrity_hash_fields``.
 _INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
     "receipt_id",
     "gauntlet_id",
@@ -131,6 +136,22 @@ _INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
     "verdict",
     "confidence",
 )
+
+# Additional fields bound into the hash when a receipt carries a ``cruxes``
+# block (crux cards, #8227 / schema >= 1.2). ``schema_version`` is included so
+# a 1.2 -> 1.1 downgrade cannot silently defeat the version signal.
+_CRUX_INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
+    "cruxes",
+    "schema_version",
+)
+
+
+def _integrity_hash_fields(data: dict[str, Any]) -> tuple[str, ...]:
+    """Fields the artifact hash covers for THIS receipt (honest coverage)."""
+    if data.get("cruxes") is not None:
+        return _INTEGRITY_HASH_FIELDS + _CRUX_INTEGRITY_HASH_FIELDS
+    return _INTEGRITY_HASH_FIELDS
+
 
 # Decision-integrity fields covered by the legacy ``checksum`` field.
 _LEGACY_CHECKSUM_FIELDS: tuple[str, ...] = (
@@ -161,30 +182,47 @@ def _recompute_checksum(data: dict[str, Any]) -> str:
     return hashlib.sha256(content.encode()).hexdigest()[:16]
 
 
+def _inline_artifact_hash(data: dict[str, Any]) -> str:
+    """Inline fallback for :func:`_recompute_artifact_hash`.
+
+    Byte-for-byte equivalent to ``compute_receipt_artifact_hash`` in
+    ``aragora.gauntlet.receipt_models`` (equivalence is pinned by tests); used
+    only when the gauntlet package is not importable. Covers the fields in
+    :data:`_INTEGRITY_HASH_FIELDS`, plus :data:`_CRUX_INTEGRITY_HASH_FIELDS`
+    when a ``cruxes`` block is present (schema >= 1.2 downgrade-tamper
+    protection).
+    """
+    payload: dict[str, Any] = {
+        "receipt_id": data.get("receipt_id", ""),
+        "gauntlet_id": data.get("gauntlet_id", ""),
+        "input_hash": data.get("input_hash", ""),
+        "risk_summary": data.get("risk_summary", {}),
+        "verdict": data.get("verdict", ""),
+        "confidence": data.get("confidence", 0.0),
+    }
+    if data.get("cruxes") is not None:
+        payload["cruxes"] = data.get("cruxes")
+        payload["schema_version"] = data.get("schema_version", "")
+    content = json.dumps(payload, sort_keys=True)
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
 def _recompute_artifact_hash(data: dict[str, Any]) -> str:
     """Recompute the canonical content-addressable ``artifact_hash``.
 
-    Mirrors ``DecisionReceipt._calculate_hash`` so that receipts emitted by the
-    canonical producer (``DecisionReceipt.to_dict``, used by ``aragora demo`` and
-    the gauntlet) -- which store their integrity hash under ``artifact_hash`` and
-    do *not* emit a separate ``checksum`` key -- can be verified by this command.
-
-    Implemented inline (rather than importing ``DecisionReceipt``) so verification
-    never hard-depends on the gauntlet package being importable. Covers exactly the
-    fields in :data:`_INTEGRITY_HASH_FIELDS`.
+    Delegates to ``compute_receipt_artifact_hash`` -- the single canonical
+    recipe shared with ``DecisionReceipt._calculate_hash`` -- so this command
+    can never drift from the producer (an earlier inline copy omitted the
+    ``cruxes`` branch and reported every untampered crux receipt as tampered).
+    Falls back to the byte-equivalent :func:`_inline_artifact_hash` when the
+    gauntlet package is not importable, so verification keeps working in
+    minimal installs.
     """
-    content = json.dumps(
-        {
-            "receipt_id": data.get("receipt_id", ""),
-            "gauntlet_id": data.get("gauntlet_id", ""),
-            "input_hash": data.get("input_hash", ""),
-            "risk_summary": data.get("risk_summary", {}),
-            "verdict": data.get("verdict", ""),
-            "confidence": data.get("confidence", 0.0),
-        },
-        sort_keys=True,
-    )
-    return hashlib.sha256(content.encode()).hexdigest()
+    try:
+        from aragora.gauntlet.receipt_models import compute_receipt_artifact_hash
+    except ImportError:
+        return _inline_artifact_hash(data)
+    return compute_receipt_artifact_hash(data)
 
 
 def _looks_like_artifact_hash_alias(value: Any) -> bool:
@@ -304,10 +342,12 @@ def _verify_receipt(data: dict[str, Any], *, verbose: bool = False) -> dict[str,
     # checksum.
     #
     # IMPORTANT (honest coverage): this hash only covers the *decision-integrity
-    # fields* listed in ``_INTEGRITY_HASH_FIELDS`` -- it does NOT cover presentational
-    # fields like ``timestamp`` or ``schema_version``. The check is named
-    # ``integrity`` (not ``checksum``) and reports a ``covers`` list so the command
-    # does not imply whole-payload tamper-evidence. Full-payload coverage requires a
+    # fields* reported by ``_integrity_hash_fields`` -- it does NOT cover
+    # presentational fields like ``timestamp``. (``schema_version`` IS covered
+    # for crux receipts, schema >= 1.2, to block downgrade tampering; it is NOT
+    # covered for pre-crux receipts.) The check is named ``integrity`` (not
+    # ``checksum``) and reports a ``covers`` list so the command does not imply
+    # whole-payload tamper-evidence. Full-payload coverage requires a
     # cryptographic signature (check #5 / ``aragora receipt verify``).
     stored_artifact_hash = data.get("artifact_hash")
     stored_checksum = data.get("checksum")
@@ -316,7 +356,7 @@ def _verify_receipt(data: dict[str, Any], *, verbose: bool = False) -> dict[str,
     covered_fields: list[str] = []
     if stored_artifact_hash:
         expected_artifact_hash = _recompute_artifact_hash(data)
-        covered_fields.extend(_INTEGRITY_HASH_FIELDS)
+        covered_fields.extend(_integrity_hash_fields(data))
         if stored_artifact_hash == expected_artifact_hash:
             detail = f"artifact_hash={stored_artifact_hash[:16]}..."
             if verbose:
@@ -330,7 +370,7 @@ def _verify_receipt(data: dict[str, Any], *, verbose: bool = False) -> dict[str,
     if stored_checksum:
         if _looks_like_artifact_hash_alias(stored_checksum):
             expected_checksum_alias = _recompute_artifact_hash(data)
-            covered_fields.extend(_INTEGRITY_HASH_FIELDS)
+            covered_fields.extend(_integrity_hash_fields(data))
             if stored_checksum == expected_checksum_alias:
                 detail = f"checksum artifact_hash alias={stored_checksum[:16]}..."
                 if verbose:

--- a/aragora/cli/commands/verify.py
+++ b/aragora/cli/commands/verify.py
@@ -125,9 +125,10 @@ def _is_valid_iso_timestamp(value: str) -> bool:
 # (mirrors ``DecisionReceipt._calculate_hash``). These -- and ONLY these -- are the
 # fields whose tampering this command's integrity check detects. Reported to the
 # user via the ``covers`` key so the command does not overclaim coverage of
-# presentational fields (timestamp, ...) the hash does not include. Crux
-# receipts (schema >= 1.2) additionally bind ``cruxes`` and ``schema_version``
-# (downgrade-tamper protection) -- see ``_integrity_hash_fields``.
+# presentational fields (timestamp, ...) the hash does not include. Receipts
+# carrying ``cruxes`` additionally bind the crux block, and receipts stamped
+# schema 1.2 also bind ``schema_version`` (downgrade-tamper protection) -- see
+# ``_integrity_hash_fields``.
 _INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
     "receipt_id",
     "gauntlet_id",
@@ -137,20 +138,23 @@ _INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
     "confidence",
 )
 
-# Additional fields bound into the hash when a receipt carries a ``cruxes``
-# block (crux cards, #8227 / schema >= 1.2). ``schema_version`` is included so
-# a 1.2 -> 1.1 downgrade cannot silently defeat the version signal.
-_CRUX_INTEGRITY_HASH_FIELDS: tuple[str, ...] = (
-    "cruxes",
-    "schema_version",
-)
+# Schema version at which receipts bind ``schema_version`` into the hash
+# (mirrors ``RECEIPT_SCHEMA_VERSION_CRUXES`` in receipt_models; kept as a local
+# literal so this command never hard-depends on the gauntlet package). The
+# binding is version-gated, NOT crux-presence-gated: #9414 shipped crux binding
+# before the 1.2 stamp existed, so receipts with cruxes + schema_version 1.1
+# hashed without schema_version and must keep verifying.
+_SCHEMA_VERSION_CRUXES = "1.2"
 
 
 def _integrity_hash_fields(data: dict[str, Any]) -> tuple[str, ...]:
     """Fields the artifact hash covers for THIS receipt (honest coverage)."""
+    fields = _INTEGRITY_HASH_FIELDS
     if data.get("cruxes") is not None:
-        return _INTEGRITY_HASH_FIELDS + _CRUX_INTEGRITY_HASH_FIELDS
-    return _INTEGRITY_HASH_FIELDS
+        fields = fields + ("cruxes",)
+        if data.get("schema_version") == _SCHEMA_VERSION_CRUXES:
+            fields = fields + ("schema_version",)
+    return fields
 
 
 # Decision-integrity fields covered by the legacy ``checksum`` field.
@@ -187,10 +191,11 @@ def _inline_artifact_hash(data: dict[str, Any]) -> str:
 
     Byte-for-byte equivalent to ``compute_receipt_artifact_hash`` in
     ``aragora.gauntlet.receipt_models`` (equivalence is pinned by tests); used
-    only when the gauntlet package is not importable. Covers the fields in
-    :data:`_INTEGRITY_HASH_FIELDS`, plus :data:`_CRUX_INTEGRITY_HASH_FIELDS`
-    when a ``cruxes`` block is present (schema >= 1.2 downgrade-tamper
-    protection).
+    only when the gauntlet package is not importable. Covers the fields
+    reported by :func:`_integrity_hash_fields`: the base decision-integrity
+    fields, plus ``cruxes`` when present, plus ``schema_version`` only for
+    receipts stamped :data:`_SCHEMA_VERSION_CRUXES` (downgrade-tamper
+    protection, version-gated for #9414-era 1.1 crux receipts).
     """
     payload: dict[str, Any] = {
         "receipt_id": data.get("receipt_id", ""),
@@ -202,7 +207,11 @@ def _inline_artifact_hash(data: dict[str, Any]) -> str:
     }
     if data.get("cruxes") is not None:
         payload["cruxes"] = data.get("cruxes")
-        payload["schema_version"] = data.get("schema_version", "")
+        # Missing schema_version defaults to "1.0" (the from_dict convention)
+        # so the same JSON cannot hash two ways.
+        schema_version = data.get("schema_version", "1.0")
+        if schema_version == _SCHEMA_VERSION_CRUXES:
+            payload["schema_version"] = schema_version
     content = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(content.encode()).hexdigest()
 
@@ -354,6 +363,23 @@ def _verify_receipt(data: dict[str, Any], *, verbose: bool = False) -> dict[str,
     proof_details: list[str] = []
     proof_failures: list[str] = []
     covered_fields: list[str] = []
+    # Crux receipts (a ``cruxes`` block, or a schema 1.2 stamp) MUST be
+    # verified against the full artifact hash: the legacy 16-char checksum
+    # covers neither cruxes nor schema_version, so accepting it alone would
+    # let an attacker strip ``artifact_hash`` and evade crux/downgrade
+    # tamper-protection. Pre-crux receipts keep the legacy fallback.
+    requires_full_artifact_hash = (
+        data.get("cruxes") is not None or data.get("schema_version") == _SCHEMA_VERSION_CRUXES
+    )
+    if (
+        requires_full_artifact_hash
+        and not stored_artifact_hash
+        and not _looks_like_artifact_hash_alias(stored_checksum)
+    ):
+        proof_failures.append(
+            "crux receipt (cruxes present or schema >= 1.2) requires the full "
+            "artifact_hash; the legacy checksum does not cover cruxes/schema_version"
+        )
     if stored_artifact_hash:
         expected_artifact_hash = _recompute_artifact_hash(data)
         covered_fields.extend(_integrity_hash_fields(data))

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1218,7 +1218,7 @@ def _add_ask_parser(subparsers) -> None:
     ask_parser.add_argument(
         "--crux-cards",
         action="store_true",
-        help="Attach crux cards (load-bearing disagreements) to the result and decision receipt",
+        help="Attach crux cards (load-bearing disagreements) to the receipt; requires --local",
     )
     ask_parser.add_argument(
         "--preset",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1222,6 +1222,14 @@ def _add_ask_parser(subparsers) -> None:
         help="Generate and display decision explanation (evidence chains, vote pivots)",
     )
     ask_parser.add_argument(
+        "--crux-cards",
+        action="store_true",
+        help=(
+            "Attach crux cards (load-bearing disagreements) to the debate result "
+            "and decision receipt (sets enable_crux_cards on the protocol)"
+        ),
+    )
+    ask_parser.add_argument(
         "--preset",
         choices=[
             "sme",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1218,7 +1218,7 @@ def _add_ask_parser(subparsers) -> None:
     ask_parser.add_argument(
         "--crux-cards",
         action="store_true",
-        help="Attach crux cards (load-bearing disagreements) to the receipt (forces local run)",
+        help="Attach crux cards (load-bearing disagreements) to the receipt; local-only",
     )
     ask_parser.add_argument(
         "--preset",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1076,9 +1076,7 @@ def _add_ask_parser(subparsers) -> None:
         "--no-learn", dest="learn", action="store_false", help="Don't store patterns"
     )
     ask_parser.add_argument(
-        "--demo",
-        action="store_true",
-        help="Run with built-in demo agents (no API keys required)",
+        "--demo", action="store_true", help="Run with built-in demo agents (no API keys required)"
     )
     ask_parser.add_argument(
         "--mode",
@@ -1119,14 +1117,10 @@ def _add_ask_parser(subparsers) -> None:
     )
     debate_type = ask_parser.add_mutually_exclusive_group()
     debate_type.add_argument(
-        "--graph",
-        action="store_true",
-        help="Run a graph debate with branching (API mode only)",
+        "--graph", action="store_true", help="Run a graph debate with branching (API mode only)"
     )
     debate_type.add_argument(
-        "--matrix",
-        action="store_true",
-        help="Run a matrix debate with scenarios (API mode only)",
+        "--matrix", action="store_true", help="Run a matrix debate with scenarios (API mode only)"
     )
     ask_parser.add_argument(
         "--graph-rounds",
@@ -1224,10 +1218,7 @@ def _add_ask_parser(subparsers) -> None:
     ask_parser.add_argument(
         "--crux-cards",
         action="store_true",
-        help=(
-            "Attach crux cards (load-bearing disagreements) to the debate result "
-            "and decision receipt (sets enable_crux_cards on the protocol)"
-        ),
+        help="Attach crux cards (load-bearing disagreements) to the result and decision receipt",
     )
     ask_parser.add_argument(
         "--preset",

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1218,7 +1218,7 @@ def _add_ask_parser(subparsers) -> None:
     ask_parser.add_argument(
         "--crux-cards",
         action="store_true",
-        help="Attach crux cards (load-bearing disagreements) to the receipt; requires --local",
+        help="Attach crux cards (load-bearing disagreements) to the receipt (forces local run)",
     )
     ask_parser.add_argument(
         "--preset",

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -465,10 +465,15 @@ def build_crux_receipt_from_proof(
 #   1.2 — carries a ``cruxes`` block (crux cards, #8227). Cruxes are bound
 #         into ``artifact_hash`` together with ``schema_version`` itself, so
 #         a 1.2→1.1 downgrade breaks verification instead of silently
-#         defeating the version signal. Pre-1.2 receipts (no cruxes) keep the
-#         original hash recipe (schema_version NOT bound), so existing stored
-#         hashes keep verifying; pre-1.2 verifiers recomputing without cruxes
-#         must treat the version bump — not tampering — as the signal.
+#         defeating the version signal.
+#
+# Hash-binding rule: ``cruxes`` is bound whenever present; ``schema_version``
+# is bound ONLY when it is exactly 1.2 (version-gated, not presence-gated).
+# Crux binding shipped on main (#9414) BEFORE the 1.2 stamp existed, so
+# already-persisted audit receipts carry cruxes with schema_version 1.1 and a
+# hash computed WITHOUT schema_version — those must keep verifying. Receipts
+# stamped 1.2 bind schema_version, so a downgrade to 1.1 breaks verification.
+# Pre-crux receipts (no cruxes) keep the original recipe untouched.
 RECEIPT_SCHEMA_VERSION = "1.1"
 RECEIPT_SCHEMA_VERSION_CRUXES = "1.2"
 
@@ -480,10 +485,12 @@ def compute_receipt_artifact_hash(data: Any) -> str:
     _calculate_hash`` and the standalone ``aragora verify`` command both
     delegate here, so the hashed field set cannot drift between producer and
     verifier. Covers the decision-integrity fields (receipt_id, gauntlet_id,
-    input_hash, risk_summary, verdict, confidence) and — for schema >= 1.2
-    receipts carrying a ``cruxes`` block — additionally binds ``cruxes`` and
-    ``schema_version`` (downgrade-tamper protection). Pre-crux receipts hash
-    exactly as before.
+    input_hash, risk_summary, verdict, confidence); binds ``cruxes`` whenever
+    present; and binds ``schema_version`` only for receipts stamped 1.2
+    (downgrade-tamper protection). The version binding is gated on the 1.2
+    stamp — NOT on crux presence — because #9414 shipped crux binding before
+    the stamp existed: receipts with cruxes + schema_version 1.1 hashed
+    without schema_version and must keep verifying (see changelog above).
     """
     if not isinstance(data, dict):
         data = {}
@@ -497,7 +504,11 @@ def compute_receipt_artifact_hash(data: Any) -> str:
     }
     if data.get("cruxes") is not None:
         payload["cruxes"] = data.get("cruxes")
-        payload["schema_version"] = data.get("schema_version", "")
+        # Missing schema_version defaults to "1.0" (the from_dict convention)
+        # so the same JSON cannot hash two ways.
+        schema_version = data.get("schema_version", "1.0")
+        if schema_version == RECEIPT_SCHEMA_VERSION_CRUXES:
+            payload["schema_version"] = schema_version
     content = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(content.encode()).hexdigest()
 
@@ -662,10 +673,11 @@ class DecisionReceipt:
         Delegates to :func:`compute_receipt_artifact_hash` — the single
         canonical recipe shared with ``aragora verify`` — so producer and
         verifier cannot drift. Crux cards are audit-bearing content: when
-        present they are bound into the integrity material together with
-        ``schema_version`` (a 1.2→1.1 downgrade breaks
-        ``verify_integrity()``). Pre-crux receipts (``cruxes is None``) hash
-        exactly as before, so existing stored hashes keep verifying.
+        present they are bound into the integrity material, and receipts
+        stamped 1.2 additionally bind ``schema_version`` (a 1.2→1.1 downgrade
+        breaks ``verify_integrity()``). Pre-crux receipts and pre-stamp
+        #9414-era crux receipts (schema 1.1) hash exactly as before, so
+        existing stored hashes keep verifying.
         """
         return compute_receipt_artifact_hash(
             {

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -458,20 +458,43 @@ def build_crux_receipt_from_proof(
     )
 
 
+# Receipt schema version changelog:
+#   1.0 — original receipt schema
+#   1.1 — current baseline (agent responses, provenance enrichment)
+#   1.2 — carries a ``cruxes`` block (crux cards, #8227). Cruxes are bound
+#         into ``artifact_hash``, so pre-1.2 verifiers recomputing the hash
+#         without them must treat the version bump — not tampering — as the
+#         signal.
+RECEIPT_SCHEMA_VERSION = "1.1"
+RECEIPT_SCHEMA_VERSION_CRUXES = "1.2"
+
+
+def receipt_schema_version(cruxes: dict[str, Any] | None) -> str:
+    """Schema version for a receipt given its cruxes block.
+
+    Bumps to 1.2 exactly when a cruxes block is carried, giving older
+    verifiers a version signal instead of a spurious tampering report.
+    Shared by ``DecisionReceipt.from_debate_result`` and the CLI receipt
+    persistence so version and content cannot drift apart.
+    """
+    return RECEIPT_SCHEMA_VERSION_CRUXES if cruxes is not None else RECEIPT_SCHEMA_VERSION
+
+
 def crux_cards_from_metadata(metadata: Any) -> dict[str, Any] | None:
     """Return the crux-cards block from debate-result metadata, or None.
 
     Crux cards (#8227) are attached by the consensus phase when the debate ran
     with ``enable_crux_cards``. The block is only carried into receipts when it
     has items — a missing or empty block keeps flag-off receipts byte-identical
-    to pre-crux output. Shared by ``DecisionReceipt.from_debate_result`` and
-    the CLI receipt persistence so this invariant cannot drift.
+    to pre-crux output. Returns a shallow copy so receipts never alias the live
+    result metadata. Shared by ``DecisionReceipt.from_debate_result`` and the
+    CLI receipt persistence so this invariant cannot drift.
     """
     if not isinstance(metadata, dict):
         return None
     crux_cards = metadata.get("crux_cards")
     if isinstance(crux_cards, dict) and crux_cards.get("items"):
-        return crux_cards
+        return dict(crux_cards)
     return None
 
 
@@ -1594,6 +1617,7 @@ class DecisionReceipt:
             cost_summary=cost_summary,
             settlement_metadata=settlement_metadata,
             cruxes=cruxes,
+            schema_version=receipt_schema_version(cruxes),
             config_used=config_used,
         )
 

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -463,11 +463,43 @@ def build_crux_receipt_from_proof(
 #   1.0 — original receipt schema
 #   1.1 — current baseline (agent responses, provenance enrichment)
 #   1.2 — carries a ``cruxes`` block (crux cards, #8227). Cruxes are bound
-#         into ``artifact_hash``, so pre-1.2 verifiers recomputing the hash
-#         without them must treat the version bump — not tampering — as the
-#         signal.
+#         into ``artifact_hash`` together with ``schema_version`` itself, so
+#         a 1.2→1.1 downgrade breaks verification instead of silently
+#         defeating the version signal. Pre-1.2 receipts (no cruxes) keep the
+#         original hash recipe (schema_version NOT bound), so existing stored
+#         hashes keep verifying; pre-1.2 verifiers recomputing without cruxes
+#         must treat the version bump — not tampering — as the signal.
 RECEIPT_SCHEMA_VERSION = "1.1"
 RECEIPT_SCHEMA_VERSION_CRUXES = "1.2"
+
+
+def compute_receipt_artifact_hash(data: Any) -> str:
+    """Canonical ``artifact_hash`` recipe for a receipt-shaped mapping.
+
+    Single source of truth for the integrity hash: ``DecisionReceipt.
+    _calculate_hash`` and the standalone ``aragora verify`` command both
+    delegate here, so the hashed field set cannot drift between producer and
+    verifier. Covers the decision-integrity fields (receipt_id, gauntlet_id,
+    input_hash, risk_summary, verdict, confidence) and — for schema >= 1.2
+    receipts carrying a ``cruxes`` block — additionally binds ``cruxes`` and
+    ``schema_version`` (downgrade-tamper protection). Pre-crux receipts hash
+    exactly as before.
+    """
+    if not isinstance(data, dict):
+        data = {}
+    payload: dict[str, Any] = {
+        "receipt_id": data.get("receipt_id", ""),
+        "gauntlet_id": data.get("gauntlet_id", ""),
+        "input_hash": data.get("input_hash", ""),
+        "risk_summary": data.get("risk_summary", {}),
+        "verdict": data.get("verdict", ""),
+        "confidence": data.get("confidence", 0.0),
+    }
+    if data.get("cruxes") is not None:
+        payload["cruxes"] = data.get("cruxes")
+        payload["schema_version"] = data.get("schema_version", "")
+    content = json.dumps(payload, sort_keys=True)
+    return hashlib.sha256(content.encode()).hexdigest()
 
 
 def receipt_schema_version(cruxes: dict[str, Any] | None) -> str:
@@ -627,24 +659,26 @@ class DecisionReceipt:
     def _calculate_hash(self) -> str:
         """Calculate content-addressable hash.
 
-        Versioned hash path: crux cards are audit-bearing content, so they
-        are bound into the integrity material when present — tampering with
-        a stored ``cruxes`` block breaks ``verify_integrity()``. Pre-crux
-        receipts (``cruxes is None``) hash exactly as before, so existing
-        stored hashes keep verifying.
+        Delegates to :func:`compute_receipt_artifact_hash` — the single
+        canonical recipe shared with ``aragora verify`` — so producer and
+        verifier cannot drift. Crux cards are audit-bearing content: when
+        present they are bound into the integrity material together with
+        ``schema_version`` (a 1.2→1.1 downgrade breaks
+        ``verify_integrity()``). Pre-crux receipts (``cruxes is None``) hash
+        exactly as before, so existing stored hashes keep verifying.
         """
-        payload: dict[str, Any] = {
-            "receipt_id": self.receipt_id,
-            "gauntlet_id": self.gauntlet_id,
-            "input_hash": self.input_hash,
-            "risk_summary": self.risk_summary,
-            "verdict": self.verdict,
-            "confidence": self.confidence,
-        }
-        if self.cruxes is not None:
-            payload["cruxes"] = self.cruxes
-        content = json.dumps(payload, sort_keys=True)
-        return hashlib.sha256(content.encode()).hexdigest()
+        return compute_receipt_artifact_hash(
+            {
+                "receipt_id": self.receipt_id,
+                "gauntlet_id": self.gauntlet_id,
+                "input_hash": self.input_hash,
+                "risk_summary": self.risk_summary,
+                "verdict": self.verdict,
+                "confidence": self.confidence,
+                "cruxes": self.cruxes,
+                "schema_version": self.schema_version,
+            }
+        )
 
     def verify_integrity(self) -> bool:
         """Verify receipt has not been tampered with."""

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -458,6 +458,23 @@ def build_crux_receipt_from_proof(
     )
 
 
+def crux_cards_from_metadata(metadata: Any) -> dict[str, Any] | None:
+    """Return the crux-cards block from debate-result metadata, or None.
+
+    Crux cards (#8227) are attached by the consensus phase when the debate ran
+    with ``enable_crux_cards``. The block is only carried into receipts when it
+    has items — a missing or empty block keeps flag-off receipts byte-identical
+    to pre-crux output. Shared by ``DecisionReceipt.from_debate_result`` and
+    the CLI receipt persistence so this invariant cannot drift.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    crux_cards = metadata.get("crux_cards")
+    if isinstance(crux_cards, dict) and crux_cards.get("items"):
+        return crux_cards
+    return None
+
+
 def _compute_risk_summary_from_critiques(
     critiques: list,
     dissenting_views: list,
@@ -1509,10 +1526,7 @@ class DecisionReceipt:
         # Crux cards (#8227): attached by the consensus phase when the debate
         # ran with enable_crux_cards. Only carried when items exist — a missing
         # or empty block keeps the receipt byte-identical to pre-crux output.
-        crux_cards = metadata.get("crux_cards")
-        cruxes: dict[str, Any] | None = None
-        if isinstance(crux_cards, dict) and crux_cards.get("items"):
-            cruxes = crux_cards
+        cruxes = crux_cards_from_metadata(metadata)
 
         # Determine verdict from consensus
         if zero_evidence:

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -13,6 +13,7 @@ The main receipt.py re-exports all models for backward compatibility.
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import uuid
@@ -486,15 +487,17 @@ def crux_cards_from_metadata(metadata: Any) -> dict[str, Any] | None:
     Crux cards (#8227) are attached by the consensus phase when the debate ran
     with ``enable_crux_cards``. The block is only carried into receipts when it
     has items — a missing or empty block keeps flag-off receipts byte-identical
-    to pre-crux output. Returns a shallow copy so receipts never alias the live
-    result metadata. Shared by ``DecisionReceipt.from_debate_result`` and the
-    CLI receipt persistence so this invariant cannot drift.
+    to pre-crux output. Returns a deep copy so receipts never alias the live
+    result metadata at any nesting depth (cruxes bind into ``artifact_hash``,
+    so a later nested mutation must not flip ``verify_integrity``). Shared by
+    ``DecisionReceipt.from_debate_result`` and the CLI receipt persistence so
+    this invariant cannot drift.
     """
     if not isinstance(metadata, dict):
         return None
     crux_cards = metadata.get("crux_cards")
     if isinstance(crux_cards, dict) and crux_cards.get("items"):
-        return dict(crux_cards)
+        return copy.deepcopy(crux_cards)
     return None
 
 

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -287,6 +287,16 @@ class TestArgumentParser:
         assert args.offline is True
         assert args.receipt == "aragora-demo-receipt.json"
 
+    def test_real_parser_accepts_ask_crux_cards(self):
+        """--crux-cards must stay wired on the real ask parser (default off)."""
+        parser = cli_parser.build_parser()
+
+        args = parser.parse_args(["ask", "Task", "--crux-cards"])
+        assert args.crux_cards is True
+
+        args = parser.parse_args(["ask", "Task"])
+        assert args.crux_cards is False
+
     def test_parse_serve_command(self, parser):
         """Should parse serve command with defaults."""
         args = parser.parse_args(["serve"])

--- a/tests/cli/test_debate_receipt.py
+++ b/tests/cli/test_debate_receipt.py
@@ -176,3 +176,56 @@ def test_receipt_agents_fall_back_to_artifact_authors(
     assert receipt_path is not None
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert set(data["agents"]) == {"grok", "mistral-api"}
+
+
+def test_receipt_carries_crux_cards_from_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A debate run with enable_crux_cards (--crux-cards) attaches a crux_cards
+    block to result metadata; the persisted receipt must carry it as cruxes
+    and still verify."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _mixed_family_result()
+    result.metadata["crux_cards"] = {
+        "items": [
+            {
+                "claim_id": "c1",
+                "statement": "Rate limiter should be token-bucket",
+                "crux_score": 0.72,
+                "author": "grok",
+                "contesting_agents": ["mistral-api"],
+            }
+        ],
+        "total_claims": 4,
+        "total_disagreements": 1,
+        "convergence_barrier": 0.4,
+        "detector": "belief_network",
+    }
+
+    receipt_path = _persist_debate_receipt(result)
+
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    assert data["cruxes"]["items"][0]["claim_id"] == "c1"
+    assert data["cruxes"]["detector"] == "belief_network"
+    assert DecisionReceipt.from_dict(data).verify_integrity() is True
+
+
+def test_receipt_omits_cruxes_when_crux_cards_absent_or_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Flag-off receipts must stay byte-identical: no cruxes key without items."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    result = _mixed_family_result()
+    receipt_path = _persist_debate_receipt(result)
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    assert "cruxes" not in data
+
+    empty = _mixed_family_result()
+    empty.metadata["crux_cards"] = {"items": []}
+    receipt_path = _persist_debate_receipt(empty)
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    assert "cruxes" not in data

--- a/tests/cli/test_debate_receipt.py
+++ b/tests/cli/test_debate_receipt.py
@@ -208,6 +208,9 @@ def test_receipt_carries_crux_cards_from_metadata(
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert data["cruxes"]["items"][0]["claim_id"] == "c1"
     assert data["cruxes"]["detector"] == "belief_network"
+    # Cruxes bind into artifact_hash, so the schema version must signal it
+    # to older verifiers instead of reading as tampering.
+    assert data["schema_version"] == "1.2"
     assert DecisionReceipt.from_dict(data).verify_integrity() is True
 
 
@@ -222,6 +225,7 @@ def test_receipt_omits_cruxes_when_crux_cards_absent_or_empty(
     assert receipt_path is not None
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert "cruxes" not in data
+    assert data["schema_version"] == "1.1"
 
     empty = _mixed_family_result()
     empty.metadata["crux_cards"] = {"items": []}
@@ -229,3 +233,4 @@ def test_receipt_omits_cruxes_when_crux_cards_absent_or_empty(
     assert receipt_path is not None
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert "cruxes" not in data
+    assert data["schema_version"] == "1.1"

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -237,6 +237,61 @@ def test_cmd_ask_demo_forces_local_offline(monkeypatch):
     assert os.getenv("ARAGORA_OFFLINE") == "1"
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore:unclosed <socket.socket.*:ResourceWarning")
+def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
+    """--crux-cards should plumb enable_crux_cards into the debate protocol."""
+    from aragora.cli.commands import debate as debate_cmd
+    from aragora.core import DebateResult
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+
+    args = argparse.Namespace(
+        task="smoke demo",
+        agents="claude,openai",
+        rounds=5,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=True,
+        api=False,
+        local=False,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        crux_cards=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+    )
+
+    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate:
+        mock_result = DebateResult(task=args.task, final_answer="demo answer", metadata={})
+        mock_run_debate.return_value = mock_result
+
+        debate_cmd.cmd_ask(args)
+
+        call_kwargs = mock_run_debate.call_args.kwargs
+        assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
+
+
 def test_cmd_ask_demo_quality_pipeline_skips_provider_repairs(monkeypatch):
     """Demo/offline asks should not invoke provider repair agents in quality loops."""
     from aragora.cli.commands import debate as debate_cmd

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -282,12 +282,85 @@ def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
         di_execution_mode=None,
     )
 
-    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate:
+    with (
+        patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate,
+        patch.object(debate_cmd, "_trusted_server_available", return_value=False),
+    ):
         mock_result = DebateResult(task=args.task, final_answer="demo answer", metadata={})
         mock_run_debate.return_value = mock_result
 
         debate_cmd.cmd_ask(args)
 
+        call_kwargs = mock_run_debate.call_args.kwargs
+        assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore:unclosed <socket.socket.*:ResourceWarning")
+def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path):
+    """Plain --crux-cards (no --api/--local) must force local execution and
+    never probe or auto-select a trusted API server."""
+    from pathlib import Path
+
+    from aragora.cli.commands import debate as debate_cmd
+    from aragora.core import DebateResult
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    args = argparse.Namespace(
+        task="smoke demo",
+        agents="claude,openai",
+        rounds=2,
+        consensus="judge",
+        context="",
+        learn=False,
+        db=":memory:",
+        demo=False,
+        api=False,
+        local=False,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        crux_cards=True,
+        post_consensus_quality=False,
+        upgrade_to_good=False,
+        quality_fail_closed=False,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+    )
+
+    with (
+        patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate,
+        patch.object(debate_cmd, "_trusted_server_available") as mock_trusted,
+        patch(
+            "aragora.config.provider_readiness.agent_type_has_configured_provider",
+            return_value=True,
+        ),
+    ):
+        mock_result = DebateResult(task=args.task, final_answer="answer", metadata={})
+        mock_run_debate.return_value = mock_result
+
+        debate_cmd.cmd_ask(args)
+
+        mock_trusted.assert_not_called()
         call_kwargs = mock_run_debate.call_args.kwargs
         assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
 
@@ -335,7 +408,10 @@ def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
         di_execution_mode=None,
     )
 
-    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate:
+    with (
+        patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate,
+        patch.object(debate_cmd, "_trusted_server_available", return_value=False),
+    ):
         with pytest.raises(SystemExit) as excinfo:
             debate_cmd.cmd_ask(args)
 

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -292,6 +292,57 @@ def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
         assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
 
 
+def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
+    """--crux-cards is local-only: explicit --api dispatch must fail closed
+    (exit 2) instead of silently dropping the promised cruxes block."""
+    from aragora.cli.commands import debate as debate_cmd
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+
+    args = argparse.Namespace(
+        task="smoke demo",
+        agents="claude,openai",
+        rounds=2,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=False,
+        api=True,
+        local=False,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        crux_cards=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+    )
+
+    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate:
+        with pytest.raises(SystemExit) as excinfo:
+            debate_cmd.cmd_ask(args)
+
+    assert excinfo.value.code == 2
+    mock_run_debate.assert_not_called()
+
+
 def test_cmd_ask_demo_quality_pipeline_skips_provider_repairs(monkeypatch):
     """Demo/offline asks should not invoke provider repair agents in quality loops."""
     from aragora.cli.commands import debate as debate_cmd

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -245,6 +245,7 @@ def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
     from aragora.core import DebateResult
 
     monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    monkeypatch.delenv("ARAGORA_API_URL", raising=False)
 
     args = argparse.Namespace(
         task="smoke demo",
@@ -269,7 +270,7 @@ def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
         trending=True,
         crux_cards=True,
         mode=None,
-        api_url="http://localhost:8080",
+        api_url=None,
         api_key=None,
         verbose=False,
         graph_rounds=3,
@@ -297,15 +298,17 @@ def test_cmd_ask_crux_cards_flag_sets_protocol_override(monkeypatch):
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.filterwarnings("ignore:unclosed <socket.socket.*:ResourceWarning")
-def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path):
-    """Plain --crux-cards (no --api/--local) must force local execution and
-    never probe or auto-select a trusted API server."""
+def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path, capsys):
+    """Plain --crux-cards (no explicit API config) must force local execution,
+    print a Note (never a silent path), and never probe or auto-select a
+    trusted API server."""
     from pathlib import Path
 
     from aragora.cli.commands import debate as debate_cmd
     from aragora.core import DebateResult
 
     monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    monkeypatch.delenv("ARAGORA_API_URL", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     args = argparse.Namespace(
@@ -334,7 +337,7 @@ def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path):
         upgrade_to_good=False,
         quality_fail_closed=False,
         mode=None,
-        api_url="http://localhost:8080",
+        api_url=None,
         api_key=None,
         verbose=False,
         graph_rounds=3,
@@ -364,13 +367,32 @@ def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path):
         call_kwargs = mock_run_debate.call_args.kwargs
         assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
 
+    assert "Note: --crux-cards" in capsys.readouterr().err
 
-def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
-    """--crux-cards is local-only: explicit --api dispatch must fail closed
-    (exit 2) instead of silently dropping the promised cruxes block."""
+
+@pytest.mark.parametrize(
+    "explicit_config",
+    [
+        pytest.param({"api": True}, id="api-flag"),
+        pytest.param({"api_url": "http://localhost:8080"}, id="api-url-flag"),
+        pytest.param({"graph": True}, id="graph"),
+        pytest.param({"matrix": True}, id="matrix"),
+        pytest.param("env", id="aragora-api-url-env"),
+    ],
+)
+def test_cmd_ask_crux_cards_rejects_explicit_api_config(monkeypatch, explicit_config):
+    """--crux-cards is local-only: every explicit API configuration (--api,
+    --api-url, ARAGORA_API_URL, --graph, --matrix) must fail closed (exit 2)
+    before dispatch instead of silently dropping the promised cruxes block."""
     from aragora.cli.commands import debate as debate_cmd
 
     monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    monkeypatch.delenv("ARAGORA_API_URL", raising=False)
+    if explicit_config == "env":
+        monkeypatch.setenv("ARAGORA_API_URL", "http://localhost:8080")
+        overrides = {}
+    else:
+        overrides = explicit_config
 
     args = argparse.Namespace(
         task="smoke demo",
@@ -381,7 +403,7 @@ def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
         learn=True,
         db=":memory:",
         demo=False,
-        api=True,
+        api=False,
         local=False,
         graph=False,
         matrix=False,
@@ -395,7 +417,7 @@ def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
         trending=True,
         crux_cards=True,
         mode=None,
-        api_url="http://localhost:8080",
+        api_url=None,
         api_key=None,
         verbose=False,
         graph_rounds=3,
@@ -407,6 +429,8 @@ def test_cmd_ask_crux_cards_rejects_api_mode(monkeypatch):
         di_plan_strategy="single_task",
         di_execution_mode=None,
     )
+    for key, value in overrides.items():
+        setattr(args, key, value)
 
     with (
         patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate,

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -370,6 +370,87 @@ def test_cmd_ask_crux_cards_forces_local_over_auto_api(monkeypatch, tmp_path, ca
     assert "Note: --crux-cards" in capsys.readouterr().err
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore:unclosed <socket.socket.*:ResourceWarning")
+@pytest.mark.parametrize(
+    "local_mode",
+    [
+        pytest.param("local", id="local-flag-with-env-api-url"),
+        pytest.param("demo", id="demo-flag-with-env-api-url"),
+        pytest.param("offline", id="offline-env-with-env-api-url"),
+    ],
+)
+def test_cmd_ask_crux_cards_allows_already_local_runs(monkeypatch, tmp_path, local_mode):
+    """A merely-exported ARAGORA_API_URL must not reject runs that are already
+    local (--local, --demo, ARAGORA_OFFLINE=1): they can never dispatch to an
+    API server, so the explicit-API rejection does not apply."""
+    from pathlib import Path
+
+    from aragora.cli.commands import debate as debate_cmd
+    from aragora.core import DebateResult
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+    monkeypatch.setenv("ARAGORA_API_URL", "http://localhost:8080")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    if local_mode == "offline":
+        monkeypatch.setenv("ARAGORA_OFFLINE", "1")
+
+    args = argparse.Namespace(
+        task="smoke demo",
+        agents="claude,openai",
+        rounds=2,
+        consensus="judge",
+        context="",
+        learn=False,
+        db=":memory:",
+        demo=(local_mode == "demo"),
+        api=False,
+        local=(local_mode == "local"),
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        crux_cards=True,
+        post_consensus_quality=False,
+        upgrade_to_good=False,
+        quality_fail_closed=False,
+        mode=None,
+        api_url=None,
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+    )
+
+    with (
+        patch.object(debate_cmd, "run_debate", new_callable=AsyncMock) as mock_run_debate,
+        patch.object(debate_cmd, "_trusted_server_available", return_value=False),
+        patch(
+            "aragora.config.provider_readiness.agent_type_has_configured_provider",
+            return_value=True,
+        ),
+    ):
+        mock_result = DebateResult(task=args.task, final_answer="answer", metadata={})
+        mock_run_debate.return_value = mock_result
+
+        debate_cmd.cmd_ask(args)
+
+        call_kwargs = mock_run_debate.call_args.kwargs
+        assert call_kwargs["protocol_overrides"]["enable_crux_cards"] is True
+
+
 @pytest.mark.parametrize(
     "explicit_config",
     [

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -239,6 +239,112 @@ class TestVerifyReceipt:
         assert "recomputed=" in checksum_check["detail"]
 
 
+def _sample_cruxes() -> dict[str, Any]:
+    return {
+        "items": [
+            {
+                "claim_id": "c1",
+                "statement": "The latency budget holds under burst load",
+                "author": "agent-alpha",
+                "crux_score": 0.82,
+                "contesting_agents": ["agent-beta"],
+            }
+        ],
+        "total_claims": 5,
+        "total_disagreements": 1,
+        "convergence_barrier": 0.41,
+        "detector": "belief_network",
+    }
+
+
+class TestCruxReceiptIntegrity:
+    """Crux receipts (schema >= 1.2) through the flagship `aragora verify`.
+
+    Regression for #9506 round 5: an earlier inline hash copy omitted the
+    cruxes branch, so every untampered --crux-cards receipt was reported
+    tampered by this command (while `aragora receipt verify` passed).
+    """
+
+    def _crux_receipt_data(self) -> dict[str, Any]:
+        data = _make_receipt_data(schema_version="1.2", include_checksum=False)
+        data["input_hash"] = "deadbeef"
+        data["risk_summary"] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "total": 0}
+        data["cruxes"] = _sample_cruxes()
+        return data
+
+    def test_untampered_crux_receipt_from_canonical_producer_verifies(self):
+        """Round-trip: canonical producer hash -> _verify_receipt passes."""
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+
+        data = self._crux_receipt_data()
+        receipt_dict = DecisionReceipt.from_dict(data).to_dict()
+        assert receipt_dict["cruxes"] == data["cruxes"]
+
+        result = _verify_receipt(receipt_dict)
+
+        assert result["valid"] is True
+        integrity = next(c for c in result["checks"] if c["name"] == "integrity")
+        assert integrity["passed"] is True
+        # Honest coverage: crux receipts report cruxes + schema_version too.
+        assert "cruxes" in integrity["covers"]
+        assert "schema_version" in integrity["covers"]
+
+    def test_tampered_cruxes_detected(self):
+        data = self._crux_receipt_data()
+        data["artifact_hash"] = _recompute_artifact_hash(data)
+        data["cruxes"]["items"][0]["statement"] = "tampered"
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is False
+
+    def test_schema_downgrade_detected(self):
+        """1.2 -> 1.1 downgrade must fail: schema_version is bound into the
+        hash for crux receipts, so the version signal cannot be stripped."""
+        data = self._crux_receipt_data()
+        data["artifact_hash"] = _recompute_artifact_hash(data)
+        data["schema_version"] = "1.1"
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is False
+
+    def test_legacy_receipt_hash_recipe_unchanged(self):
+        """Pre-crux (1.1) receipts keep the original recipe: schema_version
+        and cruxes are NOT bound, so existing stored hashes keep verifying."""
+        data = _make_receipt_data(schema_version="1.1", include_checksum=False)
+        legacy_material = json.dumps(
+            {
+                "receipt_id": data["receipt_id"],
+                "gauntlet_id": data["gauntlet_id"],
+                "input_hash": data.get("input_hash", ""),
+                "risk_summary": data.get("risk_summary", {}),
+                "verdict": data["verdict"],
+                "confidence": data["confidence"],
+            },
+            sort_keys=True,
+        )
+        data["artifact_hash"] = hashlib.sha256(legacy_material.encode()).hexdigest()
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is True
+        integrity = next(c for c in result["checks"] if c["name"] == "integrity")
+        assert "schema_version" not in integrity["covers"]
+
+    def test_inline_fallback_matches_canonical_recipe(self):
+        """The no-gauntlet fallback must stay byte-equivalent to the shared
+        canonical recipe for both crux and pre-crux receipts."""
+        from aragora.cli.commands.verify import _inline_artifact_hash
+        from aragora.gauntlet.receipt_models import compute_receipt_artifact_hash
+
+        plain = _make_receipt_data(include_checksum=False)
+        crux = self._crux_receipt_data()
+        for data in (plain, crux):
+            assert _inline_artifact_hash(data) == compute_receipt_artifact_hash(data)
+            assert _recompute_artifact_hash(data) == _inline_artifact_hash(data)
+
+
 # ---------------------------------------------------------------------------
 # CLI cmd_verify tests
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_verify.py
+++ b/tests/cli/test_verify.py
@@ -309,6 +309,56 @@ class TestCruxReceiptIntegrity:
 
         assert result["valid"] is False
 
+    def test_pre_stamp_crux_receipt_with_11_schema_still_verifies(self):
+        """#9414 shipped crux binding on main BEFORE the 1.2 stamp existed:
+        persisted receipts carry cruxes + schema_version 1.1 with a hash
+        computed WITHOUT schema_version. The version binding is gated on the
+        1.2 stamp, so those audit receipts must keep verifying."""
+        data = self._crux_receipt_data()
+        data["schema_version"] = "1.1"
+        pre_pr_material = json.dumps(
+            {
+                "receipt_id": data["receipt_id"],
+                "gauntlet_id": data["gauntlet_id"],
+                "input_hash": data["input_hash"],
+                "risk_summary": data["risk_summary"],
+                "verdict": data["verdict"],
+                "confidence": data["confidence"],
+                "cruxes": data["cruxes"],
+            },
+            sort_keys=True,
+        )
+        data["artifact_hash"] = hashlib.sha256(pre_pr_material.encode()).hexdigest()
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is True
+        integrity = next(c for c in result["checks"] if c["name"] == "integrity")
+        assert "cruxes" in integrity["covers"]
+        assert "schema_version" not in integrity["covers"]
+
+    def test_stripped_artifact_hash_crux_receipt_rejected(self):
+        """Stripping artifact_hash from a crux receipt must not downgrade
+        verification to the legacy 16-char checksum, which covers neither
+        cruxes nor schema_version."""
+        data = self._crux_receipt_data()
+        data.pop("artifact_hash", None)
+        data["checksum"] = _recompute_checksum(data)
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is False
+        integrity = next(c for c in result["checks"] if c["name"] == "integrity")
+        assert "requires the full" in integrity["detail"]
+
+    def test_legacy_pre_crux_receipt_via_checksum_still_valid(self):
+        """Pre-crux receipts keep the legacy checksum fallback."""
+        data = _make_receipt_data(include_checksum=True)
+
+        result = _verify_receipt(data)
+
+        assert result["valid"] is True
+
     def test_legacy_receipt_hash_recipe_unchanged(self):
         """Pre-crux (1.1) receipts keep the original recipe: schema_version
         and cruxes are NOT bound, so existing stored hashes keep verifying."""
@@ -334,13 +384,16 @@ class TestCruxReceiptIntegrity:
 
     def test_inline_fallback_matches_canonical_recipe(self):
         """The no-gauntlet fallback must stay byte-equivalent to the shared
-        canonical recipe for both crux and pre-crux receipts."""
+        canonical recipe for pre-crux, 1.2-stamped crux, and pre-stamp
+        (#9414-era, schema 1.1) crux receipts."""
         from aragora.cli.commands.verify import _inline_artifact_hash
         from aragora.gauntlet.receipt_models import compute_receipt_artifact_hash
 
         plain = _make_receipt_data(include_checksum=False)
         crux = self._crux_receipt_data()
-        for data in (plain, crux):
+        pre_stamp_crux = self._crux_receipt_data()
+        pre_stamp_crux["schema_version"] = "1.1"
+        for data in (plain, crux, pre_stamp_crux):
             assert _inline_artifact_hash(data) == compute_receipt_artifact_hash(data)
             assert _recompute_artifact_hash(data) == _inline_artifact_hash(data)
 

--- a/tests/gauntlet/test_receipt_crux_cards.py
+++ b/tests/gauntlet/test_receipt_crux_cards.py
@@ -100,6 +100,18 @@ class TestReceiptCruxesField:
         )
         assert receipt.cruxes is None
 
+    def test_schema_downgrade_breaks_integrity(self) -> None:
+        """schema_version is bound into the hash for crux receipts: a
+        1.2 -> 1.1 downgrade must fail verification instead of silently
+        defeating the version signal."""
+        receipt = DecisionReceipt.from_debate_result(
+            _debate_result(metadata={"crux_cards": _sample_cards()})
+        )
+        assert receipt.verify_integrity() is True
+        downgraded = receipt.to_dict()
+        downgraded["schema_version"] = "1.1"
+        assert DecisionReceipt.from_dict(downgraded).verify_integrity() is False
+
     def test_schema_version_bumps_exactly_when_cruxes_attach(self) -> None:
         """Cruxes bind into artifact_hash, so carrying them must bump the
         schema version (1.1 -> 1.2) — older verifiers get a version signal

--- a/tests/gauntlet/test_receipt_crux_cards.py
+++ b/tests/gauntlet/test_receipt_crux_cards.py
@@ -100,6 +100,33 @@ class TestReceiptCruxesField:
         )
         assert receipt.cruxes is None
 
+    def test_schema_version_bumps_exactly_when_cruxes_attach(self) -> None:
+        """Cruxes bind into artifact_hash, so carrying them must bump the
+        schema version (1.1 -> 1.2) — older verifiers get a version signal
+        instead of a spurious tampering report. Flag-off stays at 1.1."""
+        without = DecisionReceipt.from_debate_result(_debate_result())
+        with_cards = DecisionReceipt.from_debate_result(
+            _debate_result(metadata={"crux_cards": _sample_cards()})
+        )
+        empty = DecisionReceipt.from_debate_result(
+            _debate_result(metadata={"crux_cards": {"items": []}})
+        )
+        assert without.schema_version == "1.1"
+        assert with_cards.schema_version == "1.2"
+        assert empty.schema_version == "1.1"
+
+    def test_crux_block_is_copied_not_aliased(self) -> None:
+        """The receipt must not hold a live reference to result metadata:
+        mutating the source block after receipt creation cannot change the
+        hashed audit content."""
+        metadata = {"crux_cards": _sample_cards()}
+        receipt = DecisionReceipt.from_debate_result(_debate_result(metadata=metadata))
+        assert receipt.cruxes is not metadata["crux_cards"]
+        assert receipt.cruxes == metadata["crux_cards"]
+        metadata["crux_cards"]["detector"] = "tampered"
+        assert receipt.cruxes["detector"] == "belief_network"
+        assert receipt.verify_integrity() is True
+
     def test_integrity_hash_binds_cruxes(self) -> None:
         """Crux cards are audit content: the artifact hash binds them when
         present (tampering breaks verify_integrity), while pre-crux receipts

--- a/tests/gauntlet/test_receipt_crux_cards.py
+++ b/tests/gauntlet/test_receipt_crux_cards.py
@@ -116,15 +116,22 @@ class TestReceiptCruxesField:
         assert empty.schema_version == "1.1"
 
     def test_crux_block_is_copied_not_aliased(self) -> None:
-        """The receipt must not hold a live reference to result metadata:
-        mutating the source block after receipt creation cannot change the
-        hashed audit content."""
+        """The receipt must not hold a live reference to result metadata at
+        any depth: mutating the source block — including a nested item dict —
+        after receipt creation cannot change the hashed audit content."""
         metadata = {"crux_cards": _sample_cards()}
         receipt = DecisionReceipt.from_debate_result(_debate_result(metadata=metadata))
         assert receipt.cruxes is not metadata["crux_cards"]
+        assert receipt.cruxes["items"] is not metadata["crux_cards"]["items"]
         assert receipt.cruxes == metadata["crux_cards"]
         metadata["crux_cards"]["detector"] = "tampered"
+        metadata["crux_cards"]["items"][0]["statement"] = "tampered nested item"
+        metadata["crux_cards"]["items"][0]["contesting_agents"].append("tampered-agent")
         assert receipt.cruxes["detector"] == "belief_network"
+        assert receipt.cruxes["items"][0]["statement"] == (
+            "The latency budget holds under burst load"
+        )
+        assert receipt.cruxes["items"][0]["contesting_agents"] == ["agent-beta"]
         assert receipt.verify_integrity() is True
 
     def test_integrity_hash_binds_cruxes(self) -> None:

--- a/tests/gauntlet/test_receipt_crux_cards.py
+++ b/tests/gauntlet/test_receipt_crux_cards.py
@@ -100,6 +100,31 @@ class TestReceiptCruxesField:
         )
         assert receipt.cruxes is None
 
+    def test_pre_stamp_crux_receipt_still_verifies(self) -> None:
+        """#9414 shipped crux binding BEFORE the 1.2 stamp existed: persisted
+        receipts carry cruxes + schema_version 1.1 with a hash computed
+        WITHOUT schema_version. The version binding is gated on the 1.2 stamp
+        so those audit receipts must keep verifying."""
+        receipt = DecisionReceipt.from_debate_result(
+            _debate_result(metadata={"crux_cards": _sample_cards()})
+        )
+        data = receipt.to_dict()
+        data["schema_version"] = "1.1"
+        pre_stamp_material = json.dumps(
+            {
+                "receipt_id": data["receipt_id"],
+                "gauntlet_id": data["gauntlet_id"],
+                "input_hash": data["input_hash"],
+                "risk_summary": data["risk_summary"],
+                "verdict": data["verdict"],
+                "confidence": data["confidence"],
+                "cruxes": data["cruxes"],
+            },
+            sort_keys=True,
+        )
+        data["artifact_hash"] = hashlib.sha256(pre_stamp_material.encode()).hexdigest()
+        assert DecisionReceipt.from_dict(data).verify_integrity() is True
+
     def test_schema_downgrade_breaks_integrity(self) -> None:
         """schema_version is bound into the hash for crux receipts: a
         1.2 -> 1.1 downgrade must fail verification instead of silently


### PR DESCRIPTION
## Summary

Closes the named W3 EU AI Act bundle gap from #9427: *"crux-cards receipt — needs API-key debate with `enable_crux_cards=True` — no CLI flag exposes it"*. A crux-cards decision receipt can now be produced without writing Python.

- Add `--crux-cards` flag (default off) to `aragora ask`, wired through `protocol_overrides` to `DebateProtocol.enable_crux_cards` — same pattern as the existing cross-pollination feature flags.
- `DecisionReceipt.from_debate_result` (used by `--decision-integrity`) and the auto-persisted `~/.aragora/receipts` receipt both carry the crux block via shared helpers (`crux_cards_from_metadata`, `receipt_schema_version`).
- **Uniform local-only rule:** `--crux-cards` requires local execution. `--graph`/`--matrix` rejected unconditionally; explicit API config (`--api`, `--api-url`, exported `ARAGORA_API_URL`) rejected only when the run is not already local (`--local`/`--demo`/`ARAGORA_OFFLINE`); auto-discovery case forces local with a stderr `Note:`.
- **Receipt schema 1.2 + unified, version-gated hash:** crux receipts stamp `schema_version` 1.2; the single canonical recipe `compute_receipt_artifact_hash()` (shared by `DecisionReceipt._calculate_hash` and `aragora verify`) binds `cruxes` whenever present and binds `schema_version` only for 1.2-stamped receipts. Legacy 1.1 receipts — including #9414-era crux receipts persisted before the stamp existed — keep their exact stored hashes. `aragora verify` requires the full artifact hash for crux/1.2 receipts (legacy 16-char checksum fallback stays pre-crux-only).

## Bundle runbook invocation

```bash
aragora ask "<decision question>" --agents anthropic-api,openai-api --local --crux-cards --decision-integrity
```

(`--local` is optional — `--crux-cards` forces local with a stderr Note — but kept explicit in the runbook for clarity.) The persisted receipt (and the decision-integrity package receipt) carry the `cruxes` block at schema_version 1.2 and verify under both `aragora verify` and `aragora receipt verify`.

## Reviewed design tradeoffs

Round 6 (compat edges), all addressed:

1. **P2 (claude) — presence-gated binding broke #9414-era receipts:** crux hash-binding shipped on main (#9414, 00b9c140fd) before the 1.2 stamp existed, so persisted audit receipts carry cruxes + `schema_version` 1.1 with hashes computed WITHOUT schema_version. The schema_version binding is now gated on `schema_version == RECEIPT_SCHEMA_VERSION_CRUXES` ("1.2") — not on crux presence — in `compute_receipt_artifact_hash`, the `verify.py` inline fallback, and `_integrity_hash_fields` coverage reporting. Pinned by tests that hash a 1.1+cruxes receipt with the pre-PR recipe and assert it verifies in both `_verify_receipt` and `DecisionReceipt.verify_integrity`. Downgrade protection is preserved: 1.2-stamped hashes bind the version, so editing 1.2 → 1.1 still fails verification.
2. **P3 (claude) — default skew:** missing `schema_version` now defaults to "1.0" (the `from_dict` convention) in both hash implementations, so the same JSON cannot hash two ways.
3. **P2 (openai) — legacy-checksum evasion:** stripping `artifact_hash` from a crux receipt no longer downgrades verification to the legacy 16-char checksum (which covers neither cruxes nor schema_version). `_verify_receipt` requires the full artifact hash (or a full-hash checksum alias) whenever cruxes are present or the receipt is stamped 1.2; the legacy fallback is kept for pre-crux receipts. Tests: stripped-hash crux receipt → invalid with explicit detail; pre-crux checksum-only receipt → still valid.

Round 5: single canonical hash recipe (`compute_receipt_artifact_hash`) shared by producer and `aragora verify` (P1 false-TAMPERED regression fixed), byte-equivalent tested inline fallback for minimal installs, downgrade-tamper binding, honest `covers` reporting.
Round 4: already-local runs not rejected by a merely-exported `ARAGORA_API_URL`; crux block deep-copied (nested mutation cannot flip `verify_integrity`).
Round 3: uniform local-only rule; schema 1.1→1.2 bump exactly when cruxes attach; parametrized guard coverage; Note on the auto-discovery path.
Round 2: explicit-opt-in gating; decision before context engineering/env mutation; hermetic tests; shared `crux_cards_from_metadata`.
Round 1: silent API no-op resolved by the local-only rule.

## Follow-up (not in this PR)

- Forward `enable_crux_cards` through the API debate contract so `--crux-cards` also works in `--api` mode, then lift the explicit-API rejection.

## Tests

- `tests/cli/test_cli_main.py`: real-parser `--crux-cards` wiring
- `tests/cli/test_offline_golden_path.py`: protocol plumbing; forced-local + `Note:`; parametrized rejection (5 explicit API configs) + acceptance (3 already-local combos)
- `tests/cli/test_debate_receipt.py`: persisted receipt carries `cruxes` at schema 1.2 and verifies; flag-off stays 1.1
- `tests/cli/test_verify.py` (`TestCruxReceiptIntegrity`, 8 tests): canonical-producer crux receipt passes with honest `covers`; tampered cruxes fail; 1.2→1.1 downgrade fails; #9414-era 1.1+cruxes recipe pinned; stripped-hash crux receipt rejected; pre-crux checksum fallback intact; legacy 1.1 recipe pinned; inline fallback == canonical across all three receipt shapes
- `tests/gauntlet/test_receipt_crux_cards.py`: version bumps exactly when cruxes attach; deep-copy immunity; pre-stamp 1.1+cruxes verifies; 1.2→1.1 downgrade breaks `verify_integrity`; legacy no-crux recipe pinned
- 136 passed (CLI incl. verify) + 162 passed (receipt suites; 1 pre-existing env-only failure: `jsonschema` missing locally); ruff clean; changed-file mypy clean; ratchet PASS (parser.py 5399 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)