### PR TITLE
fix(debate): record each message once; the mock was hiding the duplication (#9661)

### DIFF
--- a/aragora/debate/debate_state.py
+++ b/aragora/debate/debate_state.py
@@ -375,10 +375,10 @@ class DebateContext:
         return self.proposals.get(agent_name, "")
 
     def add_message(self, msg: Message) -> None:
-        """Add a message to both context and partial tracking."""
+        """Record one message in context, recovery, and final-result tracking."""
         self.context_messages.append(msg)
         self.partial_messages.append(msg)
-        if self.result:
+        if self.result is not None:
             self.result.messages.append(msg)
 
     def record_agent_failure(

--- a/aragora/debate/phases/critique_generator.py
+++ b/aragora/debate/phases/critique_generator.py
@@ -166,15 +166,21 @@ class CritiqueGenerator:
         async def generate_critique(critic: Agent, proposal_agent: str, proposal: str):
             """Generate critique and return CritiqueResult."""
             logger.debug("critique_generating critic=%s target=%s", critic.name, proposal_agent)
+            # Bound once so the optional-callable narrowing holds at every call
+            # site below (the attribute form defeats it).
+            critique_with_agent = self._critique_with_agent
+            if critique_with_agent is None:
+                return None
             base_timeout = getattr(critic, "timeout", AGENT_TIMEOUT_SECONDS)
             timeout = get_complexity_governor().get_scaled_timeout(float(base_timeout))
             task_id = f"{critic.name}:critique:{proposal_agent}"
 
             try:
                 with streaming_task_context(task_id):
-                    if self._with_timeout:
-                        crit_result = await self._with_timeout(
-                            self._critique_with_agent(
+                    with_timeout = self._with_timeout
+                    if with_timeout is not None:
+                        crit_result = await with_timeout(
+                            critique_with_agent(
                                 critic,
                                 proposal,
                                 ctx.env.task if ctx.env else "",
@@ -185,7 +191,7 @@ class CritiqueGenerator:
                             timeout_seconds=timeout,
                         )
                     else:
-                        crit_result = await self._critique_with_agent(
+                        crit_result = await critique_with_agent(
                             critic,
                             proposal,
                             ctx.env.task if ctx.env else "",
@@ -201,9 +207,10 @@ class CritiqueGenerator:
                     )
                     retry_task_id = f"{critic.name}:critique:{proposal_agent}:retry"
                     with streaming_task_context(retry_task_id):
-                        if self._with_timeout:
-                            crit_result = await self._with_timeout(
-                                self._critique_with_agent(
+                        retry_with_timeout = self._with_timeout
+                        if retry_with_timeout is not None:
+                            crit_result = await retry_with_timeout(
+                                critique_with_agent(
                                     critic,
                                     proposal,
                                     ctx.env.task if ctx.env else "",
@@ -214,7 +221,7 @@ class CritiqueGenerator:
                                 timeout_seconds=timeout,
                             )
                         else:
-                            crit_result = await self._critique_with_agent(
+                            crit_result = await critique_with_agent(
                                 critic,
                                 proposal,
                                 ctx.env.task if ctx.env else "",
@@ -558,8 +565,7 @@ class CritiqueGenerator:
             content=critique_content,
             round=round_num,
         )
-        ctx.add_message(msg)
-        result.messages.append(msg)
+        ctx.add_message(msg)  # also appends to result.messages (#9661)
         partial_messages.append(msg)
         new_messages.append(msg)
 

--- a/aragora/debate/phases/critique_generator.py
+++ b/aragora/debate/phases/critique_generator.py
@@ -156,7 +156,8 @@ class CritiqueGenerator:
         new_messages: list[Message] = []
         new_critiques: list[Critique] = []
 
-        if not self._critique_with_agent:
+        critique_with_agent = self._critique_with_agent
+        if critique_with_agent is None:
             logger.warning("No critique_with_agent callback, skipping critiques")
             return (new_messages, new_critiques)
 
@@ -166,11 +167,6 @@ class CritiqueGenerator:
         async def generate_critique(critic: Agent, proposal_agent: str, proposal: str):
             """Generate critique and return CritiqueResult."""
             logger.debug("critique_generating critic=%s target=%s", critic.name, proposal_agent)
-            # Bound once so the optional-callable narrowing holds at every call
-            # site below (the attribute form defeats it).
-            critique_with_agent = self._critique_with_agent
-            if critique_with_agent is None:
-                return None
             base_timeout = getattr(critic, "timeout", AGENT_TIMEOUT_SECONDS)
             timeout = get_complexity_governor().get_scaled_timeout(float(base_timeout))
             task_id = f"{critic.name}:critique:{proposal_agent}"

--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -1237,8 +1237,7 @@ class DebateRoundsPhase:
                     content=critique_content,
                     round=round_num,
                 )
-                ctx.add_message(msg)
-                result.messages.append(msg)
+                ctx.add_message(msg)  # also appends to result.messages (#9661)
                 self._partial_messages.append(msg)
 
         return round_critiques
@@ -1499,8 +1498,7 @@ class DebateRoundsPhase:
                     content=revised_str,
                     round=round_num,
                 )
-                ctx.add_message(msg)
-                result.messages.append(msg)
+                ctx.add_message(msg)  # also appends to result.messages (#9661)
                 self._partial_messages.append(msg)
 
                 # Emit message event

--- a/aragora/debate/phases/debate_rounds_helpers.py
+++ b/aragora/debate/phases/debate_rounds_helpers.py
@@ -520,8 +520,7 @@ async def execute_final_synthesis_round(
                     content=final_proposal,
                     round=round_num,
                 )
-                ctx.add_message(msg)
-                result.messages.append(msg)
+                ctx.add_message(msg)  # also appends to result.messages (#9661)
                 partial_messages.append(msg)
 
                 # Emit event
@@ -630,7 +629,7 @@ async def fire_propulsion_event(
     round_num: int,
     propulsion_engine: Any,
     enable_propulsion: bool,
-    data: dict = None,
+    data: dict | None = None,
 ) -> None:
     """Fire propulsion event to push work to the next stage.
 

--- a/aragora/debate/phases/revision_phase.py
+++ b/aragora/debate/phases/revision_phase.py
@@ -148,7 +148,9 @@ class RevisionGenerator:
         proposals = ctx.proposals
         updated_proposals: dict[str, str] = {}
 
-        if not self._generate_with_agent or not self._build_revision_prompt:
+        generate_with_agent = self._generate_with_agent
+        build_revision_prompt = self._build_revision_prompt
+        if generate_with_agent is None or build_revision_prompt is None:
             logger.warning("Missing callbacks for revision phase")
             return updated_proposals
 
@@ -168,16 +170,13 @@ class RevisionGenerator:
                 self._start_molecule(agent.name)
                 with streaming_task_context(task_id):
                     with_timeout = self._with_timeout
-                    generate = self._generate_with_agent
-                    if generate is None:
-                        return None
                     if with_timeout is not None:
                         return await with_timeout(
-                            generate(agent, revision_prompt, ctx.context_messages),
+                            generate_with_agent(agent, revision_prompt, ctx.context_messages),
                             agent.name,
                             timeout_seconds=timeout,
                         )
-                    return await generate(agent, revision_prompt, ctx.context_messages)
+                    return await generate_with_agent(agent, revision_prompt, ctx.context_messages)
 
         # Build revision tasks for all proposers
         revision_tasks = []
@@ -192,7 +191,7 @@ class RevisionGenerator:
                 logger.debug("No critiques targeting %s, skipping revision", agent.name)
                 continue
 
-            revision_prompt = self._build_revision_prompt(
+            revision_prompt = build_revision_prompt(
                 agent, proposals.get(agent.name, ""), agent_critiques, round_num
             )
             revision_tasks.append(generate_revision_bounded(agent, revision_prompt))

--- a/aragora/debate/phases/revision_phase.py
+++ b/aragora/debate/phases/revision_phase.py
@@ -167,16 +167,17 @@ class RevisionGenerator:
                 # Mark molecule as in_progress
                 self._start_molecule(agent.name)
                 with streaming_task_context(task_id):
-                    if self._with_timeout:
-                        return await self._with_timeout(
-                            self._generate_with_agent(agent, revision_prompt, ctx.context_messages),
+                    with_timeout = self._with_timeout
+                    generate = self._generate_with_agent
+                    if generate is None:
+                        return None
+                    if with_timeout is not None:
+                        return await with_timeout(
+                            generate(agent, revision_prompt, ctx.context_messages),
                             agent.name,
                             timeout_seconds=timeout,
                         )
-                    else:
-                        return await self._generate_with_agent(
-                            agent, revision_prompt, ctx.context_messages
-                        )
+                    return await generate(agent, revision_prompt, ctx.context_messages)
 
         # Build revision tasks for all proposers
         revision_tasks = []
@@ -295,8 +296,7 @@ class RevisionGenerator:
                 content=revised_str,
                 round=round_num,
             )
-            ctx.add_message(msg)
-            result.messages.append(msg)
+            ctx.add_message(msg)  # also appends to result.messages (#9661)
             partial_messages.append(msg)
 
             # Emit message event
@@ -316,11 +316,14 @@ class RevisionGenerator:
                     logger.debug("Recorder error for revision: %s", e)
 
             # Record position for grounded personas
-            if self._record_grounded_position:
+            record_position = self._record_grounded_position
+            if record_position is not None:
                 debate_id = (
-                    result.id if hasattr(result, "id") else (ctx.env.task[:50] if ctx.env else "")
+                    result.id
+                    if result is not None and hasattr(result, "id")
+                    else (ctx.env.task[:50] if ctx.env else "")
                 )
-                self._record_grounded_position(agent.name, revised_str, debate_id, round_num, 0.75)
+                record_position(agent.name, revised_str, debate_id, round_num, 0.75)
 
             # Observe rhetorical patterns for audience engagement
             loop_id = ctx.loop_id if hasattr(ctx, "loop_id") else ""

--- a/tests/debate/phases/test_critique_generator.py
+++ b/tests/debate/phases/test_critique_generator.py
@@ -64,6 +64,7 @@ class MockDebateContext:
     env: MockEnv = field(default_factory=MockEnv)
     proposals: dict = field(default_factory=dict)
     context_messages: list = field(default_factory=list)
+    partial_messages: list = field(default_factory=list)
     debate_id: str = "test-debate-123"
     agent_failures: dict = field(default_factory=dict)
 
@@ -85,8 +86,10 @@ class MockDebateContext:
         self.agent_failures.setdefault(agent_name, []).append(record)
 
     def add_message(self, msg: Any) -> None:
-        """Add a message to context messages."""
+        """Mirror production message tracking."""
         self.context_messages.append(msg)
+        self.partial_messages.append(msg)
+        self.result.messages.append(msg)
 
 
 @dataclass
@@ -455,6 +458,35 @@ class TestExecuteCritiquePhase:
 
         # Should generate critiques since proposals are valid
         assert critique_cb.called
+        assert len(ctx.result.messages) == 1
+        assert len(ctx.context_messages) == 1
+        assert len(ctx.partial_messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_uses_callback_bound_at_phase_entry(self):
+        """A later attribute mutation must not yield a silent None task result."""
+        mock_critique = create_critique(agent="critic1", target_agent="proposer1")
+        critique_cb = AsyncMock(return_value=mock_critique)
+        gen = CritiqueGenerator(critique_with_agent=critique_cb)
+
+        def select_critics(_proposal_agent, critics):
+            gen._critique_with_agent = None
+            return critics
+
+        gen._select_critics_for_proposal = select_critics
+        ctx = MockDebateContext(proposals={"proposer1": "A proposal"})
+
+        messages, critiques = await gen.execute_critique_phase(
+            ctx=ctx,
+            critics=[MockAgent(name="critic1")],
+            round_num=1,
+            partial_messages=[],
+            partial_critiques=[],
+        )
+
+        assert len(messages) == 1
+        assert len(critiques) == 1
+        critique_cb.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_skips_empty_proposals(self):

--- a/tests/debate/phases/test_revision_phase.py
+++ b/tests/debate/phases/test_revision_phase.py
@@ -88,12 +88,25 @@ class MockDebateContext:
         self.env = MockEnvironment(task=task)
         self.result = MockDebateResult(id=debate_id)
         self.context_messages = []
+        self.partial_messages = []
         self.loop_id = "loop-1"
         self.debate_id = debate_id
 
     def add_message(self, msg):
-        """Add a message to context."""
+        """Mirror :meth:`DebateContext.add_message` — all three destinations.
+
+        The real method appends to ``context_messages``, ``partial_messages``
+        AND ``result.messages`` (``debate_state.py``). This mock previously
+        appended only to ``context_messages``, so phases that *also* appended to
+        ``result.messages`` themselves looked correct here while double-counting
+        every message in production — which is exactly how #9661 survived: the
+        assertion below expects one message and got one, because the mock did
+        not reproduce the duplication the real context caused.
+        """
         self.context_messages.append(msg)
+        self.partial_messages.append(msg)
+        if self.result is not None:
+            self.result.messages.append(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -2543,3 +2556,28 @@ class TestRevisionGeneratorIntegration:
 
         assert ctx.proposals["agent1"] == "Revised A1"
         assert ctx.proposals["agent2"] == "Untouched A2"
+
+
+@pytest.mark.asyncio
+async def test_revision_message_is_recorded_exactly_once():
+    """#9661: every mid-debate message was recorded twice.
+
+    `DebateContext.add_message` already appends to `result.messages`, and the
+    phases appended again themselves, so each message landed twice — inflating
+    `agent_contributions` and putting byte-identical duplicate claims into the
+    crux top-k, which distorted card ranking in published receipts.
+
+    Asserting "exactly once" rather than "at least one" is the point: the old
+    assertion passed against a mock that did not reproduce the duplication.
+    """
+    generator = RevisionGenerator(
+        generate_with_agent=AsyncMock(return_value="Revised proposal"),
+        build_revision_prompt=MagicMock(return_value="Revision prompt"),
+    )
+    ctx = MockDebateContext(proposers=[MockAgent("agent1")], proposals={"agent1": "Proposal"})
+
+    await generator.execute_revision_phase(ctx, 1, [MockCritique("critic", "agent1")], [])
+
+    assert len(ctx.result.messages) == 1
+    assert len(ctx.context_messages) == 1
+    assert len(ctx.partial_messages) == 1

--- a/tests/debate/phases/test_revision_phase.py
+++ b/tests/debate/phases/test_revision_phase.py
@@ -2557,6 +2557,32 @@ class TestRevisionGeneratorIntegration:
         assert ctx.proposals["agent1"] == "Revised A1"
         assert ctx.proposals["agent2"] == "Untouched A2"
 
+    @pytest.mark.asyncio
+    async def test_uses_callbacks_bound_at_phase_entry(self):
+        """A later attribute mutation must not yield a silent None revision."""
+        generate = AsyncMock(return_value="Revised A1")
+        generator = RevisionGenerator(generate_with_agent=generate)
+
+        def build_prompt(*_args):
+            generator._generate_with_agent = None
+            return "prompt"
+
+        generator._build_revision_prompt = build_prompt
+        ctx = MockDebateContext(
+            proposers=[MockAgent("agent1")],
+            proposals={"agent1": "Old A1"},
+        )
+
+        result = await generator.execute_revision_phase(
+            ctx,
+            1,
+            [MockCritique("critic", "agent1")],
+            [],
+        )
+
+        assert result == {"agent1": "Revised A1"}
+        generate.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 async def test_revision_message_is_recorded_exactly_once():

--- a/tests/debate/test_debate_context.py
+++ b/tests/debate/test_debate_context.py
@@ -219,14 +219,16 @@ class TestMessageTracking:
         assert ctx.partial_messages[0] == msg
 
     def test_add_message_to_result(self):
-        """Should add message to result when result exists."""
+        """One call should record exactly once in every production destination."""
         ctx = DebateContext(env=MockEnvironment())
         ctx.result = MockDebateResult()
         msg = MockMessage(content="Test message")
 
         ctx.add_message(msg)
 
-        assert len(ctx.result.messages) == 1
+        assert ctx.context_messages == [msg]
+        assert ctx.partial_messages == [msg]
+        assert ctx.result.messages == [msg]
 
     def test_add_message_no_result(self):
         """Should not crash when result is None."""


### PR DESCRIPTION
## Summary

Fixes the first and most consequential defect in #9661: **every mid-debate
response was recorded twice** in DecisionReceipts.

## Root cause

`DebateContext.add_message` already appends to `context_messages`,
`partial_messages` **and** `result.messages` (`debate_state.py:377-382`). Five
call sites then appended to `result.messages` again — `revision_phase`,
`debate_rounds` (×2), `critique_generator`, `debate_rounds_helpers`.

Effects on published receipts:

- `agent_responses` held each round-1/round-2 message twice
- `agent_contributions` overcounted — codex showed `messages: 4` for two actual
  messages
- duplicated messages entered the crux belief network as **byte-identical
  claims** that occupied top-k slots, distorting `crux_score` ranking

Dissent attribution was unaffected: `disagreement_score` takes the max per
author, so duplicate edges from one agent do not accumulate. That distinction is
why the July bundle's crux gate is currently recorded as *"met for dissent
attribution; ranking provisional"* rather than closed — this PR is what lets it
close.

## Why the tests did not catch it

`MockDebateContext.add_message` appended only to `context_messages`, unlike the
real method. The mock **cancelled the production bug out**: phases
double-appended, the mock single-appended, and
`test_execute_appends_to_result_messages` asserted `== 1` and passed.

A test that actively protected the defect. The mock now mirrors the real
contract on all three destinations, and a new test asserts each message is
recorded **exactly once** in all three — "exactly once" rather than "at least
one" is the entire point. It fails against the previous implementation.

`self._partial_messages` in `debate_rounds` is a genuinely separate list exposed
via `get_partial_messages()`, so those appends are deliberately untouched.

## Unplanned scope — flagged, not buried

The pre-push mypy hook gates on changed files, so touching these four pulled in
**8 pre-existing type errors** that had to be cleared to land a 4-line fix.

Those changes are mechanical narrowing (binding optional callables to locals so
mypy can narrow them; one implicit-Optional default), **with one caveat worth a
reviewer's attention**: two sites now `return None` early where a `None`
callable would previously have raised `TypeError`. That path should not occur —
the callbacks are always wired by the Arena, and there is already a
`if not self._critique_with_agent: skip` guard upstream — but it is a real
behaviour change on a branch that is unreachable in practice.

## Testing

**1624 debate tests pass.** mypy clean on all four touched files (was 8 errors
on `main`).

## Still open in #9661

Untouched here and deliberately not bundled: non-reproducible `input_hash` (and
the `evidence_hash` fields that reuse its pre-image), `rounds_used: 2` against
responses spanning rounds 0–2, and the receipt recording no generating commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
