### PR TITLE
ci(benchmark-truth): use fine-scoped PAT for draft PR creation (#9519 option B)

### DIFF
--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -337,7 +337,9 @@ jobs:
           # metadata: read every fine-grained PAT carries — gh pr list needs it) so
           # draft PR creation works despite the org policy that blocks the Actions
           # token from creating PRs (#9519, option B). Falls back to the Actions
-          # token, which keeps the branch-backed handoff path as the fallback.
+          # token, which keeps the branch-backed handoff as a bounded stopgap —
+          # persistent degradation escalates to a red run (see the stranded-branch
+          # check below), so handoff-only is not a quiet indefinite steady state.
           GH_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
           GITHUB_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
         run: |
@@ -450,25 +452,30 @@ jobs:
               } >> "$GITHUB_STEP_SUMMARY"
 
               # Escalate persistent degradation. A degraded run strands a
-              # benchmark-truth-publication/<run_id> branch with NO pull request;
-              # branches from successful runs carry a draft PR (open until
-              # promoted, then merged), so only PR-less branches indicate
-              # degraded runs. git ls-remote uses the checkout's Actions
-              # credentials, which work even when the PAT is the broken
-              # credential; if the per-branch gh query fails (e.g. dead PAT),
-              # the branch counts as stranded — the correct escalation for a
-              # dead token.
+              # benchmark-truth-publication/<run_id> branch with NO pull
+              # request; successful runs carry a draft PR. Only PR-less
+              # branches whose tip commit is from the last 7 days count, so
+              # stale pre-PAT backlog or a lone transient failure cannot trip
+              # this — it takes >=3 recent degraded runs. One batched gh call
+              # lists PR-carrying heads (if it fails, e.g. dead PAT, nothing
+              # is excluded and recent stranded branches count — the correct
+              # escalation for a dead token); the branch tips are fetched once
+              # with the checkout's Actions credentials, which survive PAT
+              # death, and dated locally.
+              pr_heads="$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
+              git fetch --quiet --depth=1 origin '+refs/heads/benchmark-truth-publication/*:refs/remotes/strand-check/*' 2>/dev/null || true
+              now_epoch="$(date +%s)"
               stranded_count=0
-              while read -r _sha ref; do
-                br="${ref#refs/heads/}"
-                [[ -z "$br" ]] && continue
-                pr_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$br" --state all --json number --jq 'length' 2>/dev/null || echo "")"
-                if [[ -z "$pr_count" || "$pr_count" -eq 0 ]]; then
-                  stranded_count=$((stranded_count+1))
+              while read -r ref; do
+                br="benchmark-truth-publication/${ref##*/}"
+                grep -qxF "$br" <<<"$pr_heads" && continue
+                tip_epoch="$(git log -1 --format=%ct "$ref" 2>/dev/null || echo 0)"
+                if (( now_epoch - tip_epoch <= 7 * 24 * 3600 )); then
+                  stranded_count=$((stranded_count + 1))
                 fi
-              done < <(git ls-remote --heads origin 'benchmark-truth-publication/*' 2>/dev/null)
+              done < <(git for-each-ref --format='%(refname)' 'refs/remotes/strand-check/*')
               if [[ "$stranded_count" -ge 3 ]]; then
-                echo "::error::${stranded_count} PR-less benchmark-truth-publication branches on origin — draft PR auto-creation has been degraded across multiple runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes; once cadence is restored, prune only the PR-less (stranded) branches (#9519)."
+                echo "::error::${stranded_count} PR-less benchmark-truth-publication branches from the last 7 days — draft PR auto-creation has been degraded across multiple recent runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes; once cadence is restored, prune only the PR-less (stranded) branches (#9519)."
                 exit 1
               fi
               exit 0

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -391,7 +391,7 @@ jobs:
 
           pr_url=""
           for _ in 1 2 3; do
-            pr_url="$(find_draft_pr)"
+            pr_url="$(find_draft_pr || true)"
             if [[ -n "$pr_url" ]]; then
               break
             fi
@@ -424,7 +424,7 @@ jobs:
           fi
 
           for _ in 1 2 3 4 5; do
-            pr_url="$(find_draft_pr)"
+            pr_url="$(find_draft_pr || true)"
             if [[ -n "$pr_url" ]]; then
               break
             fi
@@ -448,6 +448,18 @@ jobs:
                 fi
                 echo "Open draft PR manually: $compare_url"
               } >> "$GITHUB_STEP_SUMMARY"
