### PR TITLE
fix(health): CI-parity required lane + mypy shrink-only baseline for pristine-main instrument

### DIFF
--- a/scripts/baselines/mypy_full_baseline.json
+++ b/scripts/baselines/mypy_full_baseline.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Shrink-only full-codebase mypy debt baseline (issue #9045). check_mypy_baseline.py fails only when the live count EXCEEDS error_count; it never rewrites this file. Tighten deliberately with --update-baseline in a reviewed change.",
+  "command": "mypy aragora/ --ignore-missing-imports",
+  "error_count": 1869,
+  "file_count": 505,
+  "generated_at": "2026-07-22T00:00:00+00:00",
+  "measured_on": "pristine origin/main cea33a630123d237433909db278fe093b85ad748, mypy 2.1.0"
+}

--- a/scripts/check_mypy_baseline.py
+++ b/scripts/check_mypy_baseline.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Shrink-only full-codebase mypy baseline checker (issue #9045).
+
+``make ci-required`` runs raw full-codebase mypy, which carries ~1.9k errors of
+frozen historical debt; the actual required CI ``typecheck`` check gates touched
+files only. This checker gives instruments (scripts/pristine_main_health.py) a
+CI-parity signal for the FULL codebase without either lying green or drowning in
+frozen debt: it fails only when the error count EXCEEDS the recorded baseline.
+
+Shrink-only ratchet: when the count drops below the baseline the check passes
+and reports the delta; the baseline file is never rewritten automatically.
+Tighten it deliberately with ``--update-baseline`` in its own reviewed change.
+
+Exit codes:
+    0  error count at or below baseline (shrink reported when below)
+    1  error count exceeds baseline (regression)
+    2  infrastructure failure (mypy missing/crashed, unparsable output,
+       missing baseline) — inconclusive, message prefixed MYPY_BASELINE_INFRA
+
+Usage:
+    python scripts/check_mypy_baseline.py
+    python scripts/check_mypy_baseline.py --baseline scripts/baselines/mypy_full_baseline.json
+    python scripts/check_mypy_baseline.py --update-baseline   # deliberate tighten
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_BASELINE = _SCRIPT_DIR / "baselines" / "mypy_full_baseline.json"
+DEFAULT_PATHS = ("aragora/",)
+MYPY_FLAGS = ("--ignore-missing-imports",)
+INFRA_EXIT = 2
+INFRA_PREFIX = "MYPY_BASELINE_INFRA:"
+EVIDENCE_TAIL_LINES = 20
+
+
+class InfraError(RuntimeError):
+    """The mypy run itself is broken — inconclusive about the codebase."""
+
+
+def _run_mypy(
+    mypy_bin: str, paths: list[str], *, cwd: Path, timeout_seconds: float
+) -> tuple[int, str]:
+    cmd = [mypy_bin, *paths, *MYPY_FLAGS]
+    try:
+        proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout_seconds)
+    except subprocess.TimeoutExpired as exc:
+        raise InfraError(f"mypy timed out after {timeout_seconds:g}s: {' '.join(cmd)}") from exc
+    except OSError as exc:
+        raise InfraError(
+            f"mypy launch failed ({type(exc).__name__}: {exc}): {' '.join(cmd)}"
+        ) from exc
+    return proc.returncode, f"{proc.stdout}\n{proc.stderr}"
+
+
+def count_errors(output: str, returncode: int) -> tuple[int, int]:
+    """Parse mypy's final summary into (error_count, file_count).
+
+    mypy exits 0 on success and 1 when errors were found; anything else
+    (2 = fatal/usage error) is inconclusive infrastructure breakage.
+    """
+    if returncode not in (0, 1):
+        tail = "\n".join(output.strip().splitlines()[-EVIDENCE_TAIL_LINES:])
+        raise InfraError(f"mypy exited {returncode} (not a checked-code verdict):\n{tail}")
+    if re.search(r"(?m)^Success: no issues found", output):
+        return 0, 0
+    summary = None
+    for summary in re.finditer(
+        r"(?m)^Found (?P<errors>\d+) errors? in (?P<files>\d+) files?", output
+    ):
+        pass  # keep the LAST summary line (mypy may emit per-daemon chatter above)
+    if summary is None:
+        tail = "\n".join(output.strip().splitlines()[-EVIDENCE_TAIL_LINES:])
+        raise InfraError(f"could not parse mypy summary line from output:\n{tail}")
+    return int(summary.group("errors")), int(summary.group("files"))
+
+
+def load_baseline(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise InfraError(
+            f"baseline file missing: {path} (generate with --update-baseline)"
+        ) from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        raise InfraError(f"baseline file unreadable: {path}: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("error_count"), int):
+        raise InfraError(f"baseline file malformed (no integer error_count): {path}")
+    return data
+
+
+def write_baseline(path: Path, *, error_count: int, file_count: int, paths: list[str]) -> None:
+    payload = {
+        "comment": (
+            "Shrink-only full-codebase mypy debt baseline (issue #9045). "
+            "check_mypy_baseline.py fails only when the live count EXCEEDS "
+            "error_count; it never rewrites this file. Tighten deliberately "
+            "with --update-baseline in a reviewed change."
+        ),
+        "command": f"mypy {' '.join(paths)} {' '.join(MYPY_FLAGS)}",
+        "error_count": error_count,
+        "file_count": file_count,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--paths", nargs="+", default=list(DEFAULT_PATHS))
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="directory to run mypy in")
+    parser.add_argument("--mypy-bin", default=None, help="mypy executable (default: PATH lookup)")
+    parser.add_argument("--timeout-seconds", type=float, default=3600)
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help="rewrite the baseline to the measured count (deliberate tighten only)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        mypy_bin = args.mypy_bin or shutil.which("mypy")
+        if mypy_bin is None:
+            raise InfraError("mypy missing from PATH")
+        returncode, output = _run_mypy(
+            mypy_bin, args.paths, cwd=args.root, timeout_seconds=args.timeout_seconds
+        )
+        error_count, file_count = count_errors(output, returncode)
+        if args.update_baseline:
+            write_baseline(
+                args.baseline,
+                error_count=error_count,
+                file_count=file_count,
+                paths=args.paths,
+            )
+            print(
+                f"baseline updated: {error_count} errors in {file_count} files -> {args.baseline}"
+            )
+            return 0
+        baseline = load_baseline(args.baseline)
+    except InfraError as exc:
+        print(f"{INFRA_PREFIX} {exc}", file=sys.stderr)
+        return INFRA_EXIT
+
+    allowed = baseline["error_count"]
+    if error_count > allowed:
+        delta = error_count - allowed
+        print(
+            f"FAIL: full-codebase mypy errors grew: {error_count} > baseline {allowed} "
+            f"(+{delta}). New type errors were introduced; fix them or, if the "
+            f"baseline is deliberately being raised, update {args.baseline} in a "
+            f"reviewed change.",
+            file=sys.stderr,
+        )
+        tail = "\n".join(output.strip().splitlines()[-EVIDENCE_TAIL_LINES:])
+        print(tail, file=sys.stderr)
+        return 1
+    if error_count < allowed:
+        shrink = allowed - error_count
+        print(
+            f"PASS (shrink): full-codebase mypy errors {error_count} are {shrink} below "
+            f"baseline {allowed}. Consider tightening the baseline with "
+            f"--update-baseline in its own reviewed change."
+        )
+        return 0
+    print(f"PASS: full-codebase mypy errors at baseline ({error_count}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_nightly_health_launchd.sh
+++ b/scripts/install_nightly_health_launchd.sh
@@ -72,7 +72,9 @@ command_for() {
       probe_q="$(shell_quote "import pytest")"
       import_label_q="$(shell_quote "pytest")"
       runtime_label_q="$(shell_quote "pristine-main health runtime")"
-      printf 'source %s && PYTHON_BIN="$(resolve_aragora_python %s %s %s)" && exec "$PYTHON_BIN" %s --repo-root %s --pristine-dir %s --halt-file %s' \
+      # --suite required pinned explicitly: the full suite cannot finish in the
+      # nightly timeout budget on this host (issue #9045); "full" is manual-only.
+      printf 'source %s && PYTHON_BIN="$(resolve_aragora_python %s %s %s)" && exec "$PYTHON_BIN" %s --repo-root %s --pristine-dir %s --halt-file %s --suite required' \
         "${runtime_q}" "${probe_q}" "${import_label_q}" "${runtime_label_q}" \
         "${script_q}" "${repo_q}" "${pristine_q}" "${halt_q}"
       ;;

--- a/scripts/pristine_main_health.py
+++ b/scripts/pristine_main_health.py
@@ -11,8 +11,8 @@ marker after verifying main is green. Results append to the throughput ledger.
 Read-only vs GitHub. Intended to run nightly under launchd (installation of
 the LaunchAgent is an operator action); safe to run by hand:
 
-    python3 scripts/pristine_main_health.py --suite required   # fast lane
-    python3 scripts/pristine_main_health.py --suite full       # full shards
+    python3 scripts/pristine_main_health.py --suite required   # fast lane (default)
+    python3 scripts/pristine_main_health.py --suite full       # full shards (manual)
 """
 
 from __future__ import annotations
@@ -42,10 +42,82 @@ INFRA_ERROR_EXIT = 2
 SUITE_TERMINATION_GRACE_SECONDS = 30.0
 
 # Suite commands run INSIDE the pristine worktree. "required" mirrors the
-# required-check lane; "full" runs the whole suite including path-gated shards
-# (the ones that go silently red) minus the known-broken collection module.
+# steps of `make ci-required` — NOT the make target itself — with ONE swap for
+# CI parity (issue #9045): the make target's raw full-codebase mypy carries
+# ~1.9k errors of frozen debt and can never go green, while the actual required
+# CI `typecheck` check gates touched files only. The instrument instead runs
+# mypy through the shrink-only baseline checker (fails only when the count
+# EXCEEDS scripts/baselines/mypy_full_baseline.json). `make ci-required` stays
+# unchanged as the strict local developer contract. The checker and baseline
+# are taken from THIS checkout (the instrument's own, versioned tooling) while
+# every other step uses the pristine checkout's scripts, mirroring make.
+# "full" runs the whole suite including path-gated shards (the ones that go
+# silently red) minus the known-broken collection module.
+_OPENAPI_SPEC_PATH = "/tmp/openapi_pristine_health.json"
 SUITES: dict[str, list[list[str]]] = {
-    "required": [["make", "ci-required"]],
+    "required": [
+        ["ruff", "check", "aragora/", "tests/", "scripts/"],
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "check_mypy_baseline.py"),
+            "--baseline",
+            str(_REPO_ROOT / "scripts" / "baselines" / "mypy_full_baseline.json"),
+        ],
+        [sys.executable, "scripts/check_version_alignment.py"],
+        [
+            sys.executable,
+            "scripts/check_sdk_parity.py",
+            "--strict",
+            "--baseline",
+            "scripts/baselines/check_sdk_parity.json",
+            "--budget",
+            "scripts/baselines/check_sdk_parity_budget.json",
+        ],
+        [
+            sys.executable,
+            "scripts/check_sdk_namespace_parity.py",
+            "--strict",
+            "--baseline",
+            "scripts/baselines/check_sdk_namespace_parity.json",
+        ],
+        [
+            sys.executable,
+            "scripts/check_cross_sdk_parity.py",
+            "--strict",
+            "--baseline",
+            "scripts/baselines/cross_sdk_parity.json",
+        ],
+        [
+            sys.executable,
+            "scripts/generate_openapi.py",
+            "--output",
+            _OPENAPI_SPEC_PATH,
+            "--format",
+            "json",
+            "--quiet",
+        ],
+        [sys.executable, "scripts/add_openapi_operation_ids.py", "--spec", _OPENAPI_SPEC_PATH],
+        [sys.executable, "scripts/add_openapi_param_descriptions.py", "--spec", _OPENAPI_SPEC_PATH],
+        [sys.executable, "scripts/add_openapi_descriptions.py", "--spec", _OPENAPI_SPEC_PATH],
+        [
+            sys.executable,
+            "scripts/verify_sdk_contracts.py",
+            "--strict",
+            "--baseline",
+            "scripts/baselines/verify_sdk_contracts.json",
+            "--extra-spec",
+            _OPENAPI_SPEC_PATH,
+        ],
+        [
+            sys.executable,
+            "scripts/validate_openapi_routes.py",
+            "--spec",
+            _OPENAPI_SPEC_PATH,
+            "--fail-on-missing",
+            "--baseline",
+            "scripts/baselines/validate_openapi_routes.json",
+        ],
+    ],
     "full": [
         [
             sys.executable,
@@ -162,6 +234,9 @@ def _format_process_failure(cmd: list[str], proc: subprocess.CompletedProcess) -
 _INFRA_OUTPUT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?m)^make(\[\d+\])?: .*(command not found|No such file or directory)"),
     re.compile(r"(?m)command not found"),
+    # check_mypy_baseline.py could not produce a verdict (mypy crashed, output
+    # unparsable, baseline file missing) — inconclusive, exactly like a timeout.
+    re.compile(r"(?m)^MYPY_BASELINE_INFRA: .*"),
 )
 _MISSING_MODULE_PATTERN = re.compile(
     r"(?m)^(?:ModuleNotFoundError|ImportError): No module named ['\"]?(?P<module>[A-Za-z0-9_.]+)"
@@ -401,7 +476,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--repo-root", type=Path, default=_REPO_ROOT)
     parser.add_argument("--pristine-dir", type=Path, default=DEFAULT_PRISTINE_DIR)
     parser.add_argument("--halt-file", type=Path, default=DEFAULT_HALT_FILE)
-    parser.add_argument("--suite", choices=sorted(SUITES), default="full")
+    # Default is the CI-parity required lane: the full suite cannot finish
+    # inside the nightly timeout budget on the launchd host (every run since
+    # Jul 11 ended TIMEOUT/infra_error — issue #9045), so "full" is reserved
+    # for manual or sharded use.
+    parser.add_argument("--suite", choices=sorted(SUITES), default="required")
     parser.add_argument("--timeout-minutes", type=float, default=180, help="per-command timeout")
     parser.add_argument(
         "--no-halt-file",

--- a/tests/scripts/test_check_mypy_baseline.py
+++ b/tests/scripts/test_check_mypy_baseline.py
@@ -1,0 +1,192 @@
+"""Tests for scripts/check_mypy_baseline.py (issue #9045).
+
+Shrink-only ratchet over the frozen full-codebase mypy debt: fail only when
+the live error count EXCEEDS the recorded baseline, report shrink when below,
+never rewrite the baseline automatically.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_mypy_baseline.py"
+
+
+@pytest.fixture()
+def mod():
+    spec = importlib.util.spec_from_file_location("check_mypy_baseline_under_test", _SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_fake_mypy(bin_dir: Path, *, stdout: str, exit_code: int) -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    executable = bin_dir / "mypy"
+    executable.write_text(
+        f"#!/bin/sh\ncat <<'EOF'\n{stdout}\nEOF\nexit {exit_code}\n", encoding="utf-8"
+    )
+    executable.chmod(0o755)
+    return executable
+
+
+def _write_baseline(path: Path, error_count: int = 1869) -> None:
+    path.write_text(
+        json.dumps({"command": "mypy aragora/", "error_count": error_count, "file_count": 505}),
+        encoding="utf-8",
+    )
+
+
+def _args(baseline: Path, mypy: Path, tmp_path: Path) -> list[str]:
+    return [
+        "--baseline",
+        str(baseline),
+        "--mypy-bin",
+        str(mypy),
+        "--root",
+        str(tmp_path),
+    ]
+
+
+def test_count_at_baseline_passes(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="aragora/x.py:1: error: boom  [assignment]\nFound 1869 errors in 505 files (checked 4287 source files)",
+        exit_code=1,
+    )
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == 0
+    assert "at baseline (1869)" in capsys.readouterr().out
+
+
+def test_count_above_baseline_fails_with_delta(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="aragora/x.py:1: error: fresh regression  [assignment]\nFound 1872 errors in 506 files (checked 4287 source files)",
+        exit_code=1,
+    )
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == 1
+    err = capsys.readouterr().err
+    assert "1872 > baseline 1869" in err
+    assert "+3" in err
+    assert "fresh regression" in err  # bounded evidence tail includes real errors
+
+
+def test_count_below_baseline_passes_and_reports_shrink(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="Found 1800 errors in 490 files (checked 4287 source files)",
+        exit_code=1,
+    )
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == 0
+    out = capsys.readouterr().out
+    assert "shrink" in out
+    assert "69 below" in out
+    # Shrink-only: the baseline file itself is never rewritten.
+    assert json.loads(baseline.read_text())["error_count"] == 1869
+
+
+def test_clean_mypy_success_passes(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 10)
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="Success: no issues found in 4287 source files",
+        exit_code=0,
+    )
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == 0
+    assert "10 below" in capsys.readouterr().out
+
+
+def test_mypy_fatal_exit_is_infra(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="mypy: error: invalid syntax in config",
+        exit_code=2,
+    )
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == mod.INFRA_EXIT
+    err = capsys.readouterr().err
+    assert err.startswith(mod.INFRA_PREFIX)
+    assert "exited 2" in err
+
+
+def test_unparsable_mypy_output_is_infra(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    mypy = _write_fake_mypy(tmp_path / "bin", stdout="no summary line here", exit_code=1)
+
+    assert mod.main(_args(baseline, mypy, tmp_path)) == mod.INFRA_EXIT
+    err = capsys.readouterr().err
+    assert err.startswith(mod.INFRA_PREFIX)
+    assert "could not parse" in err
+
+
+def test_mypy_missing_from_path_is_infra(mod, tmp_path, monkeypatch, capsys):
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, 1869)
+    empty_bin = tmp_path / "bin"
+    empty_bin.mkdir()
+    monkeypatch.setenv("PATH", str(empty_bin))
+
+    assert mod.main(["--baseline", str(baseline), "--root", str(tmp_path)]) == mod.INFRA_EXIT
+    err = capsys.readouterr().err
+    assert err.startswith(mod.INFRA_PREFIX)
+    assert "missing from PATH" in err
+
+
+def test_missing_baseline_file_is_infra(mod, tmp_path, capsys):
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="Found 1 error in 1 file (checked 1 source file)",
+        exit_code=1,
+    )
+
+    rc = mod.main(_args(tmp_path / "absent.json", mypy, tmp_path))
+
+    assert rc == mod.INFRA_EXIT
+    err = capsys.readouterr().err
+    assert err.startswith(mod.INFRA_PREFIX)
+    assert "baseline file missing" in err
+
+
+def test_update_baseline_writes_measured_count(mod, tmp_path, capsys):
+    baseline = tmp_path / "baseline.json"
+    mypy = _write_fake_mypy(
+        tmp_path / "bin",
+        stdout="Found 1500 errors in 400 files (checked 4287 source files)",
+        exit_code=1,
+    )
+
+    rc = mod.main([*_args(baseline, mypy, tmp_path), "--update-baseline"])
+
+    assert rc == 0
+    data = json.loads(baseline.read_text())
+    assert data["error_count"] == 1500
+    assert data["file_count"] == 400
+    assert "baseline updated" in capsys.readouterr().out
+
+
+def test_repo_baseline_file_matches_checker_contract(mod):
+    """The committed baseline must be loadable by the checker."""
+    baseline_path = _SCRIPT.parent / "baselines" / "mypy_full_baseline.json"
+    data = mod.load_baseline(baseline_path)
+    assert data["error_count"] >= 0

--- a/tests/scripts/test_install_nightly_health_launchd.py
+++ b/tests/scripts/test_install_nightly_health_launchd.py
@@ -19,7 +19,7 @@ CASES = [
         "com.aragora.pristine-main-health",
         {"Hour": 3, "Minute": 30},
         "pristine_main_health.py",
-        ["--pristine-dir", "--halt-file"],
+        ["--pristine-dir", "--halt-file", "--suite required"],
     ),
     (
         "throughput-snapshot",

--- a/tests/scripts/test_pristine_main_health.py
+++ b/tests/scripts/test_pristine_main_health.py
@@ -623,3 +623,98 @@ def test_failure_evidence_caps_single_long_line(mod):
 def test_full_suite_ignores_known_broken_collection(mod):
     (full_cmd,) = mod.SUITES["full"]
     assert "--ignore=tests/connectors" in full_cmd
+
+
+def test_required_suite_mirrors_ci_with_baseline_mypy_not_make(mod):
+    """CI parity (issue #9045): the required lane mirrors `make ci-required`'s
+    steps but swaps raw full-codebase mypy (frozen ~1.9k-error debt, never
+    green) for the shrink-only baseline checker. `make ci-required` itself
+    stays the strict developer contract and is NOT invoked."""
+    commands = mod.SUITES["required"]
+    flattened = [" ".join(cmd) for cmd in commands]
+
+    assert not any(cmd[0] == "make" for cmd in commands)
+    # No raw mypy invocation anywhere in the lane.
+    assert not any(Path(cmd[0]).name == "mypy" for cmd in commands)
+
+    (mypy_step,) = [line for line in flattened if "check_mypy_baseline.py" in line]
+    assert "--baseline" in mypy_step
+    assert "mypy_full_baseline.json" in mypy_step
+
+    # The other ci-required steps are preserved as-is.
+    assert any(cmd[:2] == ["ruff", "check"] for cmd in commands)
+    for step in (
+        "check_version_alignment.py",
+        "check_sdk_parity.py",
+        "check_sdk_namespace_parity.py",
+        "check_cross_sdk_parity.py",
+        "generate_openapi.py",
+        "verify_sdk_contracts.py",
+        "validate_openapi_routes.py",
+    ):
+        assert any(step in line for line in flattened), f"missing ci-required step: {step}"
+
+
+def test_default_suite_is_required(mod, monkeypatch, tmp_path):
+    """The nightly full suite TIMEOUTs every run (issue #9045); the default
+    lane must be the one that can actually produce a verdict."""
+    _install_fake_worktree(mod, monkeypatch)
+    monkeypatch.setattr(mod, "_run", lambda cmd, *, cwd, timeout: _Proc(0, "ok"))
+    rc = mod.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--pristine-dir",
+            str(tmp_path / "pristine"),
+            "--halt-file",
+            str(tmp_path / "halt.json"),
+        ]
+    )
+    assert rc == 0
+    from aragora.nomic.throughput import ThroughputLedger
+
+    (record,) = ThroughputLedger(tmp_path).records()
+    assert record.data["suite"] == "required"
+
+
+def test_mypy_baseline_infra_output_is_infra_not_red(mod):
+    """A checker that cannot produce a verdict is inconclusive, never main_red."""
+    proc = _Proc(2, "", "MYPY_BASELINE_INFRA: mypy missing from PATH")
+    assert mod._infra_failure_signature(proc) is not None
+    # But a genuine baseline regression IS main_red.
+    proc = _Proc(1, "FAIL: full-codebase mypy errors grew: 1872 > baseline 1869 (+3)", "")
+    assert mod._infra_failure_signature(proc) is None
+
+
+def test_mypy_baseline_infra_in_suite_never_writes_halt(mod, monkeypatch, tmp_path, capsys):
+    _install_fake_worktree(mod, monkeypatch)
+    monkeypatch.setattr(mod, "_check_test_runtime", lambda repo: None)
+
+    def fake_suite(cmd, *, cwd, timeout):
+        if "check_mypy_baseline.py" in " ".join(cmd):
+            return _Proc(2, "", "MYPY_BASELINE_INFRA: baseline file missing: x.json")
+        return _Proc(0, "ok")
+
+    monkeypatch.setattr(mod, "_run_suite", fake_suite)
+    halt = tmp_path / "halt.json"
+    rc = mod.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--pristine-dir",
+            str(tmp_path / "pristine"),
+            "--halt-file",
+            str(halt),
+            "--suite",
+            "required",
+        ]
+    )
+
+    assert rc == mod.INFRA_ERROR_EXIT
+    assert not halt.exists()
+    assert "MYPY_BASELINE_INFRA" in capsys.readouterr().err
+
+    from aragora.nomic.throughput import ThroughputLedger
+
+    (record,) = ThroughputLedger(tmp_path).records()
+    assert record.data["status"] == "infra_error"


### PR DESCRIPTION
Fixes the two instrument defects that have kept the pristine-main health instrument (#9058, issue #9043) at **29 runs / zero green days** since arming Jul 9. Diagnosis: https://github.com/synaptent/aragora/issues/9045#issuecomment-5051564150 (part of #9045 Phase-1-exit entry criteria — the "7 instrument-verified green days" counter re-arms when this merges).

## Defects

1. **Required lane parity gap** — the lane ran `make ci-required`, whose raw full-codebase `mypy aragora/ --ignore-missing-imports` carries **1,869 frozen-debt errors in 505 files** (measured on pristine origin/main `cea33a6301`, mypy 2.1.0). The actual required CI `typecheck` check gates touched files only and is green on main. Every `main_red` reading traced to this.
2. **Full-suite lane** — the nightly default `--suite full` ends `TIMEOUT after 180m` (`status: infra_error`) every night; no verdict is ever produced.

## Fix (Tier 1-2 instrument surface)

- **`scripts/check_mypy_baseline.py`** — shrink-only ratchet over the frozen full-codebase mypy debt. Fails only when the live error count **exceeds** `scripts/baselines/mypy_full_baseline.json` (1,869); reports the delta when the count shrinks; never rewrites the baseline (tighten deliberately with `--update-baseline` in a reviewed change). Infra breakage (mypy missing/crashed, unparsable output, missing baseline) exits 2 with a `MYPY_BASELINE_INFRA` prefix that the health script classifies as `infra_error`, never `main_red`.
- **`scripts/pristine_main_health.py`** — the required lane now mirrors the steps of `make ci-required` directly, with only the mypy step swapped for the baseline checker (checker + baseline taken from the instrument's own checkout; every other step uses the pristine checkout's scripts, as make would). **`make ci-required` itself is unchanged** — it stays the strict local developer contract. Mypy-floor toolchain `infra_error` detection preserved.
- **Default suite → `required`** (script default and the launchd nightly invocation, now pinned explicitly). `--suite full` remains available for manual/sharded use.

## Path taken: count-based baseline, not `.mypy-baseline`

Investigated wiring the lane through the existing `.mypy-baseline` (3,115 lines) + `scripts/ci/mypy_with_baseline.py` mechanism instead. It is stale/unconsumed as a gate:

- `mypy-baseline filter` on pristine origin/main exits **100 with ~201 unsynced "new" violations** — wiring through it would keep every night red for pre-existing debt.
- No automated consumer runs the filter: pre-push explicitly dropped it (`.pre-commit-config.yaml` comment), and `mypy-baseline-ratchet.yml` only ratchets the file's `wc -l`, never running the filter.
- The count-based baseline also exactly matches the `make ci-required` step it replaces (`mypy aragora/ --ignore-missing-imports`), whereas `.mypy-baseline` covers `aragora/ scripts/` with different flags.

## Verification

- `tests/scripts/test_check_mypy_baseline.py` (new, 10 tests) + extended `test_pristine_main_health.py` / `test_install_nightly_health_launchd.py`: **38 passed** (count-at-baseline passes, count-above fails with delta + evidence tail, count-below passes with shrink report, mypy-floor violation and checker infra both stay `infra_error` without touching the halt marker).
- End-to-end against a pristine origin/main worktree (`--suite required --no-halt-file`): **`GREEN: pristine main 16e1d5d45e9c passed suite 'required'`** — the instrument can now produce green days.

Refs #9045, #9043, #9058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)