### PR TITLE
fix(settle): surface reviewer findings so a dissent is diagnosable in one run

### DIFF
--- a/aragora/cli/commands/review_queue_comment_verdicts.py
+++ b/aragora/cli/commands/review_queue_comment_verdicts.py
@@ -167,6 +167,12 @@ _DEFAULT_BLOCKING_MARKER_STRIP = re.compile(r"^(?:\*\*)?\[(?:p0|p1|p2)\](?:\*\*)
 _PRIORITY_MARKER = re.compile(r"^(?:\*\*)?\[(?P<sev>p0|p1)\](?:\*\*)?(?:\s|$|[:.;—–-])", re.I)
 _PRIORITY_MARKER_STRIP = re.compile(r"^(?:\*\*)?\[(?:p0|p1)\](?:\*\*)?\s*", re.I)
 
+# Any-severity variants, used ONLY by the diagnostic :func:`extract_finding_lines`.
+# Kept separate from the gate markers above so widening the diagnostic view can
+# never widen what counts as blocking.
+_ANY_PRIORITY_MARKER = re.compile(r"^(?:\*\*)?\[(?P<sev>p\d)\](?:\*\*)?(?:\s|$|[:.;—–-])", re.I)
+_ANY_PRIORITY_MARKER_STRIP = re.compile(r"^(?:\*\*)?\[p\d\](?:\*\*)?\s*", re.I)
+
 
 def _strip_decoration(text: str) -> str:
     return re.sub(r"^(?:[#>\-*+\s]+|\d+[.)]\s+)+", "", text.strip())
@@ -350,6 +356,45 @@ def highest_blocking_severity(body: str) -> str | None:
         if severity == "P1":
             best = "P1"
     return best
+
+
+def extract_finding_lines(body: str) -> list[str]:
+    """Return every real ``[Pn]`` finding line in ``body``, at any severity.
+
+    Purely **diagnostic**: this reports what a reviewer wrote so a dissent can be
+    read without re-running the reviewer. It gates nothing — blocking severity
+    stays :func:`highest_blocking_severity` / :func:`has_blocking_finding_or_label`,
+    which are deliberately ``[P0]``/``[P1]`` only.
+
+    Severity is deliberately *not* filtered here: a ``[P2]``-only dissent is the
+    common case a human needs to read (it blocks by default, and is advisory only
+    under ``ARAGORA_ENABLE_SEVERITY_GATED_DISSENT``), so hiding it would leave the
+    exact gap this exists to close.
+
+    Reuses :func:`_semantic_review_lines` and the same decoration/no-finding-head
+    handling as the gate, so a fenced or blockquoted ``[P2]`` example that the gate
+    ignores is never reported here as a live finding.
+    """
+    findings: list[str] = []
+    for stripped in _semantic_review_lines(body):
+        if not stripped:
+            continue
+        line = _strip_decoration(stripped)
+        marker = _ANY_PRIORITY_MARKER.match(line)
+        if not marker:
+            continue
+        rest = _ANY_PRIORITY_MARKER_STRIP.sub("", line)
+        head = _normalize_value(rest).split(":", 1)[0].strip(" .;—–-")
+        if head in _NO_FINDING_HEADS:
+            # "[P2] None" / "[P3] N/A" are explicit non-findings.
+            continue
+        # Re-emit as a normalised "[Pn] text" line. `_strip_decoration` removes the
+        # leading "- **" of a bolded bullet but leaves the closing "**" stranded on
+        # the marker, so echoing the raw line would print "[P2]** ...".
+        severity = marker.group("sev").upper()
+        detail = rest.lstrip(" :.;—–-").strip()
+        findings.append(f"[{severity}] {detail}" if detail else f"[{severity}]")
+    return findings
 
 
 def has_blocking_finding_or_label(body: str) -> bool:

--- a/aragora/swarm/settle_plan.py
+++ b/aragora/swarm/settle_plan.py
@@ -21,6 +21,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+from aragora.cli.commands.review_queue_comment_verdicts import extract_finding_lines
+
 # Tier 0-2 can settle unattended on a green model quorum (auto-merge path);
 # Tier 3-4 require a head-bound human risk settlement by a trusted operator.
 AUTO_MERGE_MAX_TIER = 2
@@ -210,13 +212,20 @@ def summarize_collect(payload: Mapping[str, Any]) -> dict[str, Any]:
             # A malformed (non-dict) item must not crash the flatten the way the
             # top-level error envelope is already guarded against -- skip it.
             continue
+        body = str(it.get("body") or "")
         items.append(
             {
                 "family": it.get("family"),
                 "verdict": it.get("verdict"),
                 "would_count": bool(it.get("would_count")),
                 "counted_reviewer_ids": list(it.get("counted_reviewer_ids") or []),
+                # ``problems`` are countability codes ("blocking_or_negative_verdict",
+                # "no_counted_model_family", ...). They say a reviewer dissented but
+                # never WHY, so a dissent used to cost a second full reviewer run to
+                # diagnose. ``findings`` carries the reviewer's actual [Pn] lines.
                 "problems": list(it.get("problems") or []),
+                "findings": extract_finding_lines(body),
+                "body": body,
             }
         )
     return {

--- a/scripts/settle_pr.py
+++ b/scripts/settle_pr.py
@@ -142,6 +142,17 @@ def _render_human(summary: dict[str, Any], plan: Any) -> None:
             f"  - {str(it['family']):8} verdict={str(it['verdict']):18} "
             f"would_count={it['would_count']} problems={it['problems']}"
         )
+        # ``problems`` are countability codes and never say WHY a reviewer
+        # dissented. Print the reviewer's own findings so a dissent is
+        # diagnosable here, instead of costing a second full reviewer run.
+        for finding in it.get("findings") or []:
+            print(f"      {finding}")
+        if not it.get("findings") and not it.get("would_count"):
+            print("      (no [Pn] finding lines parsed — see --show-review-bodies)")
+        if it.get("body"):
+            print("      --- full review body ---")
+            for line in str(it["body"]).splitlines():
+                print(f"      {line}")
     print(f"  ready_to_mutate:       {plan.ready_to_mutate}")
     for b in plan.blockers:
         print(f"    blocker: {b}")
@@ -171,6 +182,13 @@ def main(argv: list[str] | None = None) -> int:
         "(branch-protection preflight workaround)",
     )
     ap.add_argument("--json", action="store_true", help="emit a JSON summary instead of text")
