### PR TITLE
fix(receipts): preserve debate message fidelity (#9661)

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -820,7 +820,7 @@ def _collect_agent_contributions(result: Any) -> dict[str, dict[str, int]]:
         )
         entry[kind] += 1
 
-    for msg in getattr(result, "messages", []) or []:
+    for msg in _unique_debate_messages(result):
         if str(getattr(msg, "content", "") or "").strip():
             _bump(getattr(msg, "agent", ""), "messages")
     proposals = getattr(result, "proposals", None)
@@ -832,6 +832,35 @@ def _collect_agent_contributions(result: Any) -> dict[str, dict[str, int]]:
     for vote in getattr(result, "votes", []) or []:
         _bump(getattr(vote, "agent", ""), "votes")
     return contributions
+
+
+def _unique_debate_messages(result: Any) -> list[Any]:
+    """Return each recorded debate message once, preserving first-seen order."""
+    unique: list[Any] = []
+    seen: set[tuple[str, str, int, str]] = set()
+    for msg in getattr(result, "messages", []) or []:
+        key = (
+            str(getattr(msg, "agent", "") or "").strip(),
+            str(getattr(msg, "role", "") or "").strip(),
+            int(getattr(msg, "round", 0) or 0),
+            str(getattr(msg, "content", "") or "").strip(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(msg)
+    return unique
+
+
+def _receipt_source_revision() -> str:
+    """Resolve the code revision that generated a CLI debate receipt."""
+    try:
+        from aragora.server.build_info import get_build_info
+
+        revision = str(get_build_info().get("sha", "") or "").strip()
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        return "unknown"
+    return revision or "unknown"
 
 
 def _create_revision_agent(
@@ -884,7 +913,7 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         task = str(getattr(result, "task", "") or "")
         metadata = getattr(result, "metadata", None)
         agent_models = metadata.get("agent_models", {}) if isinstance(metadata, dict) else {}
-        messages = list(getattr(result, "messages", []) or [])
+        messages = _unique_debate_messages(result)
         agent_responses = []
         for msg in messages[:40]:
             agent_name = str(getattr(msg, "agent", "") or "").strip()
@@ -931,17 +960,8 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
                 name, {"messages": 0, "proposals": 0, "critiques": 0, "votes": 0}
             )
         contributing_agents = [name for name in agents if any(contributions[name].values())]
-        input_hash = hashlib.sha256(
-            json.dumps(
-                {
-                    "task": task,
-                    "agents": agents,
-                    "agent_responses": agent_responses,
-                },
-                sort_keys=True,
-                default=str,
-            ).encode()
-        ).hexdigest()
+        input_hash = hashlib.sha256(task.encode()).hexdigest() if task else ""
+        evidence_hash = hashlib.sha256(final_answer.encode()).hexdigest() if final_answer else ""
         receipt = {
             "receipt_id": f"debate-{debate_id}",
             "gauntlet_id": str(debate_id),
@@ -976,7 +996,7 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
                 "supporting_agents": contributing_agents if consensus_reached else [],
                 "dissenting_agents": [],
                 "method": "majority",
-                "evidence_hash": input_hash,
+                "evidence_hash": evidence_hash,
             },
             "provenance_chain": [
                 {
@@ -984,9 +1004,18 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
                     "event_type": "verdict",
                     "agent": "aragora ask",
                     "description": "Debate receipt persisted from aragora ask.",
-                    "evidence_hash": input_hash,
+                    "evidence_hash": evidence_hash,
                 }
             ],
+            "config_used": {
+                "source_revision": _receipt_source_revision(),
+                "input_hash_recipe": "sha256(utf8(task))",
+                "evidence_hash_recipe": "sha256(utf8(final_answer))",
+                "round_numbering": (
+                    "round 0 is the seed proposal; rounds_used counts subsequent "
+                    "deliberation rounds"
+                ),
+            },
         }
         model_comparison = metadata.get("model_comparison") if isinstance(metadata, dict) else None
         if isinstance(model_comparison, dict):

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -33,6 +33,7 @@ from aragora.config import (
 from aragora.config.secrets import get_secret_presence
 from aragora.core import Environment
 from aragora.debate.arena_primary_configs import MLConfig, MemoryConfig
+from aragora.debate.message_utils import unique_debate_messages
 from aragora.debate.orchestrator import Arena, DebateProtocol
 from aragora.memory.store import CritiqueStore
 from aragora.modes import ModeRegistry
@@ -820,7 +821,7 @@ def _collect_agent_contributions(result: Any) -> dict[str, dict[str, int]]:
         )
         entry[kind] += 1
 
-    for msg in _unique_debate_messages(result):
+    for msg in unique_debate_messages(getattr(result, "messages", []) or []):
         if str(getattr(msg, "content", "") or "").strip():
             _bump(getattr(msg, "agent", ""), "messages")
     proposals = getattr(result, "proposals", None)
@@ -832,24 +833,6 @@ def _collect_agent_contributions(result: Any) -> dict[str, dict[str, int]]:
     for vote in getattr(result, "votes", []) or []:
         _bump(getattr(vote, "agent", ""), "votes")
     return contributions
-
-
-def _unique_debate_messages(result: Any) -> list[Any]:
-    """Return each recorded debate message once, preserving first-seen order."""
-    unique: list[Any] = []
-    seen: set[tuple[str, str, int, str]] = set()
-    for msg in getattr(result, "messages", []) or []:
-        key = (
-            str(getattr(msg, "agent", "") or "").strip(),
-            str(getattr(msg, "role", "") or "").strip(),
-            int(getattr(msg, "round", 0) or 0),
-            str(getattr(msg, "content", "") or "").strip(),
-        )
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(msg)
-    return unique
 
 
 def _receipt_source_revision() -> str:
@@ -909,11 +892,11 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         debate_id = getattr(result, "debate_id", None) or "unknown"
         consensus_reached = getattr(result, "consensus_reached", False)
         confidence = getattr(result, "confidence", 0.0)
-        final_answer = getattr(result, "final_answer", "") or ""
+        final_answer = str(getattr(result, "final_answer", "") or "")
         task = str(getattr(result, "task", "") or "")
         metadata = getattr(result, "metadata", None)
         agent_models = metadata.get("agent_models", {}) if isinstance(metadata, dict) else {}
-        messages = _unique_debate_messages(result)
+        messages = unique_debate_messages(getattr(result, "messages", []) or [])
         agent_responses = []
         for msg in messages[:40]:
             agent_name = str(getattr(msg, "agent", "") or "").strip()
@@ -960,6 +943,9 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
                 name, {"messages": 0, "proposals": 0, "critiques": 0, "votes": 0}
             )
         contributing_agents = [name for name in agents if any(contributions[name].values())]
