### PR TITLE
fix(observability): keep SLO metric state coherent (#9122)

### DIFF
--- a/aragora/observability/metrics/slo.py
+++ b/aragora/observability/metrics/slo.py
@@ -224,6 +224,32 @@ SLO_LATENCY_HISTOGRAM: Any = None
 SLO_VIOLATION_MARGIN: Any = None  # How much over the threshold
 
 
+def _slo_metrics_ready() -> bool:
+    """Return whether the lazy-init flag and metric objects are coherent."""
+    return _initialized and all(
+        metric is not None
+        for metric in (
+            SLO_CHECKS_TOTAL,
+            SLO_VIOLATIONS_TOTAL,
+            SLO_LATENCY_HISTOGRAM,
+            SLO_VIOLATION_MARGIN,
+        )
+    )
+
+
+def _init_noop_metrics() -> None:
+    """Initialize the complete SLO metric set with no-op collectors."""
+    global _initialized
+    global SLO_CHECKS_TOTAL, SLO_VIOLATIONS_TOTAL
+    global SLO_LATENCY_HISTOGRAM, SLO_VIOLATION_MARGIN
+
+    SLO_CHECKS_TOTAL = NoOpMetric()
+    SLO_VIOLATIONS_TOTAL = NoOpMetric()
+    SLO_LATENCY_HISTOGRAM = NoOpMetric()
+    SLO_VIOLATION_MARGIN = NoOpMetric()
+    _initialized = True
+
+
 def init_slo_metrics() -> bool:
     """Initialize SLO Prometheus metrics lazily.
 
@@ -234,17 +260,15 @@ def init_slo_metrics() -> bool:
     global SLO_CHECKS_TOTAL, SLO_VIOLATIONS_TOTAL
     global SLO_LATENCY_HISTOGRAM, SLO_VIOLATION_MARGIN
 
-    if _initialized:
+    if _slo_metrics_ready():
         return True
+    if _initialized:
+        logger.warning("SLO metric state was incomplete; reinitializing all metric objects")
+        _initialized = False
 
     config = get_metrics_config()
     if not config.enabled:
-        # Use NoOp metrics
-        SLO_CHECKS_TOTAL = NoOpMetric()
-        SLO_VIOLATIONS_TOTAL = NoOpMetric()
-        SLO_LATENCY_HISTOGRAM = NoOpMetric()
-        SLO_VIOLATION_MARGIN = NoOpMetric()
-        _initialized = True
+        _init_noop_metrics()
         return False
 
     try:
@@ -282,11 +306,7 @@ def init_slo_metrics() -> bool:
 
     except (ImportError, ValueError):
         logger.warning("prometheus-client not installed, SLO metrics disabled")
-        SLO_CHECKS_TOTAL = NoOpMetric()
-        SLO_VIOLATIONS_TOTAL = NoOpMetric()
-        SLO_LATENCY_HISTOGRAM = NoOpMetric()
-        SLO_VIOLATION_MARGIN = NoOpMetric()
-        _initialized = True
+        _init_noop_metrics()
         return False
 
 
@@ -302,8 +322,7 @@ def record_slo_check(
         passed: Whether the check passed
         percentile: SLO percentile checked (p50, p90, p99)
     """
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     result = "pass" if passed else "fail"
     SLO_CHECKS_TOTAL.labels(
@@ -336,8 +355,7 @@ def record_slo_violation(
     Returns:
         The calculated severity level
     """
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     # Auto-calculate severity based on how much threshold was exceeded
     if severity is None:
@@ -385,8 +403,7 @@ def record_operation_latency(operation: str, latency_ms: float) -> None:
         operation: Operation name
         latency_ms: Latency in milliseconds
     """
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     SLO_LATENCY_HISTOGRAM.labels(operation=operation).observe(latency_ms)
 
@@ -410,8 +427,7 @@ def check_and_record_slo(
     """
     from aragora.config.performance_slos import check_latency_slo, get_slo_config
 
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     # Record latency in histogram
     record_operation_latency(operation, latency_ms)
@@ -457,8 +473,7 @@ def track_operation_slo(
             result = await mound.query(...)
             ctx["result_count"] = len(result.items)
     """
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     ctx: dict = {}
     start_time = time.perf_counter()
@@ -483,8 +498,7 @@ def get_slo_metrics_summary() -> dict:
     Returns:
         Dict with metric summaries
     """
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     # This would need prometheus_client inspection which varies
     # Return basic status for now
@@ -724,8 +738,7 @@ def check_and_record_slo_with_recovery(
     """
     from aragora.config.performance_slos import check_latency_slo, get_slo_config
 
-    if not _initialized:
-        init_slo_metrics()
+    init_slo_metrics()
 
     # Record latency in histogram
     record_operation_latency(operation, latency_ms)

--- a/tests/observability/conftest.py
+++ b/tests/observability/conftest.py
@@ -93,6 +93,11 @@ def _cleanup() -> None:
         mod = sys.modules.get(mod_name)
         if mod and hasattr(mod, "_initialized"):
             mod._initialized = False
+            if mod_name == "aragora.observability.metrics.slo":
+                mod.SLO_CHECKS_TOTAL = None
+                mod.SLO_VIOLATIONS_TOTAL = None
+                mod.SLO_LATENCY_HISTOGRAM = None
+                mod.SLO_VIOLATION_MARGIN = None
 
     try:
         from aragora.observability.server_metrics import ACTIVE_DEBATES

--- a/tests/observability/test_slo_webhook_reliability.py
+++ b/tests/observability/test_slo_webhook_reliability.py
@@ -489,6 +489,37 @@ class TestSLORecoveryWebhookReliability:
         slo_module._notification_count = 0
         slo_module._recovery_count = 0
 
+    def test_recovery_path_survives_global_noop_initialization(self):
+        """Global no-op initialization leaves SLO collectors coherent."""
+        from aragora.observability.metrics.initialization import _init_noop_metrics_all
+        from aragora.observability.metrics import slo as slo_module
+
+        slo_module._initialized = False
+        slo_module.SLO_CHECKS_TOTAL = None
+        slo_module.SLO_VIOLATIONS_TOTAL = None
+        slo_module.SLO_LATENCY_HISTOGRAM = None
+        slo_module.SLO_VIOLATION_MARGIN = None
+
+        _init_noop_metrics_all()
+
+        passed, _ = slo_module.check_and_record_slo_with_recovery(
+            "km_query",
+            100.0,
+            "p99",
+        )
+
+        assert passed is True
+        assert slo_module._initialized is True
+        assert all(
+            metric is not None
+            for metric in (
+                slo_module.SLO_CHECKS_TOTAL,
+                slo_module.SLO_VIOLATIONS_TOTAL,
+                slo_module.SLO_LATENCY_HISTOGRAM,
+                slo_module.SLO_VIOLATION_MARGIN,
+            )
+        )
+
     def test_recovery_notification_includes_duration(self):
         """Recovery notification includes violation duration."""
         from aragora.observability.metrics.slo import (


### PR DESCRIPTION
## Summary

- give the SLO metrics module a complete `_init_noop_metrics()` hook so global disabled-mode initialization cannot set `_initialized=True` while collectors remain `None`
- make every SLO recording surface verify the lazy-init flag and collector objects as one coherent state
- reset the SLO flag and collector objects atomically in the observability fixture
- add a regression that drives the real global no-op initializer before the recovery webhook path

## Incident evidence

This is the source/test-only repair for the SLO state-pollution failure classified on #9533: https://github.com/synaptent/aragora/pull/9533#issuecomment-5058332694

The affected test passed in isolation on both the PR head and its main control while the shard failed with `_initialized=True` and `SLO_LATENCY_HISTOGRAM=None`. The repair removes that invalid state instead of weakening or rerunning the optional gate.

Refs #9122. This PR addresses the concrete SLO pollution specimen; it does not claim to close the broader gate-level pollution-quarantine issue.

## Validation

- `python3 -m pytest -q tests/observability/test_slo_webhook_reliability.py::TestSLORecoveryWebhookReliability::test_recovery_path_survives_global_noop_initialization` — 1 passed
- `python3 -m pytest -q tests/observability/test_slo_webhook_reliability.py tests/observability/metrics/test_slo.py` — 31 passed
- `python3 -m pytest -q tests/observability` — 1,678 passed
- `python3 -m ruff check aragora/observability/metrics/slo.py tests/observability/conftest.py tests/observability/test_slo_webhook_reliability.py` — passed
- `python3 -m ruff format --check aragora/observability/metrics/slo.py tests/observability/conftest.py tests/observability/test_slo_webhook_reliability.py` — passed
- `python3 -m mypy aragora/observability/metrics/slo.py` — passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — passed
- `git diff --check` — passed

## Scope

No workflow, required-check, branch-protection, evidence, settlement, or merge behavior changed. This is a net-negative hard-drain exception: it removes a demonstrated false-red source without adding a new program surface.