+
+              # Escalate persistent degradation: each degraded run strands one
+              # benchmark-truth-publication/<run_id> branch, so an accumulating
+              # backlog means auto-PR creation has been broken for days (e.g. a
+              # dead BENCHMARK_TRUTH_PR_TOKEN) while runs stayed green. git
+              # ls-remote uses the checkout's Actions credentials, so it works
+              # even when the PAT is the broken credential.
+              stranded_count="$(git ls-remote --heads origin 'benchmark-truth-publication/*' 2>/dev/null | wc -l | tr -d ' ')"
+              if [[ "${stranded_count:-0}" -ge 3 ]]; then
+                echo "::error::${stranded_count} stranded benchmark-truth-publication branches on origin — draft PR auto-creation has been degraded across multiple runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes and prune merged handoff branches (#9519)."
+                exit 1
+              fi
               exit 0
             fi
 

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -337,9 +337,12 @@ jobs:
           # metadata: read every fine-grained PAT carries — gh pr list needs it) so
           # draft PR creation works despite the org policy that blocks the Actions
           # token from creating PRs (#9519, option B). Falls back to the Actions
-          # token, which keeps the branch-backed handoff as a bounded stopgap —
-          # persistent degradation escalates to a red run (see the stranded-branch
-          # check below), so handoff-only is not a quiet indefinite steady state.
+          # token, which keeps the branch-backed handoff path as the fallback.
+          # Persistent degradation (stale status surfaces, accumulating PR-less
+          # branches) is detected externally by the Stage-Gate Conductor, which
+          # files stage-gate-drift issues — see #9519 itself. Escalation is
+          # deliberately NOT done in-workflow: a broken credential cannot be
+          # trusted to report its own breakage without false reds.
           GH_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
           GITHUB_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
         run: |
@@ -450,34 +453,6 @@ jobs:
                 fi
                 echo "Open draft PR manually: $compare_url"
               } >> "$GITHUB_STEP_SUMMARY"
-
-              # Escalate persistent degradation. A degraded run strands a
-              # benchmark-truth-publication/<run_id> branch with NO pull
-              # request; successful runs carry a draft PR. Only PR-less
-              # branches whose tip commit is from the last 7 days count, so
-              # stale pre-PAT backlog or a lone transient failure cannot trip
-              # this — it takes >=3 recent degraded runs. One batched gh call
-              # lists PR-carrying heads (if it fails, e.g. dead PAT, nothing
-              # is excluded and recent stranded branches count — the correct
-              # escalation for a dead token); the branch tips are fetched once
-              # with the checkout's Actions credentials, which survive PAT
-              # death, and dated locally.
-              pr_heads="$(gh pr list --repo "$GITHUB_REPOSITORY" --state all --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || true)"
-              git fetch --quiet --depth=1 origin '+refs/heads/benchmark-truth-publication/*:refs/remotes/strand-check/*' 2>/dev/null || true
-              now_epoch="$(date +%s)"
-              stranded_count=0
-              while read -r ref; do
-                br="benchmark-truth-publication/${ref##*/}"
-                grep -qxF "$br" <<<"$pr_heads" && continue
-                tip_epoch="$(git log -1 --format=%ct "$ref" 2>/dev/null || echo 0)"
-                if (( now_epoch - tip_epoch <= 7 * 24 * 3600 )); then
-                  stranded_count=$((stranded_count + 1))
-                fi
-              done < <(git for-each-ref --format='%(refname)' 'refs/remotes/strand-check/*')
-              if [[ "$stranded_count" -ge 3 ]]; then
-                echo "::error::${stranded_count} PR-less benchmark-truth-publication branches from the last 7 days — draft PR auto-creation has been degraded across multiple recent runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes; once cadence is restored, prune only the PR-less (stranded) branches (#9519)."
-                exit 1
-              fi
               exit 0
             fi
 

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -332,10 +332,12 @@ jobs:
 
       - name: Commit, publish, and verify draft PR for refreshed trust-loop surfaces
         env:
