### PR TITLE
fix(security): raise docs-site PostCSS floor past GHSA-6g55-p6wh-862q

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -13918,9 +13918,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -14800,9 +14800,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14819,7 +14819,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -43,7 +43,7 @@
     "uuid": "^14.0.0",
     "lodash": "^4.18.0",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.22",
     "yaml": "^1.10.3",
     "brace-expansion": "^2.0.3",
     "openapi-to-postmanv2": {


### PR DESCRIPTION
## Summary
- Bump the `postcss` override in `docs-site/package.json` from `^8.5.10` to `^8.5.22`, refreshing the lockfile (postcss 8.5.10 → 8.5.22, plus its `nanoid` dependency 3.3.11 → 3.3.16).
- This clears the last lockfile in the repo still resolving postcss `<=8.5.11` (GHSA-6g55-p6wh-862q, high severity — arbitrary file read via `sourceMappingURL`).
- Mirrors #9560 (aragora/live, merged earlier today) and #9548 (examples/sveltekit).

## Context
The blocking `security-gate` npm audit only scans `aragora/live` and `sdk/typescript`; both pass since #9560 merged, and every security-gate run after that merge is green. docs-site was the remaining vulnerable copy repo-wide — fixed here as hygiene so repo-wide scanners and future audit expansion stay clean.

## Verification
- `npm audit --audit-level=high` in `docs-site`: 0 postcss findings (pre-existing unrelated js-yaml advisory tracked separately).
- Lockfile diff limited to postcss + nanoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)