### PR TITLE
feat(models): documented long-context tier pricing in catalog + estimators

### DIFF
--- a/aragora/models/catalog.py
+++ b/aragora/models/catalog.py
@@ -68,9 +68,30 @@ class ModelSpec:
     # (the 14-day availability rule); None = long-established.
     soak_until: date | None = None
     aliases: tuple[str, ...] = field(default_factory=tuple)
+    # Documented long-context tier: requests whose PROMPT reaches
+    # ``long_context_threshold`` tokens are billed at the ``*_long`` rates for
+    # ALL tokens in the request (xAI's documented model; source recorded per
+    # entry). None = flat pricing. The OpenRouter snapshot mirrors only the
+    # flat fields, so tier rates are verified against provider pricing pages.
+    long_context_threshold: int | None = None
+    input_per_mtok_long: float | None = None
+    output_per_mtok_long: float | None = None
 
     def all_ids(self) -> tuple[str, ...]:
         return (self.canonical_id, self.direct_id, self.openrouter_id, *self.aliases)
+
+    def rates_for(self, prompt_tokens: int) -> tuple[float, float]:
+        """Applicable (input, output) USD-per-MTok pair for a request whose
+        prompt is ``prompt_tokens`` long. Falls back to flat rates when the
+        model has no documented tier."""
+        if (
+            self.long_context_threshold is not None
+            and prompt_tokens >= self.long_context_threshold
+            and self.input_per_mtok_long is not None
+            and self.output_per_mtok_long is not None
+        ):
+            return (self.input_per_mtok_long, self.output_per_mtok_long)
+        return (self.input_per_mtok, self.output_per_mtok)
 
     def is_under_soak(self, today: date | None = None) -> bool:
         """True while the model is inside its post-release soak window
@@ -176,6 +197,11 @@ CATALOG: dict[str, ModelSpec] = {
             max_output_tokens=64_000,
             release_date=date(2026, 7, 8),
             soak_until=date(2026, 7, 22),
+            # docs.x.ai/developers/pricing (verified 2026-07-27): prompts
+            # >= 200k tokens bill 2x for the whole request.
+            long_context_threshold=200_000,
+            input_per_mtok_long=4.00,
+            output_per_mtok_long=12.00,
         ),
         ModelSpec(
             canonical_id="grok-4.3",
@@ -187,6 +213,10 @@ CATALOG: dict[str, ModelSpec] = {
             context_window=1_000_000,
             max_output_tokens=64_000,
             release_date=date(2026, 4, 1),
+            # docs.x.ai/developers/pricing (verified 2026-07-27).
+            long_context_threshold=200_000,
+            input_per_mtok_long=2.50,
+            output_per_mtok_long=5.00,
         ),
         ModelSpec(
             canonical_id="qwen3.7-max",

--- a/aragora/pdb/real_invoker.py
+++ b/aragora/pdb/real_invoker.py
@@ -48,6 +48,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Mapping, Protocol as _TypingProtocol, Sequence
 
+from aragora.models import by_any_id
 from aragora.pdb.panel_config import PDBPanelSlot
 from aragora.pdb.protocol import (
     SlotCritiqueResponse,
@@ -283,6 +284,13 @@ def estimate_cost_usd(
     """
     tokens_in = max(0, int(tokens_in or 0))
     tokens_out = max(0, int(tokens_out or 0))
+    spec = by_any_id(model)
+    if spec is not None:
+        # Tier-aware catalog rates (documented long-context pricing);
+        # identical to the flat row below the threshold.
+        in_price, out_price = spec.rates_for(tokens_in)
+        cost = (tokens_in / 1_000_000.0) * in_price + (tokens_out / 1_000_000.0) * out_price
+        return round(cost, 6)
     rates = _PRICE_PER_MTOK.get(model)
     if rates is None:
         # Strip provider prefixes (``anthropic/...`` etc.) and try again.

