### PR TITLE
fix(frontend): stop published frontend images dialing localhost for WebSockets

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,14 +186,15 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
 
-      # Next.js inlines NEXT_PUBLIC_* at build time, so the published image needs
-      # them passed here. Without build-args the image inherits the Dockerfile's
-      # localhost ARG defaults; src/config.ts then derives api.<serving-host> at
-      # runtime, so the image still works, but it is built as a development
-      # bundle: NEXT_PUBLIC_API_URL contains "localhost", so _isProductionBuild is
-      # false, SSR renders dev defaults while the client renders production ones
-      # (hydration mismatch), and the "NEXT_PUBLIC_WS_URL not set" banner fires.
-      # Values match deploy-frontend.yml so both publishing lanes agree.
+      # Deliberately passes no NEXT_PUBLIC_* build-args. This is a general-purpose
+      # published image: self-hosters pull it (see deploy/helm values.yaml) and
+      # serve it from their own domain, and NEXT_PUBLIC_* is inlined at build
+      # time, so baking https://api.aragora.ai here would make every self-hosted
+      # deployment send browser API and WebSocket traffic to Aragora's backend.
+      # The image is host-agnostic instead: it inherits the Dockerfile's localhost
+      # defaults, which src/config.ts recognises as unusable and replaces with a
+      # derivation from the serving host. aragora.ai itself is built with explicit
+      # production values by deploy-frontend.yml's Vercel lane, not from this image.
       - name: Build and push frontend
         uses: docker/build-push-action@v5
         with:
@@ -205,9 +206,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
-          build-args: |
-            NEXT_PUBLIC_API_URL=https://api.aragora.ai
-            NEXT_PUBLIC_WS_URL=wss://api.aragora.ai
 
       - name: Build frontend for scanning
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -186,6 +186,14 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
 
+      # Next.js inlines NEXT_PUBLIC_* at build time, so the published image needs
+      # them passed here. Without build-args the image inherits the Dockerfile's
+      # localhost ARG defaults; src/config.ts then derives api.<serving-host> at
+      # runtime, so the image still works, but it is built as a development
+      # bundle: NEXT_PUBLIC_API_URL contains "localhost", so _isProductionBuild is
+      # false, SSR renders dev defaults while the client renders production ones
+      # (hydration mismatch), and the "NEXT_PUBLIC_WS_URL not set" banner fires.
+      # Values match deploy-frontend.yml so both publishing lanes agree.
       - name: Build and push frontend
         uses: docker/build-push-action@v5
         with:
@@ -197,6 +205,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            NEXT_PUBLIC_API_URL=https://api.aragora.ai
+            NEXT_PUBLIC_WS_URL=wss://api.aragora.ai
 
       - name: Build frontend for scanning
         run: |

--- a/aragora/live/src/__tests__/config.bakedLocalhost.test.ts
+++ b/aragora/live/src/__tests__/config.bakedLocalhost.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Images built from `deploy/Dockerfile.frontend` without NEXT_PUBLIC_* build-args
+ * inherit the Dockerfile's localhost ARG defaults, and Next.js inlines those into
+ * the client bundle at build time. Once such a bundle is served from a real
+ * hostname the baked values are unusable, so the resolvers in `config.ts` must
+ * fall back to deriving from the serving host.
+ *
+ * These cases pin the serving hostname via the jsdom environment URL — jsdom's
+ * `window.location` is non-configurable, so it cannot be stubbed per-test.
+ *
+ * @jest-environment-options {"url": "https://aragora.ai/"}
+ */
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+const originalControlPlaneUrl = process.env.NEXT_PUBLIC_CONTROL_PLANE_WS_URL;
+
+/** Reproduce a bundle built with the Dockerfile's localhost ARG defaults. */
+function bakeLocalhostDefaults(): void {
+  process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8080';
+  process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8765/ws';
+}
+
+describe('config resolution for a localhost-baked bundle served from a production host', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.NEXT_PUBLIC_WS_URL;
+    delete process.env.NEXT_PUBLIC_CONTROL_PLANE_WS_URL;
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    const restore: ReadonlyArray<readonly [string, string | undefined]> = [
+      ['NEXT_PUBLIC_API_URL', originalApiUrl],
+      ['NEXT_PUBLIC_WS_URL', originalWsUrl],
+      ['NEXT_PUBLIC_CONTROL_PLANE_WS_URL', originalControlPlaneUrl],
+    ];
+    for (const [key, value] of restore) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('derives the WebSocket URL from the serving host instead of the baked localhost value', async () => {
+    bakeLocalhostDefaults();
+
+    const config = await import('../config');
+
+    expect(config.WS_URL).toBe('wss://api.aragora.ai/ws');
+  });
+
+  it('already derives the API base URL from the serving host', async () => {
+    bakeLocalhostDefaults();
+
+    const config = await import('../config');
+
+    expect(config.API_BASE_URL).toBe('https://api.aragora.ai');
+  });
+
+  it('derives the control-plane WebSocket URL from the serving host too', async () => {
+    bakeLocalhostDefaults();
+    process.env.NEXT_PUBLIC_CONTROL_PLANE_WS_URL =
+      'ws://localhost:8766/api/control-plane/stream';
+
+    const config = await import('../config');
+
+    expect(config.CONTROL_PLANE_WS_URL).toBe(
+      'wss://api.aragora.ai/api/control-plane/stream',
+    );
+  });
+
+  it('carries the correction through URLs derived from WS_URL', async () => {
+    bakeLocalhostDefaults();
+
+    const config = await import('../config');
+
+    expect(config.ORACLE_WS_URL).toBe('wss://api.aragora.ai/ws/oracle');
+    expect(config.PROMPT_ENGINE_WS_URL).toBe('wss://api.aragora.ai/ws/prompt-engine');
+  });
+
+  it('honours an explicitly configured production WebSocket URL verbatim', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.aragora.ai';
+    process.env.NEXT_PUBLIC_WS_URL = 'wss://ws.aragora.ai/ws';
+
+    const config = await import('../config');
+
+    expect(config.WS_URL).toBe('wss://ws.aragora.ai/ws');
+  });
+});

