### PR TITLE
ci(live): extend Node 24 runtime contract to security/openapi/sbom lanes [Tier 4]

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -168,10 +168,10 @@ jobs:
           "$PY_BIN" --version
           pip --version || "$PY_BIN" -m pip --version
 
-      - name: Set up Node 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.18.0"
 
       - name: Configure npm cache for self-hosted runners
         shell: bash

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24.18.0'
 
       - name: Install dependencies
         working-directory: ${{ matrix.package.path }}

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24.18.0"
 
       # ---------------------------------------------------------------
       # npm audit: check frontend dependencies for high/critical vulns

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24.18.0'
 
       - name: Install npm dependencies (live)
         working-directory: aragora/live

--- a/tests/ci/test_live_node_runtime_workflows.py
+++ b/tests/ci/test_live_node_runtime_workflows.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -29,12 +30,16 @@ EXPECTED_SELECTOR_VERSIONS = {
     ("merge-group-frontend-typecheck.yml", "frontend-typecheck"): LIVE_NODE_VERSION,
     ("nightly-full-matrix.yml", "frontend-build"): LIVE_NODE_VERSION,
     ("onramp-integration.yml", "playground-build"): LIVE_NODE_VERSION,
+    ("openapi.yml", "generate-run"): LIVE_NODE_VERSION,
     ("production-monitor.yml", "production-health"): LIVE_NODE_VERSION,
     ("production-monitor.yml", "production-auth"): LIVE_NODE_VERSION,
     ("production-monitor.yml", "production-full"): LIVE_NODE_VERSION,
     ("release.yml", "sdk-parity-gate"): "20",
     ("release.yml", "security-gate"): LIVE_NODE_VERSION,
     ("release.yml", "frontend-build"): LIVE_NODE_VERSION,
+    ("sbom.yml", "generate-node-sbom"): LIVE_NODE_VERSION,
+    ("security-gate.yml", "npm-security"): LIVE_NODE_VERSION,
+    ("security.yml", "dependency-check"): LIVE_NODE_VERSION,
     ("test.yml", "version-check"): "20",
     ("test.yml", "sdk-typescript-compile-gate"): "20",
     ("test.yml", "frontend"): LIVE_NODE_VERSION,
@@ -48,6 +53,8 @@ NON_LIVE_SELECTORS = {
 }
 
 APPROVED_WORKFLOWS = {workflow_name for workflow_name, _job_name in EXPECTED_SELECTOR_VERSIONS}
+MATRIX_REFERENCE = re.compile(r"\$\{\{\s*matrix\.([A-Za-z0-9_.-]+)\s*\}\}")
+NPM_LIVE_PREFIX = re.compile(r"\bnpm\s+--prefix(?:=|\s+)[\"']?aragora/live(?:/|\b)")
 
 
 def _load_workflow(workflow_name: str) -> dict[str, Any]:
@@ -91,12 +98,61 @@ def _cache_dependency_paths(step: dict[str, Any]) -> list[str]:
     return str(value).splitlines()
 
 
+def _matrix_reference_values(job: dict[str, Any], reference: str) -> list[str]:
+    matrix = job.get("strategy", {}).get("matrix", {})
+    if not isinstance(matrix, dict):
+        return []
+
+    parts = reference.split(".")
+
+    def resolve(value: Any, remaining: list[str]) -> list[Any]:
+        candidates = value if isinstance(value, list) else [value]
+        for part in remaining:
+            resolved: list[Any] = []
+            for candidate in candidates:
+                if not isinstance(candidate, dict) or part not in candidate:
+                    continue
+                nested = candidate[part]
+                resolved.extend(nested if isinstance(nested, list) else [nested])
+            candidates = resolved
+        return candidates
+
+    values = resolve(matrix.get(parts[0], []), parts[1:])
+    for included in matrix.get("include", []):
+        if not isinstance(included, dict) or parts[0] not in included:
+            continue
+        values.extend(resolve(included[parts[0]], parts[1:]))
+    return [str(value) for value in values]
+
+
+def _expanded_working_directories(job: dict[str, Any], value: str) -> set[str]:
+    expanded = {value}
+    for match in MATRIX_REFERENCE.finditer(value):
+        replacements = _matrix_reference_values(job, match.group(1))
+        if not replacements:
+            continue
+        expanded = {
+            candidate.replace(match.group(0), replacement)
+            for candidate in expanded
+            for replacement in replacements
+        }
+    return expanded
+
+
+def _is_live_path(value: str) -> bool:
+    return value == "aragora/live" or value.startswith("aragora/live/")
+
+
 def _job_operates_on_live(job: dict[str, Any]) -> bool:
     for step in job.get("steps", []):
         working_directory = str(step.get("working-directory", ""))
-        if working_directory == "aragora/live" or working_directory.startswith("aragora/live/"):
+        if any(
+            _is_live_path(path) for path in _expanded_working_directories(job, working_directory)
+        ):
             return True
-        if "aragora/live/package-lock.json" in _cache_dependency_paths(step):
+        if any(_is_live_path(path) for path in _cache_dependency_paths(step)):
+            return True
+        if NPM_LIVE_PREFIX.search(str(step.get("run", ""))):
             return True
     return False
 
@@ -121,8 +177,12 @@ def test_approved_workflows_own_the_complete_node_selector_inventory() -> None:
         "merge-group-frontend-typecheck.yml",
         "nightly-full-matrix.yml",
         "onramp-integration.yml",
+        "openapi.yml",
         "production-monitor.yml",
         "release.yml",
+        "sbom.yml",
+        "security-gate.yml",
+        "security.yml",
         "test.yml",
     }
 
