### PR TITLE
ci(contract-drift): durable trajectory artifact upload + inherited typing-debt closure [Tier 4]

### DIFF
--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -66,3 +66,6 @@ jobs:
           python3 -B scripts/check_contract_drift_ratchet.py --mode program \
             --ref "$SOURCE_SHA" --as-of "$(date -u +%F)" --strict --json \
             --repo-root "$GITHUB_WORKSPACE" | tee contract-drift-program-trajectory.json
+      - if: always() && !cancelled()
+        uses: actions/upload-artifact@v4
+        with: {name: "contract-drift-program-trajectory-${{ github.sha }}", path: contract-drift-program-trajectory.json}

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, overload
 
 import pytest
 import scripts.check_contract_drift_ratchet as ratchet
@@ -74,6 +74,32 @@ def _write_docs(repo: Path, docs: dict[str, dict]) -> None:
     for alias, (rel_path, _keys) in gen.BASELINE_SPECS.items():
         if alias in docs:
             _write_json(repo / rel_path, docs[alias])
+
+
+@overload
+def _seed(
+    tmp_path: Path,
+    *,
+    verify: dict | None = None,
+    routes: dict | None = None,
+    parity: dict | None = None,
+    program: dict | None = None,
+    inventory_items: list[dict] | None = None,
+    commit: Literal[True] = True,
+) -> tuple[dict[str, Path], Path, str]: ...
+
+
+@overload
+def _seed(
+    tmp_path: Path,
+    *,
+    verify: dict | None = None,
+    routes: dict | None = None,
+    parity: dict | None = None,
+    program: dict | None = None,
+    inventory_items: list[dict] | None = None,
+    commit: Literal[False],
+) -> tuple[dict[str, Path], Path, None]: ...
 
 
 def _seed(
@@ -219,8 +245,8 @@ def test_program_numbers_read_only_from_program_baseline(tmp_path: Path):
 
 def test_program_schedule_math_per_class_and_batch_clocks(tmp_path: Path):
     cohort_verify = {"python_sdk_drift": ["a", "b"], "typescript_sdk_drift": []}
-    routes = {"missing_in_spec": [], "orphaned_in_spec": []}
-    parity = {"missing_from_both_sdks": []}
+    routes: dict[str, list[str]] = {"missing_in_spec": [], "orphaned_in_spec": []}
+    parity: dict[str, list[str]] = {"missing_from_both_sdks": []}
     paths, repo, cohort = _seed(
         tmp_path,
         verify=cohort_verify,
@@ -338,8 +364,8 @@ def test_fail_closed_unknown_status(tmp_path: Path):
 def test_resolved_items_excluded_but_retained(tmp_path: Path):
     today = date.today().isoformat()
     cohort_verify = {"python_sdk_drift": ["a", "gone"], "typescript_sdk_drift": []}
-    routes = {"missing_in_spec": [], "orphaned_in_spec": []}
-    parity = {"missing_from_both_sdks": []}
+    routes: dict[str, list[str]] = {"missing_in_spec": [], "orphaned_in_spec": []}
+    parity: dict[str, list[str]] = {"missing_from_both_sdks": []}
     paths, repo, cohort = _seed(
         tmp_path,
         verify=cohort_verify,
@@ -1616,7 +1642,7 @@ def _boundary_git_repo(
             )
         if sdk_debt_partition is not None and boundary == sdk_debt_at:
             category, literal = _fixture_sdk_literal(sdk_debt_partition)
-            verify = {"python_sdk_drift": [], "typescript_sdk_drift": []}
+            verify: dict[str, list[str]] = {"python_sdk_drift": [], "typescript_sdk_drift": []}
             verify[category] = [literal]
             _write_json(baselines / "verify_sdk_contracts.json", verify)
         (repo / "fixture.txt").write_text(f"boundary-{index}\n", encoding="utf-8")
@@ -2463,23 +2489,21 @@ def test_canonical_cohort_and_provenance_artifacts_are_in_authority_closure(
     )
 
     external_artifacts = captured["manifest"]["inventory"]["external_artifacts"]
-    assert external_artifacts == sorted(
-        [
-            {
-                "byte_length": cohort_path.stat().st_size,
-                "canonical_bytes": True,
-                "path": cohort_path.name,
-                "sha256": hashlib.sha256(cohort_path.read_bytes()).hexdigest(),
-            },
-            {
-                "byte_length": provenance_path.stat().st_size,
-                "canonical_bytes": True,
-                "path": provenance_path.name,
-                "sha256": hashlib.sha256(provenance_path.read_bytes()).hexdigest(),
-            },
-        ],
-        key=lambda item: item["path"],
-    )
+    expected_artifacts: list[dict[str, Any]] = [
+        {
+            "byte_length": cohort_path.stat().st_size,
+            "canonical_bytes": True,
+            "path": cohort_path.name,
+            "sha256": hashlib.sha256(cohort_path.read_bytes()).hexdigest(),
+        },
+        {
+            "byte_length": provenance_path.stat().st_size,
+            "canonical_bytes": True,
+            "path": provenance_path.name,
+            "sha256": hashlib.sha256(provenance_path.read_bytes()).hexdigest(),
+        },
+    ]
+    assert external_artifacts == sorted(expected_artifacts, key=lambda item: item["path"])
 
 
 def test_external_authority_manifest_and_evidence_index_bytes_are_canonical_before_semantic_digest(

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -24,3 +24,25 @@ def test_pr_admission_is_event_bound_absolute_and_terminal():
     assert receipt["env"]["SOURCE_SHA"] == program["env"]["SOURCE_SHA"]
     assert "needs" not in receipt and "needs" not in program
     assert "--mode program" in str(program) and "continue-on-error" not in str(program)
+
+
+def test_program_trajectory_upload_is_sha_qualified_and_never_masks_the_analyzer():
+    program = JOBS["program-trajectory"]
+    assert "continue-on-error" not in program  # job level: analyzer red stays red
+    *_, analyzer, upload = program["steps"]
+    # The analyzer stays the unconditioned terminal enforcement step: no `if`
+    # and no `continue-on-error`, so its exit code alone decides the job.
+    assert "--mode program" in analyzer["run"]
+    assert "tee contract-drift-program-trajectory.json" in analyzer["run"]
+    assert "if" not in analyzer and "continue-on-error" not in analyzer
+    # The durable upload is exactly one SHA-qualified actions/upload-artifact@v4
+    # step that runs on success or failure but not cancellation, and carries no
+    # extra keys that could soften or reinterpret the analyzer outcome.
+    assert upload == {
+        "if": "always() && !cancelled()",
+        "uses": "actions/upload-artifact@v4",
+        "with": {
+            "name": "contract-drift-program-trajectory-${{ github.sha }}",
+            "path": "contract-drift-program-trajectory.json",
+        },
+    }


### PR DESCRIPTION
## Tier-4 parked draft — operator settlement required

**Feature:** `cdg-corrective-bootstrap-observability-closure` (mission 4f616812, milestone `cdg-bootstrap-route-truth`)

Closes the deferred trajectory-observability and inherited typing debt explicitly excluded from the exact Decision-351 corrective atom, now that PR #9645 is settled, merged (`d3e45fafe6`), and fresh-main validated.

### Scope (exactly three files)

1. **`.github/workflows/contract-drift-governance.yml`** — adds one SHA-qualified durable upload to the `program-trajectory` job: `actions/upload-artifact@v4`, name `contract-drift-program-trajectory-${{ github.sha }}`, path `contract-drift-program-trajectory.json`, condition `if: always() && !cancelled()`. The analyzer step remains the unconditioned terminal enforcement step; trajectory pass/fail semantics and the immutable-release authority are unchanged. No other job or line is touched.
2. **`tests/scripts/test_contract_drift_workflow.py`** — new test binds the exact upload action, condition, artifact name, path, and non-masking shape (no `continue-on-error` at job or step level; analyzer step has no `if`).
3. **`tests/scripts/test_check_contract_drift_ratchet.py`** — clears the 50 inherited mypy diagnostics (44 `arg-type`, 5 `var-annotated`, 1 `return-value`; Decision-351 adjudicated debt owned by this feature) through correct annotations only: `Literal`-typed `_seed` overloads binding `commit=True` to a `str` cohort SHA, three empty-dict local annotations, and a typed expected-artifacts list for the `sorted()` key. No assertion, semantics, or config change; no ignores; no baseline edit.

### Untouched invariants

Accepted authority, cohort/provenance/projection bytes, analyzer pins (`716d360c...`/H3 `1722a614...`), residue semantics, program arithmetic, PR #9645 history, and existing receipt/admission artifacts are all unchanged. The reference-relative guard-v2 implementation and its two exact tests (part of merged PR #9645) are not rewritten.

### Validation (all on head a6069181ba)

- `python3 -m pytest tests/scripts/test_check_contract_drift_ratchet.py tests/scripts/test_contract_drift_workflow.py -q` -> **128 passed** (127 inherited + 1 new upload-binding test; red-first verified)
- `MYPY_CACHE_DIR=<fresh> python3 -m mypy tests/scripts/test_check_contract_drift_ratchet.py` -> **0 errors** (was exactly the 50 adjudicated diagnostics)
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh cache) -> Success, 2 files
- `python3 -m pytest tests/scripts/test_contract_drift_trusted_bootstrap.py -q` -> 31 passed
- Stage-1 matrix (`test_generate_contract_drift_inventory.py` + `test_tier4_merge_train.py` + `tests/governance/test_contract_drift_measurement_authority_tier.py`) -> **873 passed**
- `tests/scripts/test_check_required_check_priority_policy.py` -> 26 passed
- `make lint` + `ruff format --check aragora/ tests/ scripts/` -> clean
- `actionlint .github/workflows/contract-drift-governance.yml` -> clean
- `make test-smoke` (AWS-neutralized) -> pass; `scripts/test_tiers.sh smoke` -> 138 passed
- Multi-seed sweep (1/42/100/2024/12345) of touched test files -> green
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

**LOC:** +72/-23 = 95 changed lines (measured `git diff --numstat origin/main...HEAD`).

### Risks

Low. The workflow delta is a single additive upload step gated `always() && !cancelled()`; it cannot change job conclusions. Test-file changes are typing/binding only. Trusted-bootstrap admission evaluates this PR since it touches a watched path; the governance workflow is not a trusted-surface file, so base-owned admission applies normally.

This PR is **prepare-only**: no evidence posted, no settlement, no merge. Separate operator settlement authority is required (Tier 4).
