### PR TITLE
docs(compliance): update W3 bundle crux-cards status ahead of publication

### DIFF
--- a/docs/compliance/bundles/2026-07-eu-ai-act/README.md
+++ b/docs/compliance/bundles/2026-07-eu-ai-act/README.md
@@ -196,9 +196,12 @@ a *published* crux block additionally needs the two conditions below.
 **Two conditions still stand between that and a crux-bearing receipt, and both
 are stated here rather than discovered at audit:**
 
-1. **A crux receipt needs a 3+ agent debate.** `CruxDetector` registers a
-   disagreement only when **≥2 authors other than the claim's own** relate to
-   it, so two agents trading reciprocal critiques never reach one. #9643 also
+1. **A crux receipt needs a 3+ agent debate.**
+   `CruxDetector.compute_disagreement_scores()` registers a disagreement on a
+   claim only when **≥2 distinct authors appear among the claims related to
+   it**. Edge construction only ever links a critic to a *different* agent's
+   proposal, so in a two-agent debate every related claim comes from the single
+   other agent and the count never reaches two. #9643 also
    made `build_crux_cards` return nothing when no disagreement was detected —
    `crux_score` is a composite, so claims can clear the threshold on
    uncertainty and centrality alone, and publishing those as "crux cards" would
@@ -216,9 +219,10 @@ Also unchanged: the fix covers the network the debate builds itself (the
 default path). A KM-seeded `ctx.belief_network` — only present under
 `enable_km_belief_sync` — uses KM-derived claim ids that message-derived ids
 cannot match, so crux cards remain unproducible for those debates.
