### PR TITLE
docs(runners): correct m1 runner IP, roster counts, and record the 2026-07-27 incident

### DIFF
--- a/docs/runners/FLEET.md
+++ b/docs/runners/FLEET.md
@@ -5,28 +5,93 @@ Canonical roster of self-hosted GitHub Actions runners registered on
 `gh api repos/synaptent/aragora/actions/runners` endpoint cross-checked
 against on-host `~/actions-runner/.runner` configs.
 
-Last confirmed: **2026-04-23**.
+Last confirmed: **2026-07-27**.
 
-## Registered and online
+> **LAN IPs are DHCP and drift.** Do not treat the IP column as an identity or a
+> liveness test. On 2026-07-27 `macbook-m1-16gb` was assumed dead because it stopped
+> answering at its recorded address; it had simply moved (`.170` → `.108`) and was up
+> the whole time. Identify a host by `scutil --get LocalHostName` over SSH, and judge
+> liveness by the runner API, never by pinging a value from this table.
+
+## Roster
 
 | Runner name (GH) | Host | IP | OS | Labels | Notes |
 |---|---|---|---|---|---|
 | `aragora-hetzner-cpu1` | Hetzner CX52 cloud | — | Linux x64 | `self-hosted, Linux, X64, aragora, hetzner` | Background CPU work |
 | `aragora-hetzner-cpu2` | Hetzner CX52 cloud | — | Linux x64 | `self-hosted, Linux, X64, aragora, hetzner` | Background CPU work |
 | `aragora-hetzner-cpu3` | Hetzner CX52 cloud | — | Linux x64 | `self-hosted, Linux, X64, aragora, hetzner` | Background CPU work |
-| `i-07e538fafbe61696d` | AWS EC2 (production) | — | Linux x64 | `self-hosted, Linux, X64, aragora` | Production canary — also hosts the Aragora service |
-| `i-0823e60c7c4b924e1` | AWS EC2 (production) | — | Linux x64 | `self-hosted, Linux, X64, aragora` | Production canary — also hosts the Aragora service |
-| `ip-10-50-1-235` | AWS EC2 (staging) | 10.50.1.235 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier |
-| `ip-172-31-7-189` | AWS EC2 (staging) | 172.31.7.189 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier |
-| `ip-172-31-11-203` | AWS EC2 (staging) | 172.31.11.203 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier |
-| `ip-172-31-24-39` | AWS EC2 (staging) | 172.31.24.39 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier |
+| `i-07e538fafbe61696d` | AWS EC2 (production) | — | Linux x64 | `self-hosted, Linux, X64, aragora` | Production canary. **Offline** — AWS account suspension. |
+| `i-0823e60c7c4b924e1` | AWS EC2 (production) | — | Linux x64 | `self-hosted, Linux, X64, aragora` | Production canary. **Offline** — AWS account suspension. |
+| `ip-10-50-1-235` | AWS EC2 (staging) | 10.50.1.235 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier. **Offline** — AWS account suspension. |
+| `ip-172-31-7-189` | AWS EC2 (staging) | 172.31.7.189 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier. **Offline** — AWS account suspension. |
+| `ip-172-31-11-203` | AWS EC2 (staging) | 172.31.11.203 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier. **Offline** — AWS account suspension. |
+| `ip-172-31-24-39` | AWS EC2 (staging) | 172.31.24.39 | Linux x64 | `self-hosted, Linux, X64, aragora` | Staging tier. **Offline** — AWS account suspension. |
 | `mac-studio-m3ultra` | Mac Studio (local LAN) | 10.0.0.62 / 10.0.0.90 | macOS ARM64 | `self-hosted, aragora, macOS, ARM64, mac-studio` | Apple-silicon workloads |