-          # BENCHMARK_TRUTH_PR_TOKEN: fine-scoped PAT (pull_requests: write on this
-          # repo only) so draft PR creation works despite the org policy that blocks
-          # the Actions token from creating PRs (#9519, option B). Falls back to the
-          # Actions token, which keeps the branch-backed handoff path as the fallback.
+          # BENCHMARK_TRUTH_PR_TOKEN: fine-grained PAT scoped to this repo only
+          # (pull_requests: read/write + contents: read, plus the mandatory
+          # metadata: read every fine-grained PAT carries — gh pr list needs it) so
+          # draft PR creation works despite the org policy that blocks the Actions
+          # token from creating PRs (#9519, option B). Falls back to the Actions
+          # token, which keeps the branch-backed handoff path as the fallback.
           GH_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
           GITHUB_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
         run: |
@@ -360,6 +362,7 @@ jobs:
           body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
           compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1"
           permission_blocked=0
+          create_failed=0
 
           find_draft_pr() {
             gh pr list \
@@ -410,9 +413,12 @@ jobs:
             set -e
             if [[ $create_status -ne 0 ]]; then
               echo "$create_output"
+              create_failed=1
               if grep -Fq "GitHub Actions is not permitted to create or approve pull requests" <<<"$create_output"; then
                 permission_blocked=1
                 echo "::notice::GitHub Actions token cannot create draft PRs in this repository; leaving a branch-backed handoff instead. Configure the BENCHMARK_TRUTH_PR_TOKEN repo secret (fine-scoped PAT, pull_requests: write) to restore auto-PR creation (#9519)."
+              else
+                echo "::warning::Draft PR creation failed (exit ${create_status}) for a reason other than the Actions PR-creation policy — check whether BENCHMARK_TRUTH_PR_TOKEN is expired, revoked, or mis-scoped (#9519). Leaving a branch-backed handoff instead."
               fi
             fi
           fi
@@ -426,11 +432,20 @@ jobs:
           done
 
           if [[ -z "$pr_url" ]]; then
-            if [[ $permission_blocked -eq 1 ]]; then
+            if [[ $create_failed -eq 1 ]]; then
+              # The branch push already succeeded (checkout persists the Actions
+              # token), so any PR-creation failure — the Actions policy block, an
+              # expired/revoked/mis-scoped BENCHMARK_TRUTH_PR_TOKEN, or a transient
+              # API error — degrades to the branch-backed handoff instead of
+              # leaving this daily workflow permanently red with no handoff.
               {
                 echo "Published automation branch: \`$branch\`"
                 echo ""
-                echo "Draft PR auto-creation is blocked for GitHub Actions in this repository."
+                if [[ $permission_blocked -eq 1 ]]; then
+                  echo "Draft PR auto-creation is blocked for GitHub Actions in this repository."
+                else
+                  echo "Draft PR auto-creation failed (see the ::warning above — check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes, #9519)."
+                fi
                 echo "Open draft PR manually: $compare_url"
               } >> "$GITHUB_STEP_SUMMARY"
               exit 0

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -367,6 +367,7 @@ jobs:
           body_file="$RUNNER_TEMP/benchmark-truth-publication-pr.md"
           compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/main...${branch}?expand=1"
           permission_blocked=0
+          auth_failed=0
           create_failed=0
 
           find_draft_pr() {
@@ -422,8 +423,19 @@ jobs:
               if grep -Fq "GitHub Actions is not permitted to create or approve pull requests" <<<"$create_output"; then
                 permission_blocked=1
                 echo "::notice::GitHub Actions token cannot create draft PRs in this repository; leaving a branch-backed handoff instead. Configure the BENCHMARK_TRUTH_PR_TOKEN repo secret (fine-scoped PAT, pull_requests: write) to restore auto-PR creation (#9519)."
+              elif grep -qiE "HTTP 401|Bad credentials|HTTP 403|Resource not accessible|HTTP 404" <<<"$create_output"; then
+                # Known credential failure modes for a fine-grained PAT that
+                # expired, was revoked, or is mis-scoped. These are expected
+                # eventually (PATs expire <=1y) and must not leave the daily
+                # cron permanently red: degrade to the handoff, warn loudly.
+                auth_failed=1
+                echo "::warning::Draft PR creation failed with an auth/permission error — BENCHMARK_TRUTH_PR_TOKEN is likely expired, revoked, or mis-scoped (#9519). Leaving a branch-backed handoff instead."
               else
-                echo "::warning::Draft PR creation failed (exit ${create_status}) for a reason other than the Actions PR-creation policy — check whether BENCHMARK_TRUTH_PR_TOKEN is expired, revoked, or mis-scoped (#9519). Leaving a branch-backed handoff instead."
+                # Unrecognized failure (transient API error, regression in this
+                # script): keep the handoff for continuity but fail the run so
+                # real breakage is not hidden behind green. A transient cause
+                # self-heals on tomorrow's run.
+                echo "::error::Draft PR creation failed unexpectedly (exit ${create_status}) — not the Actions PR policy and not a recognizable token/auth failure. See output above; branch-backed handoff left (#9519)."
               fi
             fi
           fi
@@ -439,21 +451,28 @@ jobs:
           if [[ -z "$pr_url" ]]; then
             if [[ $create_failed -eq 1 ]]; then
               # The branch push already succeeded (checkout persists the Actions
-              # token), so any PR-creation failure — the Actions policy block, an
-              # expired/revoked/mis-scoped BENCHMARK_TRUTH_PR_TOKEN, or a transient
-              # API error — degrades to the branch-backed handoff instead of
-              # leaving this daily workflow permanently red with no handoff.
+              # token), so every PR-creation failure leaves the branch-backed
+              # handoff in the step summary. Whether the run stays green depends
+              # on the failure class: the Actions policy block and PAT death are
+              # expected, documented modes that must not leave the daily cron
+              # permanently red; anything unrecognized fails the run so real
+              # breakage is not hidden behind green.
               {
                 echo "Published automation branch: \`$branch\`"
                 echo ""
                 if [[ $permission_blocked -eq 1 ]]; then
                   echo "Draft PR auto-creation is blocked for GitHub Actions in this repository."
+                elif [[ $auth_failed -eq 1 ]]; then
+                  echo "Draft PR auto-creation failed on auth — check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes (#9519)."
                 else
-                  echo "Draft PR auto-creation failed (see the ::warning above — check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes, #9519)."
+                  echo "Draft PR auto-creation failed unexpectedly (see the ::error above)."
                 fi
                 echo "Open draft PR manually: $compare_url"
               } >> "$GITHUB_STEP_SUMMARY"
-              exit 0
+              if [[ $permission_blocked -eq 1 || $auth_failed -eq 1 ]]; then
+                exit 0
+              fi
+              exit 1
             fi
 
             echo "::error::Benchmark publication branch was pushed but no draft PR exists for $branch"

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -449,15 +449,26 @@ jobs:
                 echo "Open draft PR manually: $compare_url"
               } >> "$GITHUB_STEP_SUMMARY"
 
-              # Escalate persistent degradation: each degraded run strands one
-              # benchmark-truth-publication/<run_id> branch, so an accumulating
-              # backlog means auto-PR creation has been broken for days (e.g. a
-              # dead BENCHMARK_TRUTH_PR_TOKEN) while runs stayed green. git
-              # ls-remote uses the checkout's Actions credentials, so it works
-              # even when the PAT is the broken credential.
-              stranded_count="$(git ls-remote --heads origin 'benchmark-truth-publication/*' 2>/dev/null | wc -l | tr -d ' ')"
-              if [[ "${stranded_count:-0}" -ge 3 ]]; then
-                echo "::error::${stranded_count} stranded benchmark-truth-publication branches on origin — draft PR auto-creation has been degraded across multiple runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes and prune merged handoff branches (#9519)."
+              # Escalate persistent degradation. A degraded run strands a
+              # benchmark-truth-publication/<run_id> branch with NO pull request;
+              # branches from successful runs carry a draft PR (open until
+              # promoted, then merged), so only PR-less branches indicate
+              # degraded runs. git ls-remote uses the checkout's Actions
+              # credentials, which work even when the PAT is the broken
+              # credential; if the per-branch gh query fails (e.g. dead PAT),
+              # the branch counts as stranded — the correct escalation for a
+              # dead token.
+              stranded_count=0
+              while read -r _sha ref; do
+                br="${ref#refs/heads/}"
+                [[ -z "$br" ]] && continue
+                pr_count="$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$br" --state all --json number --jq 'length' 2>/dev/null || echo "")"
+                if [[ -z "$pr_count" || "$pr_count" -eq 0 ]]; then
+                  stranded_count=$((stranded_count+1))
+                fi
+              done < <(git ls-remote --heads origin 'benchmark-truth-publication/*' 2>/dev/null)
+              if [[ "$stranded_count" -ge 3 ]]; then
+                echo "::error::${stranded_count} PR-less benchmark-truth-publication branches on origin — draft PR auto-creation has been degraded across multiple runs. Check BENCHMARK_TRUTH_PR_TOKEN expiry/scopes; once cadence is restored, prune only the PR-less (stranded) branches (#9519)."
                 exit 1
               fi
               exit 0

