### PR TITLE
feat(scripts): fingerprint-based dedup for Stage-Gate Conductor drift issues

### DIFF
--- a/scripts/stage_gate_drift.py
+++ b/scripts/stage_gate_drift.py
@@ -43,7 +43,11 @@ LOG_LABEL = "automation-log"
 LOG_TITLE_PREFIX = "[automation] Stage-Gate Conductor Log"
 DEFAULT_REPO = "synaptent/aragora"
 
-_FINGERPRINT_RE = re.compile(r"drift-fingerprint:\s*`?([A-Za-z0-9][A-Za-z0-9-]*)`?", re.IGNORECASE)
+_FINGERPRINT_RE = re.compile(
+    r"^[ \t]*`?drift-fingerprint:\s*([A-Za-z0-9][A-Za-z0-9-]*)`?[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_ISSUE_URL_RE = re.compile(r"https?://[^\s]+/issues/(\d+)(?:[?#][^\s]*)?")
 _MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
 _GH_TIMEOUT = 30
 
@@ -63,10 +67,10 @@ def render_fingerprint_line(slug: str) -> str:
 
 def extract_fingerprint(body: str) -> str | None:
     """Return the fingerprint slug embedded in an issue body, if any."""
-    match = _FINGERPRINT_RE.search(body or "")
-    if match is None:
+    matches = list(_FINGERPRINT_RE.finditer(body or ""))
+    if not matches:
         return None
-    return match.group(1).lower()
+    return matches[-1].group(1).lower()
 
 
 def find_anchor(issues: list[dict[str, Any]], slug: str) -> dict[str, Any] | None:
@@ -97,7 +101,7 @@ def list_open_drift_issues(*, repo: str, label: str = DRIFT_LABEL) -> list[dict[
             "--state",
             "open",
             "--limit",
-            "200",
+            "1000",
             "--json",
             "number,title,body",
         ]
@@ -121,19 +125,20 @@ def create_issue(*, repo: str, title: str, body: str, labels: list[str]) -> dict
     result = _run_gh(cmd)
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or "gh issue create failed")
-    url = str(result.stdout or "").strip().splitlines()[-1].strip()
-    number_match = re.search(r"/issues/(\d+)$", url)
+    url_matches = list(_ISSUE_URL_RE.finditer(str(result.stdout or "")))
+    if not url_matches:
+        raise RuntimeError("gh issue create returned no issue URL")
+    url_match = url_matches[-1]
     return {
-        "number": int(number_match.group(1)) if number_match else None,
+        "number": int(url_match.group(1)),
         "title": title,
-        "url": url,
+        "url": url_match.group(0),
     }
 
 
 def _ensure_fingerprint_in_body(body: str, slug: str) -> str:
-    if extract_fingerprint(body) == slug:
-        return body
-    return f"{body.rstrip()}\n\n{render_fingerprint_line(slug)}\n"
+    without_markers = _FINGERPRINT_RE.sub("", body).rstrip()
+    return f"{without_markers}\n\n{render_fingerprint_line(slug)}\n"
 
 
 def file_drift(

--- a/scripts/stage_gate_drift.py
+++ b/scripts/stage_gate_drift.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""File Stage-Gate Conductor drift issues with fingerprint-based dedup.
+
+The Stage-Gate Conductor's escalation rule allows one bounded ``[stage-gate]``
+issue per run, but repeated runs observing the *same* finding must land on a
+single anchor issue instead of opening a near-duplicate every cycle (see
+issue #9490: ~19 duplicates of the ``b0-corpus-exhausted`` finding).
+
+Contract:
+
+- Every drift issue body carries a stable machine-readable marker line::
+
+    `Drift-Fingerprint: <kebab-slug-of-finding-class>`
+
+- Before filing, search open ``stage-gate-drift`` issues for a matching
+  fingerprint. If an anchor exists, append the new observation as a comment
+  on it; only create a new issue for a genuinely new finding class.
+- The recurring run log uses one rolling anchor per month
+  (``[automation] Stage-Gate Conductor Log (YYYY-MM)``) rather than a new
+  ``automation-log`` issue per run.
+
+CLI (all subcommands are dry-run unless ``--apply`` is passed)::
+
+    python scripts/stage_gate_drift.py file --repo org/repo \
+        --fingerprint b0-corpus-exhausted \
+        --title "[stage-gate] ..." --body-file drift.md --apply
+
+    python scripts/stage_gate_drift.py log --repo org/repo \
+        --month 2026-07 --body-file run_summary.md --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+DRIFT_LABEL = "stage-gate-drift"
+LOG_LABEL = "automation-log"
+LOG_TITLE_PREFIX = "[automation] Stage-Gate Conductor Log"
+DEFAULT_REPO = "synaptent/aragora"
+
+_FINGERPRINT_RE = re.compile(r"drift-fingerprint:\s*`?([A-Za-z0-9][A-Za-z0-9-]*)`?", re.IGNORECASE)
+_MONTH_RE = re.compile(r"^\d{4}-(0[1-9]|1[0-2])$")
+_GH_TIMEOUT = 30
+
+
+def slugify_fingerprint(text: str) -> str:
+    """Normalize a finding-class name to a stable kebab-case slug."""
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug)
+    if not slug:
+        raise ValueError(f"fingerprint {text!r} normalizes to an empty slug")
+    return slug
+
+
+def render_fingerprint_line(slug: str) -> str:
+    return f"`Drift-Fingerprint: {slug}`"
+
+
+def extract_fingerprint(body: str) -> str | None:
+    """Return the fingerprint slug embedded in an issue body, if any."""
+    match = _FINGERPRINT_RE.search(body or "")
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+def find_anchor(issues: list[dict[str, Any]], slug: str) -> dict[str, Any] | None:
+    """Return the lowest-numbered open issue whose body carries ``slug``."""
+    matches = [
+        issue for issue in issues if extract_fingerprint(str(issue.get("body") or "")) == slug
+    ]
+    if not matches:
+        return None
+    return min(matches, key=lambda issue: int(issue.get("number") or 0))
+
+
+def _run_gh(args: list[str], *, timeout: int = _GH_TIMEOUT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=timeout, check=False
+    )
+
+
+def list_open_drift_issues(*, repo: str, label: str = DRIFT_LABEL) -> list[dict[str, Any]]:
+    result = _run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--label",
+            label,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,body",
+        ]
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue list failed")
+    payload = json.loads(result.stdout or "[]")
+    return [item for item in payload if isinstance(item, dict)]
+
+
+def comment_on_issue(*, repo: str, number: int, body: str) -> None:
+    result = _run_gh(["issue", "comment", str(number), "--repo", repo, "--body", body])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue comment failed")
+
+
+def create_issue(*, repo: str, title: str, body: str, labels: list[str]) -> dict[str, Any]:
+    cmd = ["issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in labels:
+        cmd.extend(["--label", label])
+    result = _run_gh(cmd)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh issue create failed")
+    url = str(result.stdout or "").strip().splitlines()[-1].strip()
+    number_match = re.search(r"/issues/(\d+)$", url)
+    return {
+        "number": int(number_match.group(1)) if number_match else None,
+        "title": title,
+        "url": url,
+    }
+
+
+def _ensure_fingerprint_in_body(body: str, slug: str) -> str:
+    if extract_fingerprint(body) == slug:
+        return body
+    return f"{body.rstrip()}\n\n{render_fingerprint_line(slug)}\n"
+
+
+def file_drift(
+    *,
+    repo: str,
+    fingerprint: str,
+    title: str,
+    body: str,
+    apply: bool = False,
+    label: str = DRIFT_LABEL,
+) -> dict[str, Any]:
+    """Comment on the existing anchor for ``fingerprint``, or create one."""
+    slug = slugify_fingerprint(fingerprint)
+    issues = list_open_drift_issues(repo=repo, label=label)
+    anchor = find_anchor(issues, slug)
+    if anchor is not None:
+        number = int(anchor["number"])
+        if not apply:
+            return {"action": "would_comment", "number": number, "fingerprint": slug}
+        comment_on_issue(repo=repo, number=number, body=body)
+        return {"action": "commented", "number": number, "fingerprint": slug}
+    if not apply:
+        return {"action": "would_create", "number": None, "fingerprint": slug}
+    created = create_issue(
+        repo=repo,
+        title=title,
+        body=_ensure_fingerprint_in_body(body, slug),
+        labels=[label],
+    )
+    return {"action": "created", "number": created.get("number"), "fingerprint": slug}
+
+
+def log_anchor_title(month: str) -> str:
+    return f"{LOG_TITLE_PREFIX} ({month})"
+
+
+def post_log_entry(
+    *,
+    repo: str,
+    month: str,
+    body: str,
+    apply: bool = False,
+) -> dict[str, Any]:
+    """Append a run summary to the rolling monthly Conductor log anchor."""
+    if not _MONTH_RE.match(month):
+        raise ValueError(f"month must be YYYY-MM, got {month!r}")
+    title = log_anchor_title(month)
+    issues = list_open_drift_issues(repo=repo, label=LOG_LABEL)
+    matches = [i for i in issues if str(i.get("title") or "").strip() == title]
+    if matches:
+        number = int(min(matches, key=lambda issue: int(issue.get("number") or 0))["number"])
+        if not apply:
+            return {"action": "would_comment", "number": number, "title": title}
+        comment_on_issue(repo=repo, number=number, body=body)
+        return {"action": "commented", "number": number, "title": title}
+    if not apply:
+        return {"action": "would_create", "number": None, "title": title}
+    created = create_issue(
+        repo=repo,
+        title=title,
+        body=(
+            f"Rolling log for the Stage-Gate Conductor automation for {month}. "
+            "Each run appends one comment; do not open per-run log issues."
+        ),
+        labels=[LOG_LABEL],
+    )
+    created_number = created.get("number")
+    if created_number is not None:
+        comment_on_issue(repo=repo, number=int(created_number), body=body)
+    return {"action": "created", "number": created_number, "title": title}
+
+
+def _read_body(args: argparse.Namespace) -> str:
+    if args.body is not None:
+        return args.body
+    if args.body_file == "-":
+        return sys.stdin.read()
+    with open(args.body_file, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    file_parser = sub.add_parser("file", help="File a drift finding with dedup")
+    file_parser.add_argument("--repo", default=DEFAULT_REPO)
+    file_parser.add_argument("--fingerprint", required=True)
+    file_parser.add_argument("--title", required=True)
+    file_parser.add_argument("--apply", action="store_true")
+    body_group = file_parser.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body")
+    body_group.add_argument("--body-file")
+
+    log_parser = sub.add_parser("log", help="Append to the monthly log anchor")
+    log_parser.add_argument("--repo", default=DEFAULT_REPO)
+    log_parser.add_argument("--month", required=True, help="YYYY-MM")
+    log_parser.add_argument("--apply", action="store_true")
+    log_body_group = log_parser.add_mutually_exclusive_group(required=True)
+    log_body_group.add_argument("--body")
+    log_body_group.add_argument("--body-file")
+
+    args = parser.parse_args(argv)
+    if args.command == "file":
+        result = file_drift(
+            repo=args.repo,
+            fingerprint=args.fingerprint,
+            title=args.title,
+            body=_read_body(args),
+            apply=args.apply,
+        )
+    else:
+        result = post_log_entry(
+            repo=args.repo, month=args.month, body=_read_body(args), apply=args.apply
+        )
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_stage_gate_drift.py
+++ b/tests/scripts/test_stage_gate_drift.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts import stage_gate_drift as mod
+
+
+def _issue(number: int, title: str = "t", body: str = "") -> dict:
+    return {"number": number, "title": title, "body": body}
+
+
+class TestSlugifyFingerprint:
+    def test_normalizes_to_kebab_slug(self) -> None:
+        assert mod.slugify_fingerprint("B0 corpus exhausted!") == "b0-corpus-exhausted"
+
+    def test_collapses_separator_runs_and_strips_edges(self) -> None:
+        assert mod.slugify_fingerprint("--B0__corpus  rev-6--") == "b0-corpus-rev-6"
+
+    def test_rejects_empty_input(self) -> None:
+        with pytest.raises(ValueError):
+            mod.slugify_fingerprint("!!!")
+
+
+class TestExtractFingerprint:
+    def test_finds_marker_in_body(self) -> None:
+        body = "## Drift\n\nstuff\n\n`Drift-Fingerprint: b0-corpus-exhausted`\n"
+        assert mod.extract_fingerprint(body) == "b0-corpus-exhausted"
+
+    def test_marker_is_case_insensitive_and_backtick_optional(self) -> None:
+        assert mod.extract_fingerprint("drift-fingerprint: My-Slug") == "my-slug"
+
+    def test_returns_none_when_absent(self) -> None:
+        assert mod.extract_fingerprint("no marker here, just corpus talk") is None
+
+    def test_returns_none_for_empty_body(self) -> None:
+        assert mod.extract_fingerprint("") is None
+
+
+class TestFindAnchor:
+    def test_picks_lowest_numbered_matching_issue(self) -> None:
+        issues = [
+            _issue(9452, body=mod.render_fingerprint_line("b0-corpus-exhausted")),
+            _issue(9438, body=mod.render_fingerprint_line("b0-corpus-exhausted")),
+            _issue(9511, body=mod.render_fingerprint_line("rs-11a-boss-ready")),
+        ]
+        anchor = mod.find_anchor(issues, "b0-corpus-exhausted")
+        assert anchor is not None
+        assert anchor["number"] == 9438
+
+    def test_returns_none_when_no_fingerprint_matches(self) -> None:
+        issues = [_issue(1, body="no marker"), _issue(2, body="drift-fingerprint: other")]
+        assert mod.find_anchor(issues, "b0-corpus-exhausted") is None
+
+
+class TestFileDrift:
+    @pytest.fixture()
+    def recorder(self, monkeypatch) -> dict:
+        calls: dict = {"comments": [], "creates": []}
+        monkeypatch.setattr(
+            mod,
+            "list_open_drift_issues",
+            lambda *, repo, label=mod.DRIFT_LABEL: calls.setdefault("listed", True)
+            and calls["issues"],
+        )
+        monkeypatch.setattr(
+            mod,
+            "comment_on_issue",
+            lambda *, repo, number, body: calls["comments"].append((number, body)),
+        )
+
+        def _create(*, repo, title, body, labels):
+            calls["creates"].append({"title": title, "body": body, "labels": labels})
+            return {"number": 9999, "title": title}
+
+        monkeypatch.setattr(mod, "create_issue", _create)
+        return calls
+
+    def test_comments_on_existing_anchor_instead_of_creating(self, recorder) -> None:
+        recorder["issues"] = [
+            _issue(9438, body="evidence\n\n" + mod.render_fingerprint_line("b0-corpus-exhausted"))
+        ]
+        result = mod.file_drift(
+            repo="org/repo",
+            fingerprint="b0-corpus-exhausted",
+            title="[stage-gate] B0 corpus exhausted",
+            body="fresh observation",
+            apply=True,
+        )
+        assert result["action"] == "commented"
+        assert result["number"] == 9438
+        assert len(recorder["comments"]) == 1
+        assert recorder["comments"][0][0] == 9438
+        assert "fresh observation" in recorder["comments"][0][1]
+        assert recorder["creates"] == []
+
+    def test_creates_new_issue_with_embedded_fingerprint_when_no_anchor(self, recorder) -> None:
+        recorder["issues"] = []
+        result = mod.file_drift(
+            repo="org/repo",
+            fingerprint="tw01-ledger-vacuous",
+            title="[stage-gate] TW-01 ledger vacuous",
+            body="observation",
+            apply=True,
+        )
+        assert result["action"] == "created"
+        assert result["number"] == 9999
+        assert len(recorder["creates"]) == 1
+        created = recorder["creates"][0]
+        assert mod.extract_fingerprint(created["body"]) == "tw01-ledger-vacuous"
+        assert mod.DRIFT_LABEL in created["labels"]
+        assert recorder["comments"] == []
+
+    def test_does_not_duplicate_marker_already_in_body(self, recorder) -> None:
+        recorder["issues"] = []
+        body = "observation\n\n" + mod.render_fingerprint_line("tw01-ledger-vacuous")
+        mod.file_drift(
+            repo="org/repo",
+            fingerprint="tw01-ledger-vacuous",
+            title="t",
+            body=body,
+            apply=True,
+        )
+        created_body = recorder["creates"][0]["body"]
+        assert created_body.lower().count("drift-fingerprint:") == 1
+
+    def test_dry_run_reports_without_mutating(self, recorder) -> None:
+        recorder["issues"] = [_issue(9438, body=mod.render_fingerprint_line("b0-corpus-exhausted"))]
+        result = mod.file_drift(
+            repo="org/repo",
+            fingerprint="b0-corpus-exhausted",
+            title="t",
+            body="b",
+            apply=False,
+        )
+        assert result["action"] == "would_comment"
+        assert result["number"] == 9438
+        assert recorder["comments"] == []
+        assert recorder["creates"] == []
+
+    def test_dry_run_reports_would_create_when_no_anchor(self, recorder) -> None:
+        recorder["issues"] = []
+        result = mod.file_drift(
+            repo="org/repo", fingerprint="new-finding", title="t", body="b", apply=False
+        )
+        assert result["action"] == "would_create"
+        assert recorder["creates"] == []
+
+    def test_fingerprint_is_slugified_before_matching(self, recorder) -> None:
+        recorder["issues"] = [_issue(9438, body=mod.render_fingerprint_line("b0-corpus-exhausted"))]
+        result = mod.file_drift(
+            repo="org/repo",
+            fingerprint="B0 Corpus Exhausted",
+            title="t",
+            body="b",
+            apply=True,
+        )
+        assert result["action"] == "commented"
+        assert result["number"] == 9438
+
+
+class TestLogAnchor:
+    @pytest.fixture()
+    def recorder(self, monkeypatch) -> dict:
+        calls: dict = {"comments": [], "creates": []}
+        monkeypatch.setattr(
+            mod,
+            "list_open_drift_issues",
+            lambda *, repo, label=mod.DRIFT_LABEL: calls["issues"],
+        )
+        monkeypatch.setattr(
+            mod,
+            "comment_on_issue",
+            lambda *, repo, number, body: calls["comments"].append((number, body)),
+        )
+
+        def _create(*, repo, title, body, labels):
+            calls["creates"].append({"title": title, "body": body, "labels": labels})
+            return {"number": 8888, "title": title}
+
+        monkeypatch.setattr(mod, "create_issue", _create)
+        return calls
+
+    def test_appends_to_existing_monthly_log_anchor(self, recorder) -> None:
+        title = mod.log_anchor_title("2026-07")
+        recorder["issues"] = [_issue(9296, title=title)]
+        result = mod.post_log_entry(
+            repo="org/repo", month="2026-07", body="run summary", apply=True
+        )
+        assert result["action"] == "commented"
+        assert result["number"] == 9296
+        assert recorder["comments"] == [(9296, "run summary")]
+        assert recorder["creates"] == []
+
+    def test_creates_monthly_log_anchor_when_missing(self, recorder) -> None:
+        recorder["issues"] = [
+            _issue(9488, title="[automation] Stage-Gate Conductor Log"),
+        ]
+        result = mod.post_log_entry(
+            repo="org/repo", month="2026-08", body="run summary", apply=True
+        )
+        assert result["action"] == "created"
+        assert result["number"] == 8888
+        assert recorder["creates"][0]["title"] == mod.log_anchor_title("2026-08")
+        assert mod.LOG_LABEL in recorder["creates"][0]["labels"]
+        # the run body must still land on the new anchor
+        assert recorder["comments"] == [(8888, "run summary")]
+
+    def test_rejects_malformed_month(self, recorder) -> None:
+        with pytest.raises(ValueError):
+            mod.post_log_entry(repo="org/repo", month="July 2026", body="b", apply=True)
+
+
+class TestCli:
+    def test_file_subcommand_dry_run_outputs_json(self, monkeypatch, capsys) -> None:
+        monkeypatch.setattr(
+            mod,
+            "list_open_drift_issues",
+            lambda *, repo, label=mod.DRIFT_LABEL: [
+                _issue(9438, body=mod.render_fingerprint_line("b0-corpus-exhausted"))
+            ],
+        )
+        rc = mod.main(
+            [
+                "file",
+                "--repo",
+                "org/repo",
+                "--fingerprint",
+                "b0-corpus-exhausted",
+                "--title",
+                "[stage-gate] B0 corpus exhausted",
+                "--body",
+                "observation",
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["action"] == "would_comment"
+        assert payload["number"] == 9438

--- a/tests/scripts/test_stage_gate_drift.py
+++ b/tests/scripts/test_stage_gate_drift.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pytest
 
@@ -36,6 +37,23 @@ class TestExtractFingerprint:
 
     def test_returns_none_for_empty_body(self) -> None:
         assert mod.extract_fingerprint("") is None
+
+    def test_ignores_inline_reference_before_marker_line(self) -> None:
+        body = (
+            "Prior Drift-Fingerprint: stale-slug was superseded.\n\n"
+            + mod.render_fingerprint_line("current-slug")
+        )
+        assert mod.extract_fingerprint(body) == "current-slug"
+
+    def test_uses_last_marker_when_legacy_body_has_duplicates(self) -> None:
+        body = "\n".join(
+            [
+                mod.render_fingerprint_line("stale-slug"),
+                "observation",
+                mod.render_fingerprint_line("current-slug"),
+            ]
+        )
+        assert mod.extract_fingerprint(body) == "current-slug"
 
 
 class TestFindAnchor:
@@ -125,6 +143,20 @@ class TestFileDrift:
         created_body = recorder["creates"][0]["body"]
         assert created_body.lower().count("drift-fingerprint:") == 1
 
+    def test_replaces_mismatched_marker_in_body(self, recorder) -> None:
+        recorder["issues"] = []
+        body = "observation\n\n" + mod.render_fingerprint_line("stale-finding")
+        mod.file_drift(
+            repo="org/repo",
+            fingerprint="current-finding",
+            title="t",
+            body=body,
+            apply=True,
+        )
+        created_body = recorder["creates"][0]["body"]
+        assert created_body.lower().count("drift-fingerprint:") == 1
+        assert mod.extract_fingerprint(created_body) == "current-finding"
+
     def test_dry_run_reports_without_mutating(self, recorder) -> None:
         recorder["issues"] = [_issue(9438, body=mod.render_fingerprint_line("b0-corpus-exhausted"))]
         result = mod.file_drift(
@@ -210,6 +242,48 @@ class TestLogAnchor:
     def test_rejects_malformed_month(self, recorder) -> None:
         with pytest.raises(ValueError):
             mod.post_log_entry(repo="org/repo", month="July 2026", body="b", apply=True)
+
+
+class TestGitHubIssueCommands:
+    def test_create_issue_finds_url_before_trailing_notice(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            mod,
+            "_run_gh",
+            lambda args: subprocess.CompletedProcess(
+                args,
+                0,
+                stdout=(
+                    "https://github.com/org/repo/issues/123?notification_referrer_id=abc\n"
+                    "A new release of gh is available\n"
+                ),
+                stderr="",
+            ),
+        )
+        created = mod.create_issue(repo="org/repo", title="t", body="b", labels=["label"])
+        assert created["number"] == 123
+        assert created["url"] == (
+            "https://github.com/org/repo/issues/123?notification_referrer_id=abc"
+        )
+
+    def test_create_issue_rejects_missing_url(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            mod,
+            "_run_gh",
+            lambda args: subprocess.CompletedProcess(args, 0, stdout="", stderr=""),
+        )
+        with pytest.raises(RuntimeError, match="returned no issue URL"):
+            mod.create_issue(repo="org/repo", title="t", body="b", labels=[])
+
+    def test_issue_listing_requests_full_supported_limit(self, monkeypatch) -> None:
+        calls: list[list[str]] = []
+
+        def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, stdout="[]", stderr="")
+
+        monkeypatch.setattr(mod, "_run_gh", _run)
+        assert mod.list_open_drift_issues(repo="org/repo") == []
+        assert calls[0][calls[0].index("--limit") + 1] == "1000"
 
 
 class TestCli:


### PR DESCRIPTION
## Summary

Resolves #9490 (Stage-Gate Conductor log/drift fragmentation). The Conductor filed ~19 near-identical `stage-gate-drift` issues for the single B0 corpus-exhaustion finding instead of maintaining one anchor. This PR adds the repo-side dedup filing path; the issue-side consolidation has already been executed (anchor #9438, 18 duplicates closed).

## What this adds

`scripts/stage_gate_drift.py` — dedup-aware filing helper for the Stage-Gate Conductor:

- **Stable fingerprint in the body, not fuzzy title match.** Every drift issue body carries a machine-readable marker line: `` `Drift-Fingerprint: <kebab-slug>` `` (e.g. `b0-corpus-exhausted`). Fingerprints are normalized via `slugify_fingerprint`.
- **Search-then-comment.** `file` subcommand lists open `stage-gate-drift` issues, and if any body carries a matching fingerprint, appends the new observation as a comment on the lowest-numbered (oldest) anchor instead of creating a new issue. Only a genuinely new finding class creates an issue (with the fingerprint embedded).
- **Rolling monthly log anchor.** `log` subcommand appends run summaries to a single `[automation] Stage-Gate Conductor Log (YYYY-MM)` issue per month (creating it only when the month rolls over), replacing the one-issue-per-run pattern (31 open log issues at last count).
- **Dry-run by default.** Both subcommands report `would_comment` / `would_create` unless `--apply` is passed.

## Tests

`tests/scripts/test_stage_gate_drift.py` — 19 tests, mocked `gh` boundary (repo convention: monkeypatch module-level `list_open_drift_issues` / `comment_on_issue` / `create_issue`): slug normalization, marker extraction, oldest-anchor selection, comment-vs-create, marker non-duplication, dry-run non-mutation, month validation, CLI JSON output.

Live read-only verification: `file --fingerprint "B0 corpus exhausted"` correctly resolves `would_comment → #9438` against the real repo.

## Reviewed design tradeoffs

- **Body marker vs. title matching:** titles of the 19 duplicates varied wildly ("exhausted", "hollow", "saturated", "memoization"); a body marker is the only stable identifier, and it survives title edits.
- **Lowest-numbered anchor:** oldest surviving issue wins, matching the consolidation convention already applied to #9438; deterministic when a race files two anchors.
- **Module-level gh wrappers instead of injected runner:** matches the existing pattern in `scripts/reconcile_proof_first_queue.py` and keeps tests monkeypatch-simple.
- **Monthly (not per-run, not eternal) log anchor:** bounds comment-thread length while keeping one durable surface per month for retrospective audits.

## Follow-up (operator action, out of repo scope)

The Conductor is an external scheduled routine (files via MCP); its prompt must be updated to call `python scripts/stage_gate_drift.py file/log ... --apply` (or replicate the search-then-comment contract) instead of raw issue creation. Noted on #9490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
