### PR TITLE
chore(deps): consolidate fastapi + uvicorn bumps (supersedes #8923, #8924)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,8 @@ test = [
     "twine>=6.2.0,<7.0",
 ]
 gateway = [
-    "fastapi>=0.138.0,<1.0",
-    "uvicorn>=0.49.0,<1.0",
+    "fastapi>=0.139.0,<1.0",
+    "uvicorn>=0.50.0,<1.0",
 ]
 blockchain = [
     "aiohttp>=3.14.1,<4.0",
@@ -132,8 +132,8 @@ dev = [
     "hatchling>=1.30.1,<2.0",
 ]
 all = [
-    "fastapi>=0.138.0,<1.0",
-    "uvicorn>=0.49.0,<1.0",
+    "fastapi>=0.139.0,<1.0",
+    "uvicorn>=0.50.0,<1.0",
     "aiohttp>=3.14.1,<4.0",
     "web3>=7.16.0,<8.0",
     "asyncpg>=0.31.0,<1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -357,8 +357,8 @@ requires-dist = [
     { name = "build", marker = "extra == 'test'", specifier = ">=1.5.0,<2.0" },
     { name = "click", specifier = ">=8.4.2,<9.0" },
     { name = "defusedxml", specifier = ">=0.7,<1.0" },
-    { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.138.0,<1.0" },
-    { name = "fastapi", marker = "extra == 'gateway'", specifier = ">=0.138.0,<1.0" },
+    { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.139.0,<1.0" },
+    { name = "fastapi", marker = "extra == 'gateway'", specifier = ">=0.139.0,<1.0" },
     { name = "hatchling", marker = "extra == 'dev'", specifier = ">=1.30.1,<2.0" },
     { name = "httpx", specifier = ">=0.27,<1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0,<3.0" },
@@ -383,8 +383,8 @@ requires-dist = [
     { name = "typer", specifier = ">=0.26.8,<1.0" },
     { name = "types-croniter", marker = "extra == 'dev'", specifier = ">=6.2.2.20260518,<7.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20260518,<7.0" },
-    { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.49.0,<1.0" },
-    { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.49.0,<1.0" },
+    { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.50.0,<1.0" },
+    { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.50.0,<1.0" },
     { name = "web3", marker = "extra == 'all'", specifier = ">=7.16.0,<8.0" },
     { name = "web3", marker = "extra == 'blockchain'", specifier = ">=7.16.0,<8.0" },
     { name = "websockets", specifier = ">=13.0,<16.2" },
@@ -1317,7 +1317,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.138.0"
+version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1326,9 +1326,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -3383,16 +3383,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.49.0"
+version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bundles two low-risk runtime dependency bumps that Dependabot raised individually.

**Why a consolidation PR:** Dependabot PRs on this repo receive **zero** required check runs (`gh pr view 8923/8924 --json statusCheckRollup` returns an empty array), so they sit permanently `BLOCKED` and can never satisfy the merge gate regardless of how much quorum evidence is collected. Re-landing the same bumps from a normal branch lets them run the full required suite. Precedent: #8692 absorbed 9 bumps.

Supersedes #8923 (fastapi), #8924 (uvicorn).

| package | floor | locked |
|---|---|---|
| fastapi | `>=0.138.0` → `>=0.139.0` | 0.139.0 |
| uvicorn | `>=0.49.0` → `>=0.50.0` | 0.51.0 |

## Notes for review

- **Lock diff is scoped.** Regenerated with `uv lock --upgrade-package fastapi==0.139.0 --upgrade-package uvicorn==0.51.0`; the diff touches only these two packages plus their `requires-dist` specifiers. The Dependabot lockfiles additionally carried unrelated marker churn (`exceptiongroup`, `importlib-metadata` — `typing-extensions`/`zipp` markers dropped) from a different uv version. That churn is deliberately **not** reproduced.
- **fastapi held at 0.139.0 on purpose.** The resolver prefers 0.140.0, but that was published `2026-07-24T21:16Z` — hours before this change. A day-zero release of the production web framework does not belong in a low-risk consolidation. 0.139.0 has 23 days of soak; uvicorn 0.51.0 has 16.
- **CVE floor preserved.** starlette stays at 1.3.1, so the `[tool.uv] constraint-dependencies` floor documented in `pyproject.toml` (CVE-2026-54283, CVE-2026-54282, CVE-2026-48818, CVE-2026-48817) still holds. fastapi stays on the 0.x line — no FastAPI 1.x migration implied, consistent with the existing rationale comment.

## Validation

Clean venv on the exact locked pins (`fastapi==0.139.0`, `uvicorn==0.51.0`, `starlette==1.3.1`), exercising the surfaces `pyproject.toml` records as aragora's direct starlette usage:

- `BaseHTTPMiddleware`, `Response`, `StreamingResponse` — import OK
- `uvicorn.Config`, `uvicorn.Server` — import OK
- `FastAPI()` route + `TestClient` round-trip → `GET /h -> {'ok': True}`

No publishing, settlement execution, evidence posting, rerun, merge, gate mutation, or `--admin` use.

Co-Authored-By: Claude <noreply@anthropic.com>