--- a/.github/workflows/benchmark-truth-publication.yml
+++ b/.github/workflows/benchmark-truth-publication.yml
@@ -332,8 +332,12 @@ jobs:
 
       - name: Commit, publish, and verify draft PR for refreshed trust-loop surfaces
         env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_TOKEN: ${{ github.token }}
+          # BENCHMARK_TRUTH_PR_TOKEN: fine-scoped PAT (pull_requests: write on this
+          # repo only) so draft PR creation works despite the org policy that blocks
+          # the Actions token from creating PRs (#9519, option B). Falls back to the
+          # Actions token, which keeps the branch-backed handoff path as the fallback.
+          GH_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ secrets.BENCHMARK_TRUTH_PR_TOKEN || github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -408,7 +412,7 @@ jobs:
               echo "$create_output"
               if grep -Fq "GitHub Actions is not permitted to create or approve pull requests" <<<"$create_output"; then
                 permission_blocked=1
-                echo "::notice::GitHub Actions token cannot create draft PRs in this repository; leaving a branch-backed handoff instead."
+                echo "::notice::GitHub Actions token cannot create draft PRs in this repository; leaving a branch-backed handoff instead. Configure the BENCHMARK_TRUTH_PR_TOKEN repo secret (fine-scoped PAT, pull_requests: write) to restore auto-PR creation (#9519)."
               fi
             fi
           fi


