### PR TITLE
fix(security): raise live PostCSS floor

### DIFF
--- a/aragora/live/package-lock.json
+++ b/aragora/live/package-lock.json
@@ -58,7 +58,7 @@
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "openapi-typescript": "^7.13.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.22",
         "tailwindcss": "4.3.2",
         "ts-jest": "^29.4.11",
         "typescript": "^5",
@@ -11051,9 +11051,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11864,9 +11864,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11883,7 +11883,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/aragora/live/package.json
+++ b/aragora/live/package.json
@@ -89,7 +89,7 @@
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "openapi-typescript": "^7.13.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.22",
     "tailwindcss": "4.3.2",
     "ts-jest": "^29.4.11",
     "typescript": "^5",
@@ -97,7 +97,7 @@
   },
   "overrides": {
     "sharp": "^0.35.3",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.22",
     "uuid": "^14.0.0",
     "brace-expansion": "^2.0.3"
   }


### PR DESCRIPTION
## Summary
- raise the `aragora/live` direct PostCSS development floor and override from `^8.5.10` to `^8.5.22`
- regenerate the lockfile so production resolves PostCSS 8.5.22 and nanoid 3.3.16
- remediate GHSA-6g55-p6wh-862q in the live frontend audited by Security Gate

## Validation
- `npm ci --ignore-scripts`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `npm run lint`
- `npm run build` (228 routes)
- `npm test -- --runInBand` (257 suites, 4025 tests passed)
- `python3 scripts/report_code_quality.py --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check origin/main...HEAD`

This is intentionally separate from #9505 and #9545. It fixes the deterministic live-frontend security failure before either PR is restacked.
