### PR TITLE
fix(deps): clear postcss + brace-expansion advisories in sdk/typescript

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1931,20 +1931,26 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/bundle-require": {
@@ -3048,9 +3054,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3214,9 +3220,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3234,7 +3240,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -75,6 +75,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "overrides": {
-    "brace-expansion": "^2.0.3"
+    "brace-expansion": "^5.0.8",
+    "postcss": "^8.5.22"
   }
 }


### PR DESCRIPTION
## Summary

Clears **both** high-severity advisories in the TypeScript SDK and repairs a `minimatch`
install that is **broken at runtime on `main`**.

Full `npm audit` goes **4 vulnerabilities (1 low, 3 high) → 1 low**.

| Package | Advisory | Sev | Fix |
|---|---|---|---|
| `postcss` | [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — path traversal in previous-source-map auto-loading | **high** | override `^8.5.22` (8.5.15 → 8.5.23) |
| `brace-expansion` | [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — exponential expansion DoS | **high** | override `^2.0.3` → `^5.0.8` |
| `brace-expansion` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — unbounded expansion OOM | **high** | same |
| `minimatch` | cascade | — | resolved by the above |

`postcss` is transitive via `tsup` (`postcss-load-config`) and `vitest` (`vite`); the bump stays
inside the 8.5.x patch line.

## The broken minimatch

The `brace-expansion: ^2.0.3` override pinned 2.1.2. This package's **only** minimatch is
10.2.4 (via `eslint@10.5.0`), and minimatch@10 calls `(0, brace_expansion_1.expand)(p, opts)` —
a named export that does not exist on brace-expansion 2.x, whose entry is a bare callable.
On `main`, today:

```
$ node -e "const m=require('minimatch'); (m.minimatch||m)('abd','a{b,c}d')"
BROKEN: (0 , brace_expansion_1.expand) is not a function
```

Raising the floor to 5.0.8 restores it (verified after a clean `npm ci`).

## Reviewed design tradeoffs

- **Why v5 here but "drop the override" in #9589.** Same root bug, different cure, because the
  dependency shape differs. `aragora/live` carries four minimatch majors *plus* `test-exclude`
  (`glob ^7` / `minimatch ^3`), so no single brace-expansion version satisfies all of them and the
  override had to be removed entirely. This package has **exactly one** minimatch, **no glob** and
  **no test-exclude** — verified with `npm ls` — so pinning v5 is both safe and sufficient.
- **This also clears the #9598 residual, for this package only.** `GHSA-mh99-v99m-4gvg` is
  unfixable in `aragora/live` (tracked in #9598) because old-shape consumers can't take v5. That
  constraint does not exist here, so the SDK gets the complete fix. #9598 stays open for
  `aragora/live`.
- **Rejected: bumping `tsup`/`vitest` instead of overriding postcss.** Both are already at their
  latest published versions; the postcss pin is transitive, so no bump exists. An override is the
  only lever.
- **Rejected: chasing the `esbuild` low.** Fixing it needs >0.28.0, pinned by both `tsup` and
  `vite` — the same upstream-block shape as #9598. Low severity, dev-only, not worth forcing a
  major into the bundler.
- **Verified rather than assumed on engines.** brace-expansion@5.0.8 declares
  `engines: "20 || >=22"`; every SDK-touching workflow runs Node 20 or 22.

## Verification

```
npm ci --ignore-scripts && npm audit --omit=dev --audit-level=high  -> found 0 vulnerabilities, exit 0
npm run lint          -> 0 errors (83 pre-existing warnings; script has no --max-warnings)
npm run typecheck     -> clean
npm test              -> 1720/1721 pass
npm run test:coverage -> same
npm run build         -> CJS + ESM + DTS all succeed
minimatch re-verified after clean npm ci
```

**Pre-existing failure, disclosed:** `parity-compat-routes.test.ts > "maps debate stats
compatibility routes"` fails. It fails **identically on `origin/main`** with main's exact
`package.json` and lockfile (checked out and re-installed to confirm). Not introduced by this PR
and not fixed by it.

Coverage mode was run deliberately: in #9589's follow-up investigation, an override set that
passed `npm audit`, lint and plain `npm test` still broke 253 suites under `--coverage`. A clean
audit is not sufficient evidence for a dependency change.

## Scope

Touches only `sdk/typescript/package.json` and `sdk/typescript/package-lock.json`.
Lock changes: `postcss` 8.5.15→8.5.23, `brace-expansion` 2.1.2→5.0.8, `balanced-match` 1.0.2→4.0.4,
`nanoid` 3.3.12→3.3.16.

Related: #9589 (aragora/live, merged), #9598 (residual tracker), #9560 (live PostCSS floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