### PR DESCRIPTION
## Summary

Implements founder-approved **option B** from #9519: the daily benchmark-truth-publication workflow runs green but the repository blocks the Actions token from creating PRs, so trust-loop surfaces (`docs/status/B0_BENCHMARK_TRUTH_STATUS.md`, `TW03_RESCUE_PRODUCTIZATION_STATUS.md`) go stale and `benchmark-truth-publication/<run_id>` branches strand (14 as of Jul 22).

- The PR-creation step authenticates with a `BENCHMARK_TRUTH_PR_TOKEN` repo secret when present — a fine-grained PAT scoped to this repo only (`pull_requests: write` + `contents: read` + mandatory `metadata: read`) — falling back to `github.token`, so the change is a no-op until the secret is provisioned (secret was added 2026-07-23).
- Both `find_draft_pr` polls tolerate a failing `gh` (`|| true`) so a dead PAT cannot abort the step under `set -e` before the degrade path runs.
- Any non-zero `gh pr create` exit degrades to the branch-backed handoff with a targeted notice (policy-blocked) or warning (token expired/mis-scoped/transient); a missing PR after a *successful* create still hard-fails.
- Least privilege preserved: all other workflow steps stay on `github.token`.

## Reviewed design tradeoffs

- **Option A rejected** (repo-wide 'allow Actions to create PRs') in favor of a fine-scoped PAT, per the no-standing-admin-keys credential architecture.
- **In-workflow degradation escalation was added and then deliberately removed** after three review rounds each found a real defect in it (absolute-count false reds; pre-PAT backlog tripping the first degraded run; stale `strand-check` refs surviving on the persistent `clean: false` mac-studio runner after operator pruning). Persistent-degradation detection belongs to the **Stage-Gate Conductor**, the external observer that filed #9519 — a workflow whose own credential is the broken piece cannot reliably self-report without false reds. The degrade path is therefore simple and green: handoff + notice/warning.
- **Failure-classification crux (claude r2 vs openai r6) resolved by classifying `gh pr create` failures**: policy block → notice + green handoff; recognizable credential death (401/403/Bad credentials — the planned ≤1y PAT-expiry mode) → warning + green handoff; unrecognized failures (transient API error, script regression) → handoff still written but the run goes red, self-healing next daily run if transient. Green-forever and red-forever are both avoided.
- PAT expiry (≤1y) is a *planned* future failure: the degrade path plus the conductor's drift detection is the designed response; the fallback token keeps handoff cadence intact.

## Activation

Secret `BENCHMARK_TRUTH_PR_TOKEN` is already provisioned (2026-07-23). After merge, the next daily 13:20 UTC run (or a manual dispatch) should open its draft PR self-serve.

Refs #9519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