-| `macbook-m1-16gb` | MacBook-Pro16GB.local | 10.0.0.170 | macOS ARM64 | `self-hosted, aragora, macOS, ARM64` | Apple-silicon MacBook |
-| `macbook-intel-64gb` | MacBook-Pro-3.local | 10.0.0.193 | macOS x64 | `self-hosted, aragora, macOS, X64` | Intel MacBook, more cores |
+| `macbook-m1-16gb` | MacBook-Pro16GB.local | 10.0.0.108 (DHCP; was 10.0.0.170) | macOS ARM64 | `self-hosted, aragora, macOS, ARM64` | Apple-silicon MacBook. **Online** — re-registered 2026-07-27, see incident below. Data volume ~95% full. |
+| `macbook-intel-64gb` | MacBook-Pro-3.local | 10.0.0.193 (stale) | macOS x64 | `self-hosted, aragora, macOS, X64` | **Not registered** as of 2026-07-27 — registration GC'd by GitHub and host is off-network. Needs power-on + re-register. |
 
-**Total online: 12**
+**Registered: 11 · Online: 5** (3 Hetzner, `mac-studio-m3ultra`, `macbook-m1-16gb`) as of 2026-07-27.
+Baseline in `runner-headcount-monitor.yml` is **12**; the 7-runner gap is 6 AWS EC2 hosts
+(account suspension) plus `macbook-intel-64gb`. Verify with:
+
+```bash
+gh api repos/synaptent/aragora/actions/runners \
+  --jq '.runners[]|"\(.status)\t\(.name)"' | sort
+```
 
 ## Past incidents
+
+### 2026-07-27 — GitHub GC'd a registration; `KeepAlive` turned it into a crash-loop
+
+**Symptom:** `macbook-m1-16gb` and `macbook-intel-64gb` absent from the runner API
+(fleet 10 registered / 4 online against a baseline of 12). Rebooting both Macs — the
+2026-04-23 fix — changed nothing.
+
+**Two misdiagnoses worth not repeating:**
+
+1. *"The machines are down."* Neither answered at its FLEET.md address, so both were
+   written off as powered off. `macbook-m1-16gb` had simply moved on DHCP
+   (`10.0.0.170` → `10.0.0.108`) and was up the entire time. A `/24` sweep plus
+   `ssh … scutil --get LocalHostName` found it in about a minute.
+2. *"It's 2026-04-23 again."* The previous incident's fingerprint is
+   `Can't assign requested address` — the host cannot open a TCP socket at all. Here the
+   log said `√ Connected to GitHub`. **That single line rules out the whole
+   network-exhaustion family** and should be the first thing checked.
+
+**Actual cause**, from `~/actions-runner/runner-launchd.log`:
+
+```
+√ Connected to GitHub
+Failed to create a session. The runner registration has been deleted from the server,
+please re-configure. Runner registrations are automatically deleted for runners that
+have not connected to the service recently.
+Runner listener exit with terminated error, stop the service, no retry needed.
+```
+
+GitHub had garbage-collected the registration for inactivity. The runner correctly
+treats this as terminal and exits. But this host ran a **non-standard**
+`~/Library/LaunchAgents/com.github.actions-runner.plist` with `KeepAlive=true` and no
+throttle, so launchd restarted it immediately, forever: `Runner.Listener` pegged at
+**100% CPU, load average 84** on a 16 GB M1 — pure crash-loop, zero work. No reboot can
+fix it, because the missing state is server-side.
+
+**Fix:** `launchctl bootout` the non-standard agent, retire that plist, then the
+documented re-registration below (`config.sh remove --local` was needed — the stale
+`.runner` made `config.sh` refuse with *"already configured"*), then
+`./svc.sh install && ./svc.sh start`, which registers the service under the canonical
+`actions.runner.synaptent-aragora.<name>` label that `svc.sh status` actually looks for.
+Online within seconds.
+
+**Lessons:**
+
+- Prefer `svc.sh install` over a hand-rolled plist. `KeepAlive=true` converts a
+  deliberate terminal exit into a CPU-burning loop, and a non-canonical `Label` makes
+  `./svc.sh status` report `not installed` on a host that is very much running one.
+- A runner absent from the API — rather than present-and-`offline` — means the
+  registration is **gone**, not merely disconnected. Offline hosts still appear in the
+  list (the six suspended EC2 hosts do). Absence ⇒ re-register; it is never a reboot.
+- Long-idle runners get GC'd. Anything expected to sit idle for weeks needs either
+  periodic use or a re-registration runbook.
 
 ### 2026-04-23 — TCP port exhaustion locked out two Mac runners
 