--- a/aragora/live/src/__tests__/config.mixedBake.test.ts
+++ b/aragora/live/src/__tests__/config.mixedBake.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A bundle built with a production NEXT_PUBLIC_API_URL but a localhost
+ * NEXT_PUBLIC_WS_URL makes `_isProductionBuild` true regardless of serving host.
+ * The localhost-rescue in resolveWsUrl must not fire for such a bundle when the
+ * browser is itself on localhost — a localhost WebSocket endpoint is correct
+ * there, and rewriting it would produce `wss://api.localhost/ws`.
+ *
+ * jsdom's default environment URL (http://localhost/) is the serving host here.
+ */
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+
+describe('config resolution for a mixed-origin bake served from localhost', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    process.env.NEXT_PUBLIC_API_URL = 'https://api.aragora.ai';
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8765/ws';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    const restore: ReadonlyArray<readonly [string, string | undefined]> = [
+      ['NEXT_PUBLIC_API_URL', originalApiUrl],
+      ['NEXT_PUBLIC_WS_URL', originalWsUrl],
+    ];
+    for (const [key, value] of restore) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('honours the baked localhost WebSocket endpoint when the browser is on localhost', async () => {
+    const config = await import('../config');
+
+    expect(config.WS_URL).toBe('ws://localhost:8765/ws');
+  });
+
+  it('never derives an api.localhost endpoint', async () => {
+    const config = await import('../config');
+
+    expect(config.WS_URL).not.toContain('api.localhost');
+  });
+});

--- a/aragora/live/src/__tests__/config.selfHosted.test.ts
+++ b/aragora/live/src/__tests__/config.selfHosted.test.ts
@@ -1,0 +1,58 @@
+/**
+ * A self-hosted deployment serves the same image from its own domain. Resolution
+ * must derive from that domain, never from a vendor-pinned constant — otherwise a
+ * self-hoster's browser would send API and WebSocket traffic to Aragora's own
+ * production backend.
+ *
+ * This is also why `deploy/Dockerfile.frontend` must not default its
+ * NEXT_PUBLIC_* ARGs to production URLs: a baked `https://api.aragora.ai` is
+ * indistinguishable from a deliberate choice and would be honoured verbatim here.
+ *
+ * @jest-environment-options {"url": "https://aragora.acme.com/"}
+ */
+
+const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+const originalWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+
+describe('config resolution for a self-hosted deployment on its own domain', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    // The Dockerfile's localhost ARG defaults, as inlined by Next.js.
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8080';
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8765/ws';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    const restore: ReadonlyArray<readonly [string, string | undefined]> = [
+      ['NEXT_PUBLIC_API_URL', originalApiUrl],
+      ['NEXT_PUBLIC_WS_URL', originalWsUrl],
+    ];
+    for (const [key, value] of restore) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it('derives both endpoints from the self-hosted domain', async () => {
+    const config = await import('../config');
+
+    expect(config.API_BASE_URL).toBe('https://api.aragora.acme.com');
+    expect(config.WS_URL).toBe('wss://api.aragora.acme.com/ws');
+  });
+
+  it('does not route the self-hosted deployment to the vendor backend', async () => {
+    const config = await import('../config');
+
+    expect(config.API_BASE_URL).not.toContain('aragora.ai');
+    expect(config.WS_URL).not.toContain('aragora.ai');
+  });
+});