--- a/aragora/routing/provider_config.py
+++ b/aragora/routing/provider_config.py
@@ -386,17 +386,21 @@ def get_estimated_cost(
         NOT projected into the enumerated table. Returns 0.0 only when the
         model is unknown to both the table and the catalog.
     """
+    # Catalog specs win for cataloged ids: rates_for() is tier-aware
+    # (documented long-context pricing, e.g. xAI bills 2x when the prompt
+    # reaches 200k tokens), which flat table rows cannot express. Below the
+    # threshold this is behavior-identical to the projected table row.
+    spec = by_any_id(provider)
+    if spec is not None:
+        rate_in, rate_out = spec.rates_for(input_tokens)
+        return (input_tokens / 1_000_000.0) * rate_in + (output_tokens / 1_000_000.0) * rate_out
+
     pricing = current_pricing_table().get(provider)
     if pricing is None:
-        spec = by_any_id(provider)
-        if spec is None:
-            # Silent 0.0 was the original #9069 bug: cost dashboards read
-            # "free" where they should read "unpriced model".
-            logger.warning("No pricing entry for model %s; returning 0.0", provider)
-            return 0.0
-        return (input_tokens / 1_000_000.0) * spec.input_per_mtok + (
-            output_tokens / 1_000_000.0
-        ) * spec.output_per_mtok
+        # Silent 0.0 was the original #9069 bug: cost dashboards read
+        # "free" where they should read "unpriced model".
+        logger.warning("No pricing entry for model %s; returning 0.0", provider)
+        return 0.0
 
     input_cost = (input_tokens / 1000.0) * pricing.input_cost_per_1k
     output_cost = (output_tokens / 1000.0) * pricing.output_cost_per_1k

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -18,11 +18,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](https://g
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,302 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,303 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,988,769 | `docs/METRICS.md` |
-| Automated tests | 224,872 test functions | `docs/METRICS.md` |
-| Test files | 5,513 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,989,763 | `docs/METRICS.md` |
+| Automated tests | 224,980 test functions | `docs/METRICS.md` |
+| Test files | 5,515 | `docs/METRICS.md` |
 | API operations | 3,084 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -342,7 +342,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,302 tracked Python files | 145 top-level modules | 224,872 test functions across 5,513 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
+**Scale:** 4,303 tracked Python files | 145 top-level modules | 224,980 test functions across 5,515 test files | canonical counts in [METRICS.md](https://github.com/synaptent/aragora/blob/main/docs/METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -28,7 +28,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,302 Python files | 224,872 tests | 3,084 API operations across 2,876 paths
+**Total**: 230+ features | 4,303 Python files | 224,980 tests | 3,084 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -158,8 +158,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,302
-- **Tests**: 224,872 across 5,513 test files
+- **Python files (`aragora/`)**: 4,303
+- **Tests**: 224,980 across 5,515 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,084 across 2,876 paths
 <!-- metrics:end -->

--- a/docs-site/docs/core-concepts/architecture.md
+++ b/docs-site/docs/core-concepts/architecture.md
@@ -766,8 +766,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 224,872 tests across 5,513 test files
-- **Source files**: 4,302 Python files under `aragora/`
+- **Test coverage**: 224,980 tests across 5,515 test files
+- **Source files**: 4,303 Python files under `aragora/`
 - **API surface**: 3,084 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,11 +13,11 @@ Live project-scale numbers are auto-regenerated in [`docs/METRICS.md`](METRICS.m
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.9.0 | `pyproject.toml` |
-| Python files under `aragora/` | 4,302 | `docs/METRICS.md` |
+| Python files under `aragora/` | 4,303 | `docs/METRICS.md` |
 | Python modules | 145 top-level package directories | `docs/METRICS.md` |
-| Lines of code under `aragora/` | 1,988,769 | `docs/METRICS.md` |
-| Automated tests | 224,872 test functions | `docs/METRICS.md` |
-| Test files | 5,513 | `docs/METRICS.md` |
+| Lines of code under `aragora/` | 1,989,763 | `docs/METRICS.md` |
+| Automated tests | 224,980 test functions | `docs/METRICS.md` |
+| Test files | 5,515 | `docs/METRICS.md` |
 | API operations | 3,084 across 2,876 paths | `docs/METRICS.md` |
 | API paths | 2,876 | `docs/METRICS.md` |
 | Knowledge Mound adapters | 46 adapter files / 41 registered specs | `docs/METRICS.md` |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -337,7 +337,7 @@ aragora/
 ```
 
 <!-- metrics:begin extended-readme-scale -->
-**Scale:** 4,302 tracked Python files | 145 top-level modules | 224,872 test functions across 5,513 test files | canonical counts in [METRICS.md](METRICS.md)
+**Scale:** 4,303 tracked Python files | 145 top-level modules | 224,980 test functions across 5,515 test files | canonical counts in [METRICS.md](METRICS.md)
 <!-- metrics:end -->
 
 ---

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -12,12 +12,12 @@
 
 | Metric | Value | Source | Command |
 |---|---|---|---|
-| Python files under aragora/ | `4302` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
-| Python lines of code under aragora/ | `1988769` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
+| Python files under aragora/ | `4303` | `aragora/` | `git ls-files aragora \| grep -E '\.py$' \| wc -l` |
+| Python lines of code under aragora/ | `1989763` | `aragora/` | `python3 -c "from pathlib import Path; import subprocess; files = subprocess.check_output(['git', 'ls-files', 'aragora'], text=True).splitlines(); print(sum(sum(1 for _ in Path(p).open(encoding='utf-8', errors='replace')) for p in files if p.endswith('.py')))"` |
 | Top-level modules under aragora/ | `145` | `aragora/` | `git ls-files aragora \| awk -F/ 'NF>2 {print $2}' \| sort -u \| wc -l` |
-| Test files (test_*.py under tests/) | `5513` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
-| Test functions (class + module level) | `224872` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
-| @pytest.mark.parametrize decorators | `941` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
+| Test files (test_*.py under tests/) | `5515` | `tests/` | `git ls-files tests \| grep -E '(^\|/)test_[^/]*\.py$' \| wc -l` |
+| Test functions (class + module level) | `224980` | `tests/` | `git grep -E '^[[:space:]]*(async )?def test_' -- tests \| wc -l` |
+| @pytest.mark.parametrize decorators | `949` | `tests/` | `git grep -E '@pytest\.mark\.parametrize' -- tests \| wc -l` |
 | CLI top-level command modules | `86` | `aragora/cli/commands/` | `git ls-files aragora/cli/commands \| grep -E '/[^/]*\.py$' \| grep -v '/__' \| wc -l` |
 | OpenAPI paths | `2876` | `docs/api/openapi.json` | `python -c "import json; print(len(json.load(open('docs/api/openapi.json'))['paths']))"` |
 | OpenAPI operations (HTTP verbs) | `3084` | `docs/api/openapi.json` | `python -c "import json; spec=json.load(open('docs/api/openapi.json')); print(sum(1 for p in spec['paths'].values() for m in p if m.lower() in {'get','post','put','delete','patch','head','options'}))"` |
@@ -28,7 +28,7 @@
 | Allowlisted agent types | `35` | `aragora/config/settings.py` | `grep -A 50 'ALLOWED_AGENT_TYPES' aragora/config/settings.py \| grep -oE "'[a-z-]+'" \| sort -u \| wc -l` |
 | Knowledge Mound adapter specs | `41` | `aragora/knowledge/mound/adapters/factory.py` | `git grep -E '"\.[a-z_]+_adapter"' -- aragora/knowledge/mound/adapters/factory.py \| wc -l` |
 | Knowledge Mound adapter files | `46` | `aragora/knowledge/mound/adapters/` | `git ls-files aragora/knowledge/mound/adapters \| grep -E '/[^/]+_adapter\.py$' \| wc -l` |
-| Markdown files under docs/ | `1104` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
+| Markdown files under docs/ | `1105` | `docs/` | `git ls-files docs \| grep -E '\.md$' \| wc -l` |
 | GitHub Actions workflows | `93` | `.github/workflows/` | `git ls-files .github/workflows \| grep -E '\.yml$' \| wc -l` |
 | Mypy baseline errors (grandfathered) | `3115` | `.mypy-baseline` | `wc -l .mypy-baseline` |
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -153,8 +153,8 @@ For the full current-status narrative, use the canonical doc:
 
 ### Codebase Metrics (generated from `docs/METRICS.md`)
 <!-- metrics:begin status-codebase-metrics -->
-- **Python files (`aragora/`)**: 4,302
-- **Tests**: 224,872 across 5,513 test files
+- **Python files (`aragora/`)**: 4,303
+- **Tests**: 224,980 across 5,515 test files
 - **KM adapters**: 41 registered adapter specs
 - **API operations**: 3,084 across 2,876 paths
 <!-- metrics:end -->

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -761,8 +761,8 @@ Critical operations use explicit transactions:
 - **Storage tests**: 4,300+ tests across all backends including KM (Phase A2)
 - **SDK breadth**: Python and TypeScript SDKs (module counts in `docs/METRICS.md`)
 <!-- metrics:begin architecture-scale -->
-- **Test coverage**: 224,872 tests across 5,513 test files
-- **Source files**: 4,302 Python files under `aragora/`
+- **Test coverage**: 224,980 tests across 5,515 test files
+- **Source files**: 4,303 Python files under `aragora/`
 - **API surface**: 3,084 API operations across 2,876 paths
 - **KM adapters**: 41 registered adapters (see `aragora/knowledge/mound/adapters/`)
 <!-- metrics:end -->

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -23,7 +23,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
 <!-- metrics:begin feature-discovery-total -->
-**Total**: 230+ features | 4,302 Python files | 224,872 tests | 3,084 API operations across 2,876 paths
+**Total**: 230+ features | 4,303 Python files | 224,980 tests | 3,084 API operations across 2,876 paths
 <!-- metrics:end -->
 
 ---

--- a/tests/models/test_catalog.py
+++ b/tests/models/test_catalog.py
@@ -236,3 +236,41 @@ def test_fallback_targets_resolve_to_catalog_specs() -> None:
             checked_enforced.add(spec.canonical_id)
     # Falsifiability anchor: the map is known to target gpt-5.5 and opus-4.8.
     assert checked_enforced, "no enforced fallback targets were checked"
+
+
+class TestLongContextTiers:
+    """Documented long-context tier pricing (xAI: prompts >= 200k tokens bill
+    the higher rate for ALL tokens in the request; docs.x.ai/developers/pricing
+    verified 2026-07-27, surfaced by openai review on #9064)."""
+
+    def test_grok_tiers_recorded(self) -> None:
+        g45 = CATALOG["grok-4.5"]
+        assert g45.long_context_threshold == 200_000
+        assert (g45.input_per_mtok_long, g45.output_per_mtok_long) == (4.00, 12.00)
+        g43 = CATALOG["grok-4.3"]
+        assert (g43.input_per_mtok_long, g43.output_per_mtok_long) == (2.50, 5.00)
+
+    def test_rates_for_switches_at_threshold(self) -> None:
+        spec = CATALOG["grok-4.5"]
+        assert spec.rates_for(199_999) == (2.00, 6.00)
+        assert spec.rates_for(200_000) == (4.00, 12.00)
+
+    def test_flat_models_ignore_threshold(self) -> None:
+        spec = CATALOG["claude-fable-5"]
+        assert spec.rates_for(10_000_000) == (spec.input_per_mtok, spec.output_per_mtok)
+
+    def test_router_estimator_is_tier_aware(self) -> None:
+        from aragora.routing.provider_config import get_estimated_cost
+
+        below = get_estimated_cost("grok-4.5", 100_000, 10_000)
+        above = get_estimated_cost("grok-4.5", 300_000, 10_000)
+        assert below == pytest.approx(0.1 * 2.00 + 0.01 * 6.00)
+        assert above == pytest.approx(0.3 * 4.00 + 0.01 * 12.00)
+
+    def test_pdb_estimator_is_tier_aware(self) -> None:
+        from aragora.pdb.real_invoker import estimate_cost_usd
+
+        below = estimate_cost_usd(model="x-ai/grok-4.5", tokens_in=100_000, tokens_out=10_000)
+        above = estimate_cost_usd(model="x-ai/grok-4.5", tokens_in=300_000, tokens_out=10_000)
+        assert below == pytest.approx(0.1 * 2.00 + 0.01 * 6.00)
+        assert above == pytest.approx(0.3 * 4.00 + 0.01 * 12.00)


### PR DESCRIPTION
## Summary
openai's review on #9064 was verified TRUE against xAI's own pricing page (2026-07-27): grok requests whose prompt reaches **200k tokens bill 2x for all tokens in the request** — our flat rates undercounted large-context debates by up to 2x on budget/billing enforcement surfaces.

- `ModelSpec` gains `long_context_threshold` / `input_per_mtok_long` / `output_per_mtok_long` and tier-aware `rates_for(prompt_tokens)`; grok-4.5 ($4/$12) and grok-4.3 ($2.50/$5) carry their documented tiers with source + verification date.
- Both centralized estimators (routing `get_estimated_cost`, pdb `estimate_cost_usd`) resolve catalog specs first and price tier-aware; behavior-identical below the threshold.
- Snapshot policy documented: OpenRouter mirrors only flat fields, so tier rates are provider-doc-verified per catalog entry.

This also retires the recorded "tiered pricing is a systemic enhancement" rationale from #9075 — the enhancement now exists.

#### Test plan
- [x] 1083 models/routing/pdb tests green incl. 5 new tier regressions
- [x] 3309 billing/metering/cost-handler tests green
- [x] preflight ok; docs chain regenerated

Generated with [Devin](https://devin.ai)