### PR TITLE
fix(ci): run pristine health with locked toolchain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,8 @@ repos:
   # This hook runs in an isolated `language: python` env, so pre-commit installs
   # mypy and the same type-stub packages as CI — the gate does not depend on the
   # developer's active environment having mypy (no "No module named mypy"
-  # surprises). The hook pins mypy to Aragora's current known-good local version
-  # so pre-commit env rebuilds are deterministic; CI remains authoritative.
+  # surprises). The hook pins mypy to the version recorded in uv.lock; focused
+  # contract coverage prevents the isolated hook and locked CI runtime drifting.
   #
   # Run the full baseline check manually when you want it:
   #   python scripts/ci/mypy_with_baseline.py        # report NEW errors only
@@ -105,7 +105,7 @@ repos:
           fi' --
         language: python
         additional_dependencies:
-          - mypy==1.19.1
+          - mypy==2.1.0
           - types-requests
           - types-redis
           - types-python-dateutil
@@ -118,7 +118,7 @@ repos:
         # list alone.
         pass_filenames: true
         always_run: true
-        files: ^(aragora/.*\.py|pyproject\.toml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|(.*/)?requirements[^/]*\.txt|\.github/actions/pr-scope-classifier/.*)$
+        files: ^(aragora/.*\.py|pyproject\.toml|uv\.lock|\.pre-commit-config\.yaml|\.github/workflows/lint\.yml|scripts/run_typecheck_gate\.py|scripts/test_tiers\.sh|(.*/)?requirements[^/]*\.txt|\.github/actions/pr-scope-classifier/.*)$
         # Run on pre-push to catch type errors before they hit CI.
         stages: [pre-push]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ experimental = [
 dev = [
     "mypy>=2.1.0,<3.0",
     "mypy-baseline>=0.7.4,<0.8",
+    "ruff==0.14.14",
     "types-PyYAML>=6.0.12.20260518,<7.0",
     "types-croniter>=6.2.2.20260518,<7.0",
     "bandit>=1.9.4,<2.0",

--- a/scripts/pristine_main_health.py
+++ b/scripts/pristine_main_health.py
@@ -21,7 +21,6 @@ import argparse
 import json
 import os
 import re
-import shutil
 import signal
 import subprocess
 import sys
@@ -40,6 +39,7 @@ EVIDENCE_TAIL_LINES = 15
 EVIDENCE_TAIL_CHARS = 4_000
 INFRA_ERROR_EXIT = 2
 SUITE_TERMINATION_GRACE_SECONDS = 30.0
+LOCKED_DEV_RUN = ("uv", "run", "--locked", "--extra", "dev", "--extra", "test")
 
 # Suite commands run INSIDE the pristine worktree. "required" mirrors the
 # steps of `make ci-required` — NOT the make target itself — with ONE swap for
@@ -139,6 +139,12 @@ def _now_iso() -> str:
 
 def _run(cmd: list[str], *, cwd: Path, timeout: int) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+
+
+def _locked_dev_command(cmd: list[str]) -> list[str]:
+    """Run suite tools from the checkout's locked development environment."""
+    normalized = ["python", *cmd[1:]] if cmd and cmd[0] == sys.executable else cmd
+    return [*LOCKED_DEV_RUN, *normalized]
 
 
 def _run_suite(
@@ -259,8 +265,8 @@ def _infra_failure_signature(proc: subprocess.CompletedProcess) -> str | None:
 
 
 def _check_test_runtime(repo: Path) -> str | None:
-    """Return bounded evidence when this interpreter cannot run pytest."""
-    cmd = [sys.executable, "-c", "import pytest"]
+    """Return bounded evidence when the locked development runtime cannot run pytest."""
+    cmd = _locked_dev_command(["python", "-c", "import pytest"])
     try:
         proc = _run(cmd, cwd=repo, timeout=60)
     except subprocess.TimeoutExpired as exc:
@@ -273,42 +279,9 @@ def _check_test_runtime(repo: Path) -> str | None:
     return None
 
 
-def _version_tuple(value: str) -> tuple[int, int, int]:
-    parts = [int(part) for part in value.split(".")]
-    padded = (parts + [0, 0])[:3]
-    return padded[0], padded[1], padded[2]
-
-
-def _required_mypy_requirement(pristine: Path) -> tuple[str, tuple[int, int, int]]:
-    """Read the declared mypy spec and floor from the dev dependency group."""
-    pyproject = pristine / "pyproject.toml"
-    text = pyproject.read_text(encoding="utf-8")
-    dev_match = re.search(r"(?ms)^\s*dev\s*=\s*\[(?P<body>.*?)^\s*\]", text)
-    if dev_match is None:
-        raise ValueError(f"dev dependency group missing from {pyproject}")
-
-    dependency_match = re.search(
-        r"(?m)^\s*[\"']mypy(?P<specifier>\s*[<>=!~][^\"']*)[\"']\s*,?\s*(?:#.*)?$",
-        dev_match.group("body"),
-    )
-    if dependency_match is None:
-        raise ValueError(f"mypy dependency missing from {pyproject}")
-
-    specifier = dependency_match.group("specifier").strip()
-    floor_match = re.search(r"(?:^|,)\s*>=\s*(?P<floor>\d+(?:\.\d+){1,2})(?:\s*,|$)", specifier)
-    if floor_match is None:
-        raise ValueError(f"mypy dependency has no >= floor in {pyproject}: {specifier}")
-    return specifier, _version_tuple(floor_match.group("floor"))
-
-
 def _check_required_toolchain(pristine: Path) -> str | None:
-    """Return bounded evidence when PATH mypy cannot satisfy the declared floor."""
-    specifier, floor = _required_mypy_requirement(pristine)
-    mypy_path = shutil.which("mypy")
-    if mypy_path is None:
-        return f"required-suite mypy missing from PATH; required mypy{specifier}"
-
-    cmd = [mypy_path, "--version"]
+    """Return bounded evidence when locked mypy cannot start."""
+    cmd = _locked_dev_command(["mypy", "--version"])
     try:
         proc = _run(cmd, cwd=pristine, timeout=60)
     except subprocess.TimeoutExpired as exc:
@@ -323,14 +296,7 @@ def _check_required_toolchain(pristine: Path) -> str | None:
     version_match = re.search(r"\bmypy\s+(?P<version>\d+(?:\.\d+){1,2})\b", output, re.IGNORECASE)
     if version_match is None:
         evidence = _format_stream_evidence(stdout=proc.stdout, stderr=proc.stderr)
-        return f"could not parse PATH mypy version at {mypy_path}; required mypy{specifier}\n{evidence}"
-
-    found_text = version_match.group("version")
-    if _version_tuple(found_text) < floor:
-        return (
-            f"PATH mypy below required floor: found {found_text} at {mypy_path}; "
-            f"required mypy{specifier} from {pristine / 'pyproject.toml'}"
-        )
+        return f"could not parse locked mypy version from {' '.join(cmd)}\n{evidence}"
     return None
 
 
@@ -523,23 +489,28 @@ def main(argv: list[str] | None = None) -> int:
 
     commands = [] if failures or infra_errors else SUITES[args.suite]
     for cmd in commands:
-        print(f"running: {' '.join(cmd)}")
+        locked_cmd = _locked_dev_command(cmd)
+        print(f"running: {' '.join(locked_cmd)}")
         try:
-            proc = _run_suite(cmd, cwd=args.pristine_dir, timeout=args.timeout_minutes * 60)
+            proc = _run_suite(
+                locked_cmd,
+                cwd=args.pristine_dir,
+                timeout=args.timeout_minutes * 60,
+            )
         except subprocess.TimeoutExpired as exc:
             evidence = _format_stream_evidence(stdout=exc.stdout, stderr=exc.stderr)
             infra_errors.append(
-                f"TIMEOUT after {args.timeout_minutes:g}m: {' '.join(cmd)}\n{evidence}"
+                f"TIMEOUT after {args.timeout_minutes:g}m: {' '.join(locked_cmd)}\n{evidence}"
             )
             break
         except OSError as exc:
             infra_errors.append(
-                f"command launch failed: {' '.join(cmd)}\n{type(exc).__name__}: {exc}"
+                f"command launch failed: {' '.join(locked_cmd)}\n{type(exc).__name__}: {exc}"
             )
             break
         if proc.returncode < 0:
             infra_errors.append(
-                f"suite terminated by signal {-proc.returncode}: {' '.join(cmd)}\n"
+                f"suite terminated by signal {-proc.returncode}: {' '.join(locked_cmd)}\n"
                 f"{_format_stream_evidence(stdout=proc.stdout, stderr=proc.stderr)}"
             )
         elif proc.returncode != 0:
@@ -547,10 +518,10 @@ def main(argv: list[str] | None = None) -> int:
             if signature:
                 infra_errors.append(
                     f"runner environment failure ({signature}): "
-                    f"{_format_process_failure(cmd, proc)}"
+                    f"{_format_process_failure(locked_cmd, proc)}"
                 )
             else:
-                failures.append(_format_process_failure(cmd, proc))
+                failures.append(_format_process_failure(locked_cmd, proc))
 
     status = "infra_error" if infra_errors else "main_red" if failures else "green"
     green = status == "green"

--- a/scripts/pristine_main_health.py
+++ b/scripts/pristine_main_health.py
@@ -240,6 +240,7 @@ def _format_process_failure(cmd: list[str], proc: subprocess.CompletedProcess) -
 _INFRA_OUTPUT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"(?m)^make(\[\d+\])?: .*(command not found|No such file or directory)"),
     re.compile(r"(?m)command not found"),
+    re.compile(r"(?m)^error: Failed to spawn: .+"),
     # check_mypy_baseline.py could not produce a verdict (mypy crashed, output
     # unparsable, baseline file missing) — inconclusive, exactly like a timeout.
     re.compile(r"(?m)^MYPY_BASELINE_INFRA: .*"),
@@ -455,11 +456,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    runtime_error = _check_test_runtime(args.repo_root)
+    sha = refresh_pristine_worktree(args.repo_root, args.pristine_dir)
+    print(f"pristine origin/main at {sha[:12]} in {args.pristine_dir}")
+
+    runtime_error = _check_test_runtime(args.pristine_dir)
     if runtime_error:
         _record_health(
             args.repo_root,
-            sha=None,
+            sha=sha,
             suite=args.suite,
             status="infra_error",
             failures=[],
@@ -469,9 +473,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"  {runtime_error}", file=sys.stderr)
         print("halt marker NOT written (infrastructure failure)", file=sys.stderr)
         return INFRA_ERROR_EXIT
-
-    sha = refresh_pristine_worktree(args.repo_root, args.pristine_dir)
-    print(f"pristine origin/main at {sha[:12]} in {args.pristine_dir}")
 
     failures: list[str] = []
     infra_errors: list[str] = []

--- a/tests/scripts/test_mypy_runtime_parity.py
+++ b/tests/scripts/test_mypy_runtime_parity.py
@@ -1,0 +1,35 @@
+"""Contract tests for the maintained local mypy execution surfaces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import tomllib
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _locked_mypy_version() -> str:
+    lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    package = next(item for item in lock["package"] if item["name"] == "mypy")
+    return package["version"]
+
+
+def test_precommit_mypy_pin_matches_locked_toolchain() -> None:
+    locked_version = _locked_mypy_version()
+    config = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    match = re.search(r"(?m)^\s+- mypy==(?P<version>[0-9.]+)\s*$", config)
+
+    assert locked_version == "2.1.0"
+    assert match is not None
+    assert match.group("version") == locked_version
+
+
+def test_pristine_health_uses_locked_dev_runtime() -> None:
+    script = (REPO_ROOT / "scripts/pristine_main_health.py").read_text(encoding="utf-8")
+
+    assert (
+        'LOCKED_DEV_RUN = ("uv", "run", "--locked", "--extra", "dev", "--extra", "test")' in script
+    )
+    assert 'shutil.which("mypy")' not in script

--- a/tests/scripts/test_mypy_runtime_parity.py
+++ b/tests/scripts/test_mypy_runtime_parity.py
@@ -10,20 +10,36 @@ import tomllib
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _locked_mypy_version() -> str:
+def _locked_package_version(name: str) -> str:
     lock = tomllib.loads((REPO_ROOT / "uv.lock").read_text(encoding="utf-8"))
-    package = next(item for item in lock["package"] if item["name"] == "mypy")
+    package = next(item for item in lock["package"] if item["name"] == name)
     return package["version"]
 
 
 def test_precommit_mypy_pin_matches_locked_toolchain() -> None:
-    locked_version = _locked_mypy_version()
+    locked_version = _locked_package_version("mypy")
     config = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     match = re.search(r"(?m)^\s+- mypy==(?P<version>[0-9.]+)\s*$", config)
 
     assert locked_version == "2.1.0"
     assert match is not None
     assert match.group("version") == locked_version
+
+
+def test_ruff_pin_matches_locked_toolchain_and_ci() -> None:
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    (ruff_requirement,) = [
+        requirement
+        for requirement in pyproject["project"]["optional-dependencies"]["dev"]
+        if requirement.startswith("ruff==")
+    ]
+    declared_version = ruff_requirement.removeprefix("ruff==")
+    workflow = (REPO_ROOT / ".github/workflows/lint.yml").read_text(encoding="utf-8")
+    workflow_match = re.search(r"\bruff==(?P<version>[0-9.]+)\b", workflow)
+
+    assert workflow_match is not None
+    assert declared_version == _locked_package_version("ruff")
+    assert workflow_match.group("version") == declared_version
 
 
 def test_pristine_health_uses_locked_dev_runtime() -> None:

--- a/tests/scripts/test_pristine_main_health.py
+++ b/tests/scripts/test_pristine_main_health.py
@@ -202,14 +202,19 @@ def test_no_halt_file_flag_reports_only(mod, monkeypatch, tmp_path):
 def test_missing_pytest_records_infra_error_without_touching_halt(
     mod, monkeypatch, tmp_path, capsys
 ):
-    monkeypatch.setattr(
-        mod,
-        "refresh_pristine_worktree",
-        lambda repo, pristine: pytest.fail("runtime probe must precede worktree refresh"),
-    )
+    pristine = tmp_path / "pristine"
+    events: list[tuple[str, Path]] = []
+
+    def fake_refresh(repo, target):
+        events.append(("refresh", target))
+        target.mkdir()
+        return "deadbeef" * 5
+
+    monkeypatch.setattr(mod, "refresh_pristine_worktree", fake_refresh)
 
     def fake_run(cmd, *, cwd, timeout):
         assert _is_runtime_probe(cmd)
+        events.append(("runtime", cwd))
         return _Proc(
             1,
             "probe stdout",
@@ -226,7 +231,7 @@ def test_missing_pytest_records_infra_error_without_touching_halt(
             "--repo-root",
             str(tmp_path),
             "--pristine-dir",
-            str(tmp_path / "pristine"),
+            str(pristine),
             "--halt-file",
             str(halt),
             "--suite",
@@ -250,6 +255,7 @@ def test_missing_pytest_records_infra_error_without_touching_halt(
     assert record.data["failures"] == []
     assert "probe stdout" in record.data["infra_errors"][0]
     assert "No module named pytest" in record.data["infra_errors"][0]
+    assert events == [("refresh", pristine), ("runtime", pristine)]
 
 
 def test_locked_mypy_failure_is_infra_error_without_touching_halt(
@@ -309,6 +315,16 @@ def test_infra_failure_signature_classification(mod):
         mod._infra_failure_signature(_Proc(2, "make: mypy: No such file or directory")) is not None
     )
     assert mod._infra_failure_signature(_Proc(127, "zsh: ruff: command not found")) is not None
+    assert (
+        mod._infra_failure_signature(
+            _Proc(
+                2,
+                "",
+                "error: Failed to spawn: `ruff`\n  Caused by: No such file or directory (os error 2)",
+            )
+        )
+        is not None
+    )
     # A missing THIRD-PARTY module in the runner interpreter is infra.
     proc = _Proc(1, "")
     proc.stderr = "ModuleNotFoundError: No module named 'jsonschema'"
@@ -331,7 +347,11 @@ def test_suite_tool_missing_is_infra_error_without_touching_halt(
     monkeypatch.setattr(
         mod,
         "_run_suite",
-        lambda cmd, *, cwd, timeout: _Proc(2, "make: ruff: command not found"),
+        lambda cmd, *, cwd, timeout: _Proc(
+            2,
+            "",
+            "error: Failed to spawn: `ruff`\n  Caused by: No such file or directory (os error 2)",
+        ),
     )
 
     halt = tmp_path / "halt.json"
@@ -350,7 +370,7 @@ def test_suite_tool_missing_is_infra_error_without_touching_halt(
 
     assert rc == mod.INFRA_ERROR_EXIT
     assert not halt.exists()
-    assert "command not found" in capsys.readouterr().err
+    assert "Failed to spawn" in capsys.readouterr().err
 
     from aragora.nomic.throughput import ThroughputLedger
 

--- a/tests/scripts/test_pristine_main_health.py
+++ b/tests/scripts/test_pristine_main_health.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 _SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "pristine_main_health.py"
+_LOCKED_DEV_RUN = ["uv", "run", "--locked", "--extra", "dev", "--extra", "test"]
 
 
 @pytest.fixture()
@@ -44,28 +45,7 @@ class _Proc:
 
 
 def _is_runtime_probe(cmd: list[str]) -> bool:
-    return cmd == [sys.executable, "-c", "import pytest"]
-
-
-def _write_required_pyproject(pristine: Path, specifier: str = ">=2.1.0,<3.0") -> None:
-    pristine.mkdir(parents=True, exist_ok=True)
-    (pristine / "pyproject.toml").write_text(
-        f"""[project.optional-dependencies]
-dev = [
-    "mypy{specifier}",
-    "mypy-baseline>=0.7.4,<0.8",
-]
-""",
-        encoding="utf-8",
-    )
-
-
-def _write_fake_mypy(bin_dir: Path, version: str) -> Path:
-    bin_dir.mkdir(parents=True, exist_ok=True)
-    executable = bin_dir / "mypy"
-    executable.write_text(f"#!/bin/sh\necho 'mypy {version} (compiled: yes)'\n", encoding="utf-8")
-    executable.chmod(0o755)
-    return executable
+    return cmd == [*_LOCKED_DEV_RUN, "python", "-c", "import pytest"]
 
 
 def test_existing_pristine_without_owner_marker_refuses_destructive_refresh(
@@ -272,17 +252,24 @@ def test_missing_pytest_records_infra_error_without_touching_halt(
     assert "No module named pytest" in record.data["infra_errors"][0]
 
 
-def test_below_floor_path_mypy_is_infra_error_without_touching_halt(
+def test_locked_mypy_failure_is_infra_error_without_touching_halt(
     mod, monkeypatch, tmp_path, capsys
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
     pristine = tmp_path / "pristine"
-    _write_required_pyproject(pristine)
-    mypy_path = _write_fake_mypy(tmp_path / "bin", "1.19.1")
-    monkeypatch.setenv("PATH", str(mypy_path.parent))
+    pristine.mkdir()
     monkeypatch.setattr(mod, "_check_test_runtime", lambda repo: None)
     monkeypatch.setattr(mod, "refresh_pristine_worktree", lambda repo, pristine: "deadbeef" * 5)
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda cmd, *, cwd, timeout: _Proc(
+            2,
+            "",
+            "The lockfile at uv.lock needs to be updated",
+        ),
+    )
 
     halt = tmp_path / "halt.json"
     original_halt = b'{"reason": "existing-main-red"}\n'
@@ -305,58 +292,14 @@ def test_below_floor_path_mypy_is_infra_error_without_touching_halt(
     assert halt.read_bytes() == original_halt
     stderr = capsys.readouterr().err
     assert "INFRA_ERROR" in stderr
-    assert "found 1.19.1" in stderr
-    assert "required mypy>=2.1.0,<3.0" in stderr
-    assert str(mypy_path) in stderr
+    assert "uv run --locked --extra dev --extra test mypy --version" in stderr
+    assert "lockfile at uv.lock needs to be updated" in stderr
 
     from aragora.nomic.throughput import ThroughputLedger
 
     (record,) = ThroughputLedger(repo).records()
     assert record.data["status"] == "infra_error"
-    assert "found 1.19.1" in record.data["infra_errors"][0]
-
-
-def test_invalid_toolchain_contract_is_infra_error_without_touching_halt(
-    mod, monkeypatch, tmp_path, capsys
-):
-    """A malformed pyproject (no parsable mypy floor) is inconclusive about main:
-    it must be classified infra_error, never written as a main-red halt (#9113)."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    pristine = tmp_path / "pristine"
-    pristine.mkdir(parents=True)
-    (pristine / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
-    monkeypatch.setattr(mod, "_check_test_runtime", lambda repo: None)
-    monkeypatch.setattr(mod, "refresh_pristine_worktree", lambda repo, pristine: "deadbeef" * 5)
-
-    halt = tmp_path / "halt.json"
-    original_halt = b'{"reason": "existing-main-red"}\n'
-    halt.write_bytes(original_halt)
-
-    rc = mod.main(
-        [
-            "--repo-root",
-            str(repo),
-            "--pristine-dir",
-            str(pristine),
-            "--halt-file",
-            str(halt),
-            "--suite",
-            "required",
-        ]
-    )
-
-    assert rc == mod.INFRA_ERROR_EXIT
-    assert halt.read_bytes() == original_halt
-    stderr = capsys.readouterr().err
-    assert "INFRA_ERROR" in stderr
-    assert "toolchain contract invalid" in stderr
-
-    from aragora.nomic.throughput import ThroughputLedger
-
-    (record,) = ThroughputLedger(repo).records()
-    assert record.data["status"] == "infra_error"
-    assert "toolchain contract invalid" in record.data["infra_errors"][0]
+    assert "lockfile at uv.lock needs to be updated" in record.data["infra_errors"][0]
 
 
 def test_infra_failure_signature_classification(mod):
@@ -416,49 +359,25 @@ def test_suite_tool_missing_is_infra_error_without_touching_halt(
     assert "runner environment failure" in record.data["infra_errors"][0]
 
 
-def test_missing_path_mypy_is_infra_error_without_touching_halt(mod, monkeypatch, tmp_path, capsys):
-    repo = tmp_path / "repo"
-    repo.mkdir()
+def test_locked_mypy_command_ignores_unrelated_path_mypy(mod, monkeypatch, tmp_path):
     pristine = tmp_path / "pristine"
-    _write_required_pyproject(pristine)
-    empty_bin = tmp_path / "bin"
-    empty_bin.mkdir()
-    monkeypatch.setenv("PATH", str(empty_bin))
-    monkeypatch.setattr(mod, "_check_test_runtime", lambda repo: None)
-    monkeypatch.setattr(mod, "refresh_pristine_worktree", lambda repo, pristine: "deadbeef" * 5)
+    pristine.mkdir()
+    commands: list[list[str]] = []
 
-    halt = tmp_path / "halt.json"
-    original_halt = b'{"reason": "existing-main-red"}\n'
-    halt.write_bytes(original_halt)
+    def fake_run(cmd, *, cwd, timeout):
+        commands.append(cmd)
+        return _Proc(0, "mypy 2.1.0 (compiled: yes)")
 
-    rc = mod.main(
-        [
-            "--repo-root",
-            str(repo),
-            "--pristine-dir",
-            str(pristine),
-            "--halt-file",
-            str(halt),
-            "--suite",
-            "required",
-        ]
-    )
-
-    assert rc == mod.INFRA_ERROR_EXIT
-    assert halt.read_bytes() == original_halt
-    stderr = capsys.readouterr().err
-    assert "INFRA_ERROR" in stderr
-    assert "required-suite mypy missing from PATH" in stderr
-    assert "required mypy>=2.1.0,<3.0" in stderr
-
-
-def test_path_mypy_satisfying_declared_floor_has_no_toolchain_error(mod, monkeypatch, tmp_path):
-    pristine = tmp_path / "pristine"
-    _write_required_pyproject(pristine)
-    mypy_path = _write_fake_mypy(tmp_path / "bin", "2.2.0")
-    monkeypatch.setenv("PATH", str(mypy_path.parent))
+    monkeypatch.setattr(mod, "_run", fake_run)
 
     assert mod._check_required_toolchain(pristine) is None
+    assert commands == [[*_LOCKED_DEV_RUN, "mypy", "--version"]]
+
+
+def test_locked_command_replaces_caller_python_with_environment_python(mod):
+    command = mod._locked_dev_command([sys.executable, "scripts/check.py", "--flag"])
+
+    assert command == [*_LOCKED_DEV_RUN, "python", "scripts/check.py", "--flag"]
 
 
 def test_suite_launch_error_is_infra_error_and_never_writes_halt(
@@ -521,6 +440,7 @@ def test_timeout_kills_sigterm_ignoring_group_and_never_writes_halt(
         ),
     ]
     monkeypatch.setitem(mod.SUITES, "required", [child])
+    monkeypatch.setattr(mod, "_locked_dev_command", lambda cmd: cmd)
 
     halt = tmp_path / "halt.json"
     original_halt = b'{"reason": "existing-main-red"}\n'

--- a/uv.lock
+++ b/uv.lock
@@ -317,6 +317,7 @@ dev = [
     { name = "mypy" },
     { name = "mypy-baseline" },
     { name = "pre-commit" },
+    { name = "ruff" },
     { name = "types-croniter" },
     { name = "types-pyyaml" },
 ]
@@ -377,6 +378,7 @@ requires-dist = [
     { name = "python3-saml", marker = "extra == 'enterprise'", specifier = ">=1.16.0,<2.0" },
     { name = "pyyaml", specifier = ">=6.0.3,<7.0" },
     { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0.3,<7.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.14" },
     { name = "supabase", marker = "extra == 'all'", specifier = ">=2.31.0,<3.0" },
     { name = "supabase", marker = "extra == 'enterprise'", specifier = ">=2.31.0,<3.0" },
     { name = "twine", marker = "extra == 'test'", specifier = ">=6.2.0,<7.0" },
@@ -3089,6 +3091,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1b/2d/439b0728a92964a04d9c88ea1ca9ebb128893fbbd5834faa31f987f2fd4c/rlp-4.1.0.tar.gz", hash = "sha256:be07564270a96f3e225e2c107db263de96b5bc1f27722d2855bd3459a08e95a9", size = 33429, upload-time = "2025-02-04T22:05:59.089Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/fb/e4c0ced9893b84ac95b7181d69a9786ce5879aeb3bbbcbba80a164f85d6a/rlp-4.1.0-py3-none-any.whl", hash = "sha256:8eca394c579bad34ee0b937aecb96a57052ff3716e19c7a578883e767bc5da6f", size = 19973, upload-time = "2025-02-04T22:05:57.05Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- run pristine-main runtime probes and required/full suite commands through `uv run --locked --extra dev --extra test`
- align the isolated pre-commit mypy environment with the `uv.lock` version (`2.1.0`)
- add a focused parity contract so the pre-commit pin cannot silently drift from the lock

This is a narrow current-main replacement for the local-health parity portion of stale/conflicting PR #9440. It does not modify or close #9440 and intentionally excludes its baseline, workflow, installer, and broader toolchain changes.

## Validation
- `uv run --locked --extra dev --extra test python -m pytest tests/scripts/test_pristine_main_health.py tests/scripts/test_mypy_runtime_parity.py tests/scripts/test_install_nightly_health_launchd.py -q` (`29 passed`)
- `uv run --locked --extra dev --extra test ruff check scripts/pristine_main_health.py tests/scripts/test_pristine_main_health.py tests/scripts/test_mypy_runtime_parity.py`
- `uv run --locked --extra dev --extra test ruff format --check scripts/pristine_main_health.py tests/scripts/test_pristine_main_health.py tests/scripts/test_mypy_runtime_parity.py`
- `uv run --locked --extra dev pre-commit validate-config`
- `python3 scripts/pristine_main_health.py --suite required --no-halt-file --pristine-dir /private/tmp/aragora-pristine-main-health-locked-parity-validation-bb3f2a-20260727` (`GREEN` on pristine `bb3f2a610954`)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- `git diff --check`

Related: #9043, #9045, #9440