--- a/aragora/live/src/__tests__/config.test.ts
+++ b/aragora/live/src/__tests__/config.test.ts
@@ -123,3 +123,42 @@ describe('config apiFetch runtime backend selection', () => {
     );
   });
 });
+
+describe('config local dev is unaffected by the localhost-baked fallback', () => {
+  // jsdom serves these from http://localhost/, matching a developer running the
+  // container locally: the baked localhost values are correct there and must be
+  // honoured verbatim rather than rewritten to an api.<host> derivation.
+  const originalApiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const originalWsUrl = process.env.NEXT_PUBLIC_WS_URL;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8080';
+    process.env.NEXT_PUBLIC_WS_URL = 'ws://localhost:8765/ws';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (originalApiUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_API_URL;
+    } else {
+      process.env.NEXT_PUBLIC_API_URL = originalApiUrl;
+    }
+    if (originalWsUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_WS_URL;
+    } else {
+      process.env.NEXT_PUBLIC_WS_URL = originalWsUrl;
+    }
+  });
+
+  it('keeps the baked localhost endpoints when served from localhost', async () => {
+    const config = await import('../config');
+
+    expect(config.API_BASE_URL).toBe('http://localhost:8080');
+    expect(config.WS_URL).toBe('ws://localhost:8765/ws');
+  });
+});

