### PR TITLE
feat(status): surface corpus-exhaustion note on B0 benchmark truth surface

### DIFF
--- a/docs-site/docs/contributing/b0-benchmark-truth-status.md
+++ b/docs-site/docs/contributing/b0-benchmark-truth-status.md
@@ -37,6 +37,8 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 | No-rescue truth success rate | 100.0% |
 | Merged-only rate | 100.0% |
 
+Corpus exhaustion note: the verified rates above reflect the previously graduated cohort, not fresh autonomy proof. All `13`/`13` proxy corpus rows in the current window were neutral with `0` fresh successes (`issue_already_resolved`) — corpus revision `6` is exhausted and generates no new execution evidence until the corpus is restocked.
+
 ## In-Flight Graduation Metrics
 
 | Metric | Value |

--- a/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+++ b/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
@@ -32,7 +32,7 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 | No-rescue truth success rate | 100.0% |
 | Merged-only rate | 100.0% |
 
-Corpus exhaustion note: the verified rates above reflect the previously graduated cohort, not fresh autonomy proof. All `13`/`13` proxy corpus rows in the current window were neutral (e.g. `issue_already_resolved`) with `0` fresh successes — corpus revision `6` is exhausted and generates no new execution evidence until the corpus is restocked.
+Corpus exhaustion note: the verified rates above reflect the previously graduated cohort, not fresh autonomy proof. All `13`/`13` proxy corpus rows in the current window were neutral with `0` fresh successes (`issue_already_resolved`) — corpus revision `6` is exhausted and generates no new execution evidence until the corpus is restocked.
 
 ## In-Flight Graduation Metrics
 

--- a/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
+++ b/docs/status/B0_BENCHMARK_TRUTH_STATUS.md
@@ -32,6 +32,8 @@ This is the repo-tracked recurring `TW-02` publication surface for the fixed ben
 | No-rescue truth success rate | 100.0% |
 | Merged-only rate | 100.0% |
 
+Corpus exhaustion note: the verified rates above reflect the previously graduated cohort, not fresh autonomy proof. All `13`/`13` proxy corpus rows in the current window were neutral (e.g. `issue_already_resolved`) with `0` fresh successes — corpus revision `6` is exhausted and generates no new execution evidence until the corpus is restocked.
+
 ## In-Flight Graduation Metrics
 
 | Metric | Value |

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -471,28 +471,33 @@ def render_status_markdown(
         ]
     )
     proxy_attempted = proxy_metrics.get("unique_issues_attempted")