+        dissenting_views = [
+            str(view)[:500] for view in (getattr(result, "dissenting_views", []) or [])
+        ]
         input_hash = hashlib.sha256(task.encode()).hexdigest() if task else ""
         evidence_hash = hashlib.sha256(final_answer.encode()).hexdigest() if final_answer else ""
         receipt = {
@@ -987,9 +973,7 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
             "agents_failed": failed_roster,
             "agent_contributions": contributions,
             "agent_responses": agent_responses,
-            "dissenting_views": [
-                str(v)[:500] for v in (getattr(result, "dissenting_views", []) or [])
-            ],
+            "dissenting_views": dissenting_views,
             "consensus_proof": {
                 "reached": bool(consensus_reached),
                 "confidence": round(confidence, 4) if confidence else 0.0,
@@ -1028,7 +1012,10 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         cruxes = crux_cards_from_metadata(metadata)
         if cruxes is not None:
             receipt["cruxes"] = cruxes
-        receipt["schema_version"] = receipt_schema_version(cruxes)
+        receipt["schema_version"] = receipt_schema_version(
+            cruxes,
+            bind_debate_content=True,
+        )
 
         receipt["artifact_hash"] = DecisionReceipt.from_dict(receipt).artifact_hash
         receipt["checksum"] = receipt["artifact_hash"]

--- a/aragora/debate/crux_cards.py
+++ b/aragora/debate/crux_cards.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from aragora.debate.message_utils import unique_debate_messages
+
 logger = logging.getLogger(__name__)
 
 CRUX_CARDS_METADATA_KEY = "crux_cards"
@@ -107,7 +109,7 @@ def _network_from_messages(messages: list[Any], critiques: list[Any] | None = No
     except ImportError:
         return None
 
-    messages = _unique_messages(messages)
+    messages = unique_debate_messages(messages)
     network = BeliefNetwork(max_iterations=3)
     added = 0
     for i, msg in enumerate(messages):
@@ -123,24 +125,6 @@ def _network_from_messages(messages: list[Any], critiques: list[Any] | None = No
         return None
     _link_critiques(network, messages, critiques or [])
     return network
-
-
-def _unique_messages(messages: list[Any]) -> list[Any]:
-    """Deduplicate mirrored debate messages while preserving their first order."""
-    unique: list[Any] = []
-    seen: set[tuple[str, str, int, str]] = set()
-    for msg in messages:
-        key = (
-            str(getattr(msg, "agent", "") or "").strip(),
-            str(getattr(msg, "role", "") or "").strip(),
-            int(getattr(msg, "round", 0) or 0),
-            str(getattr(msg, "content", "") or "").strip(),
-        )
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(msg)
-    return unique
 
 
 def _claim_ids_for_agent(messages: list[Any], agent: str, role: str) -> list[str]:

--- a/aragora/debate/crux_cards.py
+++ b/aragora/debate/crux_cards.py
@@ -107,6 +107,7 @@ def _network_from_messages(messages: list[Any], critiques: list[Any] | None = No
     except ImportError:
         return None
 
+    messages = _unique_messages(messages)
     network = BeliefNetwork(max_iterations=3)
     added = 0
     for i, msg in enumerate(messages):
@@ -122,6 +123,24 @@ def _network_from_messages(messages: list[Any], critiques: list[Any] | None = No
         return None
     _link_critiques(network, messages, critiques or [])
     return network
+
+
+def _unique_messages(messages: list[Any]) -> list[Any]:
+    """Deduplicate mirrored debate messages while preserving their first order."""
+    unique: list[Any] = []
+    seen: set[tuple[str, str, int, str]] = set()
+    for msg in messages:
+        key = (
+            str(getattr(msg, "agent", "") or "").strip(),
+            str(getattr(msg, "role", "") or "").strip(),
+            int(getattr(msg, "round", 0) or 0),
+            str(getattr(msg, "content", "") or "").strip(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(msg)
+    return unique
 
 
 def _claim_ids_for_agent(messages: list[Any], agent: str, role: str) -> list[str]:

--- a/aragora/debate/message_utils.py
+++ b/aragora/debate/message_utils.py
@@ -1,0 +1,23 @@
+"""Shared helpers for debate message consumers."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def unique_debate_messages(messages: Iterable[Any]) -> list[Any]:
+    """Deduplicate mirrored debate messages while preserving first-seen order."""
+    unique: list[Any] = []
+    seen: set[tuple[str, str, int, str]] = set()
+    for message in messages:
+        key = (
+            str(getattr(message, "agent", "") or "").strip(),
+            str(getattr(message, "role", "") or "").strip(),
+            int(getattr(message, "round", 0) or 0),
+            str(getattr(message, "content", "") or "").strip(),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(message)
+    return unique

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -476,6 +476,7 @@ def build_crux_receipt_from_proof(
 # Pre-crux receipts (no cruxes) keep the original recipe untouched.
 RECEIPT_SCHEMA_VERSION = "1.1"
 RECEIPT_SCHEMA_VERSION_CRUXES = "1.2"
+RECEIPT_SCHEMA_VERSION_DEBATE_CONTENT = "1.3"
 
 
 def compute_receipt_artifact_hash(data: Any) -> str:
@@ -502,25 +503,58 @@ def compute_receipt_artifact_hash(data: Any) -> str:
         "verdict": data.get("verdict", ""),
         "confidence": data.get("confidence", 0.0),
     }
+    schema_version = data.get("schema_version", "1.0")
     if data.get("cruxes") is not None:
         payload["cruxes"] = data.get("cruxes")
         # Missing schema_version defaults to "1.0" (the from_dict convention)
         # so the same JSON cannot hash two ways.
-        schema_version = data.get("schema_version", "1.0")
-        if schema_version == RECEIPT_SCHEMA_VERSION_CRUXES:
+        if schema_version in {
+            RECEIPT_SCHEMA_VERSION_CRUXES,
+            RECEIPT_SCHEMA_VERSION_DEBATE_CONTENT,
+        }:
             payload["schema_version"] = schema_version
+    if schema_version == RECEIPT_SCHEMA_VERSION_DEBATE_CONTENT:
+        payload.update(
+            {
+                "schema_version": schema_version,
+                "input_summary": data.get("input_summary", ""),
+                "task": data.get("task", ""),
+                "final_answer": data.get("final_answer", ""),
+                "rounds_used": data.get("rounds_used", 0),
+                "agents": data.get("agents", []),
+                "agents_requested": data.get("agents_requested", []),
+                "agents_failed": data.get("agents_failed", []),
+                "agent_contributions": data.get("agent_contributions", {}),
+                "agent_responses": data.get("agent_responses", []),
+                "dissenting_views": data.get("dissenting_views", []),
+                "consensus_proof": data.get("consensus_proof"),
+                "provenance_chain": data.get("provenance_chain", []),
+                "verdict_reasoning": data.get("verdict_reasoning", ""),
+                "config_used": data.get("config_used", {}),
+            }
+        )
     content = json.dumps(payload, sort_keys=True)
     return hashlib.sha256(content.encode()).hexdigest()
 
 
-def receipt_schema_version(cruxes: dict[str, Any] | None) -> str:
+def receipt_schema_version(
+    cruxes: dict[str, Any] | None,
+    *,
+    bind_debate_content: bool = False,
+) -> str:
     """Schema version for a receipt given its cruxes block.
 
     Bumps to 1.2 exactly when a cruxes block is carried, giving older
     verifiers a version signal instead of a spurious tampering report.
     Shared by ``DecisionReceipt.from_debate_result`` and the CLI receipt
     persistence so version and content cannot drift apart.
+
+    CLI debate receipts use 1.3 to bind their recorded debate content directly
+    into ``artifact_hash``. Older 1.1/1.2 receipts retain their original hash
+    recipe and continue to verify unchanged.
     """
+    if bind_debate_content:
+        return RECEIPT_SCHEMA_VERSION_DEBATE_CONTENT
     return RECEIPT_SCHEMA_VERSION_CRUXES if cruxes is not None else RECEIPT_SCHEMA_VERSION
 
 
@@ -649,6 +683,16 @@ class DecisionReceipt:
     # flag-off receipts remain byte-identical to pre-crux receipts.
     cruxes: dict[str, Any] | None = None
 
+    # Debate-specific content carried by CLI receipts. Schema 1.3 binds these
+    # fields directly into artifact_hash; older schemas ignore the defaults.
+    task: str = ""
+    final_answer: str = ""
+    rounds_used: int = 0
+    agents: list[str] = field(default_factory=list)
+    agents_requested: list[str] = field(default_factory=list)
+    agents_failed: list[str] = field(default_factory=list)
+    agent_contributions: dict[str, dict[str, int]] = field(default_factory=dict)
+
     # Schema version for forward compatibility
     schema_version: str = "1.1"
 
@@ -689,6 +733,22 @@ class DecisionReceipt:
                 "confidence": self.confidence,
                 "cruxes": self.cruxes,
                 "schema_version": self.schema_version,
+                "input_summary": self.input_summary,
+                "task": self.task,
+                "final_answer": self.final_answer,
+                "rounds_used": self.rounds_used,
+                "agents": self.agents,
+                "agents_requested": self.agents_requested,
+                "agents_failed": self.agents_failed,
+                "agent_contributions": self.agent_contributions,
+                "agent_responses": [response.to_dict() for response in self.agent_responses],
+                "dissenting_views": self.dissenting_views,
+                "consensus_proof": (
+                    self.consensus_proof.to_dict() if self.consensus_proof else None
+                ),
+                "provenance_chain": [record.to_dict() for record in self.provenance_chain],
+                "verdict_reasoning": self.verdict_reasoning,
+                "config_used": self.config_used,
             }
         )
 
@@ -2202,6 +2262,18 @@ class DecisionReceipt:
         # flag-off receipts stay byte-identical (#8227).
         if self.cruxes is not None:
             data["cruxes"] = self.cruxes
+        if self.schema_version == RECEIPT_SCHEMA_VERSION_DEBATE_CONTENT:
+            data.update(
+                {
+                    "task": self.task,
+                    "final_answer": self.final_answer,
+                    "rounds_used": self.rounds_used,
+                    "agents": self.agents,
+                    "agents_requested": self.agents_requested,
+                    "agents_failed": self.agents_failed,
+                    "agent_contributions": self.agent_contributions,
+                }
+            )
         # Include signature fields if present
         if self.signature:
             data["signature"] = self.signature
@@ -2253,6 +2325,13 @@ class DecisionReceipt:
             settlement_status=data.get("settlement_status"),
             explainability=data.get("explainability"),
             cruxes=data.get("cruxes"),
+            task=data.get("task", ""),
+            final_answer=data.get("final_answer", ""),
+            rounds_used=data.get("rounds_used", 0),
+            agents=data.get("agents", []) or [],
+            agents_requested=data.get("agents_requested", []) or [],
+            agents_failed=data.get("agents_failed", []) or [],
+            agent_contributions=data.get("agent_contributions", {}) or {},
             config_used=data.get("config_used", {}) or {},
             # Signature fields
             signature=data.get("signature"),

--- a/tests/cli/test_debate_receipt.py
+++ b/tests/cli/test_debate_receipt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,6 +17,10 @@ def test_persisted_debate_receipt_verifies_with_receipt_cli(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "aragora.cli.commands.debate._receipt_source_revision",
+        lambda: "a" * 40,
+    )
     result = SimpleNamespace(
         debate_id="debate-smoke",
         task="Verify provider-bootstrap dogfood receipts.",
@@ -51,6 +56,18 @@ def test_persisted_debate_receipt_verifies_with_receipt_cli(
     assert data["receipt_id"] == "debate-debate-smoke"
     assert data["verdict"] == "PASS"
     assert data["timestamp"].endswith("Z")
+    assert data["input_hash"] == hashlib.sha256(data["task"].encode()).hexdigest()
+    expected_evidence_hash = hashlib.sha256(data["final_answer"].encode()).hexdigest()
+    assert data["consensus_proof"]["evidence_hash"] == expected_evidence_hash
+    assert data["provenance_chain"][0]["evidence_hash"] == expected_evidence_hash
+    assert data["config_used"] == {
+        "source_revision": "a" * 40,
+        "input_hash_recipe": "sha256(utf8(task))",
+        "evidence_hash_recipe": "sha256(utf8(final_answer))",
+        "round_numbering": (
+            "round 0 is the seed proposal; rounds_used counts subsequent deliberation rounds"
+        ),
+    }
     assert len(data["artifact_hash"]) == 64
     assert DecisionReceipt.from_dict(data).verify_integrity() is True
 
@@ -59,6 +76,42 @@ def test_persisted_debate_receipt_verifies_with_receipt_cli(
 
     assert excinfo.value.code == 0
     assert "Result: VALID" in capsys.readouterr().out
+
+
+def test_persisted_debate_receipt_deduplicates_identical_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #9661: mirrored phase writes must not double-count responses."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    message = SimpleNamespace(
+        agent="codex",
+        role="critic",
+        round=1,
+        content="This objection should appear once.",
+    )
+    result = SimpleNamespace(
+        debate_id="debate-dedup",
+        task="Should repeated objections accumulate?",
+        consensus_reached=True,
+        confidence=0.8,
+        final_answer="Count each recorded response once.",
+        rounds_used=1,
+        dissenting_views=[],
+        participants=["codex"],
+        proposals={},
+        critiques=[],
+        votes=[],
+        metadata={},
+        messages=[message, message],
+    )
+
+    receipt_path = _persist_debate_receipt(result)
+
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    assert len(data["agent_responses"]) == 1
+    assert data["agent_contributions"]["codex"]["messages"] == 1
+    assert data["input_hash"] == hashlib.sha256(data["task"].encode()).hexdigest()
 
 
 def _mixed_family_result() -> SimpleNamespace:

--- a/tests/cli/test_debate_receipt.py
+++ b/tests/cli/test_debate_receipt.py
@@ -56,6 +56,7 @@ def test_persisted_debate_receipt_verifies_with_receipt_cli(
     assert data["receipt_id"] == "debate-debate-smoke"
     assert data["verdict"] == "PASS"
     assert data["timestamp"].endswith("Z")
+    assert data["schema_version"] == "1.3"
     assert data["input_hash"] == hashlib.sha256(data["task"].encode()).hexdigest()
     expected_evidence_hash = hashlib.sha256(data["final_answer"].encode()).hexdigest()
     assert data["consensus_proof"]["evidence_hash"] == expected_evidence_hash
@@ -76,6 +77,60 @@ def test_persisted_debate_receipt_verifies_with_receipt_cli(
 
     assert excinfo.value.code == 0
     assert "Result: VALID" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("final_answer", "Tampered answer"),
+        ("agents", ["unknown-agent"]),
+        (
+            "agent_responses",
+            [
+                {
+                    "agent": "grok_proposer",
+                    "role": "proposer",
+                    "round": 0,
+                    "response": "Tampered response",
+                }
+            ],
+        ),
+        ("dissenting_views", ["Tampered dissent"]),
+        ("config_used", {"source_revision": "tampered"}),
+    ],
+)
+def test_schema_13_receipt_binds_recorded_debate_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+    replacement: object,
+) -> None:
+    """Schema 1.3 must reject edits to externally auditable debate content."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _mixed_family_result()
+
+    receipt_path = _persist_debate_receipt(result)
+
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    data[field] = replacement
+    assert DecisionReceipt.from_dict(data).verify_integrity() is False
+
+
+def test_persisted_debate_receipt_stringifies_non_string_final_answer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Receipt persistence must not disappear when a result carries a rich answer."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    result = _mixed_family_result()
+    result.final_answer = {"decision": "ship"}
+
+    receipt_path = _persist_debate_receipt(result)
+
+    assert receipt_path is not None
+    data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
+    assert data["final_answer"] == "{'decision': 'ship'}"
+    assert DecisionReceipt.from_dict(data).verify_integrity() is True
 
 
 def test_persisted_debate_receipt_deduplicates_identical_messages(
@@ -261,9 +316,9 @@ def test_receipt_carries_crux_cards_from_metadata(
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert data["cruxes"]["items"][0]["claim_id"] == "c1"
     assert data["cruxes"]["detector"] == "belief_network"
-    # Cruxes bind into artifact_hash, so the schema version must signal it
-    # to older verifiers instead of reading as tampering.
-    assert data["schema_version"] == "1.2"
+    # CLI debate receipts use schema 1.3 to bind both cruxes and the recorded
+    # debate content into artifact_hash.
+    assert data["schema_version"] == "1.3"
     assert DecisionReceipt.from_dict(data).verify_integrity() is True
 
 
@@ -304,7 +359,7 @@ def test_receipt_omits_cruxes_when_crux_cards_absent_or_empty(
     assert receipt_path is not None
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert "cruxes" not in data
-    assert data["schema_version"] == "1.1"
+    assert data["schema_version"] == "1.3"
 
     empty = _mixed_family_result()
     empty.metadata["crux_cards"] = {"items": []}
@@ -312,4 +367,4 @@ def test_receipt_omits_cruxes_when_crux_cards_absent_or_empty(
     assert receipt_path is not None
     data = json.loads(Path(receipt_path).read_text(encoding="utf-8"))
     assert "cruxes" not in data
-    assert data["schema_version"] == "1.1"
+    assert data["schema_version"] == "1.3"

--- a/tests/debate/test_crux_cards.py
+++ b/tests/debate/test_crux_cards.py
@@ -308,6 +308,29 @@ def test_successive_critiques_anchor_to_successive_messages():
     assert sources == {"first objection", "second objection"}
 
 
+def test_duplicate_messages_do_not_duplicate_crux_nodes():
+    """Issue #9661: mirrored result messages must not distort crux ranking."""
+    proposal = Message(role="proposer", agent="claude", content="Ship the change.", round=0)
+    objection = Message(role="critic", agent="codex", content="The risk is high.", round=1)
+    critiques = [
+        Critique(
+            agent="codex",
+            target_agent="claude",
+            target_content=proposal.content,
+            issues=["risk"],
+            suggestions=[],
+            severity=5.0,
+            reasoning="r",
+        )
+    ]
+
+    network = _network_from_messages([proposal, objection, objection], critiques)
+
+    assert network is not None
+    assert len(network.nodes) == 2
+    assert len(network.factors) == 1
+
+
 def test_unmappable_critiques_are_skipped_not_raised():
     """Crux building is optional enrichment; bad input must not break a debate."""
     messages, _ = _contested_debate()


### PR DESCRIPTION
## Summary

Addresses #9661 by making externally published debate receipts reproducible and resistant to mirrored phase writes:

- deduplicates exact debate messages before receipt response/contribution accounting
- deduplicates exact messages before fallback crux-network construction so mirrored writes do not distort top-k crux ranking
- derives `input_hash` from the carried `task` and consensus/provenance evidence hashes from the carried `final_answer`
- records the generating source revision and both hash recipes
- documents the round convention: round 0 is the seed proposal, while `rounds_used` counts subsequent deliberation rounds

The deduplication is deliberately scoped to receipt and crux consumers. It does not rewrite the live debate transcript or phase orchestration.

## Validation

- `python3 -m pytest -q tests/cli/test_debate_receipt.py tests/debate/test_crux_cards.py` - 35 passed
- `python3 -m ruff check aragora/cli/commands/debate.py aragora/debate/crux_cards.py tests/cli/test_debate_receipt.py tests/debate/test_crux_cards.py` - passed
- `git diff --check` - passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` - passed
- pre-commit and pre-push hooks, including changed-file mypy - passed

## Follow-up

After this lands, the July W3 crux receipt should be regenerated from the fixed code so its response counts, crux ranking, hashes, and source revision are clean evidence rather than a disclosed provisional artifact.