+    ap.add_argument(
+        "--show-review-bodies",
+        action="store_true",
+        help="include each reviewer's full review text (parsed [Pn] findings are "
+        "always shown; this adds the complete body for the rare case the findings "
+        "do not explain the verdict)",
+    )
     args = ap.parse_args(argv)
 
     repo = _resolve_repo(args.repo)
@@ -243,6 +261,13 @@ def main(argv: list[str] | None = None) -> int:
                 "Tier 3-4: evidence prepared (collect refuses to auto-post it); "
                 "run the surfaced commands to settle -- never automated here."
             )
+
+    if not args.show_review_bodies:
+        # Findings stay (they are the diagnostic payload); the verbatim bodies are
+        # several KB per reviewer, so they are opt-in to keep the default JSON and
+        # any log that captures it readable.
+        for item in summary.get("items") or []:
+            item.pop("body", None)
 
     if args.json:
         print(

--- a/tests/swarm/test_settle_plan.py
+++ b/tests/swarm/test_settle_plan.py
@@ -311,3 +311,107 @@ def test_tier4_settle_commands_no_app_token_prefixes_merge_only():
     # only the irreversible merge-apply step carries the override
     assert not cmds[0].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")
     assert not cmds[1].startswith("ARAGORA_DISABLE_GITHUB_APP_TOKEN=1")
+
+
+# The gap these close: `problems` carries only countability codes
+# ("blocking_or_negative_verdict", "no_counted_model_family"), never the reason a
+# reviewer dissented. Diagnosing a dissent used to require a second full reviewer
+# run (~15 min). Verbatim bodies below are the real reviews from PR #9571.
+
+_OPENAI_9571_BODY = """## OpenAI independent model review
+Reviewer: openai (openai) — independent adversarial model review.
+Head: ad5b61c (ad5b61c6853c810fa1112084e8b4697369a233be).
+Model family: openai
+Verdict: CHANGES-REQUESTED
+- [P1] `aragora/swarm/auto_merge_green.py:_rollup_recency` - Recency sorts by \
+`completedAt` before `startedAt`, so a current in-progress rerun always ranks older \
+than a stale completed `SUCCESS`.
+- [P2] `aragora/swarm/auto_merge_green.py:_reduce_rollup_states` - Equal/unknown \
+recency only prefers states in `_FAILING_CHECK_STATES`.
+dogfood: yes
+"""
+
+_CLAUDE_9571_BODY = """## Claude independent model review
+Model family: claude
+Verdict: CHANGES-REQUESTED
+- **[P2]** `aragora/swarm/auto_merge_green.py` — the recency key sorts `completedAt` \
+first, so a rerun still executing ranks below any completed row.
+- **[P3]** `aragora/swarm/auto_merge_green.py` — `_reduce_rollup_states` tests state \
+without case normalization.
+"""
+
+
+def test_summarize_collect_surfaces_reviewer_findings():
+    """A dissent must be diagnosable from the summary alone."""
+    summary = summarize_collect(
+        {
+            "tier": 2,
+            "items": [
+                {"family": "openai", "verdict": "changes_requested", "body": _OPENAI_9571_BODY},
+                {"family": "claude", "verdict": "changes_requested", "body": _CLAUDE_9571_BODY},
+            ],
+        }
+    )
+    openai_findings = summary["items"][0]["findings"]
+    claude_findings = summary["items"][1]["findings"]
+
+    assert len(openai_findings) == 2
+    assert any("_rollup_recency" in f for f in openai_findings)
+    # Markdown-bolded markers (**[P2]**) must parse too — claude emits that form.
+    assert len(claude_findings) == 2
+    assert any("case normalization" in f for f in claude_findings)
+    # The full body stays available for the rare case findings do not explain it.
+    assert summary["items"][0]["body"] == _OPENAI_9571_BODY
+
+
+def test_summarize_collect_reports_all_severities_not_just_blocking():
+    """A [P2]/[P3]-only dissent is the common case a human needs to read.
+
+    ``highest_blocking_severity`` is deliberately P0/P1-only; the diagnostic view
+    must not inherit that filter or it reproduces the gap.
+    """
+    body = "Verdict: CHANGES-REQUESTED\n- [P3] nit: rename this helper\n"
+    summary = summarize_collect({"tier": 2, "items": [{"family": "claude", "body": body}]})
+    assert summary["items"][0]["findings"] == ["[P3] nit: rename this helper"]
+
+
+def test_summarize_collect_ignores_quoted_and_no_finding_lines():
+    """Fenced examples and explicit non-findings must not read as live findings.
+
+    Reviewers quote the gate syntax when reviewing parser changes; the gate's own
+    line splitter already ignores those, and the diagnostic view must agree with it.
+    """
+    body = (
+        "Verdict: PASS\n"
+        "- [P2] None\n"
+        "Example of what would block:\n"
+        "```\n"
+        "- [P1] a fenced example finding\n"
+        "```\n"
+    )
+    summary = summarize_collect({"tier": 2, "items": [{"family": "claude", "body": body}]})
+    assert summary["items"][0]["findings"] == []
+
+
+def test_summarize_collect_tolerates_missing_body():
+    """Older payloads (and error envelopes) carry no body — must not crash."""
+    summary = summarize_collect({"tier": 2, "items": [{"family": "claude", "verdict": "pass"}]})
+    assert summary["items"][0]["findings"] == []
+    assert summary["items"][0]["body"] == ""
+
+
+def test_findings_normalise_markdown_bold_markers():
+    """A bolded bullet must not leak a stray '**' into the rendered finding.
+
+    `_strip_decoration` removes the leading '- **' but leaves the closing '**'
+    attached to the marker, so echoing the raw line printed '[P2]** ...'.
+    """
+    body = "Verdict: CHANGES-REQUESTED\n- **[P2]** `mod.py` — missing case normalization\n"
+    summary = summarize_collect({"tier": 2, "items": [{"family": "claude", "body": body}]})
+    assert summary["items"][0]["findings"] == ["[P2] `mod.py` — missing case normalization"]
+
+
+def test_findings_severity_tag_is_uppercased():
+    body = "Verdict: CHANGES-REQUESTED\n- [p1] lowercase marker\n"
+    summary = summarize_collect({"tier": 2, "items": [{"family": "openai", "body": body}]})
+    assert summary["items"][0]["findings"] == ["[P1] lowercase marker"]


### PR DESCRIPTION
## The gap

When a reviewer dissented, `settle_pr` reported only *countability codes*:

```
problems=['blocking_or_negative_verdict', 'no_counted_model_family', 'no_counted_model_reviewer']
```

Those say a reviewer dissented but never **why**. The reviewer's actual text was
fetched and then discarded by `summarize_collect`, so diagnosing any dissent
required a second full `collect_quorum_evidence` run — ~15 minutes of real model
reviewers — purely to re-read something already retrieved.

Hit twice while settling #9571.

## Why it mattered more than the delay

With no visible reason, a dissent is indistinguishable from reviewer flake — and
these reviewers *are* non-deterministic (on #9571 openai returned opposite
verdicts on an identical commit 20 minutes apart). The cheap response is to
re-run until a PASS appears. On #9571 that "flake" was a genuine **P1 in
merge-authorization code**: a stale rollup row could read as green. It was
caught only by paying the 15 minutes to read the body.

A gate whose dissents are expensive to read is a gate people learn to re-roll.

## Change

- **`extract_finding_lines()`** — reports every real `[Pn]` line at any severity.
  Reuses the gate's own `_semantic_review_lines` / `_strip_decoration` /
  `_NO_FINDING_HEADS` handling, so a fenced or blockquoted `[P2]` example that
  the gate ignores is never reported as a live finding, and `[P2] None` stays a
  non-finding. Severity is deliberately unfiltered — `highest_blocking_severity`
  is `[P0]`/`[P1]`-only *by design*, and a `[P2]`-only dissent is exactly the
  common case a human needs to read.
- **`summarize_collect`** carries `findings` + the verbatim `body` per item.
- **`settle_pr`** prints findings inline under each reviewer.
  `--show-review-bodies` adds the full text (opt-in; bodies are several KB each,
  and the default JSON is often captured into logs).

## Safety

The gate module change is **45 insertions, 0 deletions** — purely additive. The
diagnostic markers (`_ANY_PRIORITY_MARKER`) are separate constants from the gate
markers (`_PRIORITY_MARKER`), so widening what is *reported* cannot widen what is
*blocking*. No existing gate logic is touched.

## Testing

347 settle/quorum tests and 103 gate-parser tests pass. New tests use the
**verbatim** claude and openai reviews from #9571, covering plain `[P1]` and
markdown `**[P2]**` forms, all-severity reporting, fenced/no-finding exclusion,
missing-body tolerance, and marker normalisation.

Before / after on that real payload:

```
- openai   verdict=changes_requested  problems=['blocking_or_negative_verdict', ...]
+ openai   verdict=changes_requested  problems=['blocking_or_negative_verdict', ...]
+     [P1] `auto_merge_green.py:_rollup_recency` - Recency sorts by `completedAt` before …
+     [P2] `auto_merge_green.py:_reduce_rollup_states` - Equal/unknown recency only prefers …
```

## Reviewed design tradeoffs

- **Findings inline vs. full bodies by default:** bodies run several KB per
  reviewer and `--json` output gets captured into logs, so verbatim text is
  opt-in while the actionable `[Pn]` lines are always shown.
- **Reusing the gate's line splitter vs. a fresh regex:** a separate parser would
  drift and could report findings the gate ignores (fenced examples), which is
  worse than no diagnostic. Reuse guarantees the view matches the gate's own
  reading.
- **Reporting all severities vs. mirroring the blocking filter:** mirroring would
  hide `[P2]`/`[P3]`-only dissents — the exact case that sends an operator back
  for a second run, so it would reproduce the gap this closes.

Found while settling #9571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
