### PR TITLE
fix(stream): adapt legacy synchronous event emissions (#8227)

### DIFF
--- a/aragora/events/types.py
+++ b/aragora/events/types.py
@@ -151,6 +151,7 @@ class StreamEventType(Enum):
     # Trickster/hollow consensus events
     HOLLOW_CONSENSUS = "hollow_consensus"  # Hollow consensus detected
     TRICKSTER_INTERVENTION = "trickster_intervention"  # Trickster challenge injected
+    DEBATE_EARLY_TERMINATED = "debate_early_terminated"  # Debate stopped before max rounds
 
     # Human intervention breakpoint events
     BREAKPOINT = "breakpoint"  # Human intervention breakpoint triggered

--- a/aragora/server/stream/emitter.py
+++ b/aragora/server/stream/emitter.py
@@ -365,6 +365,47 @@ class SyncEventEmitter:
             except (TypeError, ValueError, RuntimeError, AttributeError) as e:
                 logger.warning("[stream] Subscriber callback error: %s", e)
 
+    def emit_sync(
+        self,
+        event_type: str | StreamEventType,
+        debate_id: str = "",
+        correlation_id: str | None = None,
+        **data: Any,
+    ) -> None:
+        """Adapt legacy keyword-style emissions to the stream event schema.
+
+        Debate and memory components historically accepted an emitter with
+        ``emit_sync(event_type=..., debate_id=..., **data)``. The WebSocket
+        stream emitter instead exposed only ``emit(StreamEvent(...))``, so
+        passing it into those components raised ``AttributeError`` on live
+        intervention paths. Keep the compatibility conversion at this boundary
+        so callers do not need to know which emitter implementation they were
+        given.
+        """
+        if isinstance(event_type, StreamEventType):
+            stream_type = event_type
+        else:
+            try:
+                stream_type = StreamEventType(event_type)
+            except ValueError:
+                logger.warning("[stream] Unknown event type %r; event dropped", event_type)
+                return
+
+        raw_round = data.get("round", data.get("round_num", 0))
+        round_num = raw_round if isinstance(raw_round, int) else 0
+        raw_agent = data.get("agent", "")
+        agent = raw_agent if isinstance(raw_agent, str) else ""
+        self.emit(
+            StreamEvent(
+                type=stream_type,
+                data=dict(data),
+                round=round_num,
+                agent=agent,
+                loop_id=debate_id,
+                correlation_id=correlation_id or "",
+            )
+        )
+
     def subscribe(self, callback: Callable[[StreamEvent], None]) -> None:
         """Add synchronous subscriber for immediate event handling."""
         self._subscribers.append(callback)

--- a/tests/stream/test_emitter.py
+++ b/tests/stream/test_emitter.py
@@ -338,6 +338,63 @@ class TestSyncEventEmitter:
         assert events[0].type == StreamEventType.DEBATE_START
         assert events[0].loop_id == "loop_001"
 
+    def test_emit_sync_adapts_legacy_trickster_event(self):
+        """Legacy debate emissions are converted without crashing the stream path."""
+        from aragora.server.stream.emitter import SyncEventEmitter
+
+        emitter = SyncEventEmitter()
+
+        emitter.emit_sync(
+            event_type="trickster_intervention",
+            debate_id="debate-123",
+            correlation_id="correlation-456",
+            agent="trickster",
+            round=2,
+            challenge="Surface independent evidence",
+        )
+
+        events = emitter.drain()
+        assert len(events) == 1
+        event = events[0]
+        assert event.type == StreamEventType.TRICKSTER_INTERVENTION
+        assert event.loop_id == "debate-123"
+        assert event.correlation_id == "correlation-456"
+        assert event.agent == "trickster"
+        assert event.round == 2
+        assert event.data == {
+            "agent": "trickster",
+            "round": 2,
+            "challenge": "Surface independent evidence",
+        }
+
+    def test_emit_sync_supports_early_termination_event(self):
+        from aragora.server.stream.emitter import SyncEventEmitter
+
+        emitter = SyncEventEmitter()
+
+        emitter.emit_sync(
+            event_type="debate_early_terminated",
+            debate_id="debate-123",
+            round_num=1,
+            total_rounds=3,
+        )
+
+        [event] = emitter.drain()
+        assert event.type == StreamEventType.DEBATE_EARLY_TERMINATED
+        assert event.round == 1
+        assert event.data == {"round_num": 1, "total_rounds": 3}
+
+    def test_emit_sync_drops_unknown_event_type_with_warning(self, caplog):
+        from aragora.server.stream.emitter import SyncEventEmitter
+
+        emitter = SyncEventEmitter()
+
+        with caplog.at_level("WARNING"):
+            emitter.emit_sync(event_type="not_registered", debate_id="debate-123")
+
+        assert emitter.drain() == []
+        assert "Unknown event type 'not_registered'; event dropped" in caplog.text
+
     def test_sequence_numbers(self):
         """Test sequence numbers are assigned."""
         from aragora.server.stream.emitter import SyncEventEmitter


### PR DESCRIPTION
## Summary

- add a typed `emit_sync(...)` compatibility boundary to `SyncEventEmitter`
- register the existing `debate_early_terminated` emission in `StreamEventType`
- cover trickster, early-termination, and unknown-event behavior

## Runtime failure

A real local `aragora ask --crux-cards` run reached the low-novelty trickster path in `DebateConvergenceTracker`. That path receives the CLI's real `SyncEventEmitter` but calls the legacy keyword interface:

```text
event_emitter.emit_sync(event_type="trickster_intervention", ...)
AttributeError: 'SyncEventEmitter' object has no attribute 'emit_sync'
```

The adapter converts that established keyword shape into the authoritative typed `StreamEvent` schema at one boundary. This avoids rewriting the 27 existing static `emit_sync` callers and preserves the existing `emit(StreamEvent)` behavior. Unknown event names are logged and dropped rather than aborting an active debate.

Refs #8227 (ODR-4 crux-card dogfood path). This PR does not close the broader CLI/API/SDK/receipt issue.

## Validation

- `pytest -q tests/stream/test_emitter.py tests/debate/phases/test_convergence_tracker.py` - 81 passed
- adjacent stream/integration selection - 85 passed, 12 deselected
- direct real-emitter trickster smoke - passed
- `ruff check` and `ruff format --check` on touched files - passed
- mypy on touched source files - passed
- local pre-commit and pre-push hooks - passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - passed
- `git diff --check` - passed

## Architecture note

The advisory charter checker reports two PROPOSED `CHR-E-004` path warnings and zero binding violations. `CHR-E-004` specifically excludes new server-local metrics, tracing, or HTTP-pool homes; this PR adds none. One warning is for the existing stream-emitter module and the other is a test import of that existing module, so these are path-only heuristic false positives rather than a new excluded concern.

## Scope

Draft only. No workflow, required-check, settlement, evidence, branch-protection, or public crux-contract change is included.
