### PR TITLE
fix(boss-loop): don't count clean auto-continue skips as consecutive failures

### DIFF
--- a/aragora/swarm/boss_worker_lifecycle.py
+++ b/aragora/swarm/boss_worker_lifecycle.py
@@ -386,12 +386,18 @@ def finalize_worker_result(
                 )
 
         if loop.config.auto_continue_on_needs_human:
-            loop._consecutive_failures += 1
+            # Only deliverable-less rescue outcomes count toward the failure
+            # streak; a skip over a produced-but-untyped deliverable is clean.
+            if not raw_deliverable:
+                loop._consecutive_failures += 1
             threshold_reason = (
                 "Repeated rescue outcomes without a typed deliverable reached "
                 f"threshold ({loop.config.max_consecutive_failures})."
             )
-            if loop._consecutive_failures >= loop.config.max_consecutive_failures:
+            if (
+                not raw_deliverable
+                and loop._consecutive_failures >= loop.config.max_consecutive_failures
+            ):
                 logger.warning(
                     "boss_loop_stop issue=#%s "
                     "(needs_human, no typed deliverable, consecutive failure threshold reached)",


### PR DESCRIPTION
## Summary

Fixes #9499 — a `priority:high` regression from #6778.

A `needs_human` result carrying a truthy-but-untyped ("junk") deliverable under `auto_continue_on_needs_human=True` is skipped (`boss_loop_skip` at `aragora/swarm/boss_worker_lifecycle.py:438`), but the skip path still incremented `_consecutive_failures`. With a short feed the loop stopped with `stop_reason='consecutive_failures'` instead of exhausting the feed and resolving to `NO_SUITABLE_ISSUE`, confusing operator tooling that inspects stop reasons.

## Fix

Guard the counter increment and the threshold stop on `not raw_deliverable`: only deliverable-less rescue outcomes count toward the consecutive-failure streak. A clean auto-continue skip over a produced deliverable (untyped dict or junk value) is not a failure.

The #6778 acceptance-gate accounting is preserved:
- `acceptance_gate_failed` / `merge_gate_failed` typed deliverables still stop with `NEEDS_HUMAN` (rejected-deliverable path is upstream of this change).
- Deliverable-less `needs_human` outcomes still increment the counter and still stop with `CONSECUTIVE_FAILURES` at threshold (`test_auto_continue_needs_human_no_typed_deliverable_stops_at_threshold`, `TestFinalizeWorkerResultAutoContinueThreshold`).
- `failed` status accounting untouched.

## Reviewed design tradeoffs

- **Neutral, not reset.** A clean skip neither increments nor resets the streak. Resetting on a junk deliverable was considered and rejected: a junk deliverable (a dict or string that fails `qualify_worker_result_terminal_state` typing) is noise, not evidence of productivity. If it reset the counter, a worker alternating junk-deliverable and deliverable-less outcomes would never trip the threshold — an evasion channel that weakens exactly the acceptance-gate accounting #6778 tightened. Resets remain reserved for genuine successes: the typed-deliverable path (`boss_worker_lifecycle.py:216`) and the recovered-deliverable auto-continue path (`:259`).
- **Neutral intermediate outcomes are existing precedent in this function.** The repair path (`:302-335`) and the ping-pong retry path (`:337-386`) both return without touching `_consecutive_failures`. The streak has therefore never been strictly "adjacent iterations"; it is "deliverable-less failures since the last genuine success," and this change keeps that semantic consistent.
- The threshold stop is also gated on `not raw_deliverable` so a skip can never be the iteration that trips the stop; the next genuine deliverable-less failure still trips it at the same threshold.
- The `threshold_reason` wording ("without a typed deliverable") predates this fix; tightening it to "without a deliverable" is a cosmetic follow-up deliberately kept out of this regression fix, as tests assert on the threshold phrasing.

## Validation

- Target test: `python -m pytest "tests/swarm/test_boss_loop.py::TestBossLoop::test_needs_human_truthy_junk_deliverable_does_not_auto_continue" -x -q` — fails on `origin/main` (1a4ebc390f) with `'consecutive_failures' != 'no_suitable_issue'`; **passes** with this change.
- #6778 validation suites: `tests/swarm/test_terminal_truth_benchmark.py` + `tests/swarm/test_worker_outcome_classification.py` — **56 passed**.
- Pristine-worktree A/B on `tests/swarm/test_boss_loop.py` + `tests/swarm/test_boss_worker_lifecycle.py`: main = 19 failed + 1 error; this branch = 18 failed + 1 error. The **only failure removed is the target test**; the remaining failures are identical pre-existing main redness (hidden-red shard), plus one order-dependent `test_dispatch_auto_publish_*` flake that passes in isolation on this branch. All `test_boss_worker_lifecycle.py` tests pass on both.
- Remaining `tests/swarm` suite (excluding above files): 33 failed on this branch vs 32 identical failures on pristine main; the one extra (`test_lane_telemetry` supervisor event) passes in isolation — order-dependent flake.
- `make ci-required` equivalents: ruff clean; CI's changed-file mypy gate clean on the touched file (`mypy --ignore-missing-imports --follow-imports=skip aragora/swarm/boss_worker_lifecycle.py` → no issues; full-repo mypy debt is pre-existing and identical on main); version alignment, SDK parity ×3, OpenAPI generation + SDK contract verification all PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
