### PR TITLE
test(debate): make batch-similarity test deterministic instead of network-dependent

### DIFF
--- a/tests/debate/test_convergence_comprehensive.py
+++ b/tests/debate/test_convergence_comprehensive.py
@@ -1911,7 +1911,22 @@ class TestSentenceTransformerBackend:
         assert sim > 0.99
 
     def test_sentence_transformer_batch_similarity(self, sentence_backend):
-        """Test batch similarity with SentenceTransformer."""
+        """The optimized batch path must agree with the naive pairwise average.
+
+        Do not assert `avg_sim >= 0.0` here. Cosine similarity is [-1, 1], and this
+        backend clamps at neither end (`compute_similarity` returns the raw cosine;
+        `compute_batch_similarity_fast` returns their raw mean). The value is also
+        network-dependent: sentence-transformers downloads weights from the HF Hub,
+        and when that is rate-limited or offline it falls back to a randomly
+        initialised model. With real weights these three texts average ~0.43; with
+        random weights the average sits at ~0 and goes negative roughly half the
+        time. That made this test flake in CI (`assert 0.0 <= -0.01772175170481205`)
+        and locally about 1 run in 5.
+
+        The invariant that actually matters — and that holds under either set of
+        weights, because both paths consume the same embeddings — is that the
+        vectorised batch implementation equals the naive loop it replaces.
+        """
         texts = [
             "machine learning is powerful",
             "deep learning achieves great results",
@@ -1920,7 +1935,15 @@ class TestSentenceTransformerBackend:
 
         avg_sim = sentence_backend.compute_batch_similarity(texts)
 
-        assert 0.0 <= avg_sim <= 1.0
+        naive_pairs = [
+            sentence_backend.compute_similarity(texts[i], texts[j])
+            for i in range(len(texts))
+            for j in range(i + 1, len(texts))
+        ]
+        naive_avg = sum(naive_pairs) / len(naive_pairs)
+
+        assert avg_sim == pytest.approx(naive_avg, abs=1e-5)
+        assert -1.0 <= avg_sim <= 1.0
 
     def test_sentence_transformer_pairwise_similarities(self, sentence_backend):
         """Test pairwise similarities computation."""


### PR DESCRIPTION
## Summary

`test_sentence_transformer_batch_similarity` asserted `0.0 <= avg_sim <= 1.0` on a **cosine
similarity**. Cosine is `[-1, 1]`, and this backend clamps at neither end — `compute_similarity`
returns the raw cosine and `compute_batch_similarity_fast` returns their raw mean.

The value is also **network-dependent**: sentence-transformers downloads weights from the HF Hub,
and when that is rate-limited or offline it silently falls back to a randomly initialised model.

| Weights | avg over these 3 texts |
|---|---|
| real (download succeeds) | ~0.43 |
| random (fallback) | ~0, negative about half the time |

So the assertion was a coin flip whenever the download failed.

## Impact: it blocks unrelated PRs

Hit in CI on **#9653**:

```
FAILED tests/debate/test_convergence_comprehensive.py::TestSentenceTransformerBackend::test_sentence_transformer_batch_similarity
  - assert 0.0 <= -0.01772175170481205
```

Reproduced locally at roughly **1 run in 5**.

#9653 changes only `.pre-commit-config.yaml`, one line of `pyproject.toml`,
`scripts/pristine_main_health.py`, two test files, and `uv.lock` (adding `ruff`). It touches **no
embedding dependency**, so the failure was never attributable to it — it was just the PR unlucky
enough to be running when the coin landed tails.

## The fix

Not "widen the bound to [-1, 1]" — that would leave the test asserting essentially nothing.

Instead it asserts the invariant the test's own name claims: **the vectorised batch path equals the
naive pairwise loop it replaces**. Both paths consume the same embeddings, so this holds under
either set of weights — immune to the network fallback while actually testing the optimisation.

## Reviewed design tradeoffs

- **Rejected: widening to `-1.0 <= avg_sim <= 1.0` alone.** Non-flaky but near-vacuous — it would
  pass on any finite number the function returned, including a broken one. Kept as a secondary
  assertion, not the primary.
- **Rejected: clamping the implementation to [0, 1].** That would make the assertion true, but by
  changing production semantics to suit a test. Cosine legitimately goes negative, and callers
  (convergence detection) may depend on the sign.
- **Rejected: `@pytest.mark.flaky` / retries.** Hides a real signal and burns CI time; the
  underlying non-determinism would remain.
- **Rejected: mocking the model.** Would remove the network dependency but also stop testing the
  real backend wiring, which is the point of this class.
- **Left the sibling assertions alone.** `test_sentence_transformer_similarity` and
  `test_sentence_transformer_pairwise_similarities` also use `0.0 <=`, but they pair semantically
  close texts and additionally assert `sim > 0.1` / `> 0.99`, where positivity is a meaningful
  claim. Only the batch case averages three loosely related sentences, centring near zero. Blanket
  widening would have weakened tests that are currently fine.

## Verification

```
fixed test: 6/6 consecutive local passes (previously ~1 failure in 5)
full TestSentenceTransformerBackend class: 5 passed
```

**Proven to still catch a regression** — disabling `exclude_diagonal` in
`compute_batch_similarity_fast`:

```
assert 0.3481144309043884 == 0.022171635180711746 ± 1.0e-05
```

That run had **random weights** (naive avg 0.0222), so the guard fires under exactly the condition
that made the old assertion flake — which is the property I wanted and the reason for choosing this
invariant over a range check.

Unblocks #9653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
