### PR TITLE
fix(merge-gate): handle blocked_by_live_gate + settled instead of failing as unrecognized

### DIFF
--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -265,10 +265,10 @@ jobs:
                   "status. See docs/governance/MERGE_GATE_RECONCILIATION.md."
               )
 
-          # The PR is already merged and its settlement receipt is recorded. There is
-          # nothing left to authorize, so do not fail closed on it.
-          if status == "settled":
-              print(f"PR #{pr_number} is already merged with settlement recorded; nothing to gate.")
+          # The PR is already merged ('settled' additionally has a settlement receipt
+          # recorded). There is nothing left to authorize, so do not fail closed on it.
+          if status in ("settled", "already_merged"):
+              print(f"PR #{pr_number} is already merged (status={status}); nothing left to gate.")
               sys.exit(0)
 
           # The live gate withheld admin-squash authorization even though the model

--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -265,6 +265,29 @@ jobs:
                   "status. See docs/governance/MERGE_GATE_RECONCILIATION.md."
               )
 
+          # The PR is already merged and its settlement receipt is recorded. There is
+          # nothing left to authorize, so do not fail closed on it.
+          if status == "settled":
+              print(f"PR #{pr_number} is already merged with settlement recorded; nothing to gate.")
+              sys.exit(0)
+
+          # The live gate withheld admin-squash authorization even though the model
+          # quorum itself is satisfied — e.g. an 'operator-review-required' label, or
+          # a mergeStateStatus outside {CLEAN, BLOCKED}. Failing closed is correct: an
+          # operator hold must never be merged away. Only the reason needs surfacing,
+          # and the packet already carries it.
+          if status == "blocked_by_live_gate":
+              gate_blockers = entry.get("admin_squash_gate_blockers") or []
+              for blocker in gate_blockers:
+                  print(f"  - {blocker}")
+              detail = "; ".join(str(b) for b in gate_blockers) or "no blocker detail in packet"
+              fail(
+                  f"Tier {tier}: model quorum is satisfied, but the live gate withheld "
+                  f"admin-squash authorization ({detail}). Clear the blockers above — for "
+                  "an 'operator-review-required' label, that means an operator removing it "
+                  "— then re-run this check."
+              )
+
           fail(f"Unrecognized merge-quorum status '{status}' — failing closed.")
           PY
 

--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -228,6 +228,15 @@ jobs:
               # The statuses API returns most-recent first.
               return bool(states) and states[0] == "success"
 
+          # Already merged ('settled' additionally has a settlement receipt recorded).
+          # Checked FIRST: nothing about a merged PR is gateable, and the producer does
+          # not clear `unresolved_dissent` on settle — so any later placement is
+          # unreachable for a merged-and-settled PR that still carries that flag
+          # (#9650 openai [P2]).
+          if status in ("settled", "already_merged"):
+              print(f"PR #{pr_number} is already merged (status={status}); nothing left to gate.")
+              sys.exit(0)
+
           # Tier 0-2: model quorum alone authorizes the merge.
           if status == "satisfied":
               if verdict == "operator_advisory_settlement":
@@ -264,12 +273,6 @@ jobs:
                   "must record settlement and set the 'aragora/human-settlement' commit "
                   "status. See docs/governance/MERGE_GATE_RECONCILIATION.md."
               )
-
-          # The PR is already merged ('settled' additionally has a settlement receipt
-          # recorded). There is nothing left to authorize, so do not fail closed on it.
-          if status in ("settled", "already_merged"):
-              print(f"PR #{pr_number} is already merged (status={status}); nothing left to gate.")
-              sys.exit(0)
 
           # The live gate withheld admin-squash authorization even though the model
           # quorum itself is satisfied — e.g. an 'operator-review-required' label, or

--- a/tests/ci/test_merge_quorum_status_vocabulary.py
+++ b/tests/ci/test_merge_quorum_status_vocabulary.py
@@ -25,8 +25,16 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PRODUCER = REPO_ROOT / "aragora" / "cli" / "commands" / "review_queue.py"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "aragora-merge-quorum.yml"
 