--- a/aragora/live/src/config.ts
+++ b/aragora/live/src/config.ts
@@ -148,13 +148,22 @@ function resolveWsUrl(
   const isProd = inBrowser && isProductionEnvironment();
 
   // A localhost WebSocket URL baked in at build time cannot work once the bundle
-  // is served from a real hostname. This happens whenever a frontend image is
-  // built without NEXT_PUBLIC_WS_URL, since deploy/Dockerfile.frontend defaults
-  // the ARG to localhost and Next.js inlines it. Mirror resolveApiBaseUrl and
-  // prefer the serving host over an unusable baked value — unlike HTTP there is
-  // no same-origin rewrite to fall back on, so without this every WebSocket
-  // feature silently dials localhost.
-  if (envValue && !(isProd && isLocalWsEndpoint(envValue))) return envValue;
+  // is served from a real hostname. Images published from deploy/Dockerfile.frontend
+  // are host-agnostic by design, so they carry its localhost ARG defaults inlined.
+  // Mirror resolveApiBaseUrl and prefer the serving host over an unusable baked
+  // value — unlike HTTP there is no same-origin rewrite to fall back on, so
+  // without this every WebSocket feature silently dials localhost.
+  //
+  // Keyed on the serving hostname rather than isProductionEnvironment(): a
+  // localhost endpoint is correct whenever the browser itself is on localhost,
+  // even for a bundle whose NEXT_PUBLIC_API_URL made _isProductionBuild true.
+  const rescueBakedLocalhost =
+    inBrowser &&
+    !isLocalDevHostname(window.location.hostname) &&
+    !!envValue &&
+    isLocalWsEndpoint(envValue);
+
+  if (envValue && !rescueBakedLocalhost) return envValue;
 
   if (!inBrowser) {
     // SSR: use production default when build is production to match client render

--- a/aragora/live/src/config.ts
+++ b/aragora/live/src/config.ts
@@ -130,13 +130,33 @@ function resolveApiBaseUrl(): string {
   return 'http://localhost:8080';
 }
 
+function isLocalWsEndpoint(value: string): boolean {
+  try {
+    const { hostname } = new URL(value);
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
 function resolveWsUrl(
   envValue: string | undefined,
   prodDefault: (host: string) => string,
   devDefault: string,
 ): string {
-  if (envValue) return envValue;
-  if (typeof window === 'undefined') {
+  const inBrowser = typeof window !== 'undefined';
+  const isProd = inBrowser && isProductionEnvironment();
+
+  // A localhost WebSocket URL baked in at build time cannot work once the bundle
+  // is served from a real hostname. This happens whenever a frontend image is
+  // built without NEXT_PUBLIC_WS_URL, since deploy/Dockerfile.frontend defaults
+  // the ARG to localhost and Next.js inlines it. Mirror resolveApiBaseUrl and
+  // prefer the serving host over an unusable baked value — unlike HTTP there is
+  // no same-origin rewrite to fall back on, so without this every WebSocket
+  // feature silently dials localhost.
+  if (envValue && !(isProd && isLocalWsEndpoint(envValue))) return envValue;
+
+  if (!inBrowser) {
     // SSR: use production default when build is production to match client render
     if (_isProductionBuild) {
       try {
@@ -148,8 +168,7 @@ function resolveWsUrl(
     }
     return devDefault;
   }
-  const host = window.location.hostname;
-  return isProductionEnvironment() ? prodDefault(host) : devDefault;
+  return isProd ? prodDefault(window.location.hostname) : devDefault;
 }
 
 // In production, prefer api.<host> unless explicitly configured.

--- a/deploy/Dockerfile.frontend
+++ b/deploy/Dockerfile.frontend
@@ -6,7 +6,18 @@ FROM node:20.11-alpine AS builder
 
 WORKDIR /app
 
-# Build-time public env (injected into Next.js build)
+# Build-time public env (injected into Next.js build).
+#
+# These defaults must stay pointed at localhost. Publishing lanes pass real
+# values (see docker.yml and deploy-frontend.yml); everything else — the compose
+# files here, and anyone running `docker build` directly — is a local or
+# self-hosted deployment.
+#
+# Do NOT "fix" these to https://api.aragora.ai. src/config.ts honours a
+# non-local baked URL verbatim, so a production default would make every
+# self-hosted deployment send its API and WebSocket traffic to Aragora's own
+# backend. A localhost default is what lets config.ts detect the value as
+# unusable and derive api.<serving-host> instead.
 ARG NEXT_PUBLIC_API_URL=http://localhost:8080
 ARG NEXT_PUBLIC_WS_URL=ws://localhost:8765/ws
 

--- a/deploy/Dockerfile.frontend
+++ b/deploy/Dockerfile.frontend
@@ -8,16 +8,26 @@ WORKDIR /app
 
 # Build-time public env (injected into Next.js build).
 #
-# These defaults must stay pointed at localhost. Publishing lanes pass real
-# values (see docker.yml and deploy-frontend.yml); everything else — the compose
-# files here, and anyone running `docker build` directly — is a local or
-# self-hosted deployment.
+# These defaults must stay pointed at localhost, and the images published from
+# this Dockerfile are deliberately built WITHOUT overriding them.
 #
-# Do NOT "fix" these to https://api.aragora.ai. src/config.ts honours a
-# non-local baked URL verbatim, so a production default would make every
-# self-hosted deployment send its API and WebSocket traffic to Aragora's own
-# backend. A localhost default is what lets config.ts detect the value as
-# unusable and derive api.<serving-host> instead.
+# Next.js inlines NEXT_PUBLIC_* into the client bundle at build time, so a baked
+# value is a permanent property of the image. src/config.ts honours a non-local
+# baked URL verbatim but recognises a localhost one as unusable and derives
+# api.<serving-host> instead. That makes a localhost-defaulted image
+# host-agnostic: it works on aragora.ai, on a self-hoster's domain, and locally.
+#
+# Do NOT "fix" these to https://api.aragora.ai, and do not add production
+# build-args to the publishing workflows. This image is pulled by self-hosters
+# (deploy/helm/aragora/values.yaml), who serve it from their own domain and
+# cannot change an inlined value — their NEXT_PUBLIC_* runtime env does not
+# reach an already-built bundle. A vendor default would silently route their
+# browser API and WebSocket traffic to Aragora's own backend.
+#
+# aragora.ai itself does not run this image: deploy-frontend.yml's Vercel lane
+# builds it directly with explicit production values.
+#
+# The compose files here pass localhost explicitly for local development.
 ARG NEXT_PUBLIC_API_URL=http://localhost:8080
 ARG NEXT_PUBLIC_WS_URL=ws://localhost:8765/ws
 


### PR DESCRIPTION
## Problem

Images published from `deploy/Dockerfile.frontend` inherit its localhost ARG defaults, and Next.js inlines `NEXT_PUBLIC_*` into the client bundle at build time. A no-build-args image carries **514** occurrences of `localhost:8080` and **554** of `ws://localhost:8765`.

Pre-existing, not a regression. Surfaced as a P3 during quorum review of #9597, which makes `deploy/Dockerfile.frontend` the single frontend image definition.

## What's actually broken (narrower than reported, and asymmetric)

`src/config.ts` already derives per-host at runtime, but only on one side:

- `resolveApiBaseUrl` **overrides** a localhost-baked value when served from a real hostname → HTTP self-heals to `api.<host>`.
- `resolveWsUrl` short-circuited on `if (envValue) return envValue` → **no override**.

Executing both resolvers verbatim:

| Scenario | API resolves to | WS resolves to |
|---|---|---|
| published image @ `aragora.ai` | `https://api.aragora.ai` ✅ | `ws://localhost:8765/ws` ❌ |
| self-hosted @ `aragora.acme.com` | `https://api.aragora.acme.com` ✅ | `ws://localhost:8765/ws` ❌ |

So HTTP works; every WebSocket feature (~12 hooks — spectate, live debate, oracle, nomic, gauntlet, control-plane) silently dials localhost. Unlike HTTP there is no same-origin rewrite to fall back on.

## Fix

**`resolveWsUrl` made symmetric with `resolveApiBaseUrl`.** A localhost WS URL is ignored when the page is served from a non-local hostname, deriving `wss://api.<host>/ws` instead. The rescue is keyed on the *serving hostname*, so a bundle whose `NEXT_PUBLIC_API_URL` made `_isProductionBuild` true still keeps a localhost WS endpoint when the browser is itself on localhost.

This makes the published image **host-agnostic**: one build works on aragora.ai, on a self-hoster's domain, and locally. `deploy/Dockerfile.frontend` and `docker.yml` gain comments recording why no production build-args belong there.

## What this PR originally did, and why that was wrong

The first revision added production build-args to `docker.yml`. Quorum review raised two P2s, both correct:

1. **It vendor-pins the published image.** `deploy/helm/aragora/values.yaml` pulls a published frontend image, and a self-hoster's `NEXT_PUBLIC_*` *runtime* env cannot reach an already-inlined bundle — their browser traffic would have gone to Aragora's backend. The decisive fact I had missed: **aragora.ai does not run this image.** `deploy-frontend.yml`'s Vercel lane builds the site directly with explicit production values, so the ghcr image's audience *is* self-hosters.

2. **The value had no `/ws` path.** Copied from `deploy-frontend.yml`. `useDebateWebSocketStore` reads `NEXT_PUBLIC_WS_URL` directly and passes it unmodified to `new WebSocket()`, and the server only registers `/ws` (`servers_route_registration.py:344`), so it would connect to `/`.

Also corrected from the first revision: I claimed the missing-`NEXT_PUBLIC_WS_URL` error banner fires on a localhost-baked image. It does not — the var is set (to localhost), so `isProd && !_WS_URL` is false.

Equally rejected: **flipping the Dockerfile ARG defaults to production**, for the same reason as (1) — `config.ts` honours a non-local baked URL verbatim. The localhost default is precisely what enables per-host derivation.

## Verification

Built the image three ways and grepped the emitted `.next` bundle. Raw `grep localhost` is **not** a clean signal — the source has many hardcoded devDefault fallback literals (409 remain even with production args). Two checks that are:

- In the config chunk, a production-baked build contains `"wss://api.aragora.ai"` (bare), a string that exists nowhere in the source. Duplicate localhost literals collapse 3→1 and 2→1, leaving only the devDefaults.
- A **sentinel** build-arg lands in **105** chunks (API) and **99** (WS), exactly matching the 514→409 (−105) and 554→455 (−99) drops. That accounts for every inlined site.

Tests: 9 new cases across three host-pinned suites (jsdom's `window.location` is non-configurable, so the serving hostname is pinned per file via `@jest-environment-options`). 4 failed before the fix, all pass after. Frontend suite: **1097 passed** across config + hooks; full run 4019 passed with one unrelated suite failing on a missing `react-is` transitive dep from a local `npm install --legacy-peer-deps` — reproduced identically with this change stashed; CI uses `npm ci`. `tsc --noEmit` and eslint clean.

## Adjacent findings (filed separately, not fixed here)

- #9648 — `runtimeBackend.ts` hardcodes `https://api.aragora.ai` and ignores `NEXT_PUBLIC_*`; `apiFetch` (23 call sites) uses it in the browser, so self-hosted deployments already route those calls to Aragora's production API.
- #9651 — `deploy-frontend.yml` sets `NEXT_PUBLIC_WS_URL=wss://api.aragora.ai` with no `/ws`, which breaks `useDebateWebSocketStore` on the live Vercel deployment.

## Review note

⚠️ Touches `.github/workflows/docker.yml` — a protected surface per `docs/AGENT_OPERATING_CONTRACT.md`. The change there is now **comment-only** (no functional change); the operator approved a workflow edit before this PR was opened, and the functional part has since been reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