-[#9581](https://github.com/synaptent/aragora/issues/9581) was **closed** by the
-#9643 merge (default path); that remaining configuration is tracked separately
-as [#9649](https://github.com/synaptent/aragora/issues/9649).
+[#9581](https://github.com/synaptent/aragora/issues/9581) was **closed
+2026-07-27**; its default-path defect is what #9643 fixed. That remaining
+configuration is tracked separately as
+[#9649](https://github.com/synaptent/aragora/issues/9649).
 
 W3 plan line: "crux cards in ≥1 published receipt" — still the named gap. It is
 a **product defect**, not a credentials or infrastructure gap, and remains the

--- a/docs/compliance/bundles/2026-07-eu-ai-act/README.md
+++ b/docs/compliance/bundles/2026-07-eu-ai-act/README.md
@@ -4,12 +4,18 @@
 **Plan:** [`docs/plans/2026-07-09-thirty-day-external-proof-month.md`](../../../plans/2026-07-09-thirty-day-external-proof-month.md) (W3, Jul 23–30)
 **Scope:** GPAI / Art. 50 transparency posture ahead of the **Aug 2, 2026** EU AI Act GPAI deadline, plus the Article 14 human-oversight evidence pack (#8230 / ODR-6).
 **Assembled:** 2026-07-20
-**Status checked:** 2026-07-24 against current main. Issue #9391 remains open
-and production was re-probed directly on 2026-07-24 (`https://api.aragora.ai/health`
-returned no response), so Variant A stays blocked and Variant B remains the
-shipping default. The crux-cards gap was re-attributed on the same date after
-direct testing — see "Crux cards" below and
-[#9581](https://github.com/synaptent/aragora/issues/9581).
+**Status checked:** 2026-07-27 against current main for the crux-cards section;
+the signed-receipt and Art.14 material was last verified 2026-07-24. All
+timestamps in this bundle are UTC.
+
+Issue [#9391](https://github.com/synaptent/aragora/issues/9391) remains open and
+production was re-probed directly on 2026-07-24
+(`https://api.aragora.ai/health` returned no response), so Variant A stays
+blocked and Variant B remains the shipping default. The crux-cards gap was
+re-attributed on 2026-07-24 after direct testing and its status updated again on
+2026-07-27 — see "Crux cards" below,
+[#9581](https://github.com/synaptent/aragora/issues/9581) and
+[#9644](https://github.com/synaptent/aragora/issues/9644).
 
 This bundle packages what Aragora can already prove — signed, dissent-preserving
 decision receipts with third-party offline verification — into one auditable
@@ -30,7 +36,7 @@ with an honest pending status and the exact step that closes it.
 | 8 | Rekor transparency-log note | `rekor-note.md` | present (log entry itself: **pending** — submission is an external publish, held for operator) |
 | 9 | ODR-2 (#8225) closure comment draft | `odr2-closure-draft.md` | present (**pending-founder-review** — do not post until reviewed) |
 | 10 | Signed **production** receipt — **Variant A** | — | **pending-prod** (blocked on AWS reinstatement, [#9391](https://github.com/synaptent/aragora/issues/9391)) |
-| 11 | Crux-cards receipt (`cruxes` block populated) | — | **pending — blocked by product defect [#9581](https://github.com/synaptent/aragora/issues/9581)** (see "Crux cards" below) |
+| 11 | Crux-cards receipt (`cruxes` block populated) | — | **pending — edges fixed ([#9643](https://github.com/synaptent/aragora/pull/9643)); dissent attribution still open ([#9644](https://github.com/synaptent/aragora/issues/9644))** (see "Crux cards" below) |
 | 12 | Founder earned-claim review of the bundle | — | **pending-founder-review** (W3 exit criterion) |
 
 ## Remaining exit gates
@@ -39,7 +45,7 @@ with an honest pending status and the exact step that closes it.
 |---|---|---|
 | Production-signed receipt | infrastructure/operator | Restore production access under #9391, then run the documented Variant A export and independent verification. |
 | Rekor entry | external publish/operator | Review `rekor-note.md`, publish the digest once, and record the returned UUID. |
-| Crux-cards receipt | **product defect** | Fix [#9581](https://github.com/synaptent/aragora/issues/9581) (belief network built without factor edges), then run one debate with `aragora ask --crux-cards`, verify the populated `cruxes` block, and add the receipt. Not blocked on credentials or on AWS. |
+| Crux-cards receipt | **product defect** | Edge construction fixed in [#9643](https://github.com/synaptent/aragora/pull/9643). Still needs [#9644](https://github.com/synaptent/aragora/issues/9644) (dissent attribution) **and** a 3+ agent debate — two agents cannot register a disagreement. Verify the `cruxes` block including non-empty `contesting_agents` before adding. Not blocked on credentials or on AWS. |
 | Earned-claim and ODR-2 text | founder review | Review this bundle and `odr2-closure-draft.md`; publication and issue closure remain separate operator actions. |
 
 The repository can prepare and validate these artifacts, but none of the four
@@ -155,7 +161,8 @@ generating a crux-bearing receipt therefore "requires a real (API-key) debate
 run". Both halves are now false:
 
 - A CLI flag does exist: `aragora ask --crux-cards`, shipped in #9506 (merged
-  2026-07-22, after this bundle was assembled).
+  2026-07-23T02:43Z, after this bundle was assembled). All timestamps in this
+  bundle are UTC, matching what GitHub records.
 - Credentials are **not** the blocker. Crux cards cannot currently be produced
   by *any* standard debate — see [#9581](https://github.com/synaptent/aragora/issues/9581).
   Both paths that build the `BeliefNetwork` for crux detection
@@ -168,16 +175,46 @@ run". Both halves are now false:
 Evidence for the re-attribution: two real provider-backed debates were run on
 2026-07-24 (`aragora ask --agents claude,codex --crux-cards`, 2 and 3 rounds,
 deliberately contested prompts). Both produced receipts with
-`schema_version: 1.1` and no `cruxes` block. An isolated test confirmed the
-detector itself is sound — the same claims yield 3 cruxes once factor edges are
-added by hand.
+`schema_version: 1.1` and no `cruxes` block.
 
-W3 plan line: "crux cards in ≥1 published receipt" — this remains the named
-gap, now with an accurate cause and a tracking issue. It is a **product
-defect**, not a credentials or infrastructure gap, and it is the one remaining
-W3 gap that is neither operator-held nor blocked on AWS. When #9581 is fixed
-and a crux-bearing receipt exists, add it under `receipts/` and update this
-table.
+### Status 2026-07-27 — edge construction fixed; attribution still open
+
+[#9643](https://github.com/synaptent/aragora/pull/9643) (merged
+2026-07-27T17:10Z) fixed the missing edges: each `Critique` already records
+which agent contested whose proposal and how hard (`severity`), so those now
+become the `CONTRADICTS` edges the detector needs. Verified 0 crux cards before
+and 4 after on the same contested debate.
+
+**Two conditions still stand between that and a crux-bearing receipt, and both
+are stated here rather than discovered at audit:**
+
+1. **A crux receipt needs a 3+ agent debate.** `CruxDetector` registers a
+   disagreement only when **≥2 authors other than the claim's own** relate to
+   it, so two agents trading reciprocal critiques never reach one. #9643 also
+   made `build_crux_cards` return nothing when no disagreement was detected —
+   `crux_score` is a composite, so claims can clear the threshold on
+   uncertainty and centrality alone, and publishing those as "crux cards" would
+   put load-bearing-disagreement claims into a receipt with nothing behind
+   them. Absent is honest; mislabelled is not.
+2. **Dissent attribution is still empty**, tracked as
+   [#9644](https://github.com/synaptent/aragora/issues/9644). `detect_cruxes()`
+   calls `network.propagate()` *before* `compute_disagreement_scores()`, so
+   belief propagation converges the authors' stances and flattens the variance
+   it then measures. **Fixing #9581 alone can therefore yield a populated but
+   misattributed `cruxes` block** — the earlier claim in this section that "the
+   detector itself is sound" was under-scoped, and is corrected here.
+
+Also unchanged: the fix covers the network the debate builds itself (the
+default path). A KM-seeded `ctx.belief_network` — only present under
+`enable_km_belief_sync` — uses KM-derived claim ids that message-derived ids
+cannot match, so #9581 remains open for those debates.
+
+W3 plan line: "crux cards in ≥1 published receipt" — still the named gap. It is
+a **product defect**, not a credentials or infrastructure gap, and remains the
+one W3 gap that is neither operator-held nor blocked on AWS. Closing it needs
+#9644 fixed *and* a 3+ agent debate run with `--crux-cards`; verify the
+populated `cruxes` block **including non-empty `contesting_agents`** before
+adding the receipt under `receipts/` and updating the contents table.
 
 ## Verification chain (what an auditor can check today)
 

--- a/docs/compliance/bundles/2026-07-eu-ai-act/README.md
+++ b/docs/compliance/bundles/2026-07-eu-ai-act/README.md
@@ -45,7 +45,7 @@ with an honest pending status and the exact step that closes it.
 |---|---|---|
 | Production-signed receipt | infrastructure/operator | Restore production access under #9391, then run the documented Variant A export and independent verification. |
 | Rekor entry | external publish/operator | Review `rekor-note.md`, publish the digest once, and record the returned UUID. |
-| Crux-cards receipt | **product defect** | Edge construction fixed in [#9643](https://github.com/synaptent/aragora/pull/9643). Still needs [#9644](https://github.com/synaptent/aragora/issues/9644) (dissent attribution) **and** a 3+ agent debate — two agents cannot register a disagreement. Verify the `cruxes` block including non-empty `contesting_agents` before adding. Not blocked on credentials or on AWS. |
+| Crux-cards receipt | **product defect** | Edge construction fixed in [#9643](https://github.com/synaptent/aragora/pull/9643) (default path; KM-belief-sync path tracked as [#9649](https://github.com/synaptent/aragora/issues/9649)). Still needs [#9644](https://github.com/synaptent/aragora/issues/9644) (dissent attribution) **and** a 3+ agent debate — two agents cannot register a disagreement. Verify the `cruxes` block including non-empty `contesting_agents` before adding. Not blocked on credentials or on AWS. |
 | Earned-claim and ODR-2 text | founder review | Review this bundle and `odr2-closure-draft.md`; publication and issue closure remain separate operator actions. |
 
 The repository can prepare and validate these artifacts, but none of the four
@@ -163,14 +163,16 @@ run". Both halves are now false:
 - A CLI flag does exist: `aragora ask --crux-cards`, shipped in #9506 (merged
   2026-07-23T02:43Z, after this bundle was assembled). All timestamps in this
   bundle are UTC, matching what GitHub records.
-- Credentials are **not** the blocker. Crux cards cannot currently be produced
-  by *any* standard debate — see [#9581](https://github.com/synaptent/aragora/issues/9581).
+- Credentials are **not** the blocker. *(Assessment as of 2026-07-24; see the
+  2026-07-27 status below, which supersedes the present tense here.)* Crux cards
+  could not then be produced by *any* standard debate — see
+  [#9581](https://github.com/synaptent/aragora/issues/9581).
   Both paths that build the `BeliefNetwork` for crux detection
   (`crux_cards._network_from_messages` and
   `winner_selector.analyze_belief_network`) add claims but never add the
   `SUPPORTS`/`CONTRADICTS` factor edges that
   `CruxDetector.compute_disagreement_scores()` requires, so
-  `total_disagreements` is always `0` and no crux clears any threshold.
+  `total_disagreements` was always `0` and no crux cleared any threshold.
 
 Evidence for the re-attribution: two real provider-backed debates were run on
 2026-07-24 (`aragora ask --agents claude,codex --crux-cards`, 2 and 3 rounds,
@@ -182,8 +184,14 @@ deliberately contested prompts). Both produced receipts with
 [#9643](https://github.com/synaptent/aragora/pull/9643) (merged
 2026-07-27T17:10Z) fixed the missing edges: each `Critique` already records
 which agent contested whose proposal and how hard (`severity`), so those now
-become the `CONTRADICTS` edges the detector needs. Verified 0 crux cards before
-and 4 after on the same contested debate.
+become the `CONTRADICTS` edges the detector needs.
+
+Measured on a contested **two-agent** debate, the detector went from **0
+candidate cruxes to 4**. That is a detector-level count, not a published card
+count: at current head that same debate still emits **no** `cruxes` block,
+because two agents cannot register a disagreement (condition 1 below) and
+#9643 suppresses cards when none is detected. The edge construction is fixed;
+a *published* crux block additionally needs the two conditions below.
 
 **Two conditions still stand between that and a crux-bearing receipt, and both
 are stated here rather than discovered at audit:**
@@ -200,14 +208,17 @@ are stated here rather than discovered at audit:**
    [#9644](https://github.com/synaptent/aragora/issues/9644). `detect_cruxes()`
    calls `network.propagate()` *before* `compute_disagreement_scores()`, so
    belief propagation converges the authors' stances and flattens the variance
-   it then measures. **Fixing #9581 alone can therefore yield a populated but
+   it then measures. **The edge fix alone can therefore yield a populated but
    misattributed `cruxes` block** — the earlier claim in this section that "the
    detector itself is sound" was under-scoped, and is corrected here.
 
 Also unchanged: the fix covers the network the debate builds itself (the
 default path). A KM-seeded `ctx.belief_network` — only present under
 `enable_km_belief_sync` — uses KM-derived claim ids that message-derived ids
-cannot match, so #9581 remains open for those debates.
+cannot match, so crux cards remain unproducible for those debates.
+[#9581](https://github.com/synaptent/aragora/issues/9581) was **closed** by the
+#9643 merge (default path); that remaining configuration is tracked separately
+as [#9649](https://github.com/synaptent/aragora/issues/9649).
 
 W3 plan line: "crux cards in ≥1 published receipt" — still the named gap. It is
 a **product defect**, not a credentials or infrastructure gap, and remains the


### PR DESCRIPTION
## Summary

Consolidates the review points raised on #9583 with the outcome of #9643, in one
edit rather than three, ahead of the **Jul 30** publish target.

## What changed and why

**Corrects an under-scoped claim.** This section previously said "the detector
itself is sound", implying that closing #9581 would close the gap. #9644 shows
otherwise: `detect_cruxes()` propagates beliefs *before* measuring disagreement,
so belief propagation flattens the variance it then looks for. Fixing #9581
alone can therefore yield a **populated but misattributed** `cruxes` block. An
auditor reading the old text would have drawn the wrong conclusion.

**Records the edge fix.** #9643 (merged `50e88385b6`) made crux cards
producible at all — each `Critique` already records who contested whose proposal
and how hard, so those become the `CONTRADICTS` edges the detector needs.
Verified 0 cards before, 4 after on the same contested debate.

**States the two remaining conditions**, rather than leaving them to surface at
audit:

1. A crux receipt needs a **3+ agent debate**. `CruxDetector` registers a
   disagreement only when ≥2 authors *other than the claim's own* relate to a
   claim, so two agents trading reciprocal critiques never reach one.
2. **#9644** must land for dissent attribution — `contesting_agents` is still
   empty.

**Notes the new suppression behaviour and its rationale.** #9643 makes
`build_crux_cards` emit nothing when no disagreement was detected. `crux_score`
is a composite, so claims can clear the threshold on uncertainty and centrality
alone; publishing those as "crux cards" would put load-bearing-disagreement
claims into a receipt with nothing behind them. Absent is honest; mislabelled is
not.

**UTC timestamps.** #9506's merge date was stated in local time
(`2026-07-22`); GitHub records `2026-07-23T02:43Z`. Restated, with a note that
all bundle timestamps are UTC — a local-time date in a document read by external
auditors invites a spurious discrepancy. Both this and the point above came from
claude's review of #9583.

**Housekeeping:** exit-gate row and contents table updated to match; the
status-check line now scopes *what* was verified on *which* date, since only the
crux-cards section was re-checked today.

## Scope

Bundle README only. No other artifact changes; the signed ODR bytes, digests and
signatures are untouched. Per the bundle's PR-hygiene rule, no generated
surfaces are included.

**The gap stays open.** This PR does not close it or weaken it — it keeps the
stated cause and the remaining steps true.

Follows #9583. Tracks #9581 / #9644. Part of the W3 bundle (#9427).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