### PR DESCRIPTION
## Summary

`FLEET.md` recorded `macbook-m1-16gb` at `10.0.0.170`. It isn't there — DHCP moved it to
`10.0.0.108`. Because the recorded IP was used as a *liveness test*, the host was written off as
powered down while it was up the entire time. Corrects the roster against the live API and records
the incident.

## Roster corrections (verified 2026-07-27)

| Row | Change |
|---|---|
| `macbook-m1-16gb` | IP `.170` → `.108` (DHCP); marked **online**, re-registered today; data volume ~95% full |
| `macbook-intel-64gb` | marked **not registered** — GC'd server-side, host off-network |
| 6 × AWS EC2 | marked **offline** (account suspension) |
| `**Total online: 12**` | stale and unverifiable → Registered/Online counts, the gap explained against the monitor's baseline, and the one-liner that regenerates them |

Added a note that the IP column is neither an identity nor a liveness check — identify by
`scutil --get LocalHostName` over SSH, judge liveness by the runner API.

## The incident entry

Both Mac incidents present an **identical surface symptom**: runner absent from the API, local
install present, LaunchAgent loaded. The entry leads with the discriminator, because that is what
would actually have saved time:

| | 2026-04-23 | 2026-07-27 |
|---|---|---|
| Log line | `Can't assign requested address` | `√ Connected to GitHub` |
| Cause | TCP ephemeral-port exhaustion (93d uptime) | GitHub deleted the registration for inactivity |
| Fix | reboot | re-register (reboot cannot fix server-side state) |

**One line — `√ Connected to GitHub` — rules out the entire network-exhaustion family.**

Second half of the failure: this host ran a non-standard
`~/Library/LaunchAgents/com.github.actions-runner.plist` with `KeepAlive=true`. The runner exits
deliberately on a deleted registration (`no retry needed`), and launchd restarted it forever —
`Runner.Listener` at **100% CPU, load average 84** on a 16 GB M1, doing zero work. That non-canonical
`Label` also made `./svc.sh status` report `not installed` on a host that was very much running one.

## Reviewed design tradeoffs

- **Recorded the misdiagnoses, not just the fix.** Both wrong turns here (IP-as-liveness, and
  assuming a recurrence of the April incident) are ones the *existing* doc actively encouraged — it
  published an IP table and a single Mac-runner incident whose fix was "reboot". Documenting only
  the resolution would leave both traps armed.
- **Left the monitor baseline at 12 rather than lowering it to 11.** The gap is real and should keep
  alerting; silencing it by editing the baseline would hide the suspended EC2 fleet and the missing
  MacBook. The doc now explains the gap instead.
- **Did not add the `KeepAlive` throttle as a code change here.** The right fix is preferring
  `svc.sh install` over hand-rolled plists, which the doc already prescribes; a `ThrottleInterval`
  patch to a plist that should not exist would entrench it. Called out in Lessons instead.
- **Marked rows in the existing table rather than splitting into online/offline sections.** Keeps
  one canonical roster to diff against `gh api` output; two lists drift.

## Verification

Roster figures taken directly from:

```bash
gh api repos/synaptent/aragora/actions/runners --jq '.runners[]|"\(.status)\t\(.name)"' | sort
# 11 registered, 5 online
```

Docs-only. `node docs-site/scripts/sync-docs.js` run — 276 files synced, no mirror changes for this
file, so no `build` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