@@ -151,6 +211,32 @@ def test_approved_workflows_own_the_complete_node_selector_inventory() -> None:
 
     assert actual_versions == EXPECTED_SELECTOR_VERSIONS
     assert live_selectors == set(EXPECTED_SELECTOR_VERSIONS) - NON_LIVE_SELECTORS
+
+
+def test_all_live_workflow_consumers_are_pinned_to_node_24() -> None:
+    actual_live_versions: dict[tuple[str, str], str] = {}
+    for workflow_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        workflow = _load_workflow(workflow_path.name)
+        for job_name, job in workflow["jobs"].items():
+            if not _job_operates_on_live(job):
+                continue
+
+            setup_node_steps = _setup_node_steps(job)
+            assert len(setup_node_steps) == 1, (
+                f"{workflow_path.name}:{job_name} operates on aragora/live "
+                "without exactly one setup-node selector"
+            )
+            actual_live_versions[(workflow_path.name, job_name)] = _resolve_node_version(
+                workflow, job, setup_node_steps[0]
+            )
+
+    expected_live_versions = {
+        selector: version
+        for selector, version in EXPECTED_SELECTOR_VERSIONS.items()
+        if selector not in NON_LIVE_SELECTORS
+    }
+    assert actual_live_versions == expected_live_versions
+    assert set(actual_live_versions.values()) == {LIVE_NODE_VERSION}
 
 
 def test_live_deploy_mode_gate_builds_package_changes_on_node_24() -> None:


### PR DESCRIPTION
## Summary

This is the bounded Tier-4 follow-up to #9591 and closed issue #9577. The Node 24 runtime contract was already declared in `aragora/live`, but four workflow jobs that install, generate from, or audit that package still selected Node 20.

This draft:

- pins the OpenAPI, SBOM, security-gate, and weekly security consumers to Node `24.18.0`;
- teaches the runtime-contract test to detect `npm --prefix aragora/live`;
- resolves matrix-templated working directories such as the SBOM package matrix;
- adds a closed-world sweep over every workflow so a future live-package consumer cannot silently escape the Node 24 inventory.

## User and operational effect

Without this change, these jobs can install a package whose declared engine is `>=24.18.0 <25` under Node 20. That leaves generation, audit, and release artifacts outside the runtime contract and makes engine enforcement depend on npm warning behavior. With this change, every detected `aragora/live` workflow consumer uses the exact validated Node release.

## Per-workflow risk notes

- `openapi.yml`: `generate-run` shares one Node selector between live API type generation and SDK/spec generation. Moving the selector therefore runs the full job on Node 24, not only the live npm steps.
- `sbom.yml`: `generate-node-sbom` matrices over both `sdk/typescript` and `aragora/live`. The shared selector moves both matrix entries to Node 24, and the newer bundled npm version may produce small SBOM ordering or metadata differences.
- `security-gate.yml`: `npm-security` audits both the live package and TypeScript SDK in one job, so both audit steps now run on Node 24.
- `security.yml`: the weekly `dependency-check` job likewise audits both packages under its shared Node 24 selector.

SDK-only selectors in `release.yml`, `test.yml`, and `publish-sdk-typescript.yml` remain unchanged.

## Validation

- `pytest tests/ci/test_live_node_runtime_workflows.py -q` — 4 passed
- Parsed every `.github/workflows/*.yml` file with `yaml.safe_load`
- `ruff check tests/ci/test_live_node_runtime_workflows.py`
- `ruff format --check tests/ci/test_live_node_runtime_workflows.py`
- `actionlint` on all four changed workflows
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
- Commit and push hooks passed, including YAML, Ruff, mypy, gitleaks, portability, and secret checks

## Governance

This modifies GitHub Actions workflows and is intentionally opened as a parked Tier-4 draft. Do not mark ready, collect quorum evidence, settle, or merge without the separate exact-head operator gate.

References:

- #9591
- #9577
- [`docs/plans/2026-07-24-node-runtime-contract-9577.md`](https://github.com/synaptent/aragora/blob/main/docs/plans/2026-07-24-node-runtime-contract-9577.md)