-    corpus_exhausted = (
+    all_neutral_window = (
         isinstance(proxy_attempted, int)
         and proxy_attempted > 0
         and proxy_metrics.get("unique_issues_succeeded") == 0
         and proxy_metrics.get("unique_issues_failed") == 0
         and proxy_metrics.get("unique_issues_neutral") == proxy_attempted
     )
-    if corpus_exhausted:
-        lines.extend(
-            [
-                "",
-                (
-                    "Corpus exhaustion note: the verified rates above reflect the "
-                    "previously graduated cohort, not fresh autonomy proof. All "
-                    f"`{proxy_attempted}`/`{proxy_attempted}` proxy corpus rows in the "
-                    "current window were neutral (e.g. `issue_already_resolved`) with "
-                    "`0` fresh successes — corpus revision "
-                    f"`{_format_value(corpus.get('revision'))}` is exhausted and "
-                    "generates no new execution evidence until the corpus is restocked."
-                ),
-            ]
+    if all_neutral_window:
+        preamble = (
+            "the verified rates above reflect the previously graduated cohort, "
+            "not fresh autonomy proof. All "
+            f"`{proxy_attempted}`/`{proxy_attempted}` proxy corpus rows in the "
+            "current window were neutral with `0` fresh successes"
         )
+        corpus_exhausted = bool(neutral_classes) and set(neutral_classes) == {
+            "issue_already_resolved"
+        }
+        if corpus_exhausted:
+            note = (
+                f"Corpus exhaustion note: {preamble} (`issue_already_resolved`) — "
+                "corpus revision "
+                f"`{_format_value(corpus.get('revision'))}` is exhausted and "
+                "generates no new execution evidence until the corpus is restocked."
+            )
+        else:
+            note = f"Freshness note: {preamble} — this window produced no fresh execution evidence."
+        lines.extend(["", note])
     if in_flight_metrics:
         lines.extend(
             [

--- a/scripts/render_benchmark_truth_status.py
+++ b/scripts/render_benchmark_truth_status.py
@@ -470,6 +470,29 @@ def render_status_markdown(
             f"| Merged-only rate | {_format_percent(truth_metrics.get('merged_only_rate'))} |",
         ]
     )
+    proxy_attempted = proxy_metrics.get("unique_issues_attempted")
+    corpus_exhausted = (
+        isinstance(proxy_attempted, int)
+        and proxy_attempted > 0
+        and proxy_metrics.get("unique_issues_succeeded") == 0
+        and proxy_metrics.get("unique_issues_failed") == 0
+        and proxy_metrics.get("unique_issues_neutral") == proxy_attempted
+    )
+    if corpus_exhausted:
+        lines.extend(
+            [
+                "",
+                (
+                    "Corpus exhaustion note: the verified rates above reflect the "
+                    "previously graduated cohort, not fresh autonomy proof. All "
+                    f"`{proxy_attempted}`/`{proxy_attempted}` proxy corpus rows in the "
+                    "current window were neutral (e.g. `issue_already_resolved`) with "
+                    "`0` fresh successes — corpus revision "
+                    f"`{_format_value(corpus.get('revision'))}` is exhausted and "
+                    "generates no new execution evidence until the corpus is restocked."
+                ),
+            ]
+        )
     if in_flight_metrics:
         lines.extend(
             [

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -369,6 +369,91 @@ def test_render_status_markdown_surfaces_proxy_neutral_issue_classes(tmp_path: P
     assert "`issue_already_resolved`: 1" in markdown
 
 
+def test_render_status_markdown_flags_exhausted_corpus_window(tmp_path: Path) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 6,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+    markdown = mod.render_status_markdown(
+        corpus_path=corpus_path,
+        truth_path=latest_paths["truth_corpus_latest"],
+        scorecard_path=latest_paths["scorecard_corpus_latest"],
+        latest_paths=latest_paths,
+        truth_payload=_truth_payload(revision=6),
+        scorecard_payload={
+            **_scorecard_payload(revision=6),
+            "proxy_metrics": {
+                "no_rescue_success_rate": 0.0,
+                "unique_issues_attempted": 13,
+                "unique_issues_succeeded": 0,
+                "unique_issues_failed": 0,
+                "unique_issues_neutral": 13,
+                "total_ticks": 13,
+                "neutral_classes": {"issue_already_resolved": 13},
+            },
+        },
+    )
+
+    assert "Corpus exhaustion note:" in markdown
+    assert "not fresh autonomy proof" in markdown
+    assert "All `13`/`13` proxy corpus rows" in markdown
+    assert "corpus revision `6` is exhausted" in markdown
+    # The note must sit directly under the headline table, before in-flight metrics.
+    assert markdown.index("Corpus exhaustion note:") < markdown.index("## Proxy Metrics")
+
+
+def test_render_status_markdown_omits_exhaustion_note_on_fresh_successes(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 6,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+    markdown = mod.render_status_markdown(
+        corpus_path=corpus_path,
+        truth_path=latest_paths["truth_corpus_latest"],
+        scorecard_path=latest_paths["scorecard_corpus_latest"],
+        latest_paths=latest_paths,
+        truth_payload=_truth_payload(revision=6),
+        scorecard_payload={
+            **_scorecard_payload(revision=6),
+            "proxy_metrics": {
+                "no_rescue_success_rate": 0.5,
+                "unique_issues_attempted": 13,
+                "unique_issues_succeeded": 2,
+                "unique_issues_failed": 0,
+                "unique_issues_neutral": 11,
+                "total_ticks": 13,
+                "neutral_classes": {"issue_already_resolved": 11},
+            },
+        },
+    )
+
+    assert "Corpus exhaustion note:" not in markdown
+
+
 def test_render_status_markdown_backfills_legacy_proxy_neutral_fields(tmp_path: Path) -> None:
     corpus_path = _write_json(
         tmp_path / "corpus.json",

--- a/tests/scripts/test_render_benchmark_truth_status.py
+++ b/tests/scripts/test_render_benchmark_truth_status.py
@@ -413,6 +413,55 @@ def test_render_status_markdown_flags_exhausted_corpus_window(tmp_path: Path) ->
     assert markdown.index("Corpus exhaustion note:") < markdown.index("## Proxy Metrics")
 
 
+def test_render_status_markdown_uses_generic_note_for_mixed_neutral_classes(
+    tmp_path: Path,
+) -> None:
+    corpus_path = _write_json(
+        tmp_path / "corpus.json",
+        {
+            "corpus_id": "tw-01-bounded-execution-v1",
+            "revision": 6,
+            "recorded_on": "2026-04-14",
+            "success_contract": "mergeable_pr_or_merged_pr",
+            "issues": [{"issue_id": 1064, "title": "Issue A"}],
+        },
+    )
+    latest_paths = mod.resolve_latest_paths(
+        corpus_path=corpus_path,
+        truth_root=tmp_path / "truth",
+        scorecard_root=tmp_path / "scorecards",
+    )
+    markdown = mod.render_status_markdown(
+        corpus_path=corpus_path,
+        truth_path=latest_paths["truth_corpus_latest"],
+        scorecard_path=latest_paths["scorecard_corpus_latest"],
+        latest_paths=latest_paths,
+        truth_payload=_truth_payload(revision=6),
+        scorecard_payload={
+            **_scorecard_payload(revision=6),
+            "proxy_metrics": {
+                "no_rescue_success_rate": 0.0,
+                "unique_issues_attempted": 4,
+                "unique_issues_succeeded": 0,
+                "unique_issues_failed": 0,
+                "unique_issues_neutral": 4,
+                "total_ticks": 4,
+                "neutral_classes": {
+                    "issue_already_resolved": 2,
+                    "blocked_config": 2,
+                },
+            },
+        },
+    )
+
+    # An all-neutral window that is not purely issue_already_resolved must not
+    # claim corpus exhaustion — only that no fresh evidence was produced.
+    assert "Corpus exhaustion note:" not in markdown
+    assert "Freshness note:" in markdown
+    assert "no fresh execution evidence" in markdown
+    assert "not fresh autonomy proof" in markdown
+
+
 def test_render_status_markdown_omits_exhaustion_note_on_fresh_successes(
     tmp_path: Path,
 ) -> None:
@@ -452,6 +501,7 @@ def test_render_status_markdown_omits_exhaustion_note_on_fresh_successes(
     )
 
     assert "Corpus exhaustion note:" not in markdown
+    assert "Freshness note:" not in markdown
 
 
 def test_render_status_markdown_backfills_legacy_proxy_neutral_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Honesty fix for the recurring B0 proof surface, per #9519's finding: `docs/status/B0_BENCHMARK_TRUTH_STATUS.md` leads with a `100.0%` verified headline while the current window's proxy metrics show 13/13 rows neutral (`issue_already_resolved`) and `unique_issues_succeeded: 0` — the rev-6 corpus is exhausted and generating no fresh execution proof. The generated surface never stated that plainly; the honest framing lived only in PR bodies (#9356, #9427), which don't survive onto the surface.

Because the surface is regenerated byte-authoritatively by the daily `benchmark-truth-publication` workflow, a hand-edited note would be clobbered on the next run. This PR instead teaches the renderer to emit the note itself:

- `scripts/render_benchmark_truth_status.py`: when the proxy window is fully neutral (attempted > 0, 0 successes, 0 failures), render a **Corpus exhaustion note** directly under the Truth Metrics headline table: the verified rates reflect the previously graduated cohort, not fresh autonomy proof, and the corpus revision is exhausted until restocked.
- `docs/status/B0_BENCHMARK_TRUTH_STATUS.md`: re-rendered with the note (2-line diff; otherwise byte-identical to the instrument's own output merged in #9538 today).
- Tests: exhausted window → note present above Proxy Metrics; fresh successes → note absent.

The note disappears automatically once a restocked corpus (TW-01 rev-7) produces a fresh success or failure — no manual cleanup.

## Reviewed design tradeoffs

- Renderer-emitted vs hand-edited note: hand edits are overwritten daily by the workflow; only a generator change is durable.
- Placement under the headline table (not in Proxy Metrics): the mission of the note is that the 100% headline cannot be read without the exhaustion context.
- Trigger is fully-neutral-window (succeeded == 0 and failed == 0 and neutral == attempted): a window with any fresh success *or* fresh failure is producing execution evidence and should not carry the note.

## Verification

- `pytest tests/scripts/test_render_benchmark_truth_status.py tests/scripts/test_benchmark_truth_publication_workflow.py` — 34 passed
- `python3 scripts/check_docs_consistency.py` — no findings
- `python3 scripts/probe_proof_surface_freshness.py` — b0 + tw03 fresh, exit 0
- `ruff check` / `ruff format --check` / `mypy` on changed files — clean
- Re-render against main's published JSON artifacts is byte-identical except the 2 new lines

## Non-goals

- No workflow or Actions-settings change (#9519 options A/B — note: PR creation by `app/github-actions` is already working again as of ~Jul 18; see #9491/#9538)
- No corpus membership change; TW-01 rev-7 restock remains planning work for corpus owners

Refs #9519

🤖 Generated with [Claude Code](https://claude.com/claude-code)