-# `status = "..."` / `entry_status = "..."` assignments in the evaluator.
-_PRODUCED = re.compile(r'^\s*(?:entry_)?status = "([a-z0-9_]+)"', re.MULTILINE)
+# The evaluator defines a status two ways, and the guard must catch both:
+#   * assignment ...... `status = "..."` / `entry_status = "..."`
+#   * dict literal .... `"status": "..."`   (how `already_merged` is defined)
+# Missing the dict form is not hypothetical: the first version of this guard only
+# matched assignments, shipped green, and `already_merged` still reached the
+# catch-all in production. See #9640.
+_PRODUCED = re.compile(
+    r'^\s*(?:(?:entry_)?status = "([a-z0-9_]+)"|"status": "([a-z0-9_]+)")',
+    re.MULTILINE,
+)
 # `status == "..."` and `status in ("...", "...")` in the workflow's dispatch.
 _HANDLED_EQ = re.compile(r'status == "([a-z0-9_]+)"')
 _HANDLED_IN = re.compile(r"status in \(([^)]*)\)")
@@ -34,7 +42,9 @@ _LITERAL = re.compile(r'"([a-z0-9_]+)"')
 
 
 def produced_statuses() -> set[str]:
-    return set(_PRODUCED.findall(PRODUCER.read_text(encoding="utf-8")))
+    found = _PRODUCED.findall(PRODUCER.read_text(encoding="utf-8"))
+    # Each match yields one group per alternative; keep whichever matched.
+    return {value for groups in found for value in groups if value}
 
 
 def handled_statuses() -> set[str]:
@@ -67,9 +77,9 @@ def test_every_produced_status_is_handled_by_the_gate() -> None:
 
 
 def test_regression_9640_statuses_have_explicit_branches() -> None:
-    """Pin the two statuses that were missing, so a revert cannot silently undo the fix."""
+    """Pin the statuses that were missing, so a revert cannot silently undo the fix."""
     handled = handled_statuses()
-    for status in ("blocked_by_live_gate", "settled"):
+    for status in ("blocked_by_live_gate", "settled", "already_merged"):
         assert status in handled, (
             f"'{status}' lost its explicit branch in aragora-merge-quorum.yml; it would "
             "again hard-fail a required check via the catch-all. See #9640."

--- a/tests/ci/test_merge_quorum_status_vocabulary.py
+++ b/tests/ci/test_merge_quorum_status_vocabulary.py
@@ -86,6 +86,24 @@ def test_regression_9640_statuses_have_explicit_branches() -> None:
         )
 
 
+def test_merged_statuses_are_checked_before_the_dissent_guard() -> None:
+    """An already-merged PR must short-circuit before any fail-closed guard.
+
+    The dissent guard tests the ``unresolved_dissent`` *field*, not just the status, and
+    the producer does not clear that field when it settles a merged PR. So if the
+    settled/already_merged branch sits after it, a merged-and-settled PR carrying the
+    flag hard-fails a required check and the pass branch is unreachable (#9650 openai [P2]).
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    merged_at = text.index('if status in ("settled", "already_merged"):')
+    dissent_at = text.index('if status == "unresolved_dissent"')
+    assert merged_at < dissent_at, (
+        "the settled/already_merged branch must come BEFORE the unresolved_dissent "
+        "guard; otherwise it is unreachable for a merged PR that still carries "
+        "unresolved_dissent=True. See #9650."
+    )
+
+
 def test_blocked_by_live_gate_still_fails_closed() -> None:
     """The fix is diagnostic only — it must not turn an operator hold into a pass.
 

