### PR TITLE
docs: mirror Chinese reviewer family specification

### DIFF
--- a/docs-site/docs/specs/chinese-routed-reviewer-families-9071.md
+++ b/docs-site/docs/specs/chinese-routed-reviewer-families-9071.md
@@ -1,0 +1,59 @@
+---
+title: "Chinese-Routed Reviewer Families for #9071"
+description: "Chinese-Routed Reviewer Families for #9071"
+---
+
+# Chinese-Routed Reviewer Families for #9071
+
+**Status:** implementation preapproved; merge settlement pending
+**Date:** 2026-07-09
+**Authority:** issue #9069 founder approval, work order #9071
+**Tier:** 4 (model-family recognition changes merge-authority behavior)
+
+## Decision
+
+Activate GLM and MiniMax as OpenRouter-direct reviewer families and add Tencent
+Hy3 and ByteDance Seed as new canonical reviewer families. All four are
+Chinese-routed. They can contribute advisory diversity at every Tier, count at
+Tier 0-1, and count at Tier 2 only alongside at least one Western family. They
+remain advisory-only and are excluded from counted quorum at Tier 3-4.
+
+| Canonical family | OpenRouter model | Provider lineage | Tier 3-4 |
+| --- | --- | --- | --- |
+| `glm` | `z-ai/glm-5.2` | Z.ai / Zhipu | Advisory-only |
+| `minimax` | `minimax/minimax-m3` | MiniMax | Advisory-only |
+| `tencent` | `tencent/hy3` | Tencent Hunyuan | Advisory-only |
+| `bytedance` | `bytedance-seed/seed-2.0-lite` | ByteDance Seed | Advisory-only |
+
+The slugs and non-zero prompt/completion prices were verified against the live
+OpenRouter model catalog on 2026-07-09. Dispatch remains opt-in through
+`ARAGORA_ENABLE_OPENROUTER_REVIEWER_FALLBACK=1` plus `OPENROUTER_API_KEY`.
+
+## Jurisdiction Boundary
+
+These families may receive public OSS PR titles and diffs. They must never
+receive raw email bodies, customer PII, credentials, private legal material, or
+regulated data. This change does not alter payload routing policy; it only adds
+reviewer identities and opt-in OpenRouter dispatch for public repository diffs.
+
+## Gate Invariants
+
+- `WESTERN_FAMILIES`, `WESTERN_FRONTIER_FAMILIES`, and `tier_quorum_rule` remain
+  unchanged.
+- Tencent and ByteDance aliases normalize to one canonical family each, so a
+  provider cannot inflate distinct-family counts through naming variants.
+- Tier 3-4 settlement still requires two counted Western families.
+- Tier 2 still requires at least one Western family.
+- Named runtime agent types and allowlist counts are not added; generic
+  OpenRouter reviewer dispatch is sufficient for this work order.
+
+## Verification
+
+Focused tests cover OpenRouter dispatch, alias and reviewer-id normalization,
+non-zero pricing, and Tier 2-4 jurisdiction behavior. LongCat 2.0, Seed 2.1 /
+Doubao 2.1 Pro, and Hunyuan models beyond Hy3 remain watch items because the
+approved OpenRouter catalog snapshot did not expose the requested production
+slugs.
+
+This document records implementation scope only. The draft PR must remain
+unsettled until exact-head Tier-4 human settlement is recorded.

--- a/docs-site/docs/specs/index.md
+++ b/docs-site/docs/specs/index.md
@@ -13,6 +13,7 @@ Explore the documentation in this section to learn more.
 ## In This Section
 
 - [Aragora Roadmap Revision: Local Advocates as an Augmentation Layer (Draft v0.1)](./aragora-roadmap-revision-advocates)
+- [Chinese-Routed Reviewer Families for #9071](./chinese-routed-reviewer-families-9071)
 - [Essay Refinement Pipeline — Implementation Spec](./essay-refinement-pipeline)
 - [Finding-Severity Dissent Gate (Tier 4 Pre-Approval)](./finding-severity-gate)
 - [Independent Verifier Guide — aragora-verify](./independent-verifier-guide)

--- a/docs-site/scripts/sync-docs.js
+++ b/docs-site/scripts/sync-docs.js
@@ -408,6 +408,8 @@ const DOC_MAP = {
     'specs/advisory-review-recognizable-header.md',
   'specs/ARAGORA_ROADMAP_REVISION_ADVOCATES.md':
     'specs/aragora-roadmap-revision-advocates.md',
+  'specs/CHINESE_ROUTED_REVIEWER_FAMILIES_9071.md':
+    'specs/chinese-routed-reviewer-families-9071.md',
   'specs/ESSAY_REFINEMENT_PIPELINE.md': 'specs/essay-refinement-pipeline.md',
   'specs/FINDING_SEVERITY_GATE.md': 'specs/finding-severity-gate.md',
   'specs/INDEPENDENT_VERIFIER_GUIDE.md': 'specs/independent-verifier-guide.md',


### PR DESCRIPTION
## Summary

- add the missing `DOC_MAP` entry for `docs/specs/CHINESE_ROUTED_REVIEWER_FAMILIES_9071.md`
- generate the public Docusaurus mirror with quoted frontmatter
- add the title-sorted specs index link

## Scope

The diff is exactly these three paths (62 additions, 0 deletions):

- `docs-site/scripts/sync-docs.js`
- `docs-site/docs/specs/chinese-routed-reviewer-families-9071.md`
- `docs-site/docs/specs/index.md`

The source specification, mirror allowlist, tests, PR #9659, and PR #9645 are unchanged.

## Validation

- `node docs-site/scripts/sync-docs.js` twice, second run byte-identical across all three files
- focused specs completeness/index selectors: `2 passed`
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q`: `33 passed`
- `python3 scripts/check_docs_consistency.py`: all checks passed
- `python3 scripts/ci/check_docs_links.py`: all links and anchors passed
- `npm --prefix docs-site run build`: production build succeeded
- `make lint` and `ruff format --check aragora/ tests/ scripts/`: passed
- AWS-neutralized `make test-smoke`: passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: passed
- canonical exact-head classification: all three paths are `tier_1_additive_internal`

## Risk

Low and bounded. Generated output comes only from the repository sync script, and no authority, workflow, source-specification, or test behavior changes.