--- a/tests/ci/test_merge_quorum_status_vocabulary.py
+++ b/tests/ci/test_merge_quorum_status_vocabulary.py
@@ -1,0 +1,96 @@
+"""Guard the merge-quorum status vocabulary against producer/consumer drift.
+
+``aragora/cli/commands/review_queue.py`` decides a merge-quorum ``status`` string;
+``.github/workflows/aragora-merge-quorum.yml`` dispatches on it and ends with a
+catch-all::
+
+    fail(f"Unrecognized merge-quorum status '{status}' — failing closed.")
+
+Because ``aragora-merge-quorum`` is a *required* check, any status the evaluator
+emits that the workflow never learned becomes a hard failure with no actionable
+text — the operator sees a parser error instead of the real reason.
+
+Regression test for #9640, where exactly that happened: ``blocked_by_live_gate``
+(emitted when the live gate withholds admin squash, e.g. an ``operator-review-required``
+label) and ``settled`` (emitted for an already-merged PR) both fell through to the
+catch-all. Nothing coupled the two files, so the drift was invisible until a PR hit it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRODUCER = REPO_ROOT / "aragora" / "cli" / "commands" / "review_queue.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "aragora-merge-quorum.yml"
+
+# `status = "..."` / `entry_status = "..."` assignments in the evaluator.
+_PRODUCED = re.compile(r'^\s*(?:entry_)?status = "([a-z0-9_]+)"', re.MULTILINE)
+# `status == "..."` and `status in ("...", "...")` in the workflow's dispatch.
+_HANDLED_EQ = re.compile(r'status == "([a-z0-9_]+)"')
+_HANDLED_IN = re.compile(r"status in \(([^)]*)\)")
+_LITERAL = re.compile(r'"([a-z0-9_]+)"')
+
+
+def produced_statuses() -> set[str]:
+    return set(_PRODUCED.findall(PRODUCER.read_text(encoding="utf-8")))
+
+
+def handled_statuses() -> set[str]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    handled = set(_HANDLED_EQ.findall(text))
+    for group in _HANDLED_IN.findall(text):
+        handled.update(_LITERAL.findall(group))
+    return handled
+
+
+def test_producer_and_workflow_are_both_readable() -> None:
+    """A rename must fail loudly here rather than silently vacuous-pass the guard."""
+    assert PRODUCER.is_file(), f"missing evaluator: {PRODUCER}"
+    assert WORKFLOW.is_file(), f"missing gate workflow: {WORKFLOW}"
+    assert produced_statuses(), "extracted no statuses — the assignment pattern drifted"
+    assert handled_statuses(), "extracted no handled statuses — the dispatch pattern drifted"
+
+
+def test_every_produced_status_is_handled_by_the_gate() -> None:
+    produced = produced_statuses()
+    handled = handled_statuses()
+    unhandled = sorted(produced - handled)
+    assert not unhandled, (
+        "merge-quorum status(es) emitted by review_queue.py but not handled by "
+        f"aragora-merge-quorum.yml: {unhandled}. These fall through to the catch-all "
+        "'Unrecognized merge-quorum status' and hard-fail a REQUIRED check with no "
+        "actionable message. Add an explicit branch that either exits 0 or fails with "
+        "the real reason. See #9640."
+    )
+
+
+def test_regression_9640_statuses_have_explicit_branches() -> None:
+    """Pin the two statuses that were missing, so a revert cannot silently undo the fix."""
+    handled = handled_statuses()
+    for status in ("blocked_by_live_gate", "settled"):
+        assert status in handled, (
+            f"'{status}' lost its explicit branch in aragora-merge-quorum.yml; it would "
+            "again hard-fail a required check via the catch-all. See #9640."
+        )
+
+
+def test_blocked_by_live_gate_still_fails_closed() -> None:
+    """The fix is diagnostic only — it must not turn an operator hold into a pass.
+
+    ``blocked_by_live_gate`` is emitted when the model quorum IS satisfied but the live
+    gate withheld authorization (e.g. an ``operator-review-required`` label). Exiting 0
+    there would merge away a deliberate human hold.
+    """
+    text = WORKFLOW.read_text(encoding="utf-8")
+    start = text.index('if status == "blocked_by_live_gate":')
+    branch = text[start : start + 1200]
+    assert "fail(" in branch, (
+        "the blocked_by_live_gate branch must still fail closed — it guards an "
+        "operator hold; only the message should improve. See #9640."
+    )
+    assert "sys.exit(0)" not in branch.split("fail(")[0], (
+        "blocked_by_live_gate must not exit 0 before failing; that would drop an "
+        "'operator-review-required' hold. See #9640."
+    )


### PR DESCRIPTION
## Summary

The merge-quorum evaluator emits status strings the gate workflow never learned, so they fall
through to the catch-all:

```
##[error]Unrecognized merge-quorum status 'blocked_by_live_gate' — failing closed.
```

`aragora-merge-quorum` is a **required** check, so the operator sees a parser error instead of the
real reason — which the packet already knows. Two statuses were affected:

| Status | Emitted when | Now |
|---|---|---|
| `blocked_by_live_gate` (`review_queue.py:3057`) | quorum **is** satisfied but the live gate withheld admin squash — `operator-review-required` label, or mergeStateStatus outside `{CLEAN, BLOCKED}` | **still fails**, now naming the blockers |
| `settled` (`review_queue.py:3697`) | PR already merged, settlement receipt recorded | exits 0 — nothing left to gate |

Observed on **#9012**, which carries `operator-review-required`. `settled` was found while
enumerating the vocabulary for the drift test; not yet seen in the wild.

## `blocked_by_live_gate` still fails — deliberately

This is the whole point of the fix's shape. That status is emitted **only when the model quorum is
satisfied**, so the tempting repair — "the quorum is fine, let it pass" — would merge away a hold
an operator applied on purpose. Only the message changes; the branch renders
`admin_squash_gate_blockers`, which is already on the entry.

The test suite pins this: `test_blocked_by_live_gate_still_fails_closed` asserts the branch
contains `fail(` and does not `sys.exit(0)` before it, so a later "simplification" cannot quietly
convert an operator hold into a pass.

## Not a deadlock — correcting the record

An earlier draft of #9640 (mine) claimed a self-sustaining circular failure permanently blocking
Tier 0-2 PRs whose quorum was satisfied. **That was wrong**, and the "preferred fix" it proposed
would have weakened the gate. `review_queue_unstable.py:451` treats `BLOCKED` as an *allowed*
merge state:

```python
elif merge_state_status not in {"CLEAN", "BLOCKED"}:
```

A failing required check produces `BLOCKED`, which is permitted — so the gate's own red cannot feed
back as its own blocker. Exactly **one** ready PR is affected, and it is blocked because a human
held it. #9640 has been corrected.

## The drift guard

`tests/ci/test_merge_quorum_status_vocabulary.py` extracts the statuses the evaluator can assign
and the statuses the workflow dispatches on, then asserts the first set is a subset of the second.

Nothing coupled these two files before — that is why the drift was invisible until a PR happened to
hit it, and why enumerating the vocabulary immediately turned up a *second* unhandled status. Any
future status now fails a cheap unit test instead of a required check with unactionable text.

## Reviewed design tradeoffs

- **Rejected: keep `status = "satisfied"` and treat the live gate as advisory.** Removes an
  intentional `operator-review-required` hold. This was my original recommendation and it was wrong.
- **Rejected: exit 0 when the underlying quorum is satisfied.** Same defect, same reason.
- **Rejected: import a shared constant into the workflow.** The workflow's embedded Python is
  deliberately dependency-light (`os`, `sys`, `subprocess`, `json`); importing `aragora` there would
  couple the gate to package import health. A source-extracting test gets the same protection with
  no runtime coupling.
- **Accepted brittleness:** the guard regex-extracts from source, so a large refactor of either file
  could make it vacuously pass. Mitigated by `test_producer_and_workflow_are_both_readable`, which
  fails if either extraction returns an empty set.

## Verification

```
4/4 new tests pass
drift genuinely caught: removing the `settled` branch fails with
  "status(es) emitted by review_queue.py but not handled ... ['settled']"
  restoring it passes again
workflow YAML parses; embedded python block (123 lines) passes ast.parse
```

No production code changed — workflow + new test only.

Refs #9640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
