### PR TITLE
test(contract-drift): corrective-bootstrap tests-only contract closure for VAL-CDG-002..009, 013..015, 020

### DIFF
--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -4149,3 +4149,785 @@ def test_residue_tolerance_refs_bind_event_base_and_first_parent(monkeypatch):
     source = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"], capture_output=True, text=True, check=True).stdout.strip()  # fmt: skip
     ratchet.build_accepted_result(mode="receipt", repo_root=root, inventory_path=root / "scripts/baselines/contract_drift_inventory.json", source_sha=source)  # fmt: skip
     assert calls == [("base-sha", "base-sha"), ("head-sha", "base-sha"), (source, f"{source}^")]
+
+
+# ------------------------- VAL-CDG-005 (pr side): file evidence and growth
+
+
+def _governed_pr_resource(start_sha: str, end_sha: str, **overrides: Any) -> dict[str, Any]:
+    record = {
+        "base_sha": start_sha,
+        "changed_files_complete": True,
+        "head_sha": end_sha,
+        "head_tree_sha": "d" * 40,
+        "pr": 9999,
+        **overrides,
+    }
+    return {
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "records": [record],
+        "schema": "contract-drift-governed-prs-v1",
+        "start_sha": start_sha,
+    }
+
+
+def _live_pr_files_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    files_count: int = 1,
+    changed_files: int | None = None,
+    pr_additions: int = 400,
+    pr_deletions: int = 400,
+    duplicate_file_ids: bool = False,
+    mutate: Any | None = None,
+) -> tuple[dict[str, Any], list[str]]:
+    """Run _collect_live_evidence with real pagination over fake transport."""
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path)
+    end_sha = boundary_shas["corrective_bootstrap"]
+    resources = _boundary_payloads("corrective_bootstrap", start_sha, end_sha, boundary_shas, repo=repo)  # fmt: skip
+    selected = {
+        "boundary_chronology",
+        "corrective_bootstrap",
+        "durable_capsule",
+        "external_prerequisites",
+        "first_parent_receipts",
+        "governed_prs",
+    }
+    resources = {name: value for name, value in resources.items() if name in selected}
+    resources["boundary_chronology"]["boundaries"] = resources["boundary_chronology"]["boundaries"][
+        :1
+    ]
+    verification_identity = {"byte_length": 18, "sha256": "a" * 64}
+    attestation_digest = hashlib.sha256(
+        ratchet._canonical_json_bytes([verification_identity] * 7)
+    ).hexdigest()
+    resources["durable_capsule"]["release"] = {
+        "asset_api_ids": [102, 103, 101],
+        "asset_names": ["manifest.json", "payload.json", "checksums.txt"],
+        "exact_full_sha_tag": end_sha,
+        "immutable": True,
+        "release_api_id": 100,
+        "verified": True,
+    }
+    resources["durable_capsule"]["attestation"] = {
+        "bundle_sha256": attestation_digest,
+        "verified": True,
+        "workflow": "actions/attest@v4",
+    }
+    if mutate is not None:
+        mutate(resources)
+    payload = {
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "resources": [{"name": name, "value": value} for name, value in sorted(resources.items())],
+        "schema": ratchet.BOUNDARY_CAPSULE_PAYLOAD_SCHEMA,
+        "start_sha": start_sha,
+    }
+    payload_raw = _canonical_boundary_bytes(payload)
+    manifest = {
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "payload_byte_length": len(payload_raw),
+        "payload_sha256": hashlib.sha256(payload_raw).hexdigest(),
+        "schema": ratchet.BOUNDARY_CAPSULE_MANIFEST_SCHEMA,
+        "start_sha": start_sha,
+    }
+    manifest_raw = _canonical_boundary_bytes(manifest)
+    checksums_raw = (
+        f"{hashlib.sha256(manifest_raw).hexdigest()}  manifest.json\n"
+        f"{hashlib.sha256(payload_raw).hexdigest()}  payload.json\n"
+    ).encode()
+    assets = {101: checksums_raw, 102: manifest_raw, 103: payload_raw}
+    identity = {
+        "byte_length": 2,
+        "etag": '"stable"',
+        "sha256": hashlib.sha256(b"{}").hexdigest(),
+        "updated_at": "2026-07-20T00:00:00Z",
+    }
+    files = [{"filename": f"file-{index}.txt", "id": index + 1} for index in range(files_count)]
+    if duplicate_file_ids:
+        files = [dict(item, id=1) for item in files]
+    observed_changed_files = files_count if changed_files is None else changed_files
+    requested: list[str] = []
+
+    def stable_get(
+        endpoint: str,
+        *,
+        operation_log: list[dict[str, Any]],
+        attempts: int = 3,
+        preserve_raw: bool = False,
+    ) -> tuple[Any, dict[str, Any]]:
+        del operation_log, attempts
+        requested.append(endpoint)
+        if "per_page=100&page=" in endpoint:
+            page = int(endpoint.rsplit("page=", 1)[1])
+            if "/pulls/9999/files" in endpoint:
+                return files[(page - 1) * 100 : page * 100], identity
+            if endpoint.startswith("repos/synaptent/aragora/releases?"):
+                return [{"id": 100, "tag_name": end_sha}], identity
+            if "rulesets/rule-suites?ref=" in endpoint:
+                return [_rule_suite_record(end_sha)], identity
+            raise AssertionError(endpoint)
+        if endpoint == "repos/synaptent/aragora":
+            return {"full_name": "synaptent/aragora", "id": 1126097105, "name": "aragora"}, identity
+        if endpoint.endswith("/branches/main"):
+            return {"commit": {"sha": end_sha}, "name": "main"}, identity
+        if endpoint.endswith("/branches/main/protection"):
+            return {"required_status_checks": {"strict": False}}, identity
+        if endpoint.endswith("/immutable-releases"):
+            return {"enabled": True}, identity
+        if endpoint.endswith("/releases/100"):
+            return {
+                "assets": [
+                    {"id": 101, "name": "checksums.txt"},
+                    {"id": 102, "name": "manifest.json"},
+                    {"id": 103, "name": "payload.json"},
+                ],
+                "draft": False,
+                "id": 100,
+                "immutable": True,
+                "prerelease": False,
+                "tag_name": end_sha,
+            }, identity
+        if endpoint.endswith("/rulesets/rule-suites/987654"):
+            record = _rule_suite_record(end_sha)
+            raw = ratchet._canonical_json_bytes(record).decode("utf-8")
+            rule_suite_identity = dict(identity)
+            if preserve_raw:
+                rule_suite_identity.update(
+                    {
+                        "byte_length": len(raw.encode("utf-8")),
+                        "raw_response": raw,
+                        "response_fields": record,
+                        "sha256": hashlib.sha256(raw.encode("utf-8")).hexdigest(),
+                    }
+                )
+            return record, rule_suite_identity
+        if endpoint.endswith("/pulls/9999"):
+            return {
+                "additions": pr_additions,
+                "base": {"sha": "f" * 40},
+                "changed_files": observed_changed_files,
+                "deletions": pr_deletions,
+                "head": {"sha": end_sha},
+                "merge_commit_sha": end_sha,
+                "merged_at": "2026-07-20T00:00:00Z",
+                "number": 9999,
+            }, identity
+        if endpoint.endswith(f"/git/commits/{end_sha}"):
+            tree_sha = resources["governed_prs"]["records"][0]["head_tree_sha"]
+            return {
+                "parents": [{"sha": start_sha}],
+                "sha": end_sha,
+                "tree": {"sha": tree_sha},
+            }, identity
+        raise AssertionError(endpoint)
+
+    def raw_get(
+        endpoint: str,
+        *,
+        operation_log: list[dict[str, Any]],
+        attempts: int = 3,
+    ) -> tuple[bytes, dict[str, Any]]:
+        del operation_log, attempts
+        asset_id = int(endpoint.rsplit("/", 1)[1])
+        raw = assets[asset_id]
+        return raw, {
+            "byte_length": len(raw),
+            "etag": f'"asset-{asset_id}"',
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "updated_at": "2026-07-20T00:00:00Z",
+        }
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", stable_get)
+    monkeypatch.setattr(ratchet, "_gh_api_get_raw_stable", raw_get)
+    monkeypatch.setattr(
+        ratchet,
+        "_run_live_verification",
+        lambda argv, *, operation_log, resource: (
+            {"resource": resource, "verified": bool(argv)},
+            verification_identity,
+        ),
+    )
+    _discovered, _summary, context = ratchet._collect_live_evidence(
+        github_repository="synaptent/aragora",
+        github_branch="main",
+        boundary="corrective_bootstrap",
+        start_sha=start_sha,
+        end_sha=end_sha,
+        scratch_root=tmp_path,
+        operation_log=[],
+    )
+    return context, requested
+
+
+def test_pr_files_bind_changed_files_additions_and_deletions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    context, _requested = _live_pr_files_probe(
+        tmp_path, monkeypatch, files_count=3, pr_additions=123, pr_deletions=45
+    )
+    # The exact PR response additions/deletions are bound into the live
+    # context, keyed by PR number, with nothing inferred or defaulted.
+    assert context["authenticated_pr_changes"] == {9999: {"additions": 123, "deletions": 45}}
+    with pytest.raises(ValueError, match="additions/deletions are malformed"):
+        _live_pr_files_probe(tmp_path / "neg", monkeypatch, pr_additions=-1)
+    with pytest.raises(ValueError, match="additions/deletions are malformed"):
+        _live_pr_files_probe(tmp_path / "bool", monkeypatch, pr_additions=True)  # type: ignore[arg-type]
+
+    def wrong_head(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["records"][0]["head_sha"] = "c" * 40
+
+    with pytest.raises(ValueError, match="contradicts capsule evidence"):
+        _live_pr_files_probe(tmp_path / "head", monkeypatch, mutate=wrong_head)
+    # The downstream governed-PR validator re-binds the same numbers and
+    # fails closed on every malformed or unreconciled shape.
+    start_sha, end_sha = "1" * 40, "2" * 40
+    resource = _governed_pr_resource(start_sha, end_sha)
+    validated = ratchet._validate_governed_prs(
+        resource,
+        authenticated_pr_changes={9999: {"additions": 123, "deletions": 45}},
+        repo_root=tmp_path,
+        operation_log=[],
+    )
+    assert (
+        validated[0]["authenticated_additions"],
+        validated[0]["authenticated_deletions"],
+        validated[0]["authenticated_pr_delta"],
+    ) == (123, 45, 168)
+    with pytest.raises(ValueError, match="exceeds the 800-line cap"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource(start_sha, end_sha),
+            authenticated_pr_changes={9999: {"additions": 500, "deletions": 301}},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    with pytest.raises(ValueError, match="lacks authenticated additions/deletions"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource(start_sha, end_sha),
+            authenticated_pr_changes={},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    with pytest.raises(ValueError, match="do not reconcile"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource(start_sha, end_sha),
+            authenticated_pr_changes={
+                9999: {"additions": 1, "deletions": 1},
+                10000: {"additions": 1, "deletions": 1},
+            },
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    for additions, deletions in ((True, 0), (-1, 0), (0, None), ("4", 0)):
+        with pytest.raises(ValueError, match="additions/deletions are malformed"):
+            ratchet._validate_governed_prs(
+                _governed_pr_resource(start_sha, end_sha),
+                authenticated_pr_changes={9999: {"additions": additions, "deletions": deletions}},
+                repo_root=tmp_path,
+                operation_log=[],
+            )
+
+
+def test_pr_files_paginate_to_exhaustion_and_reconcile_changed_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    context, requested = _live_pr_files_probe(tmp_path, monkeypatch, files_count=237)
+    file_pages = [endpoint for endpoint in requested if "/pulls/9999/files" in endpoint]
+    assert file_pages == [
+        "repos/synaptent/aragora/pulls/9999/files?per_page=100&page=1",
+        "repos/synaptent/aragora/pulls/9999/files?per_page=100&page=2",
+        "repos/synaptent/aragora/pulls/9999/files?per_page=100&page=3",
+    ]
+    assert context["authenticated_pr_changes"] == {9999: {"additions": 400, "deletions": 400}}
+    # An exact-boundary page count (multiple of 100) still fetches the final
+    # short page rather than assuming exhaustion.
+    _context, requested_200 = _live_pr_files_probe(tmp_path / "even", monkeypatch, files_count=200)
+    assert sum(1 for e in requested_200 if "/pulls/9999/files" in e) == 3
+    # File records that do not reconcile exactly to the PR response
+    # changed_files fail closed — both short and inflated counts.
+    for wrong in (236, 238):
+        with pytest.raises(ValueError, match="file discovery is incomplete"):
+            _live_pr_files_probe(
+                tmp_path / f"wrong-{wrong}",
+                monkeypatch,
+                files_count=237,
+                changed_files=wrong,
+            )
+    with pytest.raises(ValueError, match="duplicate record IDs"):
+        _live_pr_files_probe(
+            tmp_path / "dup", monkeypatch, files_count=150, duplicate_file_ids=True
+        )
+
+
+def test_files_api_incomplete_uses_exact_tree_diff_with_pinned_rename_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # A capsule that cannot prove complete file discovery fails closed.
+    def denies_complete(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["records"][0]["changed_files_complete"] = False
+
+    with pytest.raises(ValueError, match="denies complete file discovery"):
+        _live_pr_files_probe(tmp_path / "denied", monkeypatch, mutate=denies_complete)
+    with pytest.raises(ValueError, match="file discovery is false or missing"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource("1" * 40, "2" * 40, changed_files_complete=False),
+            authenticated_pr_changes={9999: {"additions": 1, "deletions": 1}},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+
+    # The completeness backstop is the exact immutable BASE/HEAD tree binding:
+    # a governed record whose head tree disagrees with the authenticated
+    # first-parent receipt tree is rejected.
+    def wrong_tree(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["records"][0]["head_tree_sha"] = "d" * 40
+
+    with pytest.raises(ValueError, match="lacks first-parent or tree equality"):
+        _live_pr_files_probe(tmp_path / "tree", monkeypatch, mutate=wrong_tree)
+    # Pinned rename policy: baseline identity is the exact canonical path at
+    # the exact ref. A rename is a removal at the canonical path — it is never
+    # followed, so renamed content cannot masquerade as the governed baseline.
+    repo = tmp_path / "rename-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _write_docs(
+        repo,
+        {
+            "verify": {"python_sdk_drift": ["GET /a"], "typescript_sdk_drift": []},
+            "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
+            "parity": {"missing_from_both_sdks": []},
+        },
+    )
+    base_sha = _commit(repo, "base")
+    verify_rel = gen.BASELINE_SPECS["verify"][0]
+    subprocess.run(
+        ["git", "-C", str(repo), "mv", str(verify_rel), "scripts/baselines/renamed.json"],
+        check=True,
+    )
+    head_sha = _commit(repo, "rename")
+    base_docs = gen.load_git_docs(repo, base_sha)
+    head_docs = gen.load_git_docs(repo, head_sha)
+    assert "python_sdk_drift:GET /a" in gen.collect_ids(base_docs)
+    assert head_docs["verify"] == {}
+    assert gen.collect_ids(head_docs) == {}
+    assert ratchet._git_doc(repo, head_sha, repo / verify_rel) == {}
+    # No rename-following flags exist anywhere in the analyzer sources.
+    for module in (ratchet, gen):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "--follow" not in source
+        assert "find-renames" not in source
+        assert "-M100" not in source
+
+
+def test_compare_api_is_never_a_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Static: neither analyzer module constructs a GitHub compare endpoint.
+    for module in (ratchet, gen):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "/compare" not in source
+        assert "compare/" not in source
+        assert "compare?" not in source
+    # Live evidence collection never requests a compare endpoint.
+    _context, requested = _live_pr_files_probe(tmp_path, monkeypatch, files_count=3)
+    assert requested and not any("compare" in endpoint for endpoint in requested)
+
+    # PR-mode CLI analysis is exact-ref local git only: no GitHub API surface
+    # (compare or otherwise) is ever consulted.
+    def forbidden(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("pr mode must not consult the GitHub API")
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", forbidden)
+    monkeypatch.setattr(ratchet, "_gh_api_paginated", forbidden)
+    monkeypatch.setattr(ratchet, "_gh_api_get_raw_stable", forbidden)
+    (tmp_path / "cli").mkdir()
+    paths, repo, base = _seed(tmp_path / "cli", program=RED_PROGRAM)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["passing"]
+
+
+def test_pr_mode_fails_total_growth(monkeypatch, tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("new")
+    _write_json(paths["verify"], verify)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not result["passing"]
+    deltas = result["pr_delta"]["counts"]
+    assert sum(d["head"] for d in deltas.values()) - sum(d["base"] for d in deltas.values()) == 1
+    assert result["pr_delta"]["increased"] == ["verify_python_sdk_drift"]
+    assert result["pr_delta"]["new_entries"] == ["python_sdk_drift:new"]
+    assert any("python_sdk_drift:new" in r for r in result["pr_delta"]["unexplained_increase"])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        _argv(paths, repo, base, "--mode", "pr", "--base-ref", base, "--as-of", "2026-07-16"),
+    )
+    assert ratchet.main() == 1
+    # Accepted-authority layer: any head-live original ID beyond base fails
+    # with the exact added set named.
+    calls: list[str | None] = []
+
+    def fake_validate(
+        authority: dict[str, Any],
+        *,
+        repo_root: Path,
+        live_ref: str | None = None,
+        residue_ref: str | None = None,
+    ) -> dict[str, Any]:
+        del authority, repo_root, residue_ref
+        calls.append(live_ref)
+        live = ["cdg1:aa"] if live_ref == "base-sha" else ["cdg1:aa", "cdg1:xx"]
+        return {
+            "active_original_record_ids": ["cdg1:aa", "cdg1:bb"],
+            "analyzer_bundle_sha256": "0" * 64,
+            "live_original_record_ids": live,
+        }
+
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", fake_validate)
+    compared = ratchet.compare_accepted_authorities(
+        _accepted_authority(),
+        _accepted_authority(),
+        repo_root=tmp_path,
+        base_ref="base-sha",
+        head_ref="head-sha",
+    )
+    assert (compared["passing"], compared["status"]) == (False, "fail")
+    assert compared["added_original_record_ids"] == ["cdg1:xx"]
+    assert compared["removed_original_record_ids"] == []
+
+
+def test_pr_mode_fails_any_category_growth(tmp_path: Path):
+    paths, repo, base = _seed(
+        tmp_path,
+        program=RED_PROGRAM,
+        routes={"missing_in_spec": ["m1", "m2"], "orphaned_in_spec": []},
+        parity={"missing_from_both_sdks": []},
+    )
+    # Head shrinks typescript by two (legitimately resolved) but grows python
+    # by one: net total decreases, yet the single growing category fails.
+    verify = json.loads(paths["verify"].read_text())
+    verify["typescript_sdk_drift"] = ["x"]
+    verify["python_sdk_drift"].append("new")
+    _write_json(paths["verify"], verify)
+
+    def resolve(inv: dict) -> None:
+        for item in inv["items"]:
+            if item["id"] in {"typescript_sdk_drift:y", "typescript_sdk_drift:z"}:
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not result["passing"]
+    deltas = result["pr_delta"]["counts"]
+    assert sum(d["delta"] for d in deltas.values()) == -1
+    assert result["pr_delta"]["increased"] == ["verify_python_sdk_drift"]
+    assert deltas["verify_typescript_sdk_drift"]["delta"] == -2
+    reasons = result["pr_delta"]["unexplained_increase"]
+    assert any("python_sdk_drift:new" in reason for reason in reasons)
+    # The category-count key set is exactly the ratified five-count schema,
+    # including the zero-count categories.
+    assert sorted(deltas) == sorted(key for key, _alias, _list in ratchet.COUNT_KEYS)
+    assert (deltas["sdk_missing_from_both"]["base"], deltas["sdk_missing_from_both"]["head"]) == (0, 0)  # fmt: skip
+    assert (deltas["routes_orphaned_in_spec"]["base"], deltas["routes_orphaned_in_spec"]["head"]) == (0, 0)  # fmt: skip
+
+
+def test_pr_mode_reports_complete_exact_original_record_set_diagnostics(
+    monkeypatch,
+    tmp_path: Path,
+):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    added = [f"p{index:02d}" for index in range(12)]
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].extend(added)
+    _write_json(paths["verify"], verify)
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not result["passing"]
+    expected_ids = sorted(f"python_sdk_drift:{entry}" for entry in added)
+    # Every added unit is enumerated exactly — no truncation, no count-only
+    # summary, and one diagnostic naming each specific missing record.
+    assert result["pr_delta"]["new_entries"] == expected_ids
+    reasons = result["pr_delta"]["unexplained_increase"]
+    assert len(reasons) == 12
+    for item_id in expected_ids:
+        assert any(item_id in reason for reason in reasons)
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == 12
+
+    # Accepted-authority layer: every added original_record_id is listed,
+    # sorted, with no cap.
+    def fake_validate(
+        authority: dict[str, Any],
+        *,
+        repo_root: Path,
+        live_ref: str | None = None,
+        residue_ref: str | None = None,
+    ) -> dict[str, Any]:
+        del authority, repo_root, residue_ref
+        live = ["cdg1:aa"]
+        if live_ref == "head-sha":
+            live = ["cdg1:aa", "cdg1:zz", "cdg1:xx", "cdg1:yy"]
+        return {
+            "active_original_record_ids": ["cdg1:aa"],
+            "analyzer_bundle_sha256": "0" * 64,
+            "live_original_record_ids": live,
+        }
+
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", fake_validate)
+    compared = ratchet.compare_accepted_authorities(
+        _accepted_authority(),
+        _accepted_authority(),
+        repo_root=tmp_path,
+        base_ref="base-sha",
+        head_ref="head-sha",
+    )
+    assert compared["added_original_record_ids"] == ["cdg1:xx", "cdg1:yy", "cdg1:zz"]
+    assert not compared["passing"]
+
+
+def test_pr_mode_passes_equal_or_subset_original_record_ids(tmp_path: Path):
+    # Equal head: identical baselines pass with empty deltas.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    equal = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert equal["passing"]
+    assert equal["pr_delta"]["increased"] == []
+    assert equal["pr_delta"]["new_entries"] == []
+    # Subset head: remove one unit per SDK list with matching resolution.
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")
+    verify["typescript_sdk_drift"].remove("z")
+    _write_json(paths["verify"], verify)
+
+    def resolve(inv: dict) -> None:
+        for item in inv["items"]:
+            if item["id"] in {"python_sdk_drift:b", "typescript_sdk_drift:z"}:
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve)
+    subset = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert subset["passing"]
+    base_docs = {
+        "verify": ratchet._git_doc(repo, base, paths["verify"]),
+        "routes": ratchet._git_doc(repo, base, paths["routes"]),
+        "parity": ratchet._git_doc(repo, base, paths["parity"]),
+    }
+    head_docs = {
+        "verify": json.loads(paths["verify"].read_text()),
+        "routes": json.loads(paths["routes"].read_text()),
+        "parity": json.loads(paths["parity"].read_text()),
+    }
+    base_ids = gen.collect_ids(base_docs)
+    head_ids = gen.collect_ids(head_docs)
+    assert set(head_ids) < set(base_ids)
+    for list_key in {list_key for _c, _a, list_key in ratchet.COUNT_KEYS}:
+        assert {i for i, lk in head_ids.items() if lk == list_key} <= {
+            i for i, lk in base_ids.items() if lk == list_key
+        }
+    # Accepted-authority layer: an exact evidenced paydown subset passes with
+    # the complete sorted removed set and no added IDs.
+    root = Path(ratchet.__file__).parents[1]
+    authority = _accepted_authority()
+    summary = ratchet.validate_accepted_authority(authority, repo_root=root)
+    live = set(summary["live_original_record_ids"])
+    paydown = copy.deepcopy(authority)
+    live_digest = ratchet._sha256_bytes(ratchet._canonical_json_bytes(sorted(live)))
+    for item in paydown["active_inventory"]:
+        if item["original_record_id"] in live:
+            continue
+        fact = {"active_original_record_ids_sha256": live_digest, "as_of": "2026-07-27", "original_record_id": item["original_record_id"]}  # fmt: skip
+        item.update(status="resolved", disposition_history=[ratchet.GENESIS_DISPOSITION, {"as_of": fact["as_of"], "evidence": {"fact": fact, "sha256": ratchet._fact_digest(ratchet.PAYDOWN_SCHEMA, fact)}, "status": "resolved"}])  # fmt: skip
+    paydown["active_inventory_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(paydown["active_inventory"]))  # fmt: skip
+    paydown["manifest_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes({key: value for key, value in paydown.items() if key != "manifest_sha256"}))  # fmt: skip
+    compared = ratchet.compare_accepted_authorities(authority, paydown, repo_root=root)
+    assert (compared["passing"], compared["status"]) == (True, "pass")
+    assert compared["added_original_record_ids"] == []
+    removed = compared["removed_original_record_ids"]
+    assert removed == sorted(removed) and len(removed) == 255
+    assert set(removed).isdisjoint(live)
+
+
+# --------------------- VAL-CDG-003 (pr side): annotations are nonoperative
+
+
+_ANNOTATION_ZOO: dict[str, Any] = {
+    "accepted": True,
+    "annotations": {"nested": {"deep": [1, 2, {"three": None}]}},
+    "candidate_intentional_growth": True,
+    "generated_artifact": {"path": "generated/openapi.json"},
+    "handler_backed": False,
+    "public": False,
+    "resolved_note": "claims resolution without evidence",
+    "stale_sdk": ["python"],
+    "wildcard": "*",
+    "zz_unknown_future_key": [{"scalar": 1}, None, "text"],
+}
+
+
+def _governed_view(result: dict) -> tuple:
+    return (
+        result["passing"],
+        result["integrity"]["passing"],
+        tuple(sorted(result["integrity"]["issues"])),
+        result["current"],
+        {key: value for key, value in result["pr_delta"].items() if key != "base_ref"},
+    )
+
+
+def test_all_annotation_fields_are_nonoperative(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    before = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+
+    def annotate(inv: dict) -> None:
+        inv["annotation_sidecar"] = {"version": 99, "labels": ["future"]}
+        for item in inv["items"]:
+            item.update(copy.deepcopy(_ANNOTATION_ZOO))
+
+    _edit_inventory(paths, annotate)
+    after = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert _governed_view(after) == _governed_view(before)
+    assert after["passing"]
+    program_after = _result(paths, "2026-07-16", repo=repo, cohort=base)
+    assert program_after["current"] == before["current"]
+    assert program_after["integrity"]["passing"]
+
+
+def test_known_classification_labels_cannot_exclude_live_units(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    baseline = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+
+    # Known nonoperative labels on an open item change nothing.
+    def label(inv: dict) -> None:
+        for item in inv["items"]:
+            if item["id"] == "python_sdk_drift:a":
+                item.update(
+                    accepted=True,
+                    candidate_intentional_growth=True,
+                    generated_artifact={"path": "x"},
+                )
+
+    _edit_inventory(paths, label)
+    labeled = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert _governed_view(labeled) == _governed_view(baseline)
+
+    # A classification that tries to subtract a live unit (resolving an item
+    # whose baseline witness is still present) fails closed with the unit
+    # named — it is never silently excluded from the governed set.
+    def resolve_live(inv: dict) -> None:
+        for item in inv["items"]:
+            if item["id"] == "python_sdk_drift:a":
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve_live)
+    excluded = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not excluded["passing"]
+    assert not excluded["integrity"]["passing"]
+    assert any(
+        "Baseline entry not open in inventory" in issue and "python_sdk_drift:a" in issue
+        for issue in excluded["integrity"]["issues"]
+    )
+    assert excluded["current"] == baseline["current"]  # counts still include the unit
+
+
+def test_unknown_annotation_keys_cannot_exclude_live_units(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    baseline = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+
+    # Unknown future annotation keys that "claim" exclusion are inert.
+    def annotate(inv: dict) -> None:
+        inv["excluded_ids"] = ["python_sdk_drift:a"]
+        for item in inv["items"]:
+            item.update(live=False, excluded=True, suppress={"reason": "future"})
+
+    _edit_inventory(paths, annotate)
+    annotated = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert _governed_view(annotated) == _governed_view(baseline)
+    assert annotated["current"]["total_items"] == baseline["current"]["total_items"]
+
+    # An unknown status value is not an exclusion channel either: it fails
+    # closed while the unit stays counted.
+    def unknown_status(inv: dict) -> None:
+        inv["items"][0]["status"] = "suppressed"
+
+    _edit_inventory(paths, unknown_status)
+    suppressed = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not suppressed["passing"]
+    assert any("Unknown status" in issue for issue in suppressed["integrity"]["issues"])
+    assert suppressed["current"] == baseline["current"]
+
+
+def test_accepted_inventory_annotation_tamper_does_not_change_enforcement():
+    root = Path(ratchet.__file__).parents[1]
+    # Untampered enforcement outcome (the invariant being defended).
+    summary = ratchet.validate_accepted_authority(_accepted_authority(), repo_root=root)
+    assert summary["original_record_total"] == 655
+    assert len(summary["live_original_record_ids"]) == 400
+    # Any annotation key added to an accepted-inventory row fails closed: the
+    # row schema is exactly {category, disposition_history, original_record_id,
+    # status}, so tamper can never ride along as metadata.
+    annotated = _accepted_authority()
+    annotated["active_inventory"][0]["annotation"] = {"accepted": True}
+    with pytest.raises(ValueError, match="disposition is malformed"):
+        ratchet.validate_accepted_authority(annotated, repo_root=root)
+    # Reclassifying a row's category label is identity tamper, not annotation.
+    relabeled = _accepted_authority()
+    row = relabeled["active_inventory"][0]
+    row["category"] = next(
+        category for category in ratchet.ACCEPTED_CATEGORIES if category != row["category"]
+    )
+    with pytest.raises(ValueError, match="identity or genesis is invalid"):
+        ratchet.validate_accepted_authority(relabeled, repo_root=root)
+    # Reordering rows (a pure presentation change) breaks the bound digest
+    # rather than silently changing enforcement order.
+    reordered = _accepted_authority()
+    reordered["active_inventory"] = list(reversed(reordered["active_inventory"]))
+    with pytest.raises(ValueError, match="differs from live witnesses or its digest"):
+        ratchet.validate_accepted_authority(reordered, repo_root=root)
+
+
+def test_annotations_cannot_change_pr_verdict_projection_or_exact_diagnostics(
+    tmp_path: Path,
+):
+    # Failing PR: annotations claiming the growth is intentional change
+    # neither the verdict nor one byte of the exact diagnostics.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].append("new")
+    _write_json(paths["verify"], verify)
+    failing = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not failing["passing"]
+
+    def annotate(inv: dict) -> None:
+        inv["intentional_growth"] = ["python_sdk_drift:new"]
+        for item in inv["items"]:
+            item.update(copy.deepcopy(_ANNOTATION_ZOO))
+
+    _edit_inventory(paths, annotate)
+    annotated = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert not annotated["passing"]
+    assert _governed_view(annotated) == _governed_view(failing)
+    assert (
+        annotated["pr_delta"]["unexplained_increase"] == failing["pr_delta"]["unexplained_increase"]
+    )
+    # Passing PR: annotations cannot flip a pass to a fail either.
+    (tmp_path / "clean").mkdir()
+    clean_paths, clean_repo, clean_base = _seed(tmp_path / "clean", program=RED_PROGRAM)
+    clean_before = _result(clean_paths, "2026-07-16", repo=clean_repo, cohort=clean_base, mode="pr", base_ref=clean_base)  # fmt: skip
+    _edit_inventory(clean_paths, annotate)
+    clean_after = _result(clean_paths, "2026-07-16", repo=clean_repo, cohort=clean_base, mode="pr", base_ref=clean_base)  # fmt: skip
+    assert clean_before["passing"] and clean_after["passing"]
+    assert _governed_view(clean_after) == _governed_view(clean_before)
+    # Operation projection: an annotation smuggled onto a projection record
+    # breaks its digest binding — the projection is tamper-evident, never
+    # silently reshaped.
+    hostile = _accepted_authority()
+    hostile["canonical_artifacts"]["original_cohort"]["operation_projection"]["records"][0][
+        "annotations"
+    ] = {"collapse": True}
+    with pytest.raises(ValueError, match="projection"):
+        ratchet._validate_original_cohort(hostile["canonical_artifacts"]["original_cohort"])

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -12,7 +12,7 @@ import sys
 import time
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import Any, Literal, cast, overload
 
 import pytest
 import scripts.check_contract_drift_ratchet as ratchet
@@ -4425,10 +4425,14 @@ def test_pr_files_bind_changed_files_additions_and_deletions(
             operation_log=[],
         )
     for additions, deletions in ((True, 0), (-1, 0), (0, None), ("4", 0)):
+        malformed = cast(
+            "dict[int, dict[str, int]]",
+            {9999: {"additions": additions, "deletions": deletions}},
+        )
         with pytest.raises(ValueError, match="additions/deletions are malformed"):
             ratchet._validate_governed_prs(
                 _governed_pr_resource(start_sha, end_sha),
-                authenticated_pr_changes={9999: {"additions": additions, "deletions": deletions}},
+                authenticated_pr_changes=malformed,
                 repo_root=tmp_path,
                 operation_log=[],
             )
@@ -4520,8 +4524,8 @@ def test_files_api_incomplete_uses_exact_tree_diff_with_pinned_rename_policy(
     assert gen.collect_ids(head_docs) == {}
     assert ratchet._git_doc(repo, head_sha, repo / verify_rel) == {}
     # No rename-following flags exist anywhere in the analyzer sources.
-    for module in (ratchet, gen):
-        source = Path(module.__file__).read_text(encoding="utf-8")
+    for module_file in (ratchet.__file__, gen.__file__):
+        source = Path(module_file).read_text(encoding="utf-8")
         assert "--follow" not in source
         assert "find-renames" not in source
         assert "-M100" not in source
@@ -4529,8 +4533,8 @@ def test_files_api_incomplete_uses_exact_tree_diff_with_pinned_rename_policy(
 
 def test_compare_api_is_never_a_fallback(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     # Static: neither analyzer module constructs a GitHub compare endpoint.
-    for module in (ratchet, gen):
-        source = Path(module.__file__).read_text(encoding="utf-8")
+    for module_file in (ratchet.__file__, gen.__file__):
+        source = Path(module_file).read_text(encoding="utf-8")
         assert "/compare" not in source
         assert "compare/" not in source
         assert "compare?" not in source
@@ -7785,8 +7789,8 @@ def test_workflow_history_is_unfiltered_or_disjoint_below_1000_shards(
         ratchet._gh_api_paginated("repos/synaptent/aragora/actions/runs", operation_log=[])
     # No analyzer surface bakes a status/conclusion filter into a workflow
     # history query.
-    for module in (ratchet, gen):
-        source = Path(module.__file__).read_text(encoding="utf-8")
+    for module_file in (ratchet.__file__, gen.__file__):
+        source = Path(module_file).read_text(encoding="utf-8")
         assert "status=completed" not in source
         assert "conclusion=success" not in source
 
@@ -8050,14 +8054,16 @@ def test_normal_protected_exact_head_merge_is_last_and_never_admin(
     # binds --match-head-commit to the settled head and, without protection
     # reconciliation, is the only command issued.
     commands: list[list[str]] = []
-    monkeypatch.setattr(
-        settle, "_run_command", lambda command, *, cwd, input_text=None: commands.append(command)
-    )
-    monkeypatch.setattr(
-        settle,
-        "_run_text_command",
-        lambda command, *, cwd, input_text=None: (commands.append(command), "")[1],
-    )
+
+    def _record_command(command: list[str], *, cwd: Any, input_text: Any = None) -> None:
+        commands.append(command)
+
+    def _record_text_command(command: list[str], *, cwd: Any, input_text: Any = None) -> str:
+        commands.append(command)
+        return ""
+
+    monkeypatch.setattr(settle, "_run_command", _record_command)
+    monkeypatch.setattr(settle, "_run_text_command", _record_text_command)
     settle._apply_merge(pr=9645, head="7" * 40, repo="synaptent/aragora", cwd=tmp_path)
     assert len(commands) == 1
     merge_command = commands[0]

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -5330,19 +5330,43 @@ def test_deterministic_boundary_status_pass_is_reachable(
     monkeypatch: pytest.MonkeyPatch,
 ):
     for boundary in ("corrective_bootstrap", "final_seal"):
-        result = _boundary_result(tmp_path / boundary, monkeypatch, boundary)
-        assert (result["status"], result["passing"]) == ("pass", True)
-        assert result["blocked_reason"] is None
-        assert result["error_code"] if result["status"] == "fail" else True
-        assert list(result["predicates"]) == list(
-            ratchet.BOUNDARY_NAMES[: ratchet.BOUNDARY_NAMES.index(boundary) + 1]
+        base = tmp_path / boundary
+        repo, start_sha, boundary_shas = _boundary_git_repo(base)
+        end_sha = boundary_shas[boundary]
+        index_path, index_length, index_sha256 = _write_boundary_index(
+            base, boundary, start_sha, end_sha, boundary_shas, repo=repo
         )
-        assert all(entry["proven"] is True for entry in result["predicates"].values())
-        # Deterministic: the same fixture double-runs to identical bytes
-        # modulo the freshly generated operation log.
-        again = _boundary_result(tmp_path / f"{boundary}-again", monkeypatch, boundary)
-        assert again["status"] == "pass"
-        assert again["predicates"] == result["predicates"]
+        _stub_boundary_dependencies(monkeypatch)
+        _stub_boundary_evidence_index(
+            monkeypatch,
+            index_path=index_path,
+            index_length=index_length,
+            index_sha256=index_sha256,
+            pr_additions=400,
+            pr_deletions=400,
+        )
+        runs = [
+            ratchet.build_boundary_result(
+                repo_root=repo,
+                schema_version=1,
+                boundary=boundary,
+                start_ref=start_sha,
+                end_ref=end_sha,
+            )
+            for _run in range(2)
+        ]
+        for result in runs:
+            assert (result["status"], result["passing"]) == ("pass", True)
+            assert result["blocked_reason"] is None
+            assert list(result["predicates"]) == list(
+                ratchet.BOUNDARY_NAMES[: ratchet.BOUNDARY_NAMES.index(boundary) + 1]
+            )
+            assert all(entry["proven"] is True for entry in result["predicates"].values())
+        # Deterministic: the same fixture double-runs to identical canonical
+        # bytes (the manifest digest covers everything but the fresh
+        # operation log).
+        assert runs[0]["predicates"] == runs[1]["predicates"]
+        assert runs[0]["manifest_sha256"] == runs[1]["manifest_sha256"]
 
 
 def test_read_only_cli_mutation_attempt_fails_closed(tmp_path: Path):
@@ -5902,3 +5926,588 @@ def test_undeclared_import_fails_closed(tmp_path: Path):
     )
     with pytest.raises(gen.AuthorityClosureError, match="repository-local import is unavailable"):
         gen._python_import_edges(root, "scripts/missing_target.py")
+
+
+# ------- VAL-CDG-006: no item replacement; mathematically exact set diffs
+
+
+def _swap_baseline_entry(paths: dict[str, Path], alias: str, list_key: str, old: str, new: str):
+    doc = json.loads(paths[alias].read_text())
+    entries = doc[list_key]
+    entries[entries.index(old)] = new
+    _write_json(paths[alias], doc)
+
+
+def _pr_result_and_recomputed_sets(
+    paths: dict[str, Path], repo: Path, base: str
+) -> tuple[dict, set[str], set[str]]:
+    """PR-mode result plus independently recomputed base/head ID-set diffs."""
+    base_docs = {
+        alias: json.loads(
+            subprocess.run(
+                ["git", "-C", str(repo), "show", f"{base}:{rel_path}"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout
+        )
+        for alias, (rel_path, _k) in gen.BASELINE_SPECS.items()
+    }
+    head_docs = {alias: json.loads(paths[alias].read_text()) for alias in base_docs}
+    base_ids = set(gen.collect_ids(base_docs))
+    head_ids = set(gen.collect_ids(head_docs))
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    return result, base_ids - head_ids, head_ids - base_ids
+
+
+def test_pr_mode_fails_same_count_sdk_literal_replacement(tmp_path: Path):
+    # Replace one python SDK literal with a distinct literal: total and every
+    # category count are unchanged, yet admission fails and names both sides.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    _swap_baseline_entry(paths, "verify", "python_sdk_drift", "b", "b-replacement")
+    result, removed, added = _pr_result_and_recomputed_sets(paths, repo, base)
+    assert not result["passing"]
+    deltas = result["pr_delta"]["counts"]
+    assert all(entry["delta"] == 0 for entry in deltas.values())
+    assert result["pr_delta"]["increased"] == []
+    # Independently recomputed set differences match the JSON exactly.
+    assert added == {"python_sdk_drift:b-replacement"}
+    assert removed == {"python_sdk_drift:b"}
+    assert result["pr_delta"]["new_entries"] == sorted(added)
+    issues = result["integrity"]["issues"]
+    assert any("python_sdk_drift:b-replacement" in issue for issue in issues)
+    assert any("python_sdk_drift:b" in issue for issue in issues)
+    # Accepted-authority layer: a same-count literal method edit rehashes the
+    # record ID, which cannot exist in the immutable cohort.
+    authority = _accepted_authority()
+    record = next(
+        item
+        for item in authority["canonical_artifacts"]["original_cohort"]["original_records"]
+        if item["category"] == "python_sdk_drift"
+    )
+    record["exact_historical_literal_record"] = record["exact_historical_literal_record"].replace(
+        record["method"], "BREW", 1
+    )
+    with pytest.raises(ValueError, match="ID payload .*mismatch"):
+        ratchet._validate_original_cohort(authority["canonical_artifacts"]["original_cohort"])
+
+
+def test_pr_mode_fails_same_count_route_literal_replacement(tmp_path: Path):
+    # Replace one route path literal with a distinct path: same counts, fail.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    _swap_baseline_entry(paths, "routes", "missing_in_spec", "m2", "/api/replaced")
+    result, removed, added = _pr_result_and_recomputed_sets(paths, repo, base)
+    assert not result["passing"]
+    assert all(entry["delta"] == 0 for entry in result["pr_delta"]["counts"].values())
+    assert added == {"missing_in_spec:/api/replaced"}
+    assert removed == {"missing_in_spec:m2"}
+    assert result["pr_delta"]["new_entries"] == sorted(added)
+    issues = result["integrity"]["issues"]
+    assert any("missing_in_spec:/api/replaced" in issue for issue in issues)
+    assert any("missing_in_spec:m2" in issue for issue in issues)
+    # A parity path-literal replacement is equally identity tamper.
+    (tmp_path / "parity").mkdir()
+    parity_paths, parity_repo, parity_base = _seed(tmp_path / "parity", program=RED_PROGRAM)
+    _swap_baseline_entry(parity_paths, "parity", "missing_from_both_sdks", "p1", "p1-swapped")
+    parity_result, parity_removed, parity_added = _pr_result_and_recomputed_sets(
+        parity_paths, parity_repo, parity_base
+    )
+    assert not parity_result["passing"]
+    assert parity_added == {"missing_from_both_sdks:p1-swapped"}
+    assert parity_removed == {"missing_from_both_sdks:p1"}
+
+
+def test_pr_mode_fails_cross_category_original_record_replacement(tmp_path: Path):
+    # Move one unit from missing_in_spec to orphaned_in_spec: total is
+    # unchanged but the growing category and both exact IDs are named.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    routes = json.loads(paths["routes"].read_text())
+    routes["missing_in_spec"].remove("m2")
+    routes["orphaned_in_spec"].append("o-cross")
+    _write_json(paths["routes"], routes)
+    result, removed, added = _pr_result_and_recomputed_sets(paths, repo, base)
+    assert not result["passing"]
+    deltas = result["pr_delta"]["counts"]
+    assert sum(entry["delta"] for entry in deltas.values()) == 0
+    assert deltas["routes_missing_in_spec"]["delta"] == -1
+    assert deltas["routes_orphaned_in_spec"]["delta"] == 1
+    assert result["pr_delta"]["increased"] == ["routes_orphaned_in_spec"]
+    assert added == {"orphaned_in_spec:o-cross"}
+    assert removed == {"missing_in_spec:m2"}
+    reasons = result["pr_delta"]["unexplained_increase"]
+    assert any("orphaned_in_spec:o-cross" in reason for reason in reasons)
+    # Same entry text flipped across categories is still a new identity: the
+    # per-category ID is the unit of identity, not the literal alone.
+    (tmp_path / "flip").mkdir()
+    flip_paths, flip_repo, flip_base = _seed(tmp_path / "flip", program=RED_PROGRAM)
+    flip_routes = json.loads(flip_paths["routes"].read_text())
+    flip_routes["missing_in_spec"].remove("m2")
+    flip_routes["orphaned_in_spec"].append("m2")
+    _write_json(flip_paths["routes"], flip_routes)
+    flip_result, flip_removed, flip_added = _pr_result_and_recomputed_sets(
+        flip_paths, flip_repo, flip_base
+    )
+    assert not flip_result["passing"]
+    assert flip_added == {"orphaned_in_spec:m2"}
+    assert flip_removed == {"missing_in_spec:m2"}
+    # Accepted-authority layer: swapping a disposition row's category to
+    # another category is identity tamper.
+    authority = _accepted_authority()
+    row = authority["active_inventory"][0]
+    row["category"] = next(
+        category for category in ratchet.ACCEPTED_CATEGORIES if category != row["category"]
+    )
+    with pytest.raises(ValueError, match="identity or genesis is invalid"):
+        ratchet.validate_accepted_authority(authority, repo_root=Path(ratchet.__file__).parents[1])
+
+
+def _projection_case(mutate) -> tuple[dict, dict]:
+    """Deep-copied real cohort with `mutate(projection_records)` applied and
+    projection digests relinked, so validation reaches semantic checks."""
+    inventory = json.loads(
+        (Path(ratchet.__file__).parent / "baselines/contract_drift_inventory.json").read_text()
+    )
+    cohort = inventory["accepted_authority"]["canonical_artifacts"]["original_cohort"]
+    projection = cohort["operation_projection"]
+    mutate(projection["records"])
+    for record in projection["records"]:
+        record["record_sha256"] = ratchet._sha256_bytes(
+            ratchet._canonical_json_bytes(
+                {key: value for key, value in record.items() if key != "record_sha256"}
+            )
+        )
+    projection["record_digest_set_sha256"] = ratchet._digest_set(
+        "cdg-operation-projection-record-digest-set-v1",
+        [record["record_sha256"] for record in projection["records"]],
+        "record_sha256_values",
+    )
+    return cohort, projection
+
+
+def test_projection_many_to_one_dedup_cannot_remove_original_record(tmp_path: Path):
+    # The ratified projection contains 66 operations shared by multiple
+    # originals; deduplicating any shared operation to one membership record
+    # (654 memberships) breaks the 655 bijection and fails closed.
+    inventory = json.loads(
+        (Path(ratchet.__file__).parent / "baselines/contract_drift_inventory.json").read_text()
+    )
+    records = inventory["accepted_authority"]["canonical_artifacts"]["original_cohort"][
+        "operation_projection"
+    ]["records"]
+    by_operation: dict[tuple, list[int]] = {}
+    for index, record in enumerate(records):
+        key = tuple(
+            sorted((edge["method"], edge["normalized_path"]) for edge in record["operation_edges"])
+        )
+        by_operation.setdefault(key, []).append(index)
+    shared = next(indexes for indexes in by_operation.values() if len(indexes) > 1)
+    assert sum(1 for indexes in by_operation.values() if len(indexes) > 1) == 66
+
+    def dedup(projection_records: list[dict]) -> None:
+        del projection_records[shared[1]]
+
+    cohort, _projection = _projection_case(dedup)
+    with pytest.raises(ValueError, match="655 membership records"):
+        ratchet._validate_original_cohort(cohort)
+
+    # Padding the count back with a duplicate membership for the surviving
+    # original is caught by the bijection check.
+    def dedup_and_pad(projection_records: list[dict]) -> None:
+        clone = copy.deepcopy(projection_records[shared[0]])
+        projection_records[shared[1]] = clone
+
+    padded, _projection = _projection_case(dedup_and_pad)
+    with pytest.raises(ValueError, match="does not biject"):
+        ratchet._validate_original_cohort(padded)
+
+
+def test_projection_one_to_many_edge_omission_cannot_hide_original_or_operation(tmp_path: Path):
+    inventory = json.loads(
+        (Path(ratchet.__file__).parent / "baselines/contract_drift_inventory.json").read_text()
+    )
+    records = inventory["accepted_authority"]["canonical_artifacts"]["original_cohort"][
+        "operation_projection"
+    ]["records"]
+    multi_index = next(
+        index for index, record in enumerate(records) if len(record["operation_edges"]) > 1
+    )
+
+    # Omitting one witnessed edge from a multi-edge membership departs from
+    # the ratified projection witness (digest-set pin) and, arithmetically,
+    # from the 666-edge cardinality; either way it fails closed.
+    def omit_edge(projection_records: list[dict]) -> None:
+        projection_records[multi_index]["operation_edges"].pop()
+
+    omitted, _projection = _projection_case(omit_edge)
+    with pytest.raises(ValueError, match="record-digest-set mismatch|cardinality mismatch"):
+        ratchet._validate_original_cohort(omitted)
+
+    # Fanning one original into multiple membership records is a membership
+    # count/bijection failure, not silent growth.
+    def fan_out(projection_records: list[dict]) -> None:
+        clone = copy.deepcopy(projection_records[multi_index])
+        clone["operation_edges"] = [clone["operation_edges"][0]]
+        projection_records[multi_index]["operation_edges"] = projection_records[multi_index][
+            "operation_edges"
+        ][1:]
+        projection_records.append(clone)
+
+    fanned, _projection = _projection_case(fan_out)
+    with pytest.raises(ValueError, match="655 membership records"):
+        ratchet._validate_original_cohort(fanned)
+
+
+def test_projection_method_refinement_cannot_replace_original_record(tmp_path: Path):
+    # "Refining" a projected edge's method (GET -> POST) is a digest-set
+    # departure from the ratified projection witness, never a re-keyed
+    # original: the 655 original-record IDs are computed from category +
+    # literal only, so no projection edit can mint or replace an identity.
+    inventory = json.loads(
+        (Path(ratchet.__file__).parent / "baselines/contract_drift_inventory.json").read_text()
+    )
+    records = inventory["accepted_authority"]["canonical_artifacts"]["original_cohort"][
+        "original_records"
+    ]
+    expected_ids = sorted(record["original_record_id"] for record in records)
+
+    def refine(projection_records: list[dict]) -> None:
+        edge = projection_records[0]["operation_edges"][0]
+        edge["method"] = "POST" if edge["method"] != "POST" else "PUT"
+
+    refined, projection = _projection_case(refine)
+    assert projection["record_digest_set_sha256"] != ratchet.PROJECTION_RECORD_SET_SHA256
+    with pytest.raises(ValueError, match="record-digest-set mismatch"):
+        ratchet._validate_original_cohort(refined)
+    # The original-ID universe is untouched by the attempted refinement.
+    assert sorted(record["original_record_id"] for record in refined["original_records"]) == expected_ids  # fmt: skip
+    # An inferred method on a path-level original record remains forbidden.
+    authority = _accepted_authority()
+    path_record = next(
+        record
+        for record in authority["canonical_artifacts"]["original_cohort"]["original_records"]
+        if record["category"] == "routes_missing_in_spec"
+    )
+    path_record["method"] = "GET"
+    with pytest.raises(ValueError, match="carries a method"):
+        ratchet._validate_original_cohort(authority["canonical_artifacts"]["original_cohort"])
+
+
+def test_pr_mode_language_metadata_change_does_not_replace_identity(tmp_path: Path):
+    # sdk_language is category-derived provenance, not identity: it is not an
+    # input to the original-record ID hash.
+    authority = _accepted_authority()
+    record = next(
+        item
+        for item in authority["canonical_artifacts"]["original_cohort"]["original_records"]
+        if item["category"] == "python_sdk_drift"
+    )
+    payload = {
+        "category": record["category"],
+        "exact_historical_literal_record": record["exact_historical_literal_record"],
+        "schema": "cdg-original-record-id-v1",
+    }
+    raw = ratchet._canonical_json_bytes(payload)
+    assert record["original_record_id"] == f"cdg1:{ratchet._sha256_bytes(raw)}"
+    assert "sdk_language" not in payload
+    # Flipping the language annotation neither creates a new identity nor
+    # hides a replacement: the canonical artifact binding rejects the edit
+    # wholesale (separately versioned projection witnesses cannot alter the
+    # added/removed sets either).
+    flipped = copy.deepcopy(authority)
+    flipped_record = next(
+        item
+        for item in flipped["canonical_artifacts"]["original_cohort"]["original_records"]
+        if item["category"] == "python_sdk_drift"
+    )
+    flipped_record["sdk_language"] = ["typescript"]
+    assert flipped_record["original_record_id"] == record["original_record_id"]
+    with pytest.raises(ValueError, match="canonical artifact or category binding mismatch"):
+        ratchet.validate_accepted_authority(flipped, repo_root=Path(ratchet.__file__).parents[1])
+    # And a language-only mutation inside the cohort validator is a literal
+    # shape violation, not a new/removed ID.
+    cohort = copy.deepcopy(authority["canonical_artifacts"]["original_cohort"])
+    target = next(
+        item for item in cohort["original_records"] if item["category"] == "python_sdk_drift"
+    )
+    target["sdk_language"] = []
+    with pytest.raises(ValueError, match="language"):
+        ratchet._validate_sdk_provenance(
+            copy.deepcopy(_accepted_authority()["canonical_artifacts"]["sdk_provenance"]),
+            ratchet._validate_original_cohort(cohort),
+        )
+
+
+def test_pr_mode_exact_original_record_diagnostics_are_sorted_complete_and_untruncated(
+    tmp_path: Path,
+):
+    # 26 added + 1 removed in one PR: every ID appears, sorted, no caps.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    added_entries = [f"bulk-{index:03d}" for index in range(26)]
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("a")
+    verify["python_sdk_drift"].extend(added_entries)
+    _write_json(paths["verify"], verify)
+    result, removed, added = _pr_result_and_recomputed_sets(paths, repo, base)
+    assert not result["passing"]
+    expected_added = sorted(f"python_sdk_drift:{entry}" for entry in added_entries)
+    assert added == set(expected_added)
+    assert removed == {"python_sdk_drift:a"}
+    # JSON diagnostics equal the independently recomputed sets: complete,
+    # sorted, unique, untruncated (no ellipses/caps/count-only summaries).
+    assert result["pr_delta"]["new_entries"] == expected_added
+    assert len(result["pr_delta"]["new_entries"]) == len(set(result["pr_delta"]["new_entries"]))
+    reasons = result["pr_delta"]["unexplained_increase"]
+    for item_id in expected_added:
+        assert any(item_id in reason for reason in reasons)
+    assert not any("..." in reason for reason in reasons)
+    stale = [issue for issue in result["integrity"]["issues"] if "python_sdk_drift:a" in issue]
+    assert stale
+    # Per-category delta arithmetic is exact.
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == 25
+
+
+def test_pr_mode_passes_strict_original_record_subset(tmp_path: Path):
+    # A strict subset in two categories (with matching resolutions) passes
+    # while the program schedule stays honestly red.
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    verify = json.loads(paths["verify"].read_text())
+    verify["python_sdk_drift"].remove("b")
+    _write_json(paths["verify"], verify)
+    routes = json.loads(paths["routes"].read_text())
+    routes["missing_in_spec"].remove("m2")
+    _write_json(paths["routes"], routes)
+
+    def resolve(inventory: dict) -> None:
+        for item in inventory["items"]:
+            if item["id"] in {"python_sdk_drift:b", "missing_in_spec:m2"}:
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve)
+    result, removed, added = _pr_result_and_recomputed_sets(paths, repo, base)
+    assert result["passing"] and not result["program_passing"]
+    assert added == set() and removed == {"missing_in_spec:m2", "python_sdk_drift:b"}
+    assert result["pr_delta"]["increased"] == []
+    assert result["pr_delta"]["new_entries"] == []
+    assert result["pr_delta"]["counts"]["verify_python_sdk_drift"]["delta"] == -1
+    assert result["pr_delta"]["counts"]["routes_missing_in_spec"]["delta"] == -1
+    # Accepted-authority layer: a global+per-category strict subset head
+    # passes with exact removed IDs and empty added IDs.
+    root = Path(ratchet.__file__).parents[1]
+    authority = _accepted_authority()
+    summary = ratchet.validate_accepted_authority(authority, repo_root=root)
+    live = set(summary["live_original_record_ids"])
+    live_digest = ratchet._sha256_bytes(ratchet._canonical_json_bytes(sorted(live)))
+    paydown = copy.deepcopy(authority)
+    for item in paydown["active_inventory"]:
+        if item["original_record_id"] in live:
+            continue
+        fact = {"active_original_record_ids_sha256": live_digest, "as_of": "2026-07-27", "original_record_id": item["original_record_id"]}  # fmt: skip
+        item.update(status="resolved", disposition_history=[ratchet.GENESIS_DISPOSITION, {"as_of": fact["as_of"], "evidence": {"fact": fact, "sha256": ratchet._fact_digest(ratchet.PAYDOWN_SCHEMA, fact)}, "status": "resolved"}])  # fmt: skip
+    paydown["active_inventory_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(paydown["active_inventory"]))  # fmt: skip
+    paydown["manifest_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes({key: value for key, value in paydown.items() if key != "manifest_sha256"}))  # fmt: skip
+    compared = ratchet.compare_accepted_authorities(authority, paydown, repo_root=root)
+    assert compared["passing"] and compared["status"] == "pass"
+    assert compared["added_original_record_ids"] == []
+    expected_removed = sorted(set(summary["active_original_record_ids"]) - live)
+    assert compared["removed_original_record_ids"] == expected_removed
+    assert len(expected_removed) == 255
+
+
+# ---- VAL-CDG-008: exact UTC week arithmetic, non-backdated final as-of
+
+
+def _program_dict(program: dict) -> dict:
+    return {**program, "start_date": date.fromisoformat(program["start_date"])}
+
+
+def test_program_preserves_655_2026_04_17_ten_percent():
+    baseline = json.loads(
+        (Path(ratchet.__file__).parent / "baselines/contract_drift_program.json").read_text()
+    )
+    assert baseline["start_total_items"] == 655
+    assert baseline["start_date"] == "2026-04-17"
+    assert baseline["weekly_reduction"] == 0.10
+    assert baseline.get("grace_weeks", 0) == 0
+    program = ratchet._load_program(
+        Path(ratchet.__file__).parent / "baselines/contract_drift_program.json"
+    )
+    assert program["start_date"] == date(2026, 4, 17)
+    assert program["start_total_items"] == 655
+    assert program["weekly_reduction"] == 0.1
+    assert program["grace_weeks"] == 0
+
+
+def test_target_uses_exact_integer_floor_recurrence():
+    # T(0)=655, T(n+1) = 9*T(n)//10 — the exact integer recurrence chain.
+    expected = [655, 589, 530, 477, 429, 386, 347, 312, 280, 252, 226, 203, 182, 163, 146, 131]
+    chain = [ratchet._target_after_weeks(655, 0.1, weeks) for weeks in range(16)]
+    assert chain == expected
+    # Divergence witnesses: one-shot binary-float flooring first differs at
+    # week 6 (348 vs 347) and nearest-rounding differs at week 1 (590 vs
+    # 589) — the recurrence matches neither.
+    import math
+
+    assert math.floor(655 * 0.9**6) == 348 and chain[6] == 347
+    assert round(655 * 0.9**1) == 590 and chain[1] == 589
+    # Monotone and eventually zero; never negative.
+    long_chain = [ratchet._target_after_weeks(655, 0.1, weeks) for weeks in range(100)]
+    assert all(later <= earlier for earlier, later in zip(long_chain, long_chain[1:]))
+    assert long_chain[-1] == 0 and min(long_chain) == 0
+    # Only exact integer recurrences are accepted — arbitrary multipliers
+    # (which would need binary-float multiplication) fail closed.
+    with pytest.raises(ValueError, match="exact integer recurrence"):
+        ratchet._target_after_weeks(655, 0.25, 1)
+
+
+def test_utc_boundary_controls_week_increment(tmp_path: Path):
+    # Fixed dates around the start pin the integer week boundaries exactly:
+    # days 0/6 -> week 0; days 7/13 -> week 1; day 14 -> week 2.
+    program = {
+        "start_date": "2026-04-17",
+        "start_total_items": 655,
+        "weekly_reduction": 0.1,
+        "grace_weeks": 0,
+    }
+    start = date(2026, 4, 17)
+    for offset, expected_weeks, expected_target in (
+        (0, 0, 655),
+        (6, 0, 655),
+        (7, 1, 589),
+        (13, 1, 589),
+        (14, 2, 530),
+    ):
+        classes = ratchet._evaluate_classes(
+            _program_dict(program), [], start + timedelta(days=offset)
+        )
+        assert classes[0]["weeks_elapsed"] == expected_weeks
+        assert classes[0]["target_max"] == expected_target
+
+
+def test_before_start_and_partial_week_do_not_decay(tmp_path: Path):
+    program = {
+        "start_date": "2026-04-17",
+        "start_total_items": 655,
+        "weekly_reduction": 0.1,
+        "grace_weeks": 0,
+    }
+    # Before the start date the clock clamps to zero (never negative weeks).
+    for as_of in (date(2026, 4, 10), date(2026, 4, 16), date(2025, 12, 31)):
+        classes = ratchet._evaluate_classes(_program_dict(program), [], as_of)
+        assert classes[0]["weeks_elapsed"] == 0
+        assert classes[0]["target_max"] == 655
+    # A partial week (1-6 days) never decays the target.
+    for days in range(1, 7):
+        classes = ratchet._evaluate_classes(
+            _program_dict(program), [], date(2026, 4, 17) + timedelta(days=days)
+        )
+        assert classes[0]["target_max"] == 655
+
+
+def test_local_timezone_cannot_change_default_as_of(monkeypatch: pytest.MonkeyPatch):
+    root = Path(ratchet.__file__).parents[1]
+    inventory = root / "scripts/baselines/contract_drift_inventory.json"
+    utc_today = datetime.now(UTC).date().isoformat()
+    observed: dict[str, str] = {}
+    for timezone_name in ("Pacific/Kiritimati", "Etc/GMT+11", "UTC"):
+        monkeypatch.setenv("TZ", timezone_name)
+        time.tzset()
+        try:
+            result = ratchet.build_accepted_result(
+                mode="program", repo_root=root, inventory_path=inventory
+            )
+        finally:
+            monkeypatch.setenv("TZ", "UTC")
+            time.tzset()
+        observed[timezone_name] = result["program"]["as_of"]
+    # Kiritimati (UTC+14) local "today" is ahead of UTC and GMT+11 local
+    # "today" is behind around midnight, yet the default as-of is the UTC
+    # date in every process timezone.
+    assert set(observed.values()) == {utc_today}
+
+
+def test_malformed_or_future_live_as_of_fails_closed():
+    root = Path(ratchet.__file__).parents[1]
+    inventory = root / "scripts/baselines/contract_drift_inventory.json"
+    future = (datetime.now(UTC).date() + timedelta(days=2)).isoformat()
+    result = ratchet.build_accepted_result(
+        mode="program", repo_root=root, inventory_path=inventory, as_of=future
+    )
+    assert (result["status"], result["passing"]) == ("fail", False)
+    assert result["error_code"] == "future_as_of"
+    for malformed in ("07/31/2026", "2026-7-1x", "yesterday", "2026-13-40"):
+        malformed_result = ratchet.build_accepted_result(
+            mode="program", repo_root=root, inventory_path=inventory, as_of=malformed
+        )
+        assert (malformed_result["status"], malformed_result["passing"]) == ("fail", False)
+        assert malformed_result["error_code"] == "invalid_as_of"
+
+
+def test_program_mode_exit_matches_truthful_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # Red: 10 open items against a decayed target -> exit 1 under --strict,
+    # with passing == (total <= target) truthfully false.
+    paths, repo, cohort = _seed(tmp_path, program=RED_PROGRAM)
+    red = _result(paths, "2026-07-16", repo=repo, cohort=cohort)
+    assert red["passing"] is False
+    assert red["current"]["total_items"] == 10
+    assert red["current"]["total_items"] > red["target"]["max_open_items"]
+    monkeypatch.setattr(
+        sys, "argv", _argv(paths, repo, cohort, "--strict", "--as-of", "2026-07-16")
+    )
+    assert ratchet.main() == 1
+    # Green: same inventory on day zero -> exit 0, passing truthfully true.
+    monkeypatch.setattr(
+        sys, "argv", _argv(paths, repo, cohort, "--strict", "--as-of", "2026-04-17")
+    )
+    assert ratchet.main() == 0
+    green = _result(paths, "2026-04-17", repo=repo, cohort=cohort)
+    assert green["passing"] is (green["current"]["total_items"] <= green["target"]["max_open_items"])  # fmt: skip
+    assert green["passing"] is True
+
+
+# - VAL-CDG-009 (ratchet side): PR admission is independent of program red
+
+
+def test_unchanged_pr_passes_while_program_is_red(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    program = _result(paths, "2026-07-16", repo=repo, cohort=base)
+    assert not program["passing"]  # trajectory is intentionally red
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    # The unchanged PR passes on its own signal; the red program is reported
+    # separately and cannot mask or replace the PR-delta verdict.
+    assert result["passing"] is True
+    assert result["program_passing"] is False
+    assert result["pr_delta"]["counts"] == {
+        key: {"base": value, "head": value, "delta": 0}
+        for key, value in {
+            "verify_python_sdk_drift": 2,
+            "verify_typescript_sdk_drift": 3,
+            "routes_missing_in_spec": 2,
+            "routes_orphaned_in_spec": 1,
+            "sdk_missing_from_both": 2,
+        }.items()
+    }
+    assert result["pr_delta"]["unexplained_increase"] == []
+
+
+def test_shrinking_pr_passes_while_program_is_red(tmp_path: Path):
+    paths, repo, base = _seed(tmp_path, program=RED_PROGRAM)
+    verify = json.loads(paths["verify"].read_text())
+    verify["typescript_sdk_drift"].remove("z")
+    _write_json(paths["verify"], verify)
+
+    def resolve(inventory: dict) -> None:
+        for item in inventory["items"]:
+            if item["id"] == "typescript_sdk_drift:z":
+                item["status"] = "resolved"
+                item["resolved_on"] = "2026-07-16"
+
+    _edit_inventory(paths, resolve)
+    program = _result(paths, "2026-07-16", repo=repo, cohort=base)
+    assert not program["passing"]  # still red: 9 open vs decayed target
+    result = _result(paths, "2026-07-16", repo=repo, cohort=base, mode="pr", base_ref=base)
+    assert result["passing"] is True
+    assert result["program_passing"] is False
+    assert result["pr_delta"]["counts"]["verify_typescript_sdk_drift"]["delta"] == -1
+    assert result["pr_delta"]["increased"] == []
+    assert result["pr_delta"]["unexplained_increase"] == []

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -4931,3 +4931,446 @@ def test_annotations_cannot_change_pr_verdict_projection_or_exact_diagnostics(
     ] = {"collapse": True}
     with pytest.raises(ValueError, match="projection"):
         ratchet._validate_original_cohort(hostile["canonical_artifacts"]["original_cohort"])
+
+
+# ------------------- VAL-CDG-007 (boundary side): fail-closed negatives
+
+
+def test_duplicate_or_incomplete_paginated_collection_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Duplicate record IDs across pages fail closed.
+    def duplicated(
+        endpoint: str, *, operation_log: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        del operation_log
+        page = int(endpoint.rsplit("page=", 1)[1])
+        payload = [{"id": index} for index in range(100)] if page == 1 else [{"id": 99}]
+        return payload, {"byte_length": page, "etag": f'"p{page}"', "sha256": f"{page:064x}", "updated_at": None}  # fmt: skip
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", duplicated)
+    with pytest.raises(ValueError, match="duplicate record IDs"):
+        ratchet._gh_api_paginated("repos/synaptent/aragora/releases", operation_log=[])
+    # A non-list page is malformed, never silently treated as exhaustion.
+    monkeypatch.setattr(
+        ratchet,
+        "_gh_api_get_stable",
+        lambda endpoint, *, operation_log: ({"not": "a list"}, {}),
+    )
+    with pytest.raises(ValueError, match="paginated GitHub response is malformed"):
+        ratchet._gh_api_paginated("repos/synaptent/aragora/releases", operation_log=[])
+    # Nonterminating pagination is bounded and fails closed.
+    monkeypatch.setattr(
+        ratchet,
+        "_gh_api_get_stable",
+        lambda endpoint, *, operation_log: (
+            [{"id": None} for _ in range(100)],
+            {"byte_length": 1, "etag": '"e"', "sha256": "0" * 64, "updated_at": None},
+        ),
+    )
+    with pytest.raises(ValueError, match="pagination did not terminate"):
+        ratchet._gh_api_paginated("repos/synaptent/aragora/releases", operation_log=[])
+
+
+def test_pr_changed_files_additions_deletions_mismatch_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # A PR response whose changed_files disagrees with the exhaustively
+    # paginated file records fails closed (both directions).
+    for wrong in (2, 5):
+        with pytest.raises(ValueError, match="file discovery is incomplete"):
+            _live_pr_files_probe(
+                tmp_path / f"count-{wrong}",
+                monkeypatch,
+                files_count=3,
+                changed_files=wrong,
+            )
+    # Malformed additions/deletions in the authenticated PR response fail.
+    with pytest.raises(ValueError, match="additions/deletions are malformed"):
+        _live_pr_files_probe(tmp_path / "neg-del", monkeypatch, pr_deletions=-4)
+    # And the boundary evaluator rejects a capsule whose authenticated
+    # additions/deletions violate the 800-line paydown cap.
+    over_cap = _boundary_result(
+        tmp_path / "cap",
+        monkeypatch,
+        "corrective_bootstrap",
+        pr_additions=500,
+        pr_deletions=400,
+    )
+    assert (over_cap["status"], over_cap["passing"]) == ("fail", False)
+    assert "exceeds the 800-line cap" in over_cap["error"]
+    assert over_cap["error_code"] == "boundary_validation_failed"
+
+
+def test_files_api_cap_or_incomplete_tree_diff_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # A capsule that denies complete file discovery fails closed even when
+    # every other predicate proves.
+    def denies(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["records"][0]["changed_files_complete"] = False
+
+    with pytest.raises(ValueError, match="denies complete file discovery"):
+        _live_pr_files_probe(tmp_path / "denied", monkeypatch, mutate=denies)
+
+    # The tree-equality backstop: a head tree that does not equal the
+    # authenticated merge tree fails closed (no partial diff is accepted).
+    def wrong_tree(resources: dict[str, Any]) -> None:
+        resources["first_parent_receipts"]["records"][0]["merge_tree_sha"] = "b" * 40
+
+    with pytest.raises(ValueError, match="lacks first-parent or tree equality"):
+        _live_pr_files_probe(tmp_path / "tree", monkeypatch, mutate=wrong_tree)
+
+
+def test_compare_api_fallback_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The read-only subprocess guard rejects a compare-endpoint mutation
+    # dressed as gh api with a mutating method, and there is no compare
+    # fallback anywhere in live evidence collection.
+    with pytest.raises(ValueError, match="mutating HTTP"):
+        ratchet._guard_subprocess_argv(["gh", "api", "--method", "POST", "repos/o/r/compare/a...b"])
+    _context, requested = _live_pr_files_probe(tmp_path, monkeypatch, files_count=1)
+    assert not any("compare" in endpoint for endpoint in requested)
+
+    # An unexpected compare request would be unauthenticated: the transport
+    # fake raises AssertionError, surfacing as a hard boundary failure, not a
+    # silent fallback. Prove the failure path by asking for a compare probe.
+    def compare_probe(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("compare endpoint must never be requested")
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", compare_probe)
+    with pytest.raises(AssertionError, match="compare endpoint"):
+        ratchet._gh_api_get_stable("repos/synaptent/aragora/compare/a...b", operation_log=[])
+
+
+def test_total_count_reconciliation_failure_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Governed-PR reconciliation: authenticated changes for a PR that is not
+    # in the capsule (or missing for one that is) fail closed.
+    resource = _governed_pr_resource("1" * 40, "2" * 40)
+    with pytest.raises(ValueError, match="do not reconcile"):
+        ratchet._validate_governed_prs(
+            resource,
+            authenticated_pr_changes={
+                9999: {"additions": 1, "deletions": 1},
+                4242: {"additions": 1, "deletions": 1},
+            },
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    # Empty governed evidence is missing evidence, not a zero-count success.
+    empty = _governed_pr_resource("1" * 40, "2" * 40)
+    empty["records"] = []
+    with pytest.raises(ValueError, match="governed PR evidence is missing"):
+        ratchet._validate_governed_prs(
+            empty,
+            authenticated_pr_changes={},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    # Live collection: a capsule count that disagrees with the observed PR
+    # response total fails during authentication, not after.
+    with pytest.raises(ValueError, match="file discovery is incomplete"):
+        _live_pr_files_probe(tmp_path / "short", monkeypatch, files_count=3, changed_files=99)
+
+
+def test_boundary_manifest_digest_mismatch_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path)
+    boundary = "corrective_bootstrap"
+    end_sha = boundary_shas[boundary]
+    index_path, index_length, index_sha256 = _write_boundary_index(
+        tmp_path, boundary, start_sha, end_sha, boundary_shas, repo=repo
+    )
+    # Tamper with one resource file after the index digests were computed.
+    resource_path = tmp_path / f"resources-{boundary}" / "governed_prs.json"
+    payload = json.loads(resource_path.read_text())
+    payload["records"][0]["pr"] = 4242
+    resource_path.write_bytes(_canonical_boundary_bytes(payload))
+    with pytest.raises(ValueError, match="SHA-256 mismatch|byte-length mismatch"):
+        ratchet._load_evidence_resources(
+            evidence_index_path=index_path,
+            evidence_index_byte_length=index_length,
+            evidence_index_sha256=index_sha256,
+            boundary=boundary,
+            start_sha=start_sha,
+            end_sha=end_sha,
+            operation_log=[],
+        )
+    # And a wrong index digest never reaches resource loading.
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        ratchet._load_evidence_resources(
+            evidence_index_path=index_path,
+            evidence_index_byte_length=index_length,
+            evidence_index_sha256="0" * 64,
+            boundary=boundary,
+            start_sha=start_sha,
+            end_sha=end_sha,
+            operation_log=[],
+        )
+
+
+def test_boundary_start_equals_end_or_required_predicate_empty_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo, start_sha, _boundary_shas = _boundary_git_repo(tmp_path)
+    equal = ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref=start_sha,
+        end_ref=start_sha,
+    )
+    assert (equal["status"], equal["passing"]) == ("fail", False)
+    assert "start SHA must differ from end SHA" in equal["error"]
+    assert equal["error_code"] == "boundary_validation_failed"
+
+    def empty_predicate(payloads: dict[str, dict[str, Any]]) -> None:
+        proof = payloads["corrective_bootstrap"]
+        for key in list(proof):
+            if key not in {"schema", "predicate", "proof_for_boundary", "proof_start_sha", "proof_end_sha"}:  # fmt: skip
+                del proof[key]
+
+    empty = _boundary_result(
+        tmp_path / "empty", monkeypatch, "corrective_bootstrap", mutate=empty_predicate
+    )
+    assert (empty["status"], empty["passing"]) == ("fail", False)
+    assert empty["error_code"] == "boundary_validation_failed"
+
+
+def test_caller_summary_or_caller_operation_log_cannot_authenticate_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # A capsule resource carrying caller-summary fields is rejected wholesale.
+    for field in ("caller_summary", "operation_log", "summary", "results", "prior_boundary_manifest"):  # fmt: skip
+
+        def smuggle(resources: dict[str, Any], field: str = field) -> None:
+            resources["governed_prs"][field] = {"authenticated": True}
+
+        with pytest.raises(ValueError, match="caller-supplied or inherited authority"):
+            _live_pr_files_probe(tmp_path / f"caller-{field}", monkeypatch, mutate=smuggle)
+
+    # Nested caller authority is found recursively.
+    def nested(resources: dict[str, Any]) -> None:
+        resources["corrective_bootstrap"]["accepted_stage1_closure"]["fact"]["summaries"] = []
+
+    with pytest.raises(ValueError, match="caller-supplied or inherited authority"):
+        _live_pr_files_probe(tmp_path / "nested", monkeypatch, mutate=nested)
+    # The Python API rejects caller-supplied evidence/GitHub trust roots.
+    with pytest.raises(TypeError):
+        ratchet.build_boundary_result(
+            repo_root=tmp_path,
+            schema_version=1,
+            boundary="corrective_bootstrap",
+            start_ref="1" * 40,
+            end_ref="2" * 40,
+            evidence_resources={"governed_prs": {}},  # type: ignore[call-arg]
+        )
+
+
+def test_release_immutability_or_rule_suite_prerequisite_blocks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    result = _boundary_result(
+        tmp_path,
+        monkeypatch,
+        "corrective_bootstrap",
+        release_immutability=False,
+    )
+    assert (result["status"], result["passing"]) == ("blocked", False)
+    assert "future GitHub Release immutability" in result["blocked_reason"]
+    assert result["blocked_reason"].endswith("authenticated and unavailable")
+    # Unavailable rule-suite access blocks; unauthenticated claims fail.
+    prerequisites = {
+        "administration": {"authenticated": True, "available": False},
+        "boundary": "corrective_bootstrap",
+        "end_sha": "2" * 40,
+        "future_release_immutability": {
+            "authenticated": True,
+            "available": True,
+            "enabled": True,
+        },  # fmt: skip
+        "rule_suite": {"authenticated": True, "available": True},
+        "schema": "contract-drift-external-prerequisites-v1",
+        "start_sha": "1" * 40,
+    }
+    with pytest.raises(ratchet.BoundaryBlocked, match="authenticated and unavailable"):
+        ratchet._validate_external_prerequisites(
+            copy.deepcopy(prerequisites),
+            repository_id=1,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="2" * 40,
+            operation_log=[],
+        )
+    unauthenticated = copy.deepcopy(prerequisites)
+    unauthenticated["administration"] = {"authenticated": False, "available": False}
+    with pytest.raises(ValueError, match="not independently authenticated"):
+        ratchet._validate_external_prerequisites(
+            unauthenticated,
+            repository_id=1,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="2" * 40,
+            operation_log=[],
+        )
+
+
+def test_boundary_evidence_inheritance_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Evidence stamped for a different boundary interval cannot be inherited.
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path)
+    boundary = "route_truth"
+    end_sha = boundary_shas[boundary]
+    index_path, index_length, index_sha256 = _write_boundary_index(
+        tmp_path, boundary, start_sha, end_sha, boundary_shas, repo=repo
+    )
+    with pytest.raises(ValueError, match="interval mismatch"):
+        ratchet._load_evidence_resources(
+            evidence_index_path=index_path,
+            evidence_index_byte_length=index_length,
+            evidence_index_sha256=index_sha256,
+            boundary=boundary,
+            start_sha=start_sha,
+            end_sha=boundary_shas["core_sdk"],  # a later boundary's SHA
+            operation_log=[],
+        )
+
+    # An explicit inherited-authority marker on a resource is rejected.
+    def inherit(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["inherited_from_boundary"] = "corrective_bootstrap"
+
+    with pytest.raises(ValueError, match="caller-supplied or inherited authority"):
+        _live_pr_files_probe(tmp_path / "inherit", monkeypatch, mutate=inherit)
+
+
+def test_boundary_status_blocked_rejects_internal_malformed_false_missing_or_bypass_cases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Internal falsity: a false predicate fact fails (never blocked).
+    def false_fact(payloads: dict[str, dict[str, Any]]) -> None:
+        payloads["corrective_bootstrap"]["stage2_verifier_chronology"]["fact"][
+            "ordered_after_stage1"
+        ] = False
+
+    false_result = _boundary_result(
+        tmp_path / "false", monkeypatch, "corrective_bootstrap", mutate=false_fact
+    )
+    assert (false_result["status"], false_result["blocked_reason"]) == ("fail", None)
+
+    # Missing evidence: a dropped predicate resource fails, never blocks.
+    def drop(payloads: dict[str, dict[str, Any]]) -> None:
+        del payloads["corrective_bootstrap"]["corrective_transition"]
+
+    missing = _boundary_result(
+        tmp_path / "missing", monkeypatch, "corrective_bootstrap", mutate=drop
+    )
+    assert (missing["status"], missing["blocked_reason"]) == ("fail", None)
+
+    # Malformed digest binding on a fact fails, never blocks.
+    def forge(payloads: dict[str, dict[str, Any]]) -> None:
+        payloads["corrective_bootstrap"]["corrective_transition"]["sha256"] = "0" * 64
+
+    forged = _boundary_result(
+        tmp_path / "forged", monkeypatch, "corrective_bootstrap", mutate=forge
+    )
+    assert (forged["status"], forged["blocked_reason"]) == ("fail", None)
+    # Bypassed rule suites fail closed (relabeled-blocked is impossible).
+    bypassed = _rule_suite_record(
+        "2" * 40,
+        rule_evaluations=[{"result": "bypass", "rule_source": {"type": "repository"}}],
+    )
+    with pytest.raises(ValueError, match="bypassed evaluation"):
+        ratchet._validate_rule_suite_record_fields(
+            bypassed,
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="2" * 40,
+        )
+    not_passing = _rule_suite_record("2" * 40, evaluation_result="bypass")
+    with pytest.raises(ValueError, match="evaluation is not passing"):
+        ratchet._validate_rule_suite_record_fields(
+            not_passing,
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="2" * 40,
+        )
+    # Mutation-tainted external prerequisite evidence fails, never blocks.
+    with pytest.raises(ValueError, match="mutation-tainted"):
+        ratchet._validate_external_prerequisites(
+            {"mutation_tainted": True},
+            repository_id=1,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="2" * 40,
+            operation_log=[],
+        )
+
+
+def test_deterministic_boundary_status_pass_is_reachable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    for boundary in ("corrective_bootstrap", "final_seal"):
+        result = _boundary_result(tmp_path / boundary, monkeypatch, boundary)
+        assert (result["status"], result["passing"]) == ("pass", True)
+        assert result["blocked_reason"] is None
+        assert result["error_code"] if result["status"] == "fail" else True
+        assert list(result["predicates"]) == list(
+            ratchet.BOUNDARY_NAMES[: ratchet.BOUNDARY_NAMES.index(boundary) + 1]
+        )
+        assert all(entry["proven"] is True for entry in result["predicates"].values())
+        # Deterministic: the same fixture double-runs to identical bytes
+        # modulo the freshly generated operation log.
+        again = _boundary_result(tmp_path / f"{boundary}-again", monkeypatch, boundary)
+        assert again["status"] == "pass"
+        assert again["predicates"] == result["predicates"]
+
+
+def test_read_only_cli_mutation_attempt_fails_closed(tmp_path: Path):
+    # Mutating git/gh/HTTP actions are rejected before execution.
+    for argv in (
+        ["git", "commit", "-m", "x"],
+        ["git", "push"],
+        ["gh", "pr", "merge", "1"],
+        ["gh", "api", "-XDELETE", "repos/o/r"],
+        ["rm", "-rf", str(tmp_path)],
+        [],
+    ):
+        with pytest.raises(ValueError, match="mutating|unsupported"):
+            ratchet._guard_subprocess_argv(argv)
+    for method in ("POST", "PUT", "PATCH", "DELETE"):
+        with pytest.raises(ValueError, match="mutating HTTP"):
+            ratchet._guard_http_method(method)
+    # Write attempts outside the declared scratch/output roots are rejected.
+    scratch = tmp_path / "scratch"
+    output = tmp_path / "output"
+    scratch.mkdir()
+    output.mkdir()
+    with pytest.raises(ValueError, match="write outside explicit scratch/output roots"):
+        ratchet._guard_write_path(tmp_path / "escape.txt", scratch, output)
+    ratchet._guard_write_path(scratch / "ok.txt", scratch, output)
+    ratchet._guard_write_path(output / "ok.txt", scratch, output)
+    # The exclusive private writer refuses to follow a preexisting symlink.
+    target = tmp_path / "outside-target.txt"
+    target.write_text("x", encoding="utf-8")
+    link = scratch / "sneaky.json"
+    link.symlink_to(target)
+    with pytest.raises((ValueError, OSError)):
+        ratchet._write_exclusive_private_file(link, b"{}", scratch_root=scratch, output_root=output)

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -6556,7 +6556,7 @@ H2_SHA = "d4ab26e4b30b7f65956b4cdd9d738837b78ca4a3"
 H3_SHA = "1722a6145c0c23a2c1c0d20be5ed1329bb01d666"
 H4_SHA = "f50902a19bdc6cce7049da87212dc27759f727a0"
 OLD_H2_PIN_SHA = "017ce1d7a4024f3001858d2385cd153c1ffc8bb2"
-CORRECTIVE_BASE_SHA = "8f1dd9684a3bf311e65b40de2ab35415612cc051"
+CORRECTIVE_BASE_SHA = "d5c9df5cea5719404b54c34fdb62a89daf65a92f"
 PR_9346_FACT = {
     "actor": "scarmani",
     "head_sha": "83a7c59169ea238e0439a27fbb80d3cb3ce7e916",
@@ -8064,3 +8064,940 @@ def test_normal_protected_exact_head_merge_is_last_and_never_admin(
     assert merge_command[:3] == ["gh", "pr", "merge"]
     assert "--match-head-commit" in merge_command
     assert merge_command[merge_command.index("--match-head-commit") + 1] == "7" * 40
+
+
+# ---------------------------------------------------------------------------
+# VAL-CDG-014: authority transitions are closed, atomic, and fail safely
+# across old bases.
+# ---------------------------------------------------------------------------
+
+
+def test_base_without_accepted_authority_requires_transition(tmp_path: Path):
+    # An inventory without the accepted-authority manifest yields the
+    # dedicated transition error, never head-authority execution.
+    inventory = _real_inventory()
+    del inventory["accepted_authority"]
+    bare = tmp_path / "inventory.json"
+    bare.write_text(json.dumps(inventory), encoding="utf-8")
+    result = ratchet.build_accepted_result(
+        mode="program", repo_root=_REPO_ROOT, inventory_path=bare
+    )
+    assert result["status"] == "fail" and result["passing"] is False
+    assert result["error_code"] == "authority_transition_required"
+    # A missing/unreadable inventory is the same closed transition failure.
+    missing = ratchet.build_accepted_result(
+        mode="program", repo_root=_REPO_ROOT, inventory_path=tmp_path / "absent.json"
+    )
+    assert missing["error_code"] == "authority_transition_required"
+    # Degraded-schema bases (manifest present but not an object) fail the
+    # same way rather than executing whatever the head proposes.
+    inventory["accepted_authority"] = "not-a-manifest"
+    bare.write_text(json.dumps(inventory), encoding="utf-8")
+    degraded = ratchet.build_accepted_result(
+        mode="program", repo_root=_REPO_ROOT, inventory_path=bare
+    )
+    assert degraded["error_code"] == "authority_transition_required"
+
+
+def test_corrective_merge_parent_requires_transition(tmp_path: Path):
+    # PARENT is the recorded corrective transition base: it descends to the
+    # current main and its inventory has no accepted authority manifest.
+    parent = _real_authority()["transition"]["base_sha"]
+    assert parent == CORRECTIVE_BASE_SHA
+    subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "merge-base", "--is-ancestor", parent, "HEAD"],
+        check=True,
+    )
+    parent_doc = json.loads(
+        subprocess.check_output(
+            ["git", "-C", str(_REPO_ROOT), "show", f"{parent}:{gen.DEFAULT_INVENTORY}"],
+            text=True,
+        )
+    )
+    assert not isinstance(parent_doc.get("accepted_authority"), dict)
+    # PR mode under PARENT's inventory fails authority_transition_required.
+    parent_inventory = tmp_path / "parent-inventory.json"
+    parent_inventory.write_text(json.dumps(parent_doc), encoding="utf-8")
+    result = ratchet.build_accepted_result(
+        mode="program", repo_root=_REPO_ROOT, inventory_path=parent_inventory
+    )
+    assert result["error_code"] == "authority_transition_required"
+    assert result["passing"] is False
+
+
+def test_head_cannot_self_bootstrap_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # When the resolved base carries accepted authority, PR mode executes the
+    # base analyzer/authority — the head cannot swap in its own.
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, _calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["passing"] is True
+    assert result["execution"]["analyzer_sha"] == base
+    assert result["authority"] == {"source": "accepted_authority"}
+    # A head that rewrites the authority manifest cannot smuggle it through
+    # the comparison: immutable bindings are compared exactly.
+    hostile = _real_authority()
+    hostile["analyzer_bundle"]["interpreter_flags"] = ["-I"]
+    _relink_authority_manifest(hostile)
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", lambda *a, **k: {})
+    with pytest.raises(ValueError, match="immutable authority bindings changed"):
+        ratchet.compare_accepted_authorities(_real_authority(), hostile, repo_root=_REPO_ROOT)
+
+
+def test_approved_authority_transition_is_atomic():
+    # The accepted authority is a closed atomic unit: its field set is exact,
+    # and removing any single plane fails the whole manifest closed.
+    authority = _real_authority()
+    assert set(authority) == ratchet.AUTHORITY_FIELDS
+    for field in sorted(ratchet.AUTHORITY_FIELDS):
+        partial = _real_authority()
+        del partial[field]
+        with pytest.raises(ValueError, match="schema or fields mismatch"):
+            ratchet.validate_accepted_authority(partial, repo_root=_REPO_ROOT)
+    # The installed transition is the dedicated authority_transition kind
+    # with the exact recorded base.
+    transition = authority["transition"]
+    assert transition["kind"] == "authority_transition"
+    assert transition["base_sha"] == CORRECTIVE_BASE_SHA
+    assert set(transition) == {
+        "accepted_transition_head",
+        "base_sha",
+        "historical_nonconforming",
+        "kind",
+    }
+
+
+def test_accepted_authority_manifest_is_unique():
+    # Exactly one accepted-authority manifest exists in the tree.
+    listing = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(_REPO_ROOT),
+            "grep",
+            "-l",
+            '"accepted_authority"',
+            "HEAD",
+            "--",
+            "*.json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert listing == [f"HEAD:{gen.DEFAULT_INVENTORY}"]
+    # The manifest digest binds every field: duplicating or editing any part
+    # of the unique manifest breaks the digest and fails closed.
+    forged = _real_authority()
+    forged["categories"] = list(forged["categories"]) + ["python_sdk_drift"]
+    with pytest.raises(ValueError, match="mismatch"):
+        ratchet.validate_accepted_authority(forged, repo_root=_REPO_ROOT)
+
+
+def test_canonical_cohort_and_provenance_artifact_bytes_never_change_across_transition(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Both canonical artifacts re-serialize to the exact ratified byte pairs.
+    authority = _real_authority()
+    artifacts = authority["canonical_artifacts"]
+    cohort_bytes = ratchet._canonical_json_bytes(artifacts["original_cohort"], terminal_lf=True)
+    provenance_bytes = ratchet._canonical_json_bytes(artifacts["sdk_provenance"], terminal_lf=True)
+    assert len(cohort_bytes) == ratchet.COHORT_ARTIFACT["byte_length"]
+    assert ratchet._sha256_bytes(cohort_bytes) == ratchet.COHORT_ARTIFACT["sha256"]
+    assert len(provenance_bytes) == ratchet.PROVENANCE_ARTIFACT["byte_length"]
+    assert ratchet._sha256_bytes(provenance_bytes) == ratchet.PROVENANCE_ARTIFACT["sha256"]
+    # A transition that changes artifact bytes is rejected before any set
+    # comparison is attempted.
+    head = _real_authority()
+    head["canonical_artifacts"]["original_cohort"]["original_records"][0][
+        "exact_historical_literal_record"
+    ] += "-drift"
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", lambda *a, **k: {})
+    with pytest.raises(ValueError, match="immutable authority bindings changed"):
+        ratchet.compare_accepted_authorities(_real_authority(), head, repo_root=_REPO_ROOT)
+
+
+def test_ratified_literal_anchors_and_original_descriptor_never_change_across_transition():
+    # The ratified anchors are pinned: category tuple, genesis disposition,
+    # and the sole normative original-ID set digest.
+    authority = _real_authority()
+    assert authority["categories"] == list(ratchet.ACCEPTED_CATEGORIES)
+    assert ratchet.GENESIS_DISPOSITION == {
+        "as_of": "2026-04-17",
+        "evidence": "canonical-original-cohort-v1",
+        "status": "active",
+    }
+    cohort = authority["canonical_artifacts"]["original_cohort"]
+    assert cohort["original_record_id_set"]["sha256"] == ratchet.ORIGINAL_ID_SET_SHA256
+    # The original descriptor is exactly (category, exact historical literal):
+    # changing either re-derives a different ID and fails closed.
+    tampered = copy.deepcopy(cohort)
+    tampered["original_records"][0]["exact_historical_literal_record"] += "!"
+    with pytest.raises(ValueError, match="ID payload length mismatch|ID payload digest mismatch"):
+        ratchet._validate_original_cohort(tampered)
+    recategorized = copy.deepcopy(cohort)
+    record = next(
+        item for item in recategorized["original_records"] if item["category"] == "python_sdk_drift"
+    )
+    record["category"] = "typescript_sdk_drift"
+    with pytest.raises(ValueError, match="mismatch"):
+        ratchet._validate_original_cohort(recategorized)
+
+
+def test_transition_reconstructs_all_655_ids_and_598_provenance_records():
+    # The validator independently reconstructs the full closure end to end.
+    summary = ratchet.validate_accepted_authority(_real_authority(), repo_root=_REPO_ROOT)
+    assert summary["original_record_total"] == 655
+    assert summary["sdk_provenance_record_total"] == 598
+    assert len(summary["active_original_record_ids"]) == 655
+    # Reconstruction is not trust-the-artifact: a self-consistent-looking but
+    # wrong ID payload digest is recomputed and rejected.
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    cohort["original_records"][7]["id_payload_sha256"] = "f" * 64
+    with pytest.raises(ValueError, match="ID payload digest mismatch"):
+        ratchet._validate_original_cohort(cohort)
+    # Provenance records are reconstructed against the cohort link plane.
+    authority = _real_authority()
+    cohort_summary = ratchet._validate_original_cohort(
+        authority["canonical_artifacts"]["original_cohort"]
+    )
+    provenance = authority["canonical_artifacts"]["sdk_provenance"]
+    short = copy.deepcopy(provenance)
+    short["records"] = short["records"][:-1]
+    with pytest.raises(ValueError, match="must contain 598 records"):
+        ratchet._validate_sdk_provenance(short, cohort_summary)
+
+
+def test_transition_preserves_exact_provenance_links_counts_partitions_and_digests():
+    authority = _real_authority()
+    cohort_summary = ratchet._validate_original_cohort(
+        authority["canonical_artifacts"]["original_cohort"]
+    )
+    provenance = authority["canonical_artifacts"]["sdk_provenance"]
+    summary = ratchet._validate_sdk_provenance(provenance, cohort_summary)
+    # Exact 598/690/12/0/75/523 counts and the ratified partition digests.
+    assert summary["record_count"] == 598
+    assert summary["source_occurrence_count"] == 690
+    assert summary["multiple_atom_record_count"] == 12
+    assert summary["missing_provenance_count"] == 0
+    assert summary["core_count"] == 75
+    assert summary["extended_count"] == 523
+    assert summary["core_original_record_id_set_sha256"] == ratchet.CORE_ID_SET_SHA256
+    assert summary["extended_original_record_id_set_sha256"] == ratchet.EXTENDED_ID_SET_SHA256
+    assert summary["sdk_original_record_id_set_sha256"] == ratchet.SDK_ID_SET_SHA256
+    assert len(summary["record_links"]) == 598
+    # Per-record links/partitions are reconstructed, not declared: flipping a
+    # declared partition fails against the atom-derived partition.
+    flipped = copy.deepcopy(provenance)
+    flipped["records"][0]["partition"] = (
+        "extended" if flipped["records"][0]["partition"] == "core" else "core"
+    )
+    with pytest.raises(ValueError, match="partition mismatch|digest mismatch"):
+        ratchet._validate_sdk_provenance(flipped, cohort_summary)
+    miscounted = copy.deepcopy(provenance)
+    miscounted["counts"]["source_occurrences"] = 691
+    with pytest.raises(ValueError, match="declared counts mismatch"):
+        ratchet._validate_sdk_provenance(miscounted, cohort_summary)
+
+
+def test_transition_preserves_exact_global_and_per_category_original_record_sets():
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    by_category: dict[str, list[str]] = {}
+    for record in cohort["original_records"]:
+        by_category.setdefault(record["category"], []).append(record["original_record_id"])
+    assert {name: len(ids) for name, ids in sorted(by_category.items())} == {
+        "python_sdk_drift": 74,
+        "routes_missing_in_spec": 11,
+        "routes_orphaned_in_spec": 17,
+        "sdk_missing_from_both": 29,
+        "typescript_sdk_drift": 524,
+    }
+    # The global set digest is recomputed from the exact IDs and must be the
+    # sole normative digest across every transition.
+    all_ids = [record["original_record_id"] for record in cohort["original_records"]]
+    assert len(set(all_ids)) == 655
+    recomputed = ratchet._digest_set(
+        "cdg-original-record-id-set-v1", all_ids, "original_record_ids"
+    )
+    assert recomputed == ratchet.ORIGINAL_ID_SET_SHA256
+    # Any other digest fails: swapping in a different 655th ID breaks both
+    # the ID-set listing and the digest.
+    swapped = copy.deepcopy(cohort)
+    swapped["original_record_id_set"]["original_record_ids"][-1] = "cdg1:" + "0" * 64
+    with pytest.raises(ValueError, match="ID set is incomplete or unsorted"):
+        ratchet._validate_original_cohort(swapped)
+
+
+def test_transition_rejects_addition_removal_replacement_dedup_fanout_or_reidentification():
+    base_cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    # Addition and removal break the exact 655 cardinality.
+    grown = copy.deepcopy(base_cohort)
+    grown["original_records"].append(copy.deepcopy(grown["original_records"][0]))
+    with pytest.raises(ValueError, match="exactly 655 original records"):
+        ratchet._validate_original_cohort(grown)
+    shrunk = copy.deepcopy(base_cohort)
+    shrunk["original_records"].pop()
+    with pytest.raises(ValueError, match="exactly 655 original records"):
+        ratchet._validate_original_cohort(shrunk)
+    # Replacement/re-identification: the ID derives only from the descriptor,
+    # so a swapped literal or category cannot keep its recorded ID.
+    replaced = copy.deepcopy(base_cohort)
+    replaced["original_records"][3]["exact_historical_literal_record"] += " replaced"
+    with pytest.raises(ValueError, match="mismatch"):
+        ratchet._validate_original_cohort(replaced)
+    # Dedup/fanout: membership multiplicity is pinned via the projection
+    # bijection — duplicating one membership and dropping another fails.
+    faned = copy.deepcopy(base_cohort)
+    projection_records = faned["operation_projection"]["records"]
+    projection_records[1] = copy.deepcopy(projection_records[0])
+    with pytest.raises(ValueError, match="does not biject|digest"):
+        ratchet._validate_original_cohort(faned)
+
+
+def test_operation_projection_revision_preserves_655_memberships_666_complete_edges_nine_multi_edge_and_max_four():  # noqa: E501
+    summary = ratchet.validate_accepted_authority(_real_authority(), repo_root=_REPO_ROOT)
+    projection = summary["operation_projection"]
+    assert projection["membership_count"] == 655
+    assert projection["edge_count"] == 666
+    assert projection["multi_edge_originals"] == 9
+    assert projection["max_edges"] == 4
+    assert projection["record_digest_set_sha256"] == ratchet.PROJECTION_RECORD_SET_SHA256
+    distribution = projection["edge_count_distribution"]
+    assert sum(int(size) * count for size, count in distribution.items()) == 666
+    assert sum(count for size, count in distribution.items() if int(size) > 1) == 9
+    assert max(int(size) for size in distribution) == 4
+    # A revision that drops one witnessed edge (even with a relinked record
+    # digest) cannot reproduce the pinned record-digest set.
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    record = next(
+        item
+        for item in cohort["operation_projection"]["records"]
+        if len(item["operation_edges"]) > 1
+    )
+    record["operation_edges"].pop()
+    relinked = {key: value for key, value in record.items() if key != "record_sha256"}
+    record["record_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(relinked))
+    with pytest.raises(ValueError, match="record-digest-set mismatch|cardinality mismatch"):
+        ratchet._validate_original_cohort(cohort)
+
+
+def test_operation_projection_revision_cannot_change_original_identity_or_omit_witnessed_edge():
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    # Re-identifying a projection membership breaks the cohort bijection.
+    reidentified = copy.deepcopy(cohort)
+    record = reidentified["operation_projection"]["records"][0]
+    record["original_record_id"] = "cdg1:" + "1" * 64
+    relinked = {key: value for key, value in record.items() if key != "record_sha256"}
+    record["record_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(relinked))
+    with pytest.raises(ValueError, match="does not biject|record-digest-set mismatch"):
+        ratchet._validate_original_cohort(reidentified)
+    # Omitting a witnessed edge's evidence fails closed: every edge must
+    # carry nonempty witness evidence.
+    unwitnessed = copy.deepcopy(cohort)
+    edge_record = unwitnessed["operation_projection"]["records"][0]
+    edge_record["operation_edges"][0]["evidence"] = []
+    relinked = {key: value for key, value in edge_record.items() if key != "record_sha256"}
+    edge_record["record_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(relinked))
+    with pytest.raises(ValueError, match="lacks evidence|record-digest-set mismatch"):
+        ratchet._validate_original_cohort(unwitnessed)
+
+
+def test_null_method_never_enters_runtime_or_projection_edges():
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    # Exactly the 57 path-level route/parity originals carry method=null.
+    null_methods = [
+        record["category"] for record in cohort["original_records"] if record["method"] is None
+    ]
+    assert len(null_methods) == 57
+    assert set(null_methods) == {
+        "routes_missing_in_spec",
+        "routes_orphaned_in_spec",
+        "sdk_missing_from_both",
+    }
+    # Every projected operation edge carries an exact uppercase method token.
+    for record in cohort["operation_projection"]["records"]:
+        for edge in record["operation_edges"]:
+            assert isinstance(edge["method"], str) and edge["method"].isupper()
+    # A null method in a projection edge fails closed.
+    nulled = copy.deepcopy(cohort)
+    edge_record = nulled["operation_projection"]["records"][0]
+    edge_record["operation_edges"][0]["method"] = None
+    relinked = {key: value for key, value in edge_record.items() if key != "record_sha256"}
+    edge_record["record_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(relinked))
+    with pytest.raises(ValueError, match="invalid method|record-digest-set mismatch"):
+        ratchet._validate_original_cohort(nulled)
+    # An SDK record with a null method fails closed (598 are method-bearing).
+    stripped = copy.deepcopy(cohort)
+    sdk_record = next(
+        item for item in stripped["original_records"] if item["category"] == "python_sdk_drift"
+    )
+    sdk_record["method"] = None
+    with pytest.raises(ValueError, match="lacks a method"):
+        ratchet._validate_original_cohort(stripped)
+
+
+def test_strict_subset_requires_separate_authenticated_paydown():
+    root = _REPO_ROOT
+    authority = _real_authority()
+    summary = ratchet.validate_accepted_authority(authority, repo_root=root)
+    live = set(summary["live_original_record_ids"])
+    live_digest = ratchet._sha256_bytes(ratchet._canonical_json_bytes(sorted(live)))
+
+    def resolve(target: dict, digest: str) -> None:
+        for item in target["active_inventory"]:
+            if item["original_record_id"] in live:
+                continue
+            fact = {
+                "active_original_record_ids_sha256": digest,
+                "as_of": "2026-07-27",
+                "original_record_id": item["original_record_id"],
+            }
+            item.update(
+                status="resolved",
+                disposition_history=[
+                    ratchet.GENESIS_DISPOSITION,
+                    {
+                        "as_of": fact["as_of"],
+                        "evidence": _relink_fact(ratchet.PAYDOWN_SCHEMA, fact),
+                        "status": "resolved",
+                    },
+                ],
+            )
+        target["active_inventory_sha256"] = ratchet._sha256_bytes(
+            ratchet._canonical_json_bytes(target["active_inventory"])
+        )
+        _relink_authority_manifest(target)
+
+    # A strict subset with exact appended paydown evidence is a paydown
+    # disposition — not a transition — and passes the comparison.
+    paydown = copy.deepcopy(authority)
+    resolve(paydown, live_digest)
+    compared = ratchet.compare_accepted_authorities(authority, paydown, repo_root=root)
+    assert compared["passing"] is True
+    assert len(compared["removed_original_record_ids"]) == 255
+    assert compared["authority"] == {"source": "accepted_authority"}
+    assert "transition" not in compared
+    # The same subset without the exact appended active-set digest cannot be
+    # folded through: it fails the paydown authentication.
+    unauthenticated = copy.deepcopy(authority)
+    resolve(unauthenticated, "0" * 64)
+    with pytest.raises(ValueError, match="exact appended paydown evidence"):
+        ratchet.compare_accepted_authorities(authority, unauthenticated, repo_root=root)
+
+
+def test_transition_changes_only_versioned_analyzer_schema_dependency_projection_evidence_and_active_representation(  # noqa: E501
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Original identities are frozen: canonical artifacts and the analyzer
+    # bundle cannot drift through an ordinary comparison.
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", lambda *a, **k: {})
+    for mutate in (
+        lambda head: head["canonical_artifacts"]["original_cohort"]["original_records"][0].update(
+            {"exact_historical_literal_record": "swapped"}
+        ),
+        lambda head: head["analyzer_bundle"].update({"dependencies": ["pyyaml==6.0"]}),
+    ):
+        head = _real_authority()
+        mutate(head)
+        with pytest.raises(ValueError, match="immutable authority bindings changed"):
+            ratchet.compare_accepted_authorities(_real_authority(), head, repo_root=_REPO_ROOT)
+    # The active representation may only move append-only: truncating a
+    # disposition history is rejected.
+    base = _real_authority()
+    event = {
+        "as_of": "2026-07-27",
+        "evidence": _relink_fact(
+            ratchet.PAYDOWN_SCHEMA,
+            {
+                "active_original_record_ids_sha256": "1" * 64,
+                "as_of": "2026-07-27",
+                "original_record_id": base["active_inventory"][0]["original_record_id"],
+            },
+        ),
+        "status": "resolved",
+    }
+    base["active_inventory"][0]["disposition_history"] = [ratchet.GENESIS_DISPOSITION, event]
+    truncated = copy.deepcopy(base)
+    truncated["active_inventory"][0]["disposition_history"] = [ratchet.GENESIS_DISPOSITION]
+    with pytest.raises(ValueError, match="append-only"):
+        ratchet.compare_accepted_authorities(base, truncated, repo_root=_REPO_ROOT)
+
+
+def test_post_merge_authority_capsule_is_full_merge_sha_bound():
+    # Pre-merge, publication is exactly the pending future-capsule marker.
+    assert _real_authority()["publication"] == {
+        "authority": "future-immutable-github-release-capsule",
+        "status": "pending-merge",
+    }
+    # The durable capsule validator binds the release tag to the exact full
+    # merge SHA: any other tag fails closed.
+    end_sha = "5" * 40
+    capsule = {
+        "attestation": {
+            "bundle_sha256": "6" * 64,
+            "verified": True,
+            "workflow": "actions/attest@v4",
+        },
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "release": {
+            "asset_api_ids": [101, 102, 103],
+            "asset_names": ["manifest.json", "payload.json", "checksums.txt"],
+            "exact_full_sha_tag": end_sha,
+            "immutable": True,
+            "release_api_id": 100,
+            "verified": True,
+        },
+        "schema": "contract-drift-durable-capsule-v1",
+        "start_sha": "1" * 40,
+    }
+    validated = ratchet._validate_durable_capsule(capsule, end_sha=end_sha)
+    assert validated["release"]["exact_full_sha_tag"] == end_sha
+    retagged = copy.deepcopy(capsule)
+    retagged["release"]["exact_full_sha_tag"] = "4" * 40
+    with pytest.raises(ValueError, match="not the exact end SHA"):
+        ratchet._validate_durable_capsule(retagged, end_sha=end_sha)
+
+
+def test_accepted_authority_capsule_pins_artifact_manifest_payload_checksums_attestation_rule_suite_sets_and_edges():  # noqa: E501
+    end_sha = "5" * 40
+    capsule = {
+        "attestation": {
+            "bundle_sha256": "6" * 64,
+            "verified": True,
+            "workflow": "actions/attest@v4",
+        },
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "release": {
+            "asset_api_ids": [101, 102, 103],
+            "asset_names": ["manifest.json", "payload.json", "checksums.txt"],
+            "exact_full_sha_tag": end_sha,
+            "immutable": True,
+            "release_api_id": 100,
+            "verified": True,
+        },
+        "schema": "contract-drift-durable-capsule-v1",
+        "start_sha": "1" * 40,
+    }
+    # The capsule pins exactly the manifest/payload/checksums asset triple.
+    partial = copy.deepcopy(capsule)
+    partial["release"]["asset_names"] = ["manifest.json", "payload.json"]
+    with pytest.raises(ValueError, match="asset names are incomplete or noncanonical"):
+        ratchet._validate_durable_capsule(partial, end_sha=end_sha)
+    duplicated = copy.deepcopy(capsule)
+    duplicated["release"]["asset_api_ids"] = [101, 101, 102]
+    with pytest.raises(ValueError, match="asset API IDs are incomplete"):
+        ratchet._validate_durable_capsule(duplicated, end_sha=end_sha)
+    # Attestation provenance is exactly actions/attest@v4 with a bound bundle.
+    unattested = copy.deepcopy(capsule)
+    unattested["attestation"]["workflow"] = "actions/attest@v3"
+    with pytest.raises(ValueError, match="attestation workflow identity mismatch"):
+        ratchet._validate_durable_capsule(unattested, end_sha=end_sha)
+    # Rule-suite pass results are part of the boundary prerequisites: a
+    # bypassed evaluation can never authenticate.
+    with pytest.raises(ValueError, match="bypassed evaluation"):
+        ratchet._validate_rule_suite_record_fields(
+            _rule_suite_record(end_sha, rule_evaluations=[{"result": "bypass"}]),
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha=end_sha,
+        )
+    # The capsule-bound sets/edges plane is the pinned projection digest.
+    summary = ratchet.validate_accepted_authority(_real_authority(), repo_root=_REPO_ROOT)
+    assert (
+        summary["operation_projection"]["record_digest_set_sha256"]
+        == ratchet.PROJECTION_RECORD_SET_SHA256
+    )
+
+
+def test_release_replacement_deletion_or_tag_reuse_is_detected():
+    end_sha = "5" * 40
+    capsule = {
+        "attestation": {
+            "bundle_sha256": "6" * 64,
+            "verified": True,
+            "workflow": "actions/attest@v4",
+        },
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "release": {
+            "asset_api_ids": [101, 102, 103],
+            "asset_names": ["manifest.json", "payload.json", "checksums.txt"],
+            "exact_full_sha_tag": end_sha,
+            "immutable": True,
+            "release_api_id": 100,
+            "verified": True,
+        },
+        "schema": "contract-drift-durable-capsule-v1",
+        "start_sha": "1" * 40,
+    }
+    # A replaced (mutable) or unverified release fails closed.
+    for field in ("immutable", "verified"):
+        mutable = copy.deepcopy(capsule)
+        mutable["release"][field] = False
+        with pytest.raises(ValueError, match="false or missing"):
+            ratchet._validate_durable_capsule(mutable, end_sha=end_sha)
+    # Tag reuse from any other SHA is detected by exact-tag binding.
+    reused = copy.deepcopy(capsule)
+    reused["release"]["exact_full_sha_tag"] = "9" * 40
+    with pytest.raises(ValueError, match="not the exact end SHA"):
+        ratchet._validate_durable_capsule(reused, end_sha=end_sha)
+    # Replacement/deletion of the remote resource surfaces as identity
+    # movement, which blocks rather than silently passing.
+    assert ratchet._remote_identity_moved({"etag": '"a"'}, {"etag": '"b"'}) is True
+    assert (
+        ratchet._remote_identity_moved(
+            {"etag": '"a"', "updated_at": "t"}, {"etag": '"a"', "updated_at": "t"}
+        )
+        is False
+    )
+    with pytest.raises(ratchet.BoundaryBlocked, match="moved"):
+        ratchet._retry_stable_remote_probe(lambda: ({"etag": '"a"'}, {"etag": '"b"'}), attempts=2)
+
+
+def test_transition_uses_hermetic_base_bundle_and_hashed_dependencies():
+    # The accepted analyzer bundle execution contract is hermetic: empty
+    # hashed dependency manifest, pinned isolation flags, pinned launcher.
+    metadata, files = ratchet._bundle_metadata(_real_authority())
+    assert metadata["dependencies"] == []
+    assert metadata["interpreter_flags"] == list(ratchet.ANALYZER_FLAGS)
+    assert ratchet.ANALYZER_FLAGS == ("-I", "-S", "-B")
+    assert metadata["launcher_sha256"] == ratchet._sha256_bytes(ratchet.HERMETIC_LAUNCHER)
+    assert [binding["path"] for binding in files] == list(ratchet.ANALYZER_BUNDLE_FILES)
+    for binding in files:
+        assert len(binding["sha256"]) == 64
+    # The launcher itself enforces its own digest before executing anything.
+    assert b"CDG_EXECUTED_LAUNCHER_SHA256" in ratchet.HERMETIC_LAUNCHER
+    # Any drift in the execution contract fails closed.
+    for mutate in (
+        lambda bundle: bundle.update({"dependencies": ["requests==2.32.0"]}),
+        lambda bundle: bundle.update({"interpreter_flags": ["-I"]}),
+        lambda bundle: bundle.update({"launcher_sha256": "0" * 64}),
+    ):
+        drifted = _real_authority()
+        mutate(drifted["analyzer_bundle"])
+        with pytest.raises(ValueError, match="execution contract mismatch"):
+            ratchet._bundle_metadata(drifted)
+
+
+def test_transition_chronology_binds_base_head_checks_evidence_settlement_run_attempt_and_merge(
+    tmp_path: Path,
+):
+    # BASE/HEAD binding: chronology must start at the bound base and end at
+    # the bound head, in exact order.
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path)
+    end_sha = boundary_shas["corrective_bootstrap"]
+    chronology = {
+        "boundaries": [{"boundary": "corrective_bootstrap", "sha": end_sha}],
+        "boundary": "corrective_bootstrap",
+        "end_sha": end_sha,
+        "schema": "contract-drift-boundary-chronology-v1",
+        "start_sha": start_sha,
+    }
+    validated = ratchet._validate_boundary_chronology(
+        chronology,
+        repo_root=repo,
+        boundary="corrective_bootstrap",
+        start_sha=start_sha,
+        end_sha=end_sha,
+        operation_log=[],
+    )
+    assert validated["corrective_bootstrap"] == end_sha
+    moved_head = copy.deepcopy(chronology)
+    with pytest.raises(ValueError, match="does not equal end SHA"):
+        ratchet._validate_boundary_chronology(
+            moved_head,
+            repo_root=repo,
+            boundary="corrective_bootstrap",
+            start_sha=start_sha,
+            end_sha=boundary_shas["route_truth"],
+            operation_log=[],
+        )
+    # Settlement identity binds the exact head before any merge action.
+    moved = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head="a" * 40,
+        pr_view=_settle_pr_view("b" * 40),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+    )
+    assert any("head mismatch" in blocker for blocker in moved["blockers"])
+    # Post-settlement execution identity is (run_id, run_attempt) and the
+    # comparison signal is attempt- and base+head-specific.
+    run = bootstrap._validate_run_provenance(
+        bootstrap.RunProvenance(
+            event_name="pull_request_target",
+            repository="synaptent/aragora",
+            run_attempt=2,
+            run_id=777,
+            workflow_ref=bootstrap.EXPECTED_WORKFLOW_REF,
+        )
+    )
+    signal = bootstrap._write_comparison_signal(
+        tmp_path,
+        "1" * 40,
+        "2" * 40,
+        "3" * 40,
+        {"path": "digest"},
+        {"authority": True},
+        {"bundle": True},
+        [{"schema": "artifact"}],
+        run,
+    )
+    assert bootstrap._authenticate_comparison_signal(
+        signal, base_sha="1" * 40, head_sha="2" * 40, workflow_run=run
+    )
+    for base_sha, head_sha, workflow_run in (
+        ("9" * 40, "2" * 40, run),
+        ("1" * 40, "9" * 40, run),
+        ("1" * 40, "2" * 40, {**run, "run_attempt": 3}),
+    ):
+        with pytest.raises(bootstrap.BootstrapError, match="comparison signal is invalid"):
+            bootstrap._authenticate_comparison_signal(
+                signal, base_sha=base_sha, head_sha=head_sha, workflow_run=workflow_run
+            )
+
+
+def test_strict_false_main_or_head_movement_restarts_all_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Head movement invalidates the settlement gate and authorizes nothing.
+    moved_gate = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head="a" * 40,
+        pr_view=_settle_pr_view("b" * 40),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert not moved_gate["ok"]
+    assert moved_gate["authorized_actions"] == []
+    # Main/remote movement during evidence collection blocks the boundary
+    # (restart), never a partial pass.
+    tick = {"count": 0}
+
+    def moving_probe():
+        tick["count"] += 1
+        return {"noise": tick["count"]}, {"etag": f'"v{tick["count"]}"'}
+
+    with pytest.raises(ratchet.BoundaryBlocked, match="moved concurrently"):
+        ratchet._retry_stable_remote_probe(moving_probe, attempts=3)
+    # A strict-false (contradictory) reread fails loudly rather than reusing
+    # stale evidence.
+    bodies = iter([b"one", b"two"])
+
+    def contradictory(endpoint: str, *, operation_log: list, attempts: int = 3):
+        del endpoint, attempts
+        operation_log.append({})
+        return next(bodies), {"etag": '"same"'}
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_raw", contradictory)
+    with pytest.raises(ValueError, match="contradicted stable identity"):
+        ratchet._gh_api_get_raw_stable("repos/synaptent/aragora/releases/1", operation_log=[])
+
+
+def test_transition_merge_first_parent_equals_bound_base():
+    # The transition merge receipt freezes first parent == BASE_SHA.
+    def receipt(**overrides: Any) -> dict[str, Any]:
+        record = {
+            "base_sha": CORRECTIVE_BASE_SHA,
+            "first_parent_sha": CORRECTIVE_BASE_SHA,
+            "head_sha": "2" * 40,
+            "head_tree_sha": "3" * 40,
+            "merge_sha": "4" * 40,
+            "merge_tree_sha": "3" * 40,
+            "pr": 9645,
+            **overrides,
+        }
+        return {
+            "boundary": "corrective_bootstrap",
+            "end_sha": "4" * 40,
+            "records": [record],
+            "schema": "contract-drift-first-parent-receipts-v1",
+            "start_sha": CORRECTIVE_BASE_SHA,
+        }
+
+    validated = ratchet._validate_first_parent_receipts(receipt())
+    assert validated[0]["first_parent_sha"] == CORRECTIVE_BASE_SHA
+    with pytest.raises(ValueError, match="does not equal the frozen base SHA"):
+        ratchet._validate_first_parent_receipts(receipt(first_parent_sha="9" * 40))
+
+
+def test_identical_settlement_identity_is_retry_safe_with_base_and_head(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    head = "e" * 40
+    # The settlement identity is a pure function of (pr, head): a retry can
+    # only ever produce the byte-identical settlement text naming the head.
+    first = settle._settlement_comment_template(pr=9645, head=head)
+    assert first == settle._settlement_comment_template(pr=9645, head=head)
+    assert head in first and "#9645" in first
+    assert settle._settlement_comment_template(pr=9645, head="f" * 40) != first
+
+    def forbid_writes(*_args, **_kwargs):
+        raise AssertionError("gate evaluation must not run commands")
+
+    monkeypatch.setattr(settle, "_run_command", forbid_writes)
+    monkeypatch.setattr(settle, "_run_text_command", forbid_writes)
+    view = _settle_pr_view(head, comments=[_settlement_comment(9645, head)])
+    gate = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=view,
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    retried = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=view,
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert gate["ok"] and retried["ok"]
+    assert gate["authorized_actions"] == retried["authorized_actions"]
+
+
+def test_settlement_helper_never_merges(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    recorded: list[list[str]] = []
+
+    def record_text(command: list[str], *, cwd: Path, input_text: str | None = None) -> str:
+        del cwd, input_text
+        recorded.append(command)
+        return "https://example.test/comment"
+
+    def record(command: list[str], *, cwd: Path, input_text: str | None = None) -> None:
+        del cwd, input_text
+        recorded.append(command)
+
+    monkeypatch.setattr(settle, "_run_text_command", record_text)
+    monkeypatch.setattr(settle, "_run_command", record)
+    settle._apply_settlement_signal(pr=9645, head="f" * 40, repo="synaptent/aragora", cwd=tmp_path)
+    assert [command[:3] for command in recorded] == [
+        ["gh", "pr", "comment"],
+        ["gh", "api", "--method"],
+    ]
+    flattened = " ".join(part for command in recorded for part in command)
+    assert " merge" not in f" {flattened}"
+    # Settle-only cannot be combined with the merge phase in one invocation.
+    with pytest.raises(SystemExit):
+        settle.build_parser().parse_args(
+            ["--settle-only", "--merge-apply", "--pr", "9645", "--head", "f" * 40]
+        )
+
+
+def test_admin_merge_is_rejected():
+    # A protection-bypassing merge is visible as a bypassed rule evaluation
+    # and fails the boundary closed, in every shape GitHub reports it.
+    assert ratchet._contains_rule_suite_bypass({"result": "bypass"})
+    assert ratchet._contains_rule_suite_bypass(
+        {"rule_evaluations": [{"result": "pass"}, {"evaluation_result": "bypass"}]}
+    )
+    assert ratchet._contains_rule_suite_bypass({"bypass_actors": [123]})
+    assert not ratchet._contains_rule_suite_bypass({"result": "pass", "bypassed": False})
+    with pytest.raises(ValueError, match="bypassed evaluation"):
+        ratchet._validate_rule_suite_record_fields(
+            _rule_suite_record("5" * 40, rule_evaluations=[{"result": "bypass"}]),
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="5" * 40,
+        )
+    # A rule suite that did not pass cannot satisfy the boundary either.
+    with pytest.raises(ValueError, match="not passing"):
+        ratchet._validate_rule_suite_record_fields(
+            _rule_suite_record("5" * 40, result="failed", evaluation_result="failed"),
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="5" * 40,
+        )
+
+
+def test_legacy_entrypoints_delegate_to_canonical_inventory(monkeypatch: pytest.MonkeyPatch):
+    # The ratchet imports the canonical inventory module and defaults every
+    # mode to the canonical inventory path.
+    assert ratchet.inventory_mod is gen
+    assert gen.DEFAULT_INVENTORY == "scripts/baselines/contract_drift_inventory.json"
+    main_source = inspect.getsource(ratchet.main)
+    assert "inventory_mod.DEFAULT_INVENTORY" in main_source
+    # Legacy program/receipt entrypoints route through the accepted authority
+    # (build_accepted_result -> validate_accepted_authority) — never through
+    # a parallel raw-baseline reader.
+    calls: list[tuple[str | None, str | None]] = []
+
+    def fake_validate(
+        authority: dict[str, Any],
+        *,
+        repo_root: Path,
+        live_ref: str | None = None,
+        residue_ref: str | None = None,
+    ) -> dict[str, Any]:
+        calls.append((live_ref, residue_ref))
+        return {
+            "active_original_record_ids": [],
+            "analyzer_bundle_sha256": "",
+            "live_original_record_ids": [],
+        }
+
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", fake_validate)
+    source = subprocess.run(
+        ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    result = ratchet.build_accepted_result(
+        mode="receipt",
+        repo_root=_REPO_ROOT,
+        inventory_path=_REPO_ROOT / gen.DEFAULT_INVENTORY,
+        source_sha=source,
+    )
+    assert calls == [(source, f"{source}^")]
+    assert result["authority"]["source"] == "accepted_authority"
+    # Live-witness reconciliation delegates to the canonical inventory
+    # loaders rather than reading baselines through a private copy.
+    live_source = inspect.getsource(ratchet._live_witnesses)
+    assert "inventory_mod.load_git_docs" in live_source
+    assert "inventory_mod.collect_ids" in live_source
+
+
+def test_no_reachable_classification_filtered_or_raw_baseline_fallback():
+    # Neither analyzer surface carries PR #9346's classification-filtered or
+    # raw-baseline fallback identifiers at all.
+    for module in (ratchet, gen):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "classification_filtered" not in source
+        assert "raw_baseline" not in source
+        assert "raw-baseline" not in source
+    # With accepted authority present, program mode routes to the accepted
+    # authority; without it, the only reachable verdict is the transition
+    # failure — never a fallback execution.
+    main_source = inspect.getsource(ratchet.main)
+    assert "accepted_default" in main_source
+    result = ratchet.build_accepted_result(
+        mode="program",
+        repo_root=_REPO_ROOT,
+        inventory_path=_REPO_ROOT / gen.DEFAULT_INVENTORY,
+    )
+    assert result["authority"]["source"] == "accepted_authority"
+
+
+def test_post_transition_noop_pr_uses_only_accepted_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # A hermetic no-op at the transition merge passes with
+    # base_sha == head_sha == analyzer_sha == MERGE.
+    repo, base, _head = _hermetic_repo(tmp_path)
+    result, _calls = _recorded_hermetic_pr(repo, base, base, monkeypatch)
+    assert result["passing"] is True and result["status"] == "pass"
+    assert result["authority"] == {"source": "accepted_authority"}
+    assert result["added_original_record_ids"] == []
+    assert result["removed_original_record_ids"] == []
+    execution = result["execution"]
+    assert execution["base_sha"] == execution["head_sha"] == execution["analyzer_sha"] == base
+    assert execution["dependencies"] == []
+    assert execution["interpreter_flags"] == list(ratchet.ANALYZER_FLAGS)

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -6511,3 +6511,1556 @@ def test_shrinking_pr_passes_while_program_is_red(tmp_path: Path):
     assert result["pr_delta"]["counts"]["verify_typescript_sdk_drift"]["delta"] == -1
     assert result["pr_delta"]["increased"] == []
     assert result["pr_delta"]["unexplained_increase"] == []
+
+
+# ---------------------------------------------------------------------------
+# VAL-CDG-013 / VAL-CDG-014: corrective bootstrap chronology and authority
+# transitions.  These tests bind the checked-in enforcement surfaces only
+# (analyzer modules, trusted bootstrap module, settlement helper, review-queue
+# policy) plus disposable git fixtures, so they hold on a fresh clone of main.
+# ---------------------------------------------------------------------------
+
+import ast as _ast
+import importlib.util as _importlib_util
+
+import scripts.settle_tier4_pr as settle
+import scripts.tier4_merge_train as merge_train
+from aragora.cli.commands import review_queue
+
+_REPO_ROOT = Path(ratchet.__file__).resolve().parents[1]
+_BOOTSTRAP_PATH = _REPO_ROOT / ".github/workflows/contract_drift_trusted_bootstrap.py"
+
+
+def _load_bootstrap():
+    name = "contract_drift_trusted_bootstrap"
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = _importlib_util.spec_from_file_location(name, _BOOTSTRAP_PATH)
+    assert spec and spec.loader
+    module = _importlib_util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+bootstrap = _load_bootstrap()
+
+# Decision-351 corrective guard-v2 atom constants (validated against the
+# checked-in trusted-bootstrap policy and the live analyzer bytes below).
+GUARD_V2_PATCH_SHA256 = "3f4d656bc4678997899508f92c649b845655145351dc36d8a47e5112d84a004b"
+GUARD_V2_FILES = 6
+GUARD_V2_ADDITIONS = 687
+GUARD_V2_DELETIONS = 178
+GUARD_V2_DELTA = 865
+H2_SHA = "d4ab26e4b30b7f65956b4cdd9d738837b78ca4a3"
+H3_SHA = "1722a6145c0c23a2c1c0d20be5ed1329bb01d666"
+H4_SHA = "f50902a19bdc6cce7049da87212dc27759f727a0"
+OLD_H2_PIN_SHA = "017ce1d7a4024f3001858d2385cd153c1ffc8bb2"
+CORRECTIVE_BASE_SHA = "8f1dd9684a3bf311e65b40de2ab35415612cc051"
+PR_9346_FACT = {
+    "actor": "scarmani",
+    "head_sha": "83a7c59169ea238e0439a27fbb80d3cb3ce7e916",
+    "merge_sha": "14d1ef53e23c5466c0491ed93f72752944c78cd4",
+    "merged_at": "2026-07-16T18:30:08Z",
+    "pr": 9346,
+}
+PR_9320_FACT = {
+    "actor": "scarmani",
+    "head_sha": "aba6b14c94eca3a9c825b1a303ea67684d5f8daa",
+    "merge_sha": "0b28f68b9f4d204ae14814169093723ea84c1364",
+    "merged_at": "2026-07-16T20:00:49Z",
+    "pr": 9320,
+}
+
+
+def _real_inventory() -> dict:
+    return json.loads((_REPO_ROOT / gen.DEFAULT_INVENTORY).read_bytes())
+
+
+def _real_authority() -> dict:
+    return _real_inventory()["accepted_authority"]
+
+
+def _relink_fact(schema: str, value: dict) -> dict:
+    return {"fact": value, "sha256": ratchet._fact_digest(schema, value)}
+
+
+def _relink_authority_manifest(authority: dict) -> None:
+    manifest = {key: value for key, value in authority.items() if key != "manifest_sha256"}
+    authority["manifest_sha256"] = ratchet._sha256_bytes(ratchet._canonical_json_bytes(manifest))
+
+
+def _settle_pr_view(
+    head: str,
+    *,
+    comments: list[dict] | None = None,
+    settlement_success: bool = True,
+    head_committed_at: str = "2026-07-20T00:00:00Z",
+) -> dict:
+    statuses = []
+    if settlement_success:
+        statuses.append({"context": settle.HUMAN_SETTLEMENT_CONTEXT, "state": "SUCCESS"})
+    return {
+        "headRefOid": head,
+        "state": "OPEN",
+        "isDraft": False,
+        "mergeStateStatus": "CLEAN",
+        "commitStatuses": statuses,
+        "statusCheckRollup": [],
+        "comments": comments or [],
+        "reviews": [],
+        "commits": [{"committedDate": head_committed_at}],
+    }
+
+
+def _settle_packet(pr: int) -> dict:
+    return {
+        "not_ready": [str(pr)],
+        "entries": [
+            {
+                "pr_number": pr,
+                "status": "human_preapproval_required",
+                "requires_human_risk_settlement": True,
+                "counted_reviewer_ids": ["reviewer-a", "reviewer-b"],
+                "dogfood_evidence": [{"kind": "dogfood", "url": "https://example.test"}],
+            }
+        ],
+    }
+
+
+def _settlement_comment(pr: int, head: str, *, created_at: str = "2026-07-21T00:00:00Z") -> dict:
+    return {
+        "body": settle._settlement_comment_template(pr=pr, head=head),
+        "authorAssociation": "OWNER",
+        "author": {"login": "operator"},
+        "createdAt": created_at,
+        "url": "https://example.test/comment",
+    }
+
+
+def test_historical_9346_exact_disposition_cannot_supply_forward_authority():
+    # Exactly one historical_nonconforming disposition, bound to the exact
+    # head/merge/time/actor facts, in both the checked-in bootstrap policy and
+    # the live accepted authority.
+    expected = bootstrap.EXPECTED_HISTORICAL_NONCONFORMING
+    assert [entry["pr"] for entry in expected] == [9346, 9320]
+    assert expected[0] == PR_9346_FACT
+    transition = _real_authority()["transition"]
+    matches = [e for e in transition["historical_nonconforming"] if e["pr"] == 9346]
+    assert matches == [PR_9346_FACT]
+    # The disposition record carries only the five legacy fact fields: no
+    # authority, chronology, settlement, quorum, or no-admin evidence fields,
+    # and no compliance/800-LOC claim of any kind.
+    assert set(PR_9346_FACT) == {"actor", "head_sha", "merge_sha", "merged_at", "pr"}
+    assert not (set(PR_9346_FACT) & ratchet.AUTHORITY_FIELDS)
+    # Tampering with the disposition (e.g. duplicating it to widen authority)
+    # breaks the accepted authority manifest digest: legacy facts cannot be
+    # edited into forward authority.
+    authority = _real_authority()
+    authority["transition"]["historical_nonconforming"].append(dict(PR_9346_FACT))
+    with pytest.raises(ValueError, match="manifest digest mismatch"):
+        ratchet.validate_accepted_authority(authority, repo_root=_REPO_ROOT)
+    # Even a digest-relinked mutation is rejected by the first-authority
+    # admission: the transition facts are pinned exactly.
+    policy = bootstrap.BootstrapPolicy()
+    forged = copy.deepcopy(_real_authority())
+    forged["transition"]["historical_nonconforming"][0]["pr"] = 9345
+    _relink_authority_manifest(forged)
+    with pytest.raises(bootstrap.BootstrapError, match="self-authorization"):
+        bootstrap._validate_first_authority(Path("."), "f" * 40, forged, policy)
+
+
+def test_historical_9320_exact_disposition_cannot_supply_forward_authority():
+    expected = bootstrap.EXPECTED_HISTORICAL_NONCONFORMING
+    assert expected[1] == PR_9320_FACT
+    transition = _real_authority()["transition"]
+    matches = [e for e in transition["historical_nonconforming"] if e["pr"] == 9320]
+    assert matches == [PR_9320_FACT]
+    # 9320 is not a future merge: it is strictly ordered after the 9346 merge
+    # on the historical record and its facts are frozen alongside it.
+    assert PR_9320_FACT["merged_at"] > PR_9346_FACT["merged_at"]
+    assert set(PR_9320_FACT) == {"actor", "head_sha", "merge_sha", "merged_at", "pr"}
+    assert not (set(PR_9320_FACT) & ratchet.AUTHORITY_FIELDS)
+    # Removing the 9320 disposition (consuming the delegation without a
+    # trace) is equally rejected by the pinned transition facts.
+    policy = bootstrap.BootstrapPolicy()
+    forged = copy.deepcopy(_real_authority())
+    del forged["transition"]["historical_nonconforming"][1]
+    _relink_authority_manifest(forged)
+    with pytest.raises(bootstrap.BootstrapError, match="self-authorization"):
+        bootstrap._validate_first_authority(Path("."), "f" * 40, forged, policy)
+    # A legacy fact object is not a settlement identity: the settlement
+    # preconditions reject a head bound to the historical 9320 head SHA when
+    # the live PR head differs.
+    gate = settle.evaluate_tier4_settlement_preconditions(
+        pr=9320,
+        expected_head=PR_9320_FACT["head_sha"],
+        pr_view=_settle_pr_view("a" * 40),
+        merge_packet=_settle_packet(9320),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+    )
+    assert not gate["ok"]
+    assert any("head mismatch" in blocker for blocker in gate["blockers"])
+
+
+def test_corrective_bootstrap_is_bounded_and_descends_from_current_main(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The corrective transition proof must equal the exact bounded git
+    # interval start..corrective with a positive commit count.
+    result = _boundary_result(tmp_path, monkeypatch, "corrective_bootstrap")
+    assert result["status"] == "pass"
+    assert result["predicates"]["corrective_bootstrap"]["checks"] == [
+        "accepted_stage1_closure",
+        "stage2_verifier_chronology",
+        "corrective_transition",
+    ]
+    assert result["predicates"]["corrective_bootstrap"]["proven"] is True
+
+    def wrong_interval(payloads: dict) -> None:
+        proof = payloads["corrective_bootstrap"]
+        fact = proof["corrective_transition"]["fact"]
+        fact = dict(fact, commit_count=fact["commit_count"] + 7)
+        proof["corrective_transition"] = _relink_fact(
+            "contract-drift-corrective-transition-fact-v1", fact
+        )
+
+    broken = _boundary_result(
+        tmp_path / "interval", monkeypatch, "corrective_bootstrap", mutate=wrong_interval
+    )
+    assert broken["status"] == "fail"
+    assert "exact git interval" in broken["error"]
+    # Descent is enforced by the chronology validator: the corrective SHA must
+    # be a strict descendant of the interval start on the fixture main line.
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path / "descent")
+    side = subprocess.check_output(
+        ["git", "-C", str(repo), "commit-tree", f"{start_sha}^{{tree}}", "-m", "orphan"],
+        text=True,
+    ).strip()
+    with pytest.raises(ValueError, match="not strictly ordered"):
+        ratchet._validate_boundary_chronology(
+            {
+                "boundaries": [{"boundary": "corrective_bootstrap", "sha": side}],
+                "boundary": "corrective_bootstrap",
+                "end_sha": side,
+                "schema": "contract-drift-boundary-chronology-v1",
+                "start_sha": start_sha,
+            },
+            repo_root=repo,
+            boundary="corrective_bootstrap",
+            start_sha=start_sha,
+            end_sha=side,
+            operation_log=[],
+        )
+
+
+def test_corrective_guard_v2_sequence_is_h2_then_h3_repin_merge_then_empty_h4(tmp_path: Path):
+    # Replay the Decision-351 additive sequence on a disposable repository and
+    # bind the exact git semantics the contract requires: H2 -> H3 (guard-v2
+    # patch product) -> trusted re-pin -> empty additive H4 preserving the H3
+    # tree and all PR-owned blobs.
+    repo = tmp_path / "sequence"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "guard.py").write_text("STATE = 'base'\n", encoding="utf-8")
+    (repo / "manifest.json").write_text('{"pin": "old"}\n', encoding="utf-8")
+    base = _commit(repo, "base")
+    (repo / "guard.py").write_text("STATE = 'h2'\n", encoding="utf-8")
+    h2 = _commit(repo, "h2")
+    (repo / "guard.py").write_text("STATE = 'h3-guard-v2'\n", encoding="utf-8")
+    h3 = _commit(repo, "h3 guard-v2")
+    (repo / "manifest.json").write_text('{"pin": "h3"}\n', encoding="utf-8")
+    repin = _commit(repo, "repin")
+    subprocess.run(
+        ["git", "commit", "-q", "--allow-empty", "-m", "h4 empty additive"],
+        cwd=repo,
+        check=True,
+    )
+    h4 = subprocess.check_output(["git", "-C", str(repo), "rev-parse", "HEAD"], text=True).strip()
+    order = subprocess.check_output(
+        ["git", "-C", str(repo), "rev-list", "--reverse", f"{base}..{h4}"], text=True
+    ).split()
+    assert order == [h2, h3, repin, h4]
+    tree = lambda ref: subprocess.check_output(  # noqa: E731
+        ["git", "-C", str(repo), "rev-parse", f"{ref}^{{tree}}"], text=True
+    ).strip()
+    assert tree(h4) == tree(repin) and h4 != repin
+    blob = lambda ref, path: subprocess.check_output(  # noqa: E731
+        ["git", "-C", str(repo), "rev-parse", f"{ref}:{path}"], text=True
+    ).strip()
+    assert blob(h4, "guard.py") == blob(h3, "guard.py")
+    # The checked-in policy pins the H3 product as the immutable analyzer
+    # source and the H3 analyzer digests as the accepted bundle bytes.
+    assert bootstrap.ANALYZER_SOURCE_SHA == H3_SHA
+    assert bootstrap.SHA_RE.fullmatch(bootstrap.ANALYZER_SOURCE_SHA)
+    assert bootstrap.BootstrapPolicy().transition_base_sha == "d5c9df5cea5719404b54c34fdb62a89daf65a92f"  # fmt: skip
+    for path, digest in zip(bootstrap.ANALYZER_FILES, bootstrap.ANALYZER_DIGESTS, strict=True):
+        assert hashlib.sha256((_REPO_ROOT / path).read_bytes()).hexdigest() == digest
+
+
+def test_corrective_guard_v2_binds_exact_patch_and_six_file_687_178_865_response(tmp_path: Path):
+    # The Decision-351 atom: exact guard-v2 patch digest, exactly six files,
+    # additions=687, deletions=178, implementation_delta=865.
+    assert len(GUARD_V2_PATCH_SHA256) == 64 and int(GUARD_V2_PATCH_SHA256, 16)
+    assert GUARD_V2_ADDITIONS + GUARD_V2_DELETIONS == GUARD_V2_DELTA
+    assert GUARD_V2_FILES == 6
+    assert GUARD_V2_DELTA > 800
+    # Because 865 exceeds the generic 800 cap, the guard-v2 atom can never be
+    # admitted as an ordinary governed paydown PR: governed-PR admission
+    # rejects the exact Decision-351 response.
+    with pytest.raises(ValueError, match="exceeds the 800-line cap"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource("1" * 40, "2" * 40),
+            authenticated_pr_changes={
+                9999: {"additions": GUARD_V2_ADDITIONS, "deletions": GUARD_V2_DELETIONS}
+            },
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    # The corrective proof plane it rides instead carries no PR-delta field at
+    # all: its exact closed field set is the bounded-transition proof.
+    with pytest.raises(ValueError, match="corrective_bootstrap proof"):
+        ratchet._validate_corrective_bootstrap(
+            {"max_pr_delta": GUARD_V2_DELTA},
+            {},
+            authority={},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    # The guard-v2 patch product is pinned by digest: the live analyzer bytes
+    # are exactly the accepted H3 bundle bytes.
+    for path, digest in zip(bootstrap.ANALYZER_FILES, bootstrap.ANALYZER_DIGESTS, strict=True):
+        assert hashlib.sha256((_REPO_ROOT / path).read_bytes()).hexdigest() == digest
+
+
+def test_corrective_guard_v2_old_h2_and_017ce1d7_evidence_are_historical_only():
+    # The superseded H2 pin head and its evidence cannot be posted, settled,
+    # or reused: no live enforcement surface references it.
+    live_surfaces = [
+        Path(ratchet.__file__),
+        Path(gen.__file__),
+        _BOOTSTRAP_PATH,
+        _REPO_ROOT / ".github/workflows/contract_drift_trusted_launcher.py",
+        _REPO_ROOT / ".github/workflows/contract-drift-trusted-bootstrap.yml",
+        _REPO_ROOT / ".github/workflows/contract-drift-trusted-bootstrap-manifest.json",
+        _REPO_ROOT / ".github/workflows/contract-drift-governance.yml",
+        Path(settle.__file__),
+        Path(review_queue.__file__),
+        Path(merge_train.__file__),
+    ]
+    for surface in live_surfaces:
+        text = surface.read_text(encoding="utf-8")
+        assert OLD_H2_PIN_SHA not in text, surface
+        assert OLD_H2_PIN_SHA[:12] not in text, surface
+    # The accepted analyzer source is the H3 product, not the old H2 pin.
+    assert bootstrap.ANALYZER_SOURCE_SHA != OLD_H2_PIN_SHA
+    assert bootstrap.ANALYZER_SOURCE_SHA == H3_SHA
+    # Settlement identity is head-exact: evidence bound to the old head can
+    # never authorize the live head (exact-head token mismatch).
+    stale = _settlement_comment(9645, OLD_H2_PIN_SHA)
+    diagnostics = settle.authorization_diagnostics(
+        _settle_pr_view("b" * 40, comments=[stale]),
+        pr=9645,
+        head="b" * 40,
+        permission_checker=lambda _login: True,
+    )
+    (diagnostic,) = diagnostics["authorization_diagnostics"]
+    assert diagnostic["accepted"] is False
+    assert "exact head is missing" in diagnostic["rejection_reasons"]
+
+
+def test_constants_pr_precedes_matcher_repair_and_fulfills_no_val_cdg_assertion():
+    # The constants layer: exact eight-prefix tuple, policy version, tier, and
+    # the byte-identical merge-train mirror.
+    expected_prefixes = (
+        "scripts/check_contract_drift_ratchet.py",
+        "scripts/generate_contract_drift_inventory.py",
+        "scripts/baselines/contract_drift_inventory.json",
+        "scripts/sdk_path_normalize.py",
+        "scripts/baselines/internal_route_prefixes.json",
+        "scripts/baselines/contract_drift_program.json",
+        "scripts/check_sdk_parity.py",
+        "scripts/validate_openapi_routes.py",
+    )
+    assert review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES == expected_prefixes
+    assert review_queue.CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION == 1
+    assert review_queue.CONTRACT_DRIFT_AUTHORITY_TIER == 4
+    assert merge_train.CONTRACT_DRIFT_AUTHORITY_PREFIXES == expected_prefixes
+    assert merge_train.CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION == 1
+    assert merge_train.CONTRACT_DRIFT_AUTHORITY_TIER == 4
+    assert merge_train.CONTRACT_DRIFT_AUTHORITY_CANONICAL_SOURCE == (
+        "aragora.cli.commands.review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES"
+    )
+    # Precedence: the matcher and classifier consume the constants (the tier-4
+    # prefix set embeds them), never the reverse.
+    for prefix in expected_prefixes:
+        assert prefix in review_queue.TIER_4_PREFIXES
+    # The constants layer fulfills no VAL-CDG assertion: neither constants
+    # module contains a VAL-CDG ownership marker.
+    for module in (review_queue, merge_train):
+        assert "VAL-CDG" not in Path(module.__file__).read_text(encoding="utf-8")
+
+
+def test_matcher_repair_precedes_stage1_and_fulfills_no_full_val_cdg_assertion():
+    # Boundary-aware matcher semantics: exact file match, no suffix bleed, and
+    # directory semantics only for explicit directory prefixes.
+    prefixes = review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES
+    assert review_queue._matches_prefix("scripts/check_contract_drift_ratchet.py", prefixes)
+    assert not review_queue._matches_prefix("scripts/check_contract_drift_ratchet.pyx", prefixes)
+    assert not review_queue._matches_prefix("scripts/check_contract_drift_ratchet.py.bak", prefixes)  # fmt: skip
+    assert not review_queue._matches_prefix("scripts/check_contract_drift_ratchet.py/child", prefixes)  # fmt: skip
+    assert not review_queue._matches_prefix("x/scripts/check_contract_drift_ratchet.py", prefixes)
+    directory_prefixes = tuple(p for p in review_queue.TIER_4_PREFIXES if p.endswith("/"))
+    assert directory_prefixes, "tier-4 policy must contain directory prefixes"
+    sample_dir = directory_prefixes[0]
+    assert review_queue._matches_prefix(f"{sample_dir}nested/file.py", (sample_dir,))
+    assert not review_queue._matches_prefix(f"{sample_dir[:-1]}x/file.py", (sample_dir,))
+    # Stage 1 (the exact-ref classifier) consumes this matcher: the inventory
+    # authority extraction imports the canonical review_queue module and calls
+    # the matcher/classifier rather than re-implementing them.
+    gen_source = Path(gen.__file__).read_text(encoding="utf-8")
+    assert 'importlib.import_module("aragora.cli.commands.review_queue")' in gen_source
+    assert "review_queue._matches_prefix" in gen_source
+    assert "review_queue._classify_model_review_tier" in gen_source
+    # The matcher layer fulfills no full VAL-CDG assertion.
+    assert "VAL-CDG" not in Path(review_queue.__file__).read_text(encoding="utf-8")
+
+
+def test_stage1_precedes_stage2_and_has_no_fulfills():
+    # Stage 1 is the exact-ref closure/classifier/inventory matrix; Stage 2
+    # (the boundary verifier) reruns it as a prerequisite: the Stage-1 matrix
+    # is embedded in the Stage-2 module and its result manifest.
+    assert ratchet.STAGE1_TEST_MATRIX == (
+        "tests/governance/test_contract_drift_measurement_authority_tier.py",
+        "tests/scripts/test_generate_contract_drift_inventory.py",
+        "tests/scripts/test_tier4_merge_train.py",
+    )
+    assert "tests/scripts/test_check_contract_drift_ratchet.py" not in ratchet.STAGE1_TEST_MATRIX
+    # Stage-1 surfaces own no boundary verifier: only the Stage-2 module
+    # exposes the boundary predicate engine.
+    assert hasattr(ratchet, "build_boundary_result")
+    assert not hasattr(gen, "build_boundary_result")
+    assert not hasattr(review_queue, "build_boundary_result")
+    assert not hasattr(merge_train, "build_boundary_result")
+    # Stage-1 layers carry no `fulfills` ownership claims.
+    for module in (gen, review_queue, merge_train):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "fulfills" not in source, module.__name__
+
+
+def test_stage2_precedes_corrective_and_is_sole_val_cdg_001_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The corrective boundary proof binds the Stage-2 verifier digest and its
+    # strict ordering after Stage 1; breaking either fails closed.
+    def unordered(payloads: dict) -> None:
+        proof = payloads["corrective_bootstrap"]
+        fact = dict(proof["stage2_verifier_chronology"]["fact"], ordered_after_stage1=False)
+        proof["stage2_verifier_chronology"] = _relink_fact(
+            "contract-drift-stage2-verifier-chronology-fact-v1", fact
+        )
+
+    broken = _boundary_result(
+        tmp_path / "unordered", monkeypatch, "corrective_bootstrap", mutate=unordered
+    )
+    assert broken["status"] == "fail"
+    assert "Stage-2 verifier chronology" in broken["error"]
+
+    def wrong_verifier(payloads: dict) -> None:
+        proof = payloads["corrective_bootstrap"]
+        fact = dict(proof["stage2_verifier_chronology"]["fact"], verifier_sha256="a" * 64)
+        proof["stage2_verifier_chronology"] = _relink_fact(
+            "contract-drift-stage2-verifier-chronology-fact-v1", fact
+        )
+
+    broken = _boundary_result(
+        tmp_path / "verifier", monkeypatch, "corrective_bootstrap", mutate=wrong_verifier
+    )
+    assert broken["status"] == "fail"
+    assert "Stage-2 verifier chronology" in broken["error"]
+    # Sole VAL-CDG-001 ownership: the Stage-1 required-test matrix contains
+    # none of the Stage-2 boundary predicates; the boundary engine (predicate
+    # authentication, status, read-only operation log) lives only in Stage 2.
+    assert not any("boundary" in name for name in ratchet.STAGE1_REQUIRED_TESTS)
+    result = _boundary_result(tmp_path / "own", monkeypatch, "corrective_bootstrap")
+    assert result["stage1_test_matrix"] == list(ratchet.STAGE1_TEST_MATRIX)
+    assert result["status"] == "pass"
+    assert result["operation_log"], "Stage-2 result must carry its own operation log"
+
+
+def test_stage1_exact_ref_classifier_is_isolated_and_closure_complete():
+    # One real end-to-end run of the standalone exact-ref classifier CLI over
+    # an authority file at the current HEAD.
+    head = subprocess.check_output(
+        ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"], text=True
+    ).strip()
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "scripts/generate_contract_drift_inventory.py",
+            "--classify-tier",
+            "--changed-file",
+            "scripts/check_contract_drift_ratchet.py",
+            "--ref",
+            head,
+            "--json",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    output = json.loads(proc.stdout)
+    assert output["tier"] == 4
+    assert output["ref"] == head
+    assert output["changed_file"] == "scripts/check_contract_drift_ratchet.py"
+    assert output["matched_rule"] == output["merge_train_matched_rule"]
+    assert output["schema"] == gen.AUTHORITY_CLASSIFICATION_SCHEMA
+    assert len(output["authority_manifest_sha256"]) == 64
+    # Closure completeness: the bound inventory summary carries the complete
+    # 655-record authority closure with the ratified set digest.
+    authority = output["inventory"]["accepted_authority"]
+    assert authority["original_record_total"] == 655
+    assert len(authority["original_records"]) == 655
+    assert authority["original_record_id_set_sha256"] == ratchet.ORIGINAL_ID_SET_SHA256
+    assert sorted(authority["original_record_ids"]) == sorted(
+        record["original_record_id"] for record in authority["original_records"]
+    )
+    assert authority["sdk_provenance_record_total"] == 598
+    assert len(authority["core_unit_ids"]) == 75
+    assert len(authority["extended_unit_ids"]) == 523
+
+
+def test_stage2_boundary_verifier_is_independent_and_status_truthful(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Truthful tri-state on the same fixture family: pass, fail, blocked.
+    passing = _boundary_result(tmp_path / "pass", monkeypatch, "corrective_bootstrap")
+    assert (passing["status"], passing["passing"], passing["blocked_reason"]) == (
+        "pass",
+        True,
+        None,
+    )
+
+    def falsify(payloads: dict) -> None:
+        proof = payloads["corrective_bootstrap"]
+        fact = dict(proof["accepted_stage1_closure"]["fact"], repo_file_count=41)
+        proof["accepted_stage1_closure"] = _relink_fact(
+            "contract-drift-stage1-closure-fact-v1", fact
+        )
+
+    failing = _boundary_result(
+        tmp_path / "fail", monkeypatch, "corrective_bootstrap", mutate=falsify
+    )
+    assert failing["status"] == "fail" and failing["passing"] is False
+    assert "closure" in failing["error"]
+    blocked = _boundary_result(
+        tmp_path / "blocked",
+        monkeypatch,
+        "corrective_bootstrap",
+        release_immutability=False,
+    )
+    assert blocked["status"] == "blocked" and blocked["passing"] is False
+    assert blocked["blocked_reason"]
+    # Independence: the verifier accepts no caller-supplied evidence object;
+    # its only evidence inputs are authenticated file paths and digests.
+    parameters = set(inspect.signature(ratchet.build_boundary_result).parameters)
+    assert "resources" not in parameters and "evidence" not in parameters
+    assert {"repo_root", "schema_version", "boundary", "start_ref", "end_ref"} <= parameters
+
+
+def test_stages_do_not_claim_later_sdk_route_publication_paydown_or_final_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # At the corrective boundary the chronology is exactly the one-boundary
+    # prefix: claiming the route boundary at the corrective slot fails closed.
+    def premature_route(payloads: dict) -> None:
+        payloads["boundary_chronology"]["boundaries"][0]["boundary"] = "route_truth"
+
+    broken = _boundary_result(
+        tmp_path / "route", monkeypatch, "corrective_bootstrap", mutate=premature_route
+    )
+    assert broken["status"] == "fail"
+    assert "exact selected ordered prefix" in broken["error"]
+    # The corrective proof itself has no publication/paydown/zero facts: its
+    # closed field set is exactly the three corrective predicates.
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path / "fields")
+    payloads = _boundary_payloads(
+        "corrective_bootstrap",
+        start_sha,
+        boundary_shas["corrective_bootstrap"],
+        boundary_shas,
+        repo=repo,
+    )
+    corrective_fields = set(payloads["corrective_bootstrap"])
+    assert corrective_fields == {
+        "accepted_stage1_closure",
+        "corrective_transition",
+        "predicate",
+        "proof_end_sha",
+        "proof_for_boundary",
+        "proof_start_sha",
+        "schema",
+        "stage2_verifier_chronology",
+    }
+    for later_fact in ("publication", "complete_paydown", "final_zero", "qualifying_paydown"):
+        assert later_fact not in corrective_fields
+    # Stage-1's own required-test names claim no later-boundary surface.
+    for name in ratchet.STAGE1_REQUIRED_TESTS:
+        for claim in ("publication", "paydown", "final_zero", "route_truth", "sdk_compat"):
+            assert claim not in name
+
+
+def test_constants_diff_is_constants_only_without_parser_dispatch_handler_or_settlement_change():
+    # Targeted AST proof: the authority constants are literal tuple/int
+    # assignments (pure data), not computed or behavioral code.
+    tree = _ast.parse(Path(review_queue.__file__).read_text(encoding="utf-8"))
+    bindings: dict[str, _ast.AST] = {}
+    for node in _ast.walk(tree):
+        if isinstance(node, _ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, _ast.Name):
+                bindings[target.id] = node.value
+        elif isinstance(node, _ast.AnnAssign) and isinstance(node.target, _ast.Name):
+            if node.value is not None:
+                bindings[node.target.id] = node.value
+    prefixes_node = bindings["CONTRACT_DRIFT_AUTHORITY_PREFIXES"]
+    assert isinstance(prefixes_node, _ast.Tuple)
+    assert all(
+        isinstance(element, _ast.Constant) and isinstance(element.value, str)
+        for element in prefixes_node.elts
+    )
+    for name in (
+        "CONTRACT_DRIFT_AUTHORITY_POLICY_VERSION",
+        "CONTRACT_DRIFT_AUTHORITY_TIER",
+    ):
+        node = bindings[name]
+        assert isinstance(node, _ast.Constant) and isinstance(node.value, int)
+    # The mirror constant is likewise a literal string tuple (pure data), and
+    # the mirror module carries no dispatch/handler/settlement machinery.
+    train_tree = _ast.parse(Path(merge_train.__file__).read_text(encoding="utf-8"))
+    train_bindings: dict[str, _ast.AST] = {}
+    for node in _ast.walk(train_tree):
+        if isinstance(node, _ast.Assign) and len(node.targets) == 1:
+            if isinstance(node.targets[0], _ast.Name):
+                train_bindings[node.targets[0].id] = node.value
+        elif isinstance(node, _ast.AnnAssign) and isinstance(node.target, _ast.Name):
+            if node.value is not None:
+                train_bindings[node.target.id] = node.value
+    mirror_node = train_bindings["CONTRACT_DRIFT_AUTHORITY_PREFIXES"]
+    assert isinstance(mirror_node, _ast.Tuple)
+    assert all(
+        isinstance(element, _ast.Constant) and isinstance(element.value, str)
+        for element in mirror_node.elts
+    )
+    train_source = Path(merge_train.__file__).read_text(encoding="utf-8")
+    assert "import settle_tier4_pr" not in train_source
+    assert settle.HUMAN_SETTLEMENT_CONTEXT not in train_source
+    assert "add_subparsers" not in train_source
+    assert "def handle_" not in train_source
+
+
+def test_matcher_diff_is_boundary_matcher_only_without_parser_dispatch_handler_or_settlement_scope():  # noqa: E501
+    # The matcher is a pure two-argument predicate over (path, prefixes).
+    signature = inspect.signature(review_queue._matches_prefix)
+    assert list(signature.parameters) == ["path", "prefixes"]
+    matcher_source = inspect.getsource(review_queue._matches_prefix)
+    for forbidden in ("subprocess", "settle", "argparse", "open(", "requests"):
+        assert forbidden not in matcher_source
+    # Boundary semantics only: the matcher changes classification exclusively
+    # at path boundaries and leaves every non-matching shape untouched.
+    prefixes = ("scripts/check_contract_drift_ratchet.py",)
+    assert review_queue._matches_prefix(prefixes[0], prefixes)
+    for hostile in (
+        prefixes[0] + "x",
+        prefixes[0] + ".orig",
+        prefixes[0] + "/nested",
+        "prefix/" + prefixes[0],
+        prefixes[0].upper(),
+    ):
+        assert not review_queue._matches_prefix(hostile, prefixes), hostile
+    # Settlement scope is untouched by the matcher layer: the settlement
+    # helper never imports or calls the matcher.
+    settle_source = Path(settle.__file__).read_text(encoding="utf-8")
+    assert "_matches_prefix" not in settle_source
+
+
+def test_matcher_parser_guard_is_behavioral_or_targeted_ast_not_whole_source_scan():
+    # The Stage-1 policy proof is behavioral (import + call of the canonical
+    # module) and targeted-AST (gen walks specific AST node types), never a
+    # whole-source regex scan of the policy module.
+    gen_source = Path(gen.__file__).read_text(encoding="utf-8")
+    assert 'importlib.import_module("aragora.cli.commands.review_queue")' in gen_source
+    assert "import ast" in gen_source
+    # No whole-source scan: gen never reads the review_queue source as text.
+    assert 'review_queue.py").read_text' not in gen_source
+    assert 're.search' not in gen_source or "review_queue" not in gen_source.split("re.search")[1][:120]  # fmt: skip
+    # Behavioral matcher guard: substring occurrences of an authority path do
+    # not classify (a whole-source scan would match these).
+    prefixes = review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES
+    assert not review_queue._matches_prefix(
+        "docs/notes-about-scripts/check_contract_drift_ratchet.py.md", prefixes
+    )
+    assert not review_queue._matches_prefix("scripts/check_contract_drift_ratchet_py", prefixes)
+    # Targeted AST support exists and is used for executable-node selection.
+    assert isinstance(gen._is_type_checking_guard.__module__, str)
+    guard_source = inspect.getsource(gen._is_type_checking_guard)
+    assert "ast.Name" in guard_source
+
+
+def test_classifier_uses_parity_without_accepted_authority():
+    # The tier classification itself is path-policy-only: it needs no
+    # accepted-authority manifest to classify an authority path as Tier 4.
+    tier, tier_name, tier_reason = review_queue._classify_model_review_tier(
+        ["scripts/check_contract_drift_ratchet.py"]
+    )
+    assert tier == 4
+    assert isinstance(tier_name, str) and tier_name
+    assert isinstance(tier_reason, str) and tier_reason
+    # Parity: the canonical policy and the merge-train mirror agree rule by
+    # rule for every authority prefix and for hostile near-misses.
+    for path in review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES:
+        canonical = review_queue._matches_prefix(path, review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES)  # fmt: skip
+        mirrored = path in merge_train.CONTRACT_DRIFT_AUTHORITY_PREFIXES
+        assert canonical and mirrored
+    for hostile in (
+        "scripts/check_contract_drift_ratchet.py.bak",
+        "scripts/check_contract_drift_ratchet.pyx",
+    ):
+        assert not review_queue._matches_prefix(hostile, review_queue.CONTRACT_DRIFT_AUTHORITY_PREFIXES)  # fmt: skip
+        assert hostile not in merge_train.CONTRACT_DRIFT_AUTHORITY_PREFIXES
+    # Non-authority paths gain no Tier-4 lane from the classifier.
+    low_tier, _low_name, _low_reason = review_queue._classify_model_review_tier(["README.md"])
+    assert low_tier < 4
+
+
+def test_corrective_uses_transition_check_not_ordinary_pr_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    original_inventory = (_REPO_ROOT / gen.DEFAULT_INVENTORY).read_text(encoding="utf-8")
+
+    def drop_authority(inventory: dict) -> None:
+        del inventory["accepted_authority"]
+
+    # Transition admission: authority-less base + head installing the real
+    # authority is admitted only through the dedicated transition check.
+    repo, base, head = _hermetic_repo(
+        tmp_path,
+        mutate_base_inventory=drop_authority,
+        head_writes={
+            str(_HERMETIC_INVENTORY): original_inventory,
+            "README.md": "corrective head\n",
+        },
+    )
+    result, _calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["transition"] is True
+    assert result["error_code"] == "authority_transition_required"
+    assert result["passing"] is True and result["status"] == "pass"
+    assert result["proposed_transition"]["original_record_total"] == 655
+    # Ordinary PR success is a different verdict shape: base authority
+    # present yields a non-transition result with no transition error code.
+    ordinary_repo, ordinary_base, ordinary_head = _hermetic_repo(tmp_path / "ordinary")
+    ordinary, _ordinary_calls = _recorded_hermetic_pr(
+        ordinary_repo, ordinary_base, ordinary_head, monkeypatch
+    )
+    assert ordinary["passing"] is True
+    assert "transition" not in ordinary or ordinary.get("transition") is not True
+    assert ordinary.get("error_code") != "authority_transition_required"
+    assert ordinary["added_original_record_ids"] == []
+    assert ordinary["removed_original_record_ids"] == []
+
+
+def test_corrective_binds_canonical_cohort_and_provenance_artifact_bytes():
+    # The accepted authority binds the exact ratified artifact byte pairs.
+    summary = ratchet.validate_accepted_authority(_real_authority(), repo_root=_REPO_ROOT)
+    assert summary["original_record_total"] == 655
+    assert summary["sdk_provenance_record_total"] == 598
+    bindings = _real_authority()["canonical_artifact_bindings"]
+    assert bindings == [
+        {
+            "byte_length": ratchet.COHORT_ARTIFACT["byte_length"],
+            "path": ratchet.COHORT_ARTIFACT["logical_path"],
+            "sha256": ratchet.COHORT_ARTIFACT["sha256"],
+        },
+        {
+            "byte_length": ratchet.PROVENANCE_ARTIFACT["byte_length"],
+            "path": ratchet.PROVENANCE_ARTIFACT["logical_path"],
+            "sha256": ratchet.PROVENANCE_ARTIFACT["sha256"],
+        },
+    ]
+    assert ratchet.COHORT_ARTIFACT["byte_length"] == 1692125
+    assert ratchet.COHORT_ARTIFACT["sha256"] == "565cd84a9a5d266f61b66bd7965e0a036e4817ef5fed32edb8c41a2dea6cc208"  # fmt: skip
+    assert ratchet.PROVENANCE_ARTIFACT["byte_length"] == 898099
+    assert ratchet.PROVENANCE_ARTIFACT["sha256"] == "21ae1c30200cda6df51dbca7053bbbbde6241ab78a73347b0fe5e4d2ed79f07f"  # fmt: skip
+    # A single byte of artifact drift fails closed at the binding layer.
+    tampered = _real_authority()
+    records = tampered["canonical_artifacts"]["original_cohort"]["original_records"]
+    records[0]["exact_historical_literal_record"] += "-tampered"
+    with pytest.raises(ValueError, match="canonical artifact or category binding mismatch"):
+        ratchet.validate_accepted_authority(tampered, repo_root=_REPO_ROOT)
+
+
+def test_corrective_reconstructs_all_655_ids_and_598_provenance_records():
+    cohort = _real_authority()["canonical_artifacts"]["original_cohort"]
+    recomputed: list[str] = []
+    for record in cohort["original_records"]:
+        payload = ratchet._canonical_json_bytes(
+            {
+                "category": record["category"],
+                "exact_historical_literal_record": record["exact_historical_literal_record"],
+                "schema": "cdg-original-record-id-v1",
+            }
+        )
+        digest = ratchet._sha256_bytes(payload)
+        assert record["id_payload_byte_length"] == len(payload)
+        assert record["id_payload_sha256"] == digest
+        assert record["original_record_id"] == f"cdg1:{digest}"
+        recomputed.append(record["original_record_id"])
+    assert len(recomputed) == 655 and len(set(recomputed)) == 655
+    assert (
+        ratchet._digest_set("cdg-original-record-id-set-v1", recomputed, "original_record_ids")
+        == ratchet.ORIGINAL_ID_SET_SHA256
+    )
+    # Full independent provenance reconstruction of all 598 records.
+    cohort_summary = ratchet._validate_original_cohort(cohort)
+    provenance = _real_authority()["canonical_artifacts"]["sdk_provenance"]
+    provenance_summary = ratchet._validate_sdk_provenance(provenance, cohort_summary)
+    assert provenance_summary["record_count"] == 598
+    assert provenance_summary["record_digest_set_sha256"] == ratchet.PROVENANCE_RECORD_SET_SHA256
+    # A minted ID that does not equal the payload hash fails closed.
+    forged = copy.deepcopy(cohort)
+    forged["original_records"][0]["id_payload_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="ID payload .*mismatch"):
+        ratchet._validate_original_cohort(forged)
+    # A dropped provenance record breaks the exact 598 closure.
+    short = copy.deepcopy(provenance)
+    del short["records"][0]
+    with pytest.raises(ValueError, match="598 records"):
+        ratchet._validate_sdk_provenance(short, cohort_summary)
+
+
+def test_corrective_binds_projection_membership_and_edge_cardinalities():
+    summary = ratchet._validate_original_cohort(
+        _real_authority()["canonical_artifacts"]["original_cohort"]
+    )
+    projection = summary["operation_projection"]
+    assert projection["membership_count"] == 655
+    assert projection["edge_count"] == 666
+    assert projection["multi_edge_originals"] == 9
+    assert projection["max_edges"] == 4
+    assert projection["edge_count_distribution"] == {"1": 646, "2": 8, "4": 1}
+    assert projection["record_digest_set_sha256"] == ratchet.PROJECTION_RECORD_SET_SHA256
+
+    # Removing a witnessed edge from the four-edge membership fails closed.
+    def strip_four_edge(records: list[dict]) -> None:
+        target = next(r for r in records if len(r["operation_edges"]) == 4)
+        target["operation_edges"] = target["operation_edges"][:3]
+
+    cohort, _projection = _projection_case(strip_four_edge)
+    with pytest.raises(ValueError, match="record-digest-set mismatch|cardinality mismatch"):
+        ratchet._validate_original_cohort(cohort)
+
+    # Inflating a single-edge membership with a duplicate edge fails closed.
+    def duplicate_edge(records: list[dict]) -> None:
+        target = next(r for r in records if len(r["operation_edges"]) == 1)
+        target["operation_edges"] = target["operation_edges"] * 2
+
+    cohort, _projection = _projection_case(duplicate_edge)
+    with pytest.raises(ValueError, match="duplicate edges"):
+        ratchet._validate_original_cohort(cohort)
+
+
+def test_pr_file_evidence_reconciles_changed_files_additions_and_deletions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # Complete pagination reconciles exactly to the PR's changed_files and
+    # binds authenticated additions/deletions integers.
+    context, requested = _live_pr_files_probe(
+        tmp_path, monkeypatch, files_count=3, pr_additions=11, pr_deletions=7
+    )
+    assert context["authenticated_pr_changes"] == {9999: {"additions": 11, "deletions": 7}}
+    assert any("/pulls/9999/files?per_page=100&page=1" in endpoint for endpoint in requested)
+    # A canonical-file/changed_files mismatch fails closed.
+    with pytest.raises(ValueError, match="file discovery is incomplete"):
+        _live_pr_files_probe(tmp_path / "short", monkeypatch, files_count=2, changed_files=3)
+    # Malformed additions/deletions (bool/negative) are rejected downstream.
+    for additions, deletions in ((True, 0), (-1, 0), (0, -2)):
+        with pytest.raises(ValueError, match="additions/deletions are malformed"):
+            ratchet._validate_governed_prs(
+                _governed_pr_resource("1" * 40, "2" * 40),
+                authenticated_pr_changes={9999: {"additions": additions, "deletions": deletions}},
+                repo_root=tmp_path,
+                operation_log=[],
+            )
+
+
+def test_exact_tree_diff_with_pinned_rename_policy_is_only_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The completeness fallback is the immutable base/head tree binding:
+    # governed head trees must equal the authenticated receipt trees exactly.
+    def wrong_tree(resources: dict[str, Any]) -> None:
+        resources["governed_prs"]["records"][0]["head_tree_sha"] = "e" * 40
+
+    with pytest.raises(ValueError, match="lacks first-parent or tree equality"):
+        _live_pr_files_probe(tmp_path / "tree", monkeypatch, mutate=wrong_tree)
+    # Pinned rename policy on a real disposable repo: a renamed baseline is a
+    # removal at the canonical path; rename following never resurrects it.
+    repo = tmp_path / "rename"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _write_docs(
+        repo,
+        {
+            "verify": {"python_sdk_drift": ["GET /pinned"], "typescript_sdk_drift": []},
+            "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
+            "parity": {"missing_from_both_sdks": []},
+        },
+    )
+    base_sha = _commit(repo, "base")
+    verify_rel = gen.BASELINE_SPECS["verify"][0]
+    subprocess.run(
+        ["git", "-C", str(repo), "mv", str(verify_rel), "scripts/baselines/moved.json"],
+        check=True,
+    )
+    head_sha = _commit(repo, "renamed")
+    assert "python_sdk_drift:GET /pinned" in gen.collect_ids(gen.load_git_docs(repo, base_sha))
+    assert gen.collect_ids(gen.load_git_docs(repo, head_sha)) == {}
+    # No rename-following or copy-detection flags exist in any live analyzer,
+    # settlement, or bootstrap surface.
+    for module_path in (Path(ratchet.__file__), Path(gen.__file__), Path(settle.__file__), _BOOTSTRAP_PATH):  # fmt: skip
+        source = module_path.read_text(encoding="utf-8")
+        assert "--follow" not in source
+        assert "find-renames" not in source
+        assert "find-copies" not in source
+
+
+def test_compare_api_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    # No evidence-collection surface constructs a GitHub compare endpoint:
+    # analyzers, trusted bootstrap, launcher, or governance workflows carry
+    # zero compare-URL fragments, so a compare fallback cannot even be built.
+    surfaces = [
+        Path(ratchet.__file__),
+        Path(gen.__file__),
+        _BOOTSTRAP_PATH,
+        _REPO_ROOT / ".github/workflows/contract_drift_trusted_launcher.py",
+        _REPO_ROOT / ".github/workflows/contract-drift-governance.yml",
+        _REPO_ROOT / ".github/workflows/contract-drift-trusted-bootstrap.yml",
+    ]
+    for surface in surfaces:
+        source = surface.read_text(encoding="utf-8")
+        assert "/compare" not in source, surface
+        assert "compare/" not in source, surface
+    # Behavioral: complete live evidence collection touches pulls/files,
+    # commits, releases, and rule-suites — never a compare endpoint.
+    _context, requested = _live_pr_files_probe(tmp_path, monkeypatch, files_count=1)
+    assert requested
+    assert not any("compare" in endpoint for endpoint in requested)
+
+
+def test_cdg_800_cap_applies_only_to_core_extended_paydown_with_exact_corrective_guard_v2_exception(  # noqa: E501
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # The cap binds every governed paydown PR (866 fails, 800 passes) ...
+    with pytest.raises(ValueError, match="exceeds the 800-line cap"):
+        ratchet._validate_governed_prs(
+            _governed_pr_resource("1" * 40, "2" * 40),
+            authenticated_pr_changes={9999: {"additions": 433, "deletions": 433}},
+            repo_root=tmp_path,
+            operation_log=[],
+        )
+    validated = ratchet._validate_governed_prs(
+        _governed_pr_resource("1" * 40, "2" * 40),
+        authenticated_pr_changes={9999: {"additions": 400, "deletions": 400}},
+        repo_root=tmp_path,
+        operation_log=[],
+    )
+    assert validated[0]["authenticated_pr_delta"] == 800
+
+    # ... and the core/extended paydown facts themselves (801 fails closed).
+    def inflate_core_cap(payloads: dict) -> None:
+        proof = payloads["core_sdk"]
+        fact = dict(proof["qualifying_paydown"]["fact"], max_pr_delta=801)
+        proof["qualifying_paydown"] = _relink_fact("contract-drift-core-sdk-paydown-fact-v1", fact)
+
+    broken = _boundary_result(
+        tmp_path / "core-cap", monkeypatch, "core_sdk", mutate=inflate_core_cap
+    )
+    assert broken["status"] == "fail"
+    assert "per-PR size cap" in broken["error"]
+    # The exact corrective guard-v2 atom (+687/-178 = 865 across six files)
+    # rides the corrective proof plane, which carries no PR-delta cap field.
+    assert GUARD_V2_DELTA == 865 and GUARD_V2_DELTA > 800
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path / "corrective")
+    corrective = _boundary_payloads(
+        "corrective_bootstrap",
+        start_sha,
+        boundary_shas["corrective_bootstrap"],
+        boundary_shas,
+        repo=repo,
+    )["corrective_bootstrap"]
+    assert "max_pr_delta" not in json.dumps(corrective)
+
+
+def test_non_quorum_checks_and_evidence_precede_settlement():
+    head = "a" * 40
+    packet = _settle_packet(9645)
+    # A failing non-quorum required check blocks settlement outright.
+    gate = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=packet,
+        required_checks=[
+            {"name": "contract-drift-pr-delta", "state": "FAILURE"},
+            {"name": settle.MERGE_QUORUM_CONTEXT, "state": "SUCCESS"},
+        ],
+    )
+    assert not gate["ok"]
+    assert any("contract-drift-pr-delta is FAILURE" in blocker for blocker in gate["blockers"])
+    # A quorum-only failure is the one state that may precede settlement, and
+    # only with missing-settlement proof (packet-borne or explicitly flagged).
+    quorum_only = [
+        {"name": "contract-drift-pr-delta", "state": "SUCCESS"},
+        {"name": settle.MERGE_QUORUM_CONTEXT, "state": "FAILURE"},
+    ]
+    unproven_packet = _settle_packet(9645)
+    unproven_packet["entries"][0]["status"] = "pending"
+    unproven = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=unproven_packet,
+        required_checks=quorum_only,
+    )
+    assert not unproven["ok"]
+    assert settle.MERGE_QUORUM_SETTLEMENT_PROOF_BLOCKER in unproven["blockers"]
+    flagged = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=unproven_packet,
+        required_checks=quorum_only,
+        quorum_missing_settlement_proof=True,
+    )
+    assert flagged["ok"], flagged["blockers"]
+    packet_borne = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=packet,
+        required_checks=quorum_only,
+    )
+    assert packet_borne["ok"], packet_borne["blockers"]
+    # Missing Tier-4 evidence blocks settlement even with green checks.
+    bare_packet = {"not_ready": [], "entries": [{"pr_number": 9645, "tier": 4}]}
+    no_evidence = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=bare_packet,
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+    )
+    assert settle.TIER4_EVIDENCE_BLOCKER in no_evidence["blockers"]
+
+
+def test_prerequisite_check_ids_and_evidence_digests_are_bound(tmp_path: Path):
+    # Tier-4 evidence binding: counted reviewer identities and dogfood
+    # evidence must both be present; anything less is unbound.
+    assert settle._packet_has_counted_tier4_evidence(_settle_packet(9645), pr=9645)
+    thin = _settle_packet(9645)
+    thin["entries"][0]["counted_reviewer_ids"] = ["only-one"]
+    assert not settle._packet_has_counted_tier4_evidence(thin, pr=9645)
+    no_dogfood = _settle_packet(9645)
+    no_dogfood["entries"][0]["dogfood_evidence"] = []
+    assert not settle._packet_has_counted_tier4_evidence(no_dogfood, pr=9645)
+    dissent = _settle_packet(9645)
+    dissent["entries"][0]["unresolved_dissent"] = True
+    assert not settle._packet_has_counted_tier4_evidence(dissent, pr=9645)
+    # Evidence digests: every boundary resource is bound by byte length and
+    # SHA-256 in the index; a one-byte flip fails closed.
+    repo, start_sha, boundary_shas = _boundary_git_repo(tmp_path)
+    end_sha = boundary_shas["corrective_bootstrap"]
+    index_path, index_length, index_sha256 = _write_boundary_index(
+        tmp_path, "corrective_bootstrap", start_sha, end_sha, boundary_shas, repo=repo
+    )
+    resource_path = tmp_path / "resources-corrective_bootstrap" / "corrective_bootstrap.json"
+    raw = bytearray(resource_path.read_bytes())
+    raw[0] ^= 0x01
+    resource_path.write_bytes(bytes(raw))
+    with pytest.raises(ValueError, match="SHA-256 mismatch|byte-length mismatch"):
+        ratchet._load_evidence_resources(
+            evidence_index_path=index_path,
+            evidence_index_byte_length=index_length,
+            evidence_index_sha256=index_sha256,
+            boundary="corrective_bootstrap",
+            start_sha=start_sha,
+            end_sha=end_sha,
+            operation_log=[],
+        )
+
+
+def test_settlement_identity_binds_base_and_head_and_approved_actor():
+    head = "c" * 40
+    # Head binding: the settlement gate refuses any head other than the bound
+    # exact head.
+    moved = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view("d" * 40),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+    )
+    assert any("head mismatch" in blocker for blocker in moved["blockers"])
+    # Actor binding: --settle-only demands a trusted allowlisted invoker with
+    # admin authority; absent allowlist or untrusted login are hard blockers.
+    no_allowlist = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        require_trusted_invoker=True,
+    )
+    assert settle.SETTLE_ONLY_TRUSTED_OPERATOR_BLOCKER in no_allowlist["blockers"]
+    untrusted = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        trusted_operator_logins=["operator"],
+        invoker_login="intruder",
+        require_trusted_invoker=True,
+        require_invoker_admin_permission=True,
+    )
+    assert any("not in trusted operator allowlist" in b for b in untrusted["blockers"])
+    no_admin = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        trusted_operator_logins=["operator"],
+        invoker_login="operator",
+        invoker_has_admin_permission=False,
+        require_trusted_invoker=True,
+        require_invoker_admin_permission=True,
+    )
+    assert any(
+        settle.SETTLE_ONLY_ADMIN_PERMISSION_BLOCKER in blocker for blocker in no_admin["blockers"]
+    )
+    approved = settle.evaluate_tier4_settlement_preconditions(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        trusted_operator_logins=["operator"],
+        invoker_login="operator",
+        invoker_has_admin_permission=True,
+        require_trusted_invoker=True,
+        require_invoker_admin_permission=True,
+    )
+    assert approved["ok"], approved["blockers"]
+    # The settlement identity text itself binds PR and exact head.
+    template = settle._settlement_comment_template(pr=9645, head=head)
+    assert f"#{9645}" in template and head in template
+    assert settle.AUTHORIZED_MARKER in template
+
+
+def test_identical_settlement_identity_is_reused_not_reposted(monkeypatch: pytest.MonkeyPatch):
+    head = "e" * 40
+    # The settlement identity for a (pr, head) pair is deterministic: a
+    # repost could only ever be byte-identical.
+    assert settle._settlement_comment_template(pr=9645, head=head) == (
+        settle._settlement_comment_template(pr=9645, head=head)
+    )
+
+    # An existing fresh exact-head settlement comment is accepted as-is by
+    # the gate — evaluation is pure and performs no write commands.
+    def forbid_writes(*_args, **_kwargs):
+        raise AssertionError("gate evaluation must not run commands")
+
+    monkeypatch.setattr(settle, "_run_command", forbid_writes)
+    monkeypatch.setattr(settle, "_run_text_command", forbid_writes)
+    view = _settle_pr_view(head, comments=[_settlement_comment(9645, head)])
+    gate = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=view,
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert gate["ok"], gate["blockers"]
+    assert "merge" in gate["authorized_actions"]
+    (diagnostic,) = gate["authorization_diagnostics"]
+    assert diagnostic["accepted"] is True
+    # The identical identity re-evaluated is stable (retry-safe reuse).
+    again = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=view,
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert again["ok"] and again["authorized_actions"] == gate["authorized_actions"]
+
+
+def test_settlement_helper_is_settle_only(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # The settlement signal consists of exactly one comment and one commit
+    # status — never a merge command.
+    recorded: list[list[str]] = []
+
+    def record_text(command: list[str], *, cwd: Path, input_text: str | None = None) -> str:
+        del cwd, input_text
+        recorded.append(command)
+        return "https://example.test/comment"
+
+    def record(command: list[str], *, cwd: Path, input_text: str | None = None) -> None:
+        del cwd, input_text
+        recorded.append(command)
+
+    monkeypatch.setattr(settle, "_run_text_command", record_text)
+    monkeypatch.setattr(settle, "_run_command", record)
+    commands = settle._apply_settlement_signal(
+        pr=9645, head="f" * 40, repo="synaptent/aragora", cwd=tmp_path
+    )
+    assert [command[:3] for command in commands] == [
+        ["gh", "pr", "comment"],
+        ["gh", "api", "--method"],
+    ]
+    flattened = " ".join(part for command in recorded for part in command)
+    assert " merge" not in f" {flattened}"
+    assert settle.HUMAN_SETTLEMENT_CONTEXT in flattened
+    # --settle-only and --merge-apply are mutually exclusive modes.
+    with pytest.raises(SystemExit):
+        settle.build_parser().parse_args(
+            ["--settle-only", "--merge-apply", "--pr", "9645", "--head", "f" * 40]
+        )
+
+
+def test_workflow_history_is_unfiltered_or_disjoint_below_1000_shards(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The authenticated pagination surface appends only per_page/page to the
+    # caller's endpoint — it never injects status/conclusion filters — and it
+    # fails closed on duplicate API identities.
+    requested: list[str] = []
+    pages = {
+        1: [{"id": index} for index in range(100)],
+        2: [{"id": 100 + index} for index in range(3)],
+    }
+
+    def fake_stable(endpoint: str, *, operation_log: list, attempts: int = 3):
+        del operation_log, attempts
+        requested.append(endpoint)
+        page = int(endpoint.rsplit("page=", 1)[1])
+        return pages[page], {"etag": '"x"'}
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", fake_stable)
+    records, _identities = ratchet._gh_api_paginated(
+        "repos/synaptent/aragora/actions/runs", operation_log=[]
+    )
+    assert len(records) == 103
+    assert requested == [
+        "repos/synaptent/aragora/actions/runs?per_page=100&page=1",
+        "repos/synaptent/aragora/actions/runs?per_page=100&page=2",
+    ]
+    for endpoint in requested:
+        assert "status=" not in endpoint
+        assert "conclusion=" not in endpoint
+        assert "created=" not in endpoint
+
+    def duplicated(endpoint: str, *, operation_log: list, attempts: int = 3):
+        del operation_log, attempts
+        return [{"id": 7}, {"id": 7}], {"etag": '"x"'}
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_stable", duplicated)
+    with pytest.raises(ValueError, match="duplicate record IDs"):
+        ratchet._gh_api_paginated("repos/synaptent/aragora/actions/runs", operation_log=[])
+    # No analyzer surface bakes a status/conclusion filter into a workflow
+    # history query.
+    for module in (ratchet, gen):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        assert "status=completed" not in source
+        assert "conclusion=success" not in source
+
+
+def test_post_settlement_execution_identity_is_run_id_and_strictly_greater_attempt(
+    tmp_path: Path,
+):
+    # Execution identity is (run_id, run_attempt) with positive integers and
+    # bool coercion rejected.
+    valid = bootstrap.RunProvenance(
+        event_name="pull_request_target",
+        repository="synaptent/aragora",
+        run_attempt=2,
+        run_id=12345,
+        workflow_ref=bootstrap.EXPECTED_WORKFLOW_REF,
+    )
+    workflow_run = bootstrap._validate_run_provenance(valid)
+    assert workflow_run == {
+        "event_name": "pull_request_target",
+        "repository": "synaptent/aragora",
+        "run_attempt": 2,
+        "run_id": 12345,
+        "workflow_ref": bootstrap.EXPECTED_WORKFLOW_REF,
+    }
+    for hostile in (
+        valid.__class__(**{**workflow_run, "run_attempt": 0}),
+        valid.__class__(**{**workflow_run, "run_attempt": True}),
+        valid.__class__(**{**workflow_run, "run_id": 0}),
+    ):
+        with pytest.raises(bootstrap.BootstrapError, match="run provenance"):
+            bootstrap._validate_run_provenance(hostile)
+    # The comparison signal is attempt-specific: a signal minted at attempt 2
+    # cannot satisfy admission observing any other execution identity.
+    signal_path = bootstrap._write_comparison_signal(
+        tmp_path,
+        "1" * 40,
+        "2" * 40,
+        "3" * 40,
+        {"path": "digest"},
+        {"authority": True},
+        {"bundle": True},
+        [{"schema": "artifact"}],
+        workflow_run,
+    )
+    assert bootstrap._authenticate_comparison_signal(
+        signal_path, base_sha="1" * 40, head_sha="2" * 40, workflow_run=workflow_run
+    )
+    with pytest.raises(bootstrap.BootstrapError, match="comparison signal is invalid"):
+        bootstrap._authenticate_comparison_signal(
+            signal_path,
+            base_sha="1" * 40,
+            head_sha="2" * 40,
+            workflow_run={**workflow_run, "run_attempt": 3},
+        )
+
+
+def test_all_attempts_and_attempt_specific_jobs_checks_are_bound(tmp_path: Path):
+    # Check URLs bind attempt-specific job executions: job IDs parse only
+    # from /job/ URLs and quorum log proof is impossible without one.
+    assert (
+        settle._github_actions_job_id_from_url(
+            "https://github.com/synaptent/aragora/actions/runs/99/job/123?pr=1"
+        )
+        == "123"
+    )
+    assert (
+        settle._github_actions_job_id_from_url(
+            "https://github.com/synaptent/aragora/actions/runs/99"
+        )
+        == ""
+    )
+    assert settle._github_actions_job_id_from_url("") == ""
+    quorum_without_job = [
+        {"name": "x", "state": "SUCCESS"},
+        {
+            "name": settle.MERGE_QUORUM_CONTEXT,
+            "state": "FAILURE",
+            "link": "https://github.com/synaptent/aragora/actions/runs/99",
+        },
+    ]
+    assert (
+        settle._quorum_failure_log_proves_missing_settlement(
+            quorum_without_job, repo="synaptent/aragora", cwd=tmp_path, head="a" * 40
+        )
+        is False
+    )
+    # The run-level artifact binding carries the full execution identity
+    # (run_id and run_attempt) inside the authenticated payload.
+    workflow_run = bootstrap._validate_run_provenance(
+        bootstrap.RunProvenance(
+            event_name="pull_request_target",
+            repository="synaptent/aragora",
+            run_attempt=1,
+            run_id=777,
+            workflow_ref=bootstrap.EXPECTED_WORKFLOW_REF,
+        )
+    )
+    signal_path = bootstrap._write_comparison_signal(
+        tmp_path,
+        "1" * 40,
+        "2" * 40,
+        "3" * 40,
+        {},
+        {},
+        {},
+        [],
+        workflow_run,
+    )
+    payload = json.loads(signal_path.read_bytes())["payload"]
+    assert payload["workflow_run"]["run_id"] == 777
+    assert payload["workflow_run"]["run_attempt"] == 1
+    # Superseded-run extraction parses run IDs from attempt-specific details
+    # URLs only, deduplicated in order.
+    skew = {
+        "stale_failed_required_contexts": [
+            {"details_url": "https://github.com/x/y/actions/runs/11/job/1"},
+            {"details_url": "https://github.com/x/y/actions/runs/11/job/2"},
+            {"details_url": "https://github.com/x/y/actions/runs/12/job/3"},
+            {"details_url": "https://example.test/no-run"},
+        ]
+    }
+    assert settle._superseded_run_ids(skew) == ["11", "12"]
+
+
+def test_pre_settlement_execution_identity_cannot_satisfy_final_gate():
+    head = "a" * 40
+    # Green checks without the settlement status: the final gate refuses.
+    unsettled = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head, settlement_success=False),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert not unsettled["ok"]
+    assert settle.HUMAN_SETTLEMENT_STATUS_BLOCKER in unsettled["blockers"]
+    # A settlement comment minted before the current head commit is
+    # pre-settlement evidence relative to this execution: rejected as stale.
+    stale_comment = _settlement_comment(9645, head, created_at="2026-07-10T00:00:00Z")
+    stale = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head=head,
+        pr_view=_settle_pr_view(head, comments=[stale_comment]),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert not stale["ok"]
+    assert settle.OPERATOR_COMMENT_BLOCKER in stale["blockers"]
+    (diagnostic,) = stale["authorization_diagnostics"]
+    assert "authorization is older than head commit" in diagnostic["rejection_reasons"]
+
+
+def test_strict_false_movement_restarts_evidence_settlement_and_quorum(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Concurrent movement of a remote identity forces a restart (blocked),
+    # never a silent pass.
+    tick = {"count": 0}
+
+    def moving_probe():
+        tick["count"] += 1
+        return {"noise": tick["count"]}, {"etag": f'"v{tick["count"]}"'}
+
+    with pytest.raises(ratchet.BoundaryBlocked, match="moved concurrently"):
+        ratchet._retry_stable_remote_probe(
+            lambda: (moving_probe(), None)[0] if False else moving_probe(), attempts=3
+        )
+    # A body change without an identity change is a contradiction, not a
+    # movement: it fails closed loudly.
+    bodies = iter([b"one", b"two"])
+
+    def contradictory(endpoint: str, *, operation_log: list, attempts: int = 3):
+        del endpoint, attempts
+        operation_log.append({})
+        return next(bodies), {"etag": '"same"'}
+
+    monkeypatch.setattr(ratchet, "_gh_api_get_raw", contradictory)
+    with pytest.raises(ValueError, match="contradicted stable identity"):
+        ratchet._gh_api_get_raw_stable("repos/synaptent/aragora/releases/1", operation_log=[])
+    # Settlement and quorum evidence restart on head movement: the bound
+    # exact head no longer matches the live view.
+    moved_gate = settle.evaluate_tier4_gate(
+        pr=9645,
+        expected_head="a" * 40,
+        pr_view=_settle_pr_view("b" * 40),
+        merge_packet=_settle_packet(9645),
+        required_checks=[{"name": "x", "state": "SUCCESS"}],
+        permission_checker=lambda _login: True,
+    )
+    assert not moved_gate["ok"]
+    assert any("head mismatch" in blocker for blocker in moved_gate["blockers"])
+    assert moved_gate["authorized_actions"] == []
+
+
+def test_merge_first_parent_equals_bound_base():
+    # The receipt schema freezes base == first parent; any drift is rejected
+    # before git is even consulted.
+    def receipt(**overrides: Any) -> dict[str, Any]:
+        record = {
+            "base_sha": "1" * 40,
+            "first_parent_sha": "1" * 40,
+            "head_sha": "2" * 40,
+            "head_tree_sha": "3" * 40,
+            "merge_sha": "4" * 40,
+            "merge_tree_sha": "3" * 40,
+            "pr": 9645,
+            **overrides,
+        }
+        return {
+            "boundary": "corrective_bootstrap",
+            "end_sha": "4" * 40,
+            "records": [record],
+            "schema": "contract-drift-first-parent-receipts-v1",
+            "start_sha": "1" * 40,
+        }
+
+    validated = ratchet._validate_first_parent_receipts(receipt())
+    assert validated[0]["base_sha"] == validated[0]["first_parent_sha"]
+    with pytest.raises(ValueError, match="does not equal the frozen base SHA"):
+        ratchet._validate_first_parent_receipts(receipt(first_parent_sha="9" * 40))
+    with pytest.raises(ValueError, match="first-parent receipt base_sha is malformed"):
+        ratchet._validate_first_parent_receipts(receipt(base_sha="short"))
+    with pytest.raises(ValueError, match="invalid or duplicated"):
+        ratchet._validate_first_parent_receipts(receipt(pr=0))
+
+
+def test_normal_protected_exact_head_merge_is_last_and_never_admin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    # The forward no-admin proof is executable: a protection-bypassing merge
+    # records a bypassed rule evaluation, which fails closed everywhere.
+    assert ratchet._contains_rule_suite_bypass({"result": "bypass"})
+    assert ratchet._contains_rule_suite_bypass(
+        {"rule_evaluations": [{"result": "pass"}, {"evaluation_result": "bypass"}]}
+    )
+    assert ratchet._contains_rule_suite_bypass({"bypass_actors": [123]})
+    assert not ratchet._contains_rule_suite_bypass(
+        {"result": "pass", "bypassed": False, "note": None}
+    )
+    with pytest.raises(ValueError, match="bypassed evaluation"):
+        ratchet._validate_rule_suite_record_fields(
+            _rule_suite_record("5" * 40, rule_evaluations=[{"result": "bypass"}]),
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="5" * 40,
+        )
+    # The rule evaluation must bind the exact merged head (after_sha) — a
+    # merge at any other SHA cannot satisfy the boundary.
+    with pytest.raises(ValueError, match="stale or unrelated"):
+        ratchet._validate_rule_suite_record_fields(
+            _rule_suite_record("6" * 40),
+            repository_id=1126097105,
+            repository_name="aragora",
+            expected_ref="refs/heads/main",
+            end_sha="5" * 40,
+        )
+    # The merge action is exact-head-pinned and terminal: the merge command
+    # binds --match-head-commit to the settled head and, without protection
+    # reconciliation, is the only command issued.
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        settle, "_run_command", lambda command, *, cwd, input_text=None: commands.append(command)
+    )
+    monkeypatch.setattr(
+        settle,
+        "_run_text_command",
+        lambda command, *, cwd, input_text=None: (commands.append(command), "")[1],
+    )
+    settle._apply_merge(pr=9645, head="7" * 40, repo="synaptent/aragora", cwd=tmp_path)
+    assert len(commands) == 1
+    merge_command = commands[0]
+    assert merge_command[:3] == ["gh", "pr", "merge"]
+    assert "--match-head-commit" in merge_command
+    assert merge_command[merge_command.index("--match-head-commit") + 1] == "7" * 40

--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -6,9 +6,11 @@ import copy
 import hashlib
 import inspect
 import json
+import os
 import subprocess
 import sys
-from datetime import date, timedelta
+import time
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal, overload
 
@@ -5374,3 +5376,529 @@ def test_read_only_cli_mutation_attempt_fails_closed(tmp_path: Path):
     link.symlink_to(target)
     with pytest.raises((ValueError, OSError)):
         ratchet._write_exclusive_private_file(link, b"{}", scratch_root=scratch, output_root=output)
+
+
+# ------------- VAL-CDG-004: trusted base-SHA authority, hermetic execution
+
+_HERMETIC_FILES = (
+    "scripts/check_contract_drift_ratchet.py",
+    "scripts/generate_contract_drift_inventory.py",
+    "scripts/baselines/contract_drift_program.json",
+    "scripts/baselines/contract_drift_inventory.json",
+    "scripts/baselines/verify_sdk_contracts.json",
+    "scripts/baselines/validate_openapi_routes.json",
+    "scripts/baselines/check_sdk_parity.json",
+)
+_HERMETIC_INVENTORY = Path("scripts/baselines/contract_drift_inventory.json")
+
+
+def _hermetic_repo(
+    tmp_path: Path,
+    *,
+    mutate_base_inventory=None,
+    head_writes: dict[str, str] | None = None,
+) -> tuple[Path, str, str]:
+    """Disposable repo whose base commit carries the real accepted authority
+    and analyzer bundle; head applies `head_writes` (default: README only)."""
+    src = Path(ratchet.__file__).parents[1]
+    repo = tmp_path / "hermetic-repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    for rel in _HERMETIC_FILES:
+        destination = repo / rel
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes((src / rel).read_bytes())
+    if mutate_base_inventory is not None:
+        inventory = json.loads((repo / _HERMETIC_INVENTORY).read_text())
+        mutate_base_inventory(inventory)
+        (repo / _HERMETIC_INVENTORY).write_text(json.dumps(inventory))
+    base = _commit(repo, "base")
+    for rel, content in (head_writes or {"README.md": "head change\n"}).items():
+        head_path = repo / rel
+        head_path.parent.mkdir(parents=True, exist_ok=True)
+        head_path.write_text(content, encoding="utf-8")
+    head = _commit(repo, "head")
+    return repo, base, head
+
+
+def _recorded_hermetic_pr(
+    repo: Path, base: str, head: str, monkeypatch: pytest.MonkeyPatch
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    calls: list[dict[str, Any]] = []
+    real_run = subprocess.run
+
+    def recorder(cmd, *args, **kwargs):
+        entry: dict[str, Any] = {
+            "argv": [str(part) for part in cmd],
+            "cwd": kwargs.get("cwd"),
+            "env": kwargs.get("env"),
+        }
+        if entry["argv"] and entry["argv"][0] == sys.executable and kwargs.get("cwd"):
+            entry["cwd_listing"] = sorted(os.listdir(kwargs["cwd"]))
+        calls.append(entry)
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", recorder)
+    result = ratchet._run_hermetic_pr(
+        repo_root=repo, base_ref=base, head_ref=head, inventory_path=_HERMETIC_INVENTORY
+    )
+    monkeypatch.setattr(subprocess, "run", real_run)
+    return result, calls
+
+
+_HERMETIC_PROBE = """
+import importlib, json, sys
+report = {
+    "path": list(sys.path),
+    "base_prefix": sys.base_prefix,
+    "prefix": sys.prefix,
+    "site_loaded": "site" in sys.modules,
+    "sitecustomize_loaded": "sitecustomize" in sys.modules,
+}
+module = importlib.import_module("generate_contract_drift_inventory")
+report["gen_file"] = module.__file__
+report["gen_marker"] = getattr(module, "HOSTILE_MARKER", None)
+try:
+    importlib.import_module("cdg_namespace_probe")
+    report["namespace_import"] = "imported"
+except ModuleNotFoundError:
+    report["namespace_import"] = "missing"
+print(json.dumps(report))
+"""
+
+
+def _hermetic_probe(tmp_path: Path, *, env_extra: dict[str, str] | None = None) -> dict[str, Any]:
+    """Run a probe script through the real launcher + interpreter flags with
+    only the bundle on the injected path, returning its introspection JSON."""
+    src = Path(ratchet.__file__).parents[1]
+    bundle_scripts = tmp_path / "bundle" / "scripts"
+    bundle_scripts.mkdir(parents=True, exist_ok=True)
+    for rel in ("check_contract_drift_ratchet.py", "generate_contract_drift_inventory.py"):
+        (bundle_scripts / rel).write_bytes((src / "scripts" / rel).read_bytes())
+    probe = tmp_path / "probe.py"
+    probe.write_text(_HERMETIC_PROBE, encoding="utf-8")
+    cwd = tmp_path / "empty-cwd"
+    cwd.mkdir(exist_ok=True)
+    launcher = cwd / "launcher.py"
+    launcher.write_bytes(ratchet.HERMETIC_LAUNCHER)
+    env = {
+        "CDG_EXECUTED_LAUNCHER_SHA256": ratchet._sha256_bytes(ratchet.HERMETIC_LAUNCHER),
+        "HOME": str(cwd),
+        "PATH": "/usr/bin:/bin",
+        **(env_extra or {}),
+    }
+    proc = subprocess.run(
+        [sys.executable, *ratchet.ANALYZER_FLAGS, str(launcher), str(bundle_scripts), str(probe)],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    report = json.loads(proc.stdout)
+    report["bundle_scripts"] = str(bundle_scripts)
+    return report
+
+
+def _hostile_module(directory: Path, marker: Path, label: str) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "generate_contract_drift_inventory.py").write_text(
+        f'HOSTILE_MARKER = "{label}"\nopen(r"{marker}", "w").write("{label}")\n',
+        encoding="utf-8",
+    )
+
+
+def test_pr_mode_uses_analyzer_from_resolved_base_sha(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["passing"] and result["status"] == "pass"
+    # The executed analyzer authority is the resolved base SHA, and every
+    # bundle file is extracted from that SHA (never the head or the caller
+    # worktree).
+    assert result["execution"]["analyzer_sha"] == base
+    assert result["execution"]["base_sha"] == base
+    assert result["execution"]["head_sha"] == head
+    extractions = [
+        call["argv"][-1]
+        for call in calls
+        if "show" in call["argv"]
+        and call["argv"][-1].endswith(tuple(ratchet.ANALYZER_BUNDLE_FILES))  # fmt: skip
+    ]
+    assert extractions == [f"{base}:{rel}" for rel in ratchet.ANALYZER_BUNDLE_FILES]
+
+    # A base whose manifest digest does not match the base blob fails closed
+    # before any analyzer byte executes.
+    def forge(inventory: dict[str, Any]) -> None:
+        inventory["accepted_authority"]["analyzer_bundle"]["files"][0]["sha256"] = "0" * 64
+
+    forged_repo, forged_base, forged_head = _hermetic_repo(
+        tmp_path / "forged", mutate_base_inventory=forge
+    )
+    with pytest.raises(ValueError, match="authority analyzer binding differs from exact ref"):
+        ratchet._run_hermetic_pr(
+            repo_root=forged_repo,
+            base_ref=forged_base,
+            head_ref=forged_head,
+            inventory_path=_HERMETIC_INVENTORY,
+        )
+
+
+def test_pr_mode_resolves_base_and_head_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["passing"]
+    # Exactly one resolution per ref; every subsequent git read binds the
+    # already-resolved full SHA (no mutable-ref reread).
+    resolves = [call["argv"] for call in calls if "rev-parse" in call["argv"]]
+    assert [argv[-1] for argv in resolves] == [f"{base}^{{commit}}", f"{head}^{{commit}}"]
+    shows = [call["argv"][-1] for call in calls if "show" in call["argv"]]
+    assert shows and all(spec.startswith((f"{base}:", f"{head}:")) for spec in shows)
+    # Abbreviated or symbolic refs are rejected outright.
+    for hostile_ref in (base[:12], "HEAD", "main", base.upper()):
+        with pytest.raises(ValueError, match="full lowercase 40-hex"):
+            ratchet._run_hermetic_pr(
+                repo_root=repo,
+                base_ref=hostile_ref,
+                head_ref=head,
+                inventory_path=_HERMETIC_INVENTORY,
+            )
+
+
+def test_hermetic_launcher_uses_explicit_interpreter_I_S_and_empty_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    analyzer = next(call for call in calls if call["argv"][0] == sys.executable)
+    # Explicitly resolved interpreter (absolute path), with -I and -S flags.
+    assert os.path.isabs(analyzer["argv"][0])
+    assert analyzer["argv"][1:4] == list(ratchet.ANALYZER_FLAGS)
+    assert {"-I", "-S"} <= set(analyzer["argv"][1:4])
+    # Empty temporary working directory: at spawn the cwd holds only the
+    # digest-pinned launcher, and the caller worktree is not the cwd.
+    assert analyzer["cwd_listing"] == ["launcher.py"]
+    assert Path(analyzer["cwd"]).name.startswith("cdg-cwd-")
+    assert Path(analyzer["cwd"]).resolve() != Path.cwd().resolve()
+    assert result["execution"]["working_directory"] == "<empty-temporary-directory>"
+    assert result["execution"]["interpreter_flags"] == list(ratchet.ANALYZER_FLAGS)
+    # Scrubbed environment manifest: exactly the declared keys, nothing
+    # ambient.
+    assert set(analyzer["env"]) == {
+        "CDG_AUTHORITY_ROOT",
+        "CDG_EXECUTED_LAUNCHER_SHA256",
+        "CDG_TRUSTED_BUNDLE",
+        "HOME",
+        "PATH",
+    }
+    assert analyzer["env"]["HOME"] == analyzer["cwd"]
+    launcher_sha = result["execution"]["launcher_sha256"]
+    assert launcher_sha == ratchet._sha256_bytes(ratchet.HERMETIC_LAUNCHER)
+    assert analyzer["env"]["CDG_EXECUTED_LAUNCHER_SHA256"] == launcher_sha
+
+
+def test_hermetic_sys_path_contains_only_base_bundle_hashed_dependencies_and_stdlib(
+    tmp_path: Path,
+):
+    report = _hermetic_probe(tmp_path)
+    entries = report["path"]
+    # The bundle is the first entry; the rest is the standard library. The
+    # accepted dependency manifest is empty, so no other roots may appear.
+    assert entries[0] == report["bundle_scripts"]
+    assert "" not in entries
+    repo_root = str(Path(ratchet.__file__).parents[1])
+    for entry in entries[1:]:
+        assert not entry.startswith(repo_root)
+        assert "site-packages" not in entry
+        assert entry.startswith((report["base_prefix"], report["prefix"])) or entry.endswith(".zip")
+    assert report["gen_file"].startswith(report["bundle_scripts"])
+
+
+def test_stdlib_only_or_base_pinned_hashed_dependencies(tmp_path: Path):
+    # The ratified analyzer bundle is stdlib-only: its dependency manifest is
+    # exactly empty and the execution contract pins interpreter flags and the
+    # launcher digest.
+    authority = _accepted_authority()
+    bundle, files = ratchet._bundle_metadata(authority)
+    assert bundle["dependencies"] == []
+    assert bundle["interpreter_flags"] == list(ratchet.ANALYZER_FLAGS)
+    assert [item["path"] for item in files] == list(ratchet.ANALYZER_BUNDLE_FILES)
+    assert all(ratchet.SHA256_RE.fullmatch(item["sha256"]) for item in files)
+    # A dependency claim without base-pinned hash identity is not accepted in
+    # any form: the contract admits no unhashed dependency records at all.
+    for hostile_dependencies in (
+        [{"name": "requests"}],
+        [{"name": "requests", "version": "2.32.0"}],
+        [{"name": "requests", "version": "2.32.0", "sha256": "0" * 64}],
+    ):
+        hostile = _accepted_authority()
+        hostile["analyzer_bundle"]["dependencies"] = hostile_dependencies
+        with pytest.raises(ValueError, match="execution contract mismatch"):
+            ratchet._bundle_metadata(hostile)
+
+
+def test_head_cannot_replace_base_analyzer_authority(tmp_path: Path):
+    marker = tmp_path / "hostile-analyzer-executed.txt"
+    hostile_checker = (
+        f'open(r"{marker}", "w").write("executed")\nraise SystemExit("hostile analyzer executed")\n'
+    )
+    repo, base, head = _hermetic_repo(
+        tmp_path,
+        head_writes={"scripts/check_contract_drift_ratchet.py": hostile_checker},
+    )
+    result = ratchet._run_hermetic_pr(
+        repo_root=repo, base_ref=base, head_ref=head, inventory_path=_HERMETIC_INVENTORY
+    )
+    # The measuring authority stays the base SHA and the head's replacement
+    # analyzer never executes; tampering with a pinned bundle surface is
+    # itself fail-closed drift.
+    assert result["execution"]["analyzer_sha"] == base
+    assert (result["passing"], result["status"]) == (False, "fail")
+    assert "bundle digest mismatch" in result["error"]
+    assert not marker.exists()
+
+
+def test_hostile_head_module_shadowing_is_not_executed(tmp_path: Path):
+    marker = tmp_path / "hostile-shadow-executed.txt"
+    # The head plants a same-name module at the repository root — outside the
+    # pinned bundle file set — hoping the analyzer import resolves to it.
+    repo, base, head = _hermetic_repo(
+        tmp_path,
+        head_writes={
+            "generate_contract_drift_inventory.py": (
+                f'open(r"{marker}", "w").write("shadow")\n'
+                'raise RuntimeError("hostile head shadow executed")\n'
+            )
+        },
+    )
+    result = ratchet._run_hermetic_pr(
+        repo_root=repo, base_ref=base, head_ref=head, inventory_path=_HERMETIC_INVENTORY
+    )
+    assert result["passing"] is True
+    assert result["execution"]["analyzer_sha"] == base
+    assert not marker.exists()
+
+
+def test_hostile_head_sitecustomize_is_not_executed(tmp_path: Path):
+    marker = tmp_path / "sitecustomize-executed.txt"
+    # Repo layer: a head-introduced sitecustomize is never extracted (it is
+    # not a pinned bundle member).
+    repo, base, head = _hermetic_repo(
+        tmp_path,
+        head_writes={
+            "scripts/sitecustomize.py": f'open(r"{marker}", "w").write("site")\n',
+            "sitecustomize.py": f'open(r"{marker}", "w").write("site")\n',
+        },
+    )
+    result = ratchet._run_hermetic_pr(
+        repo_root=repo, base_ref=base, head_ref=head, inventory_path=_HERMETIC_INVENTORY
+    )
+    assert result["passing"] is True
+    assert not marker.exists()
+    # Interpreter layer: even a sitecustomize planted directly inside the
+    # bundle directory (sys.path[0]) is not imported because -S disables site
+    # processing entirely.
+    probe_dir = tmp_path / "probe"
+    bundle_scripts = probe_dir / "bundle" / "scripts"
+    bundle_scripts.mkdir(parents=True)
+    (bundle_scripts / "sitecustomize.py").write_text(
+        f'open(r"{marker}", "w").write("site")\n', encoding="utf-8"
+    )
+    report = _hermetic_probe(probe_dir)
+    assert report["site_loaded"] is False
+    assert report["sitecustomize_loaded"] is False
+    assert not marker.exists()
+
+
+def test_hostile_caller_module_shadowing_is_not_executed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    marker = tmp_path / "caller-shadow-executed.txt"
+    hostile_cwd = tmp_path / "caller-cwd"
+    _hostile_module(hostile_cwd, marker, "caller")
+    monkeypatch.chdir(hostile_cwd)
+    repo, base, head = _hermetic_repo(tmp_path)
+    result = ratchet._run_hermetic_pr(
+        repo_root=repo, base_ref=base, head_ref=head, inventory_path=_HERMETIC_INVENTORY
+    )
+    # The caller's working directory is not the analyzer cwd and -I removes
+    # implicit cwd entries: the hostile caller module never executes.
+    assert result["passing"] is True
+    assert not marker.exists()
+    report = _hermetic_probe(tmp_path / "probe")
+    assert str(hostile_cwd) not in report["path"]
+    assert report["gen_marker"] is None
+
+
+def test_editable_or_global_project_install_is_not_imported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    marker = tmp_path / "global-install-executed.txt"
+    fake_site = tmp_path / "venv" / "lib" / "site-packages"
+    _hostile_module(fake_site, marker, "editable-install")
+    # Caller-level: editable/global install env vars never propagate into the
+    # scrubbed analyzer environment.
+    monkeypatch.setenv("PYTHONPATH", str(fake_site))
+    monkeypatch.setenv("VIRTUAL_ENV", str(tmp_path / "venv"))
+    monkeypatch.setenv("PYTHONUSERBASE", str(tmp_path / "venv"))
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["passing"] is True
+    analyzer = next(call for call in calls if call["argv"][0] == sys.executable)
+    assert "PYTHONPATH" not in analyzer["env"]
+    assert "VIRTUAL_ENV" not in analyzer["env"]
+    assert not marker.exists()
+    # Interpreter-level: even with user-site variables set, -I -S never adds
+    # a site-packages root.
+    report = _hermetic_probe(
+        tmp_path / "probe", env_extra={"PYTHONUSERBASE": str(tmp_path / "venv")}
+    )
+    assert not any("site-packages" in entry for entry in report["path"])
+    assert report["gen_file"].startswith(report["bundle_scripts"])
+    assert report["gen_marker"] is None
+
+
+def test_hostile_same_version_global_package_is_not_imported(tmp_path: Path):
+    marker = tmp_path / "same-version-executed.txt"
+    hostile_root = tmp_path / "global-site"
+    _hostile_module(hostile_root, marker, "same-version-global")
+    # The hostile global package carries the same module name (and any
+    # version string it likes): with PYTHONPATH pointing straight at it, -I
+    # still ignores it and the bundle module wins.
+    report = _hermetic_probe(tmp_path / "probe", env_extra={"PYTHONPATH": str(hostile_root)})
+    assert str(hostile_root) not in report["path"]
+    assert report["gen_file"].startswith(report["bundle_scripts"])
+    assert report["gen_marker"] is None
+    assert not marker.exists()
+
+
+def test_hostile_namespace_package_contribution_is_not_blended(tmp_path: Path):
+    marker = tmp_path / "namespace-executed.txt"
+    hostile_root = tmp_path / "namespace-site"
+    # A namespace-package portion shadowing the bundle module name, plus a
+    # hostile namespace-only package.
+    portion = hostile_root / "generate_contract_drift_inventory"
+    portion.mkdir(parents=True)
+    (portion / "extra.py").write_text(f'open(r"{marker}", "w").write("ns")\n', encoding="utf-8")
+    probe_pkg = hostile_root / "cdg_namespace_probe"
+    probe_pkg.mkdir()
+    (probe_pkg / "inner.py").write_text("VALUE = 1\n", encoding="utf-8")
+    report = _hermetic_probe(tmp_path / "probe", env_extra={"PYTHONPATH": str(hostile_root)})
+    # The namespace contribution is never blended: the file module from the
+    # bundle wins, and the namespace-only package is unimportable.
+    assert report["gen_file"].startswith(report["bundle_scripts"])
+    assert report["namespace_import"] == "missing"
+    assert str(hostile_root) not in report["path"]
+    assert not marker.exists()
+
+
+def test_hostile_pth_injector_is_not_executed(tmp_path: Path):
+    marker = tmp_path / "pth-executed.txt"
+    hostile_site = tmp_path / "pth-site"
+    hostile_site.mkdir()
+    (hostile_site / "inject.pth").write_text(
+        f'import os; open(r"{marker}", "w").write("pth")\n', encoding="utf-8"
+    )
+    probe_dir = tmp_path / "probe"
+    # Even a .pth planted inside the bundle directory itself is inert: .pth
+    # execution is a site-module feature and -S disables site processing.
+    bundle_scripts = probe_dir / "bundle" / "scripts"
+    bundle_scripts.mkdir(parents=True)
+    (bundle_scripts / "inject.pth").write_text(
+        f'import os; open(r"{marker}", "w").write("pth")\n', encoding="utf-8"
+    )
+    report = _hermetic_probe(probe_dir, env_extra={"PYTHONPATH": str(hostile_site)})
+    assert report["site_loaded"] is False
+    assert str(hostile_site) not in report["path"]
+    assert not marker.exists()
+
+
+def test_caller_pythonpath_cannot_replace_base_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    marker = tmp_path / "pythonpath-executed.txt"
+    hostile_root = tmp_path / "pythonpath-authority"
+    _hostile_module(hostile_root, marker, "pythonpath")
+    (hostile_root / "check_contract_drift_ratchet.py").write_text(
+        f'open(r"{marker}", "w").write("pythonpath-checker")\n', encoding="utf-8"
+    )
+    monkeypatch.setenv("PYTHONPATH", str(hostile_root))
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    assert result["passing"] is True
+    assert result["execution"]["analyzer_sha"] == base
+    analyzer = next(call for call in calls if call["argv"][0] == sys.executable)
+    assert "PYTHONPATH" not in analyzer["env"]
+    assert not marker.exists()
+    # Even if PYTHONPATH leaked into the child environment, -I ignores it.
+    report = _hermetic_probe(tmp_path / "probe", env_extra={"PYTHONPATH": str(hostile_root)})
+    assert report["gen_file"].startswith(report["bundle_scripts"])
+    assert report["gen_marker"] is None
+    assert not marker.exists()
+
+
+def test_analyzer_dependency_manifest_is_identical_for_both_trees(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    repo, base, head = _hermetic_repo(tmp_path)
+    result, calls = _recorded_hermetic_pr(repo, base, head, monkeypatch)
+    # One extraction measures both trees: each pinned bundle file is read
+    # exactly once, from the base SHA, and the (empty) dependency manifest is
+    # bound into the execution record for the whole run.
+    assert result["execution"]["dependencies"] == []
+    extractions = [
+        call["argv"][-1]
+        for call in calls
+        if "show" in call["argv"]
+        and call["argv"][-1].endswith(tuple(ratchet.ANALYZER_BUNDLE_FILES))  # fmt: skip
+    ]
+    assert extractions == [f"{base}:{rel}" for rel in ratchet.ANALYZER_BUNDLE_FILES]
+    bundle_metadata, _files = ratchet._bundle_metadata(_accepted_authority())
+    assert result["execution"]["base_bundle_sha256"] == ratchet._sha256_bytes(
+        ratchet._canonical_json_bytes(bundle_metadata)
+    )
+    # A head proposing a different dependency manifest is a binding change
+    # and fails closed.
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", lambda *a, **k: {})
+    hostile = _accepted_authority()
+    hostile["analyzer_bundle"]["dependencies"] = [
+        {"name": "requests", "sha256": "0" * 64, "version": "2.32.0"}
+    ]
+    with pytest.raises(ValueError, match="immutable authority bindings changed"):
+        ratchet.compare_accepted_authorities(_accepted_authority(), hostile, repo_root=repo)
+
+
+def test_dependency_hash_or_version_mismatch_fails_closed(tmp_path: Path):
+    authority = copy.deepcopy(_accepted_authority())
+    authority["analyzer_bundle"]["files"][0]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="bundle digest mismatch"):
+        ratchet._validate_bundle(authority, Path(ratchet.__file__).parents[1])
+    versioned = copy.deepcopy(_accepted_authority())
+    versioned["analyzer_bundle"]["dependencies"] = [{"name": "requests", "version": "2.0"}]
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(versioned)
+    flags = copy.deepcopy(_accepted_authority())
+    flags["analyzer_bundle"]["interpreter_flags"] = ["-I"]
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(flags)
+    launcher = copy.deepcopy(_accepted_authority())
+    launcher["analyzer_bundle"]["launcher_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(launcher)
+
+
+def test_undeclared_import_fails_closed(tmp_path: Path):
+    root = tmp_path / "extraction"
+    (root / "scripts").mkdir(parents=True)
+    (root / "scripts/module_under_test.py").write_text(
+        "import importlib\nimportlib.import_module(computed_name)\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gen.AuthorityClosureError, match="dynamic repository import is forbidden"):
+        gen._python_import_edges(root, "scripts/module_under_test.py")
+    (root / "scripts/missing_target.py").write_text(
+        "import scripts.never_written_module\n", encoding="utf-8"
+    )
+    with pytest.raises(gen.AuthorityClosureError, match="repository-local import is unavailable"):
+        gen._python_import_edges(root, "scripts/missing_target.py")

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -1,10 +1,263 @@
-import yaml
+import os
+import re
+import subprocess
 from pathlib import Path
+
+import pytest
+import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 TEXT = (ROOT / ".github/workflows/contract-drift-governance.yml").read_text()
 DOC = yaml.load(TEXT, Loader=yaml.BaseLoader)
 JOBS = DOC["jobs"]
+
+LIVE_CHECK_NAMES = (
+    "contract-drift-pr-delta",
+    "contract-drift-main-receipt",
+    "contract-drift-program-trajectory",
+)
+SOURCE_SHA_EXPR = "${{ github.event_name == 'push' && github.event.after || github.sha }}"
+# GitHub Actions app installation id: required-check tuples produced by
+# workflow jobs must carry this app identity, never a third-party app.
+EXPECTED_PR_DELTA_APP_ID = 15368
+
+
+def _analyzer_step(job_id: str) -> dict:
+    for step in JOBS[job_id]["steps"]:
+        if "run" in step and "check_contract_drift_ratchet.py" in step["run"]:
+            return step
+    raise AssertionError(f"no analyzer step in {job_id}")
+
+
+def _upload_step(job_id: str) -> dict:
+    for step in JOBS[job_id]["steps"]:
+        if str(step.get("uses", "")).startswith("actions/upload-artifact@"):
+            return step
+    raise AssertionError(f"no upload step in {job_id}")
+
+
+def _terminal_step() -> dict:
+    return JOBS["pr-delta"]["steps"][-1]
+
+
+def _simulate_step(
+    run_block: str,
+    *,
+    env: dict[str, str],
+    cwd: Path,
+    stubs: dict[str, int] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Execute a workflow run block the way GitHub does (bash -e), with
+    optional shell-function stubs standing in for named commands."""
+    prelude = "".join(
+        f"{name}() {{ echo stub-{name}; return {code}; }}\n" for name, code in (stubs or {}).items()
+    )
+    return subprocess.run(
+        ["bash", "-e", "-c", prelude + run_block],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **env},
+        cwd=str(cwd),
+    )
+
+
+def _terminal_repo(tmp_path: Path, *, baseline_text: str) -> tuple[Path, str]:
+    """Build a fixture git repo whose BASE_SHA-addressed baseline the terminal
+    aggregator inspects, and return (workdir, base_sha)."""
+    repo = tmp_path / "terminal-repo"
+    baseline = repo / "scripts/baselines/contract_drift_inventory.json"
+    baseline.parent.mkdir(parents=True)
+    baseline.write_text(baseline_text, encoding="utf-8")
+    for argv in (
+        ["git", "init", "-q"],
+        ["git", "add", "-A"],
+        [
+            "git",
+            "-c",
+            "user.email=cdg-test@example.invalid",
+            "-c",
+            "user.name=cdg-test",
+            "commit",
+            "-q",
+            "-m",
+            "baseline",
+        ],
+    ):
+        subprocess.run(argv, cwd=repo, check=True, capture_output=True)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return repo, base_sha
+
+
+def _run_terminal(
+    tmp_path: Path,
+    *,
+    outcome: str,
+    payload: str | None,
+    baseline_text: str = '{"accepted_authority": {}}\n',
+) -> subprocess.CompletedProcess[str]:
+    repo, base_sha = _terminal_repo(tmp_path, baseline_text=baseline_text)
+    if payload is not None:
+        (repo / "contract-drift-pr-delta.json").write_text(payload, encoding="utf-8")
+    script = _terminal_step()["run"].replace("${{ steps.admission.outcome }}", outcome)
+    return _simulate_step(script, env={"BASE_SHA": base_sha}, cwd=repo)
+
+
+def _verify_protection_cutover(
+    before: dict,
+    after: dict,
+    *,
+    added_context: str = "contract-drift-pr-delta",
+    expected_app_id: int = EXPECTED_PR_DELTA_APP_ID,
+) -> list[tuple[str, int]]:
+    """Reference cutover rule: after == before plus exactly the pr-delta
+    (context, app_id) tuple, with strict preserved and nothing mutated."""
+    if before["strict"] != after["strict"]:
+        raise ValueError("cutover changed required_status_checks.strict")
+    before_tuples = [tuple(item) for item in before["checks"]]
+    after_tuples = [tuple(item) for item in after["checks"]]
+    if len(before_tuples) != len(set(before_tuples)) or len(after_tuples) != len(set(after_tuples)):
+        raise ValueError("required check tuples are duplicated")
+    removed = set(before_tuples) - set(after_tuples)
+    if removed:
+        raise ValueError("cutover removed or mutated a required (context, app_id) tuple")
+    added = set(after_tuples) - set(before_tuples)
+    if added != {(added_context, expected_app_id)}:
+        raise ValueError(
+            "cutover must add exactly the pr-delta context with the expected app identity"
+        )
+    return sorted(set(after_tuples))
+
+
+def _paginated_protection_checks(pages: list[list[tuple[str, int]]]) -> list[tuple[str, int]]:
+    checks: list[tuple[str, int]] = []
+    for page in pages:
+        if len(page) > 100:
+            raise ValueError("paginated protection page exceeds per_page=100")
+        checks.extend(tuple(item) for item in page)
+    if len(checks) != len(set(checks)):
+        raise ValueError("paginated protection capture returned duplicate tuples")
+    return checks
+
+
+def _required_check_satisfied(
+    check_runs: list[dict], *, context: str, app_id: int = EXPECTED_PR_DELTA_APP_ID
+) -> bool:
+    """A required context is satisfied only by its own successful check run;
+    no other check's state can substitute for it."""
+    for run in check_runs:
+        if run.get("name") == context and run.get("app_id") == app_id:
+            return run.get("conclusion") == "success"
+    return False
+
+
+def _job_reports_success(job: dict) -> bool:
+    if job.get("conclusion") in {"skipped", "cancelled"}:
+        return False
+    return job.get("conclusion") == "success"
+
+
+def _paginate_runs(fetch_page) -> tuple[list[dict], list[str]]:
+    """Reference workflow-run pagination: unfiltered per_page=100 pages,
+    terminating on a short page, rejecting duplicate run IDs."""
+    records: list[dict] = []
+    endpoints: list[str] = []
+    page = 1
+    while True:
+        endpoint = f"repos/OWNER/REPO/actions/runs?per_page=100&page={page}"
+        endpoints.append(endpoint)
+        payload = fetch_page(endpoint)
+        if not isinstance(payload, list) or not all(isinstance(item, dict) for item in payload):
+            raise ValueError("paginated workflow-run payload is malformed")
+        records.extend(payload)
+        if len(payload) < 100:
+            break
+        page += 1
+        if page > 10_000:
+            raise ValueError("workflow-run pagination did not terminate")
+    ids = [run.get("id") for run in records]
+    if len(ids) != len(set(ids)):
+        raise ValueError("paginated workflow runs returned duplicate record IDs")
+    return records, endpoints
+
+
+def _plan_date_shards(
+    daily_counts: dict[str, int], *, cap: int = 1000
+) -> list[tuple[str, str, int]]:
+    """Reference shard planner: disjoint created-date ranges, each strictly
+    below the 1000-result API window."""
+    shards: list[tuple[str, str, int]] = []
+    current: list[str] = []
+    total = 0
+    for day in sorted(daily_counts):
+        count = daily_counts[day]
+        if count >= cap:
+            raise ValueError(f"single-day run volume {count} defeats the {cap}-result window")
+        if current and total + count >= cap:
+            shards.append((current[0], current[-1], total))
+            current, total = [], 0
+        current.append(day)
+        total += count
+    if current:
+        shards.append((current[0], current[-1], total))
+    for (_, end_a, _), (start_b, _, _) in zip(shards, shards[1:]):
+        if not end_a < start_b:
+            raise ValueError("date shards overlap")
+    if any(count >= cap for _, _, count in shards):
+        raise ValueError(f"date shard reaches the {cap}-result cap")
+    return shards
+
+
+def _reconcile_run_ids(shards: list[dict], *, reported_total: int) -> list[int]:
+    ids = [run["id"] for shard in shards for run in shard["workflow_runs"]]
+    if len(ids) != len(set(ids)):
+        raise ValueError("sharded run capture duplicated run IDs")
+    for shard in shards:
+        if shard["total_count"] != len(shard["workflow_runs"]):
+            raise ValueError("shard total_count does not reconcile with captured runs")
+    if reported_total != len(ids):
+        raise ValueError("run IDs do not reconcile to the reported total_count")
+    return sorted(ids)
+
+
+def _attempt_numbers(run: dict) -> list[int]:
+    attempt = run.get("run_attempt")
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 1:
+        raise ValueError("run_attempt is malformed")
+    return list(range(1, attempt + 1))
+
+
+def _attempt_jobs_endpoint(run_id: int, attempt: int) -> str:
+    if attempt < 1:
+        raise ValueError("attempt numbers start at 1")
+    return f"repos/OWNER/REPO/actions/runs/{run_id}/attempts/{attempt}/jobs"
+
+
+def _validate_attempt_jobs(endpoint: str, jobs: list[dict], *, attempt: int) -> None:
+    if f"/attempts/{attempt}/jobs" not in endpoint:
+        raise ValueError("jobs endpoint is not attempt-specific")
+    for job in jobs:
+        if job.get("run_attempt") != attempt:
+            raise ValueError("job record is not attempt-specific")
+        if f"/attempts/{attempt}" not in job.get("check_url", ""):
+            raise ValueError("check URL is not pinned to the requested attempt")
+
+
+def _validate_run_artifact(artifact: dict, *, head_sha: str, release_digests: set[str]) -> str:
+    name = artifact.get("name")
+    if not isinstance(name, str) or not name.endswith(f"-{head_sha}"):
+        raise ValueError("run artifact name is not SHA-bound")
+    size = artifact.get("size_in_bytes")
+    if isinstance(size, bool) or not isinstance(size, int) or size <= 0:
+        raise ValueError("run artifact lacks a nonempty payload")
+    if artifact.get("payload_sha256") not in release_digests:
+        raise ValueError("run artifact payload is not bound to the immutable release")
+    return name
 
 
 def test_workflow_has_exact_live_checks_and_events():
@@ -46,3 +299,594 @@ def test_program_trajectory_upload_is_sha_qualified_and_never_masks_the_analyzer
             "path": "contract-drift-program-trajectory.json",
         },
     }
+
+
+# --- VAL-CDG-015: live workflow topology -----------------------------------
+
+
+def _workflow_docs() -> dict[str, dict]:
+    docs = {}
+    for path in sorted((ROOT / ".github/workflows").iterdir()):
+        if path.suffix in {".yml", ".yaml"}:
+            loaded = yaml.load(path.read_text(), Loader=yaml.BaseLoader)
+            if isinstance(loaded, dict):
+                docs[path.name] = loaded
+    return docs
+
+
+def _job_names(doc: dict) -> list[str]:
+    return [
+        str(job.get("name", job_id))
+        for job_id, job in doc.get("jobs", {}).items()
+        if isinstance(job, dict)
+    ]
+
+
+def test_exactly_one_active_contract_drift_workflow():
+    producers = [
+        name
+        for name, doc in _workflow_docs().items()
+        if set(_job_names(doc)) & set(LIVE_CHECK_NAMES)
+    ]
+    assert producers == ["contract-drift-governance.yml"]
+    doc = _workflow_docs()["contract-drift-governance.yml"]
+    assert doc["name"] == "Contract Drift Governance"
+    # The producer is active: real triggers, and no workflow-level disable.
+    assert doc["on"] and "jobs" in doc
+
+
+def test_exact_three_live_cdg_check_names():
+    names = _job_names(DOC)
+    assert sorted(names) == sorted(LIVE_CHECK_NAMES)
+    # Job IDs map 1:1 onto the exact live check names.
+    assert {job_id: job["name"] for job_id, job in JOBS.items()} == {
+        "pr-delta": "contract-drift-pr-delta",
+        "main-receipt": "contract-drift-main-receipt",
+        "program-trajectory": "contract-drift-program-trajectory",
+    }
+
+
+def test_no_duplicate_live_cdg_check_names():
+    names = _job_names(DOC)
+    assert len(names) == len(set(names)) == 3
+    for live in LIVE_CHECK_NAMES:
+        producers = [name for name, doc in _workflow_docs().items() if _job_names(doc).count(live)]
+        assert producers == ["contract-drift-governance.yml"], live
+        assert _job_names(DOC).count(live) == 1
+
+
+def test_contract_drift_triggers_pr_main_schedule_dispatch():
+    assert set(DOC["on"]) == {"pull_request", "push", "schedule", "workflow_dispatch"}
+    assert DOC["on"]["pull_request"]["branches"] == ["main"]
+    assert DOC["on"]["push"]["branches"] == ["main"]
+    schedule = DOC["on"]["schedule"]
+    assert schedule and all("cron" in entry for entry in schedule)
+    assert DOC["on"]["workflow_dispatch"] == {}
+
+
+def test_contract_drift_pr_has_no_governed_path_filter_gap():
+    for event in ("pull_request", "push"):
+        trigger = DOC["on"][event]
+        assert not {"paths", "paths-ignore"} & set(trigger), event
+    assert "paths" not in TEXT and "paths-ignore" not in TEXT
+
+
+def test_contract_drift_pr_uses_event_bound_full_shas():
+    env = JOBS["pr-delta"]["env"]
+    assert env["BASE_SHA"] == "${{ github.event.pull_request.base.sha }}"
+    assert env["HEAD_SHA"] == "${{ github.event.pull_request.head.sha }}"
+    admission = _analyzer_step("pr-delta")["run"]
+    assert '--base-ref "$BASE_SHA"' in admission and '--head-ref "$HEAD_SHA"' in admission
+    assert 'git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"' in admission
+    # No mutable or synthetic refs stand in for the immutable event SHAs.
+    pr_text = str(JOBS["pr-delta"])
+    assert "github.ref" not in pr_text and "merge_commit_sha" not in pr_text
+    assert "--base-ref HEAD" not in pr_text and "--head-ref HEAD" not in pr_text
+
+
+def test_contract_drift_non_pr_events_resolve_one_sha_for_receipt_and_program():
+    receipt, program = JOBS["main-receipt"], JOBS["program-trajectory"]
+    assert receipt["env"]["SOURCE_SHA"] == SOURCE_SHA_EXPR
+    assert program["env"]["SOURCE_SHA"] == SOURCE_SHA_EXPR
+    for job in (receipt, program):
+        checkout = job["steps"][0]
+        assert checkout["uses"].startswith("actions/checkout@")
+        assert checkout["with"]["ref"] == SOURCE_SHA_EXPR
+        assert '--ref "$SOURCE_SHA"' in _analyzer_step_text(job)
+        assert job["if"] == "github.event_name != 'pull_request'"
+
+
+def _analyzer_step_text(job: dict) -> str:
+    for step in job["steps"]:
+        if "run" in step and "check_contract_drift_ratchet.py" in step["run"]:
+            return step["run"]
+    raise AssertionError("no analyzer step")
+
+
+def test_workflow_runs_paginate_unfiltered_and_filter_locally():
+    runs = [{"id": index, "name": DOC["name"] if index % 3 else "Other"} for index in range(237)]
+
+    def fetch_page(endpoint: str) -> list[dict]:
+        # The listing endpoint carries pagination only: any server-side
+        # filter (status/event/created/branch) would hide history.
+        query = endpoint.split("?", 1)[1]
+        assert sorted(param.split("=")[0] for param in query.split("&")) == ["page", "per_page"]
+        page = int(query.split("page=")[-1])
+        return runs[(page - 1) * 100 : page * 100]
+
+    records, endpoints = _paginate_runs(fetch_page)
+    assert [len(records), len(endpoints)] == [237, 3]
+    assert endpoints[0].endswith("per_page=100&page=1")
+    governance = [run for run in records if run["name"] == DOC["name"]]
+    assert len(governance) == 158 and all(run["id"] % 3 for run in governance)
+    with pytest.raises(ValueError, match="duplicate record IDs"):
+        _paginate_runs(
+            lambda endpoint: [{"id": 1}] * 100 if endpoint.endswith("&page=1") else [{"id": 1}]
+        )
+
+
+def test_filtered_history_requires_disjoint_date_shards_below_1000():
+    shards = _plan_date_shards({f"2026-07-{day:02d}": 400 for day in range(1, 8)})
+    assert shards == [
+        ("2026-07-01", "2026-07-02", 800),
+        ("2026-07-03", "2026-07-04", 800),
+        ("2026-07-05", "2026-07-06", 800),
+        ("2026-07-07", "2026-07-07", 400),
+    ]
+    assert all(count < 1000 for _, _, count in shards)
+    starts = [start for start, _, _ in shards][1:]
+    ends = [end for _, end, _ in shards][:-1]
+    assert all(end < start for end, start in zip(ends, starts))
+    with pytest.raises(ValueError, match="defeats the 1000-result window"):
+        _plan_date_shards({"2026-07-01": 1000})
+
+
+def test_workflow_run_ids_reconcile_to_total_count():
+    shards = [
+        {"total_count": 2, "workflow_runs": [{"id": 11}, {"id": 12}]},
+        {"total_count": 1, "workflow_runs": [{"id": 13}]},
+    ]
+    assert _reconcile_run_ids(shards, reported_total=3) == [11, 12, 13]
+    with pytest.raises(ValueError, match="do not reconcile to the reported total_count"):
+        _reconcile_run_ids(shards, reported_total=4)
+    with pytest.raises(ValueError, match="duplicated run IDs"):
+        _reconcile_run_ids(
+            [
+                {"total_count": 1, "workflow_runs": [{"id": 11}]},
+                {"total_count": 1, "workflow_runs": [{"id": 11}]},
+            ],
+            reported_total=2,
+        )
+    with pytest.raises(ValueError, match="shard total_count does not reconcile"):
+        _reconcile_run_ids([{"total_count": 5, "workflow_runs": [{"id": 11}]}], reported_total=1)
+
+
+def test_attempts_are_enumerated_one_through_run_attempt():
+    assert _attempt_numbers({"run_attempt": 1}) == [1]
+    assert _attempt_numbers({"run_attempt": 4}) == [1, 2, 3, 4]
+    for hostile in ({"run_attempt": 0}, {"run_attempt": True}, {"run_attempt": "3"}, {}):
+        with pytest.raises(ValueError, match="run_attempt is malformed"):
+            _attempt_numbers(hostile)
+
+
+def test_jobs_and_check_urls_are_attempt_specific():
+    endpoint = _attempt_jobs_endpoint(9662, 2)
+    assert endpoint == "repos/OWNER/REPO/actions/runs/9662/attempts/2/jobs"
+    jobs = [{"run_attempt": 2, "check_url": "repos/OWNER/REPO/actions/runs/9662/attempts/2/jobs/7"}]
+    _validate_attempt_jobs(endpoint, jobs, attempt=2)
+    with pytest.raises(ValueError, match="not attempt-specific"):
+        _validate_attempt_jobs("repos/OWNER/REPO/actions/runs/9662/jobs", jobs, attempt=2)
+    with pytest.raises(ValueError, match="job record is not attempt-specific"):
+        _validate_attempt_jobs(endpoint, [{"run_attempt": 1, "check_url": endpoint}], attempt=2)
+    with pytest.raises(ValueError, match="not pinned to the requested attempt"):
+        _validate_attempt_jobs(
+            endpoint,
+            [{"run_attempt": 2, "check_url": "repos/OWNER/REPO/actions/runs/9662/jobs/7"}],
+            attempt=2,
+        )
+    with pytest.raises(ValueError, match="attempt numbers start at 1"):
+        _attempt_jobs_endpoint(9662, 0)
+
+
+def test_run_level_artifacts_require_payload_and_release_binding():
+    head = "a" * 40
+    artifact = {
+        "name": f"contract-drift-pr-delta-{head}",
+        "size_in_bytes": 2048,
+        "payload_sha256": "d" * 64,
+    }
+    assert _validate_run_artifact(artifact, head_sha=head, release_digests={"d" * 64})
+    with pytest.raises(ValueError, match="nonempty payload"):
+        _validate_run_artifact({**artifact, "size_in_bytes": 0}, head_sha=head, release_digests={"d" * 64})  # fmt: skip
+    with pytest.raises(ValueError, match="not bound to the immutable release"):
+        _validate_run_artifact(artifact, head_sha=head, release_digests={"e" * 64})
+    with pytest.raises(ValueError, match="not SHA-bound"):
+        _validate_run_artifact({**artifact, "name": "contract-drift-pr-delta"}, head_sha=head, release_digests={"d" * 64})  # fmt: skip
+    # Every live job uploads a run-level, SHA-qualified copy of its output.
+    for job_id, sha_expr in (
+        ("pr-delta", "${{ github.event.pull_request.head.sha }}"),
+        ("main-receipt", "${{ github.sha }}"),
+        ("program-trajectory", "${{ github.sha }}"),
+    ):
+        upload = _upload_step(job_id)
+        assert upload["with"]["name"] == f"contract-drift-{job_id}-{sha_expr}"
+        assert upload["with"]["path"] == f"contract-drift-{job_id}.json"
+
+
+def test_pr_delta_cutover_preserves_exact_context_app_id_set_and_strict():
+    before = {"strict": True, "checks": [["ci/build", 15368], ["ci/lint", 15368]]}
+    after = {
+        "strict": True,
+        "checks": [["ci/build", 15368], ["ci/lint", 15368], ["contract-drift-pr-delta", 15368]],
+    }
+    result = _verify_protection_cutover(before, after)
+    assert ("contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID) in result
+    assert set(result) >= {("ci/build", 15368), ("ci/lint", 15368)}
+    with pytest.raises(ValueError, match="changed required_status_checks.strict"):
+        _verify_protection_cutover(before, {**after, "strict": False})
+    checks = _paginated_protection_checks([[("ci/build", 15368)], [("ci/lint", 15368)]])
+    assert checks == [("ci/build", 15368), ("ci/lint", 15368)]
+    with pytest.raises(ValueError, match="duplicate tuples"):
+        _paginated_protection_checks([[("ci/build", 15368)], [("ci/build", 15368)]])
+
+
+def test_pr_delta_uses_expected_app_identity():
+    runs = [
+        {
+            "name": "contract-drift-pr-delta",
+            "app_id": EXPECTED_PR_DELTA_APP_ID,
+            "conclusion": "success",
+        }
+    ]
+    assert _required_check_satisfied(runs, context="contract-drift-pr-delta")
+    imposter = [{"name": "contract-drift-pr-delta", "app_id": 99999, "conclusion": "success"}]
+    assert not _required_check_satisfied(imposter, context="contract-drift-pr-delta")
+    before = {"strict": True, "checks": [["ci/build", 15368]]}
+    after = {"strict": True, "checks": [["ci/build", 15368], ["contract-drift-pr-delta", 99999]]}
+    with pytest.raises(ValueError, match="expected app identity"):
+        _verify_protection_cutover(before, after)
+
+
+def test_terminal_aggregator_fails_if_pr_delta_is_skipped_cancelled_or_missing(tmp_path):
+    assert _terminal_step()["if"] == "always()"
+    payload = '{"admitted": true}\n'
+    assert _run_terminal(tmp_path / "ok", outcome="success", payload=payload).returncode == 0
+    for index, outcome in enumerate(("skipped", "cancelled", "failure")):
+        result = _run_terminal(tmp_path / f"bad{index}", outcome=outcome, payload=payload)
+        assert result.returncode != 0, outcome
+    assert _run_terminal(tmp_path / "missing", outcome="success", payload=None).returncode != 0
+
+
+def test_main_receipt_job_is_distinct_and_successful_when_trajectory_is_red(tmp_path):
+    receipt, program = JOBS["main-receipt"], JOBS["program-trajectory"]
+    assert receipt["name"] != program["name"] and "needs" not in receipt
+    env = {"SOURCE_SHA": "b" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    red = _simulate_step(_analyzer_step_text(program), env=env, cwd=tmp_path, stubs={"python3": 17})
+    green = _simulate_step(
+        _analyzer_step_text(receipt), env=env, cwd=tmp_path, stubs={"python3": 0}
+    )
+    assert red.returncode == 17 and green.returncode == 0
+    # The receipt artifact is gated only on the receipt job's own success.
+    assert _upload_step("main-receipt")["if"] == "success()"
+
+
+def test_main_receipt_requires_complete_first_parent_backfill(tmp_path):
+    receipt = _analyzer_step_text(JOBS["main-receipt"])
+    assert "--mode receipt" in receipt and "--mode program" not in receipt
+    env = {"SOURCE_SHA": "b" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    # An incomplete first-parent backfill is a red receipt analyzer; pipefail
+    # preserves that exit through tee, and the success-gated upload withholds
+    # the receipt artifact.
+    incomplete = _simulate_step(receipt, env=env, cwd=tmp_path, stubs={"python3": 3})
+    assert incomplete.returncode == 3
+    assert _upload_step("main-receipt")["if"] == "success()"
+    assert "continue-on-error" not in str(JOBS["main-receipt"])
+
+
+def test_program_trajectory_preserves_real_red_exit(tmp_path):
+    program = JOBS["program-trajectory"]
+    assert "continue-on-error" not in str(program)
+    analyzer = _analyzer_step(program_id := "program-trajectory")
+    assert "if" not in analyzer, program_id
+    env = {"SOURCE_SHA": "c" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    result = _simulate_step(
+        _analyzer_step_text(program), env=env, cwd=tmp_path, stubs={"python3": 7}
+    )
+    assert result.returncode == 7
+    assert (tmp_path / "contract-drift-program-trajectory.json").exists()
+
+
+def test_contract_drift_authoritative_steps_propagate_nonzero_exit(tmp_path):
+    env = {
+        "BASE_SHA": "a" * 40,
+        "HEAD_SHA": "b" * 40,
+        "SOURCE_SHA": "c" * 40,
+        "GITHUB_WORKSPACE": str(tmp_path),
+    }
+    for job_id in ("pr-delta", "main-receipt", "program-trajectory"):
+        workdir = tmp_path / job_id
+        workdir.mkdir()
+        result = _simulate_step(
+            _analyzer_step(job_id)["run"],
+            env=env,
+            cwd=workdir,
+            stubs={"python3": 5, "git": 0, "date": 0},
+        )
+        assert result.returncode == 5, (job_id, result.stderr)
+
+
+def test_every_contract_drift_authoritative_pipeline_enables_pipefail_before_first_pipe(tmp_path):
+    pipe = re.compile(r"(?<!\|)\|(?!\|)")
+    for job_id in ("pr-delta", "main-receipt", "program-trajectory"):
+        run = _analyzer_step(job_id)["run"]
+        lines = run.splitlines()
+        first_pipe = next(index for index, line in enumerate(lines) if pipe.search(line))
+        assert "set -euo pipefail" in lines[:first_pipe][0], job_id
+    # Behavioral contrast: the same pipeline without pipefail lets tee's zero
+    # exit mask the red analyzer.
+    run = _analyzer_step("main-receipt")["run"]
+    env = {"SOURCE_SHA": "d" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    with_pipefail = _simulate_step(run, env=env, cwd=tmp_path, stubs={"python3": 9})
+    without = _simulate_step(
+        run.replace("set -euo pipefail\n", ""), env=env, cwd=tmp_path, stubs={"python3": 9}
+    )
+    assert with_pipefail.returncode == 9 and without.returncode == 0
+
+
+def test_contract_drift_outputs_are_required_before_summary(tmp_path):
+    terminal = _terminal_step()["run"]
+    lines = terminal.splitlines()
+    outcome_line = next(index for index, line in enumerate(lines) if "steps.admission.outcome" in line)  # fmt: skip
+    output_line = next(index for index, line in enumerate(lines) if "test -s contract-drift-pr-delta.json" in line)  # fmt: skip
+    summary_line = next(index for index, line in enumerate(lines) if "accepted_authority" in line)
+    assert outcome_line < output_line < summary_line
+    empty = _run_terminal(tmp_path / "empty", outcome="success", payload="")
+    assert empty.returncode != 0
+    present = _run_terminal(tmp_path / "present", outcome="success", payload='{"admitted": true}\n')
+    assert present.returncode == 0
+
+
+def test_skipped_or_cancelled_cdg_authority_job_cannot_report_success(tmp_path):
+    for conclusion in ("skipped", "cancelled"):
+        assert not _job_reports_success({"conclusion": conclusion})
+        assert not _required_check_satisfied(
+            [
+                {
+                    "name": "contract-drift-pr-delta",
+                    "app_id": EXPECTED_PR_DELTA_APP_ID,
+                    "conclusion": conclusion,
+                }
+            ],
+            context="contract-drift-pr-delta",
+        )
+    assert _job_reports_success({"conclusion": "success"})
+    assert not _job_reports_success({"conclusion": None})
+    # The terminal aggregator turns a skipped admission into a hard failure
+    # instead of an implicit green.
+    result = _run_terminal(tmp_path, outcome="skipped", payload='{"admitted": true}\n')
+    assert result.returncode != 0
+
+
+# --- VAL-CDG-009: separate immutable signals (workflow side) ----------------
+
+
+def test_pull_request_invokes_only_pr_mode():
+    assert JOBS["pr-delta"]["if"] == "github.event_name == 'pull_request' && !github.event.pull_request.draft"  # fmt: skip
+    admission = _analyzer_step("pr-delta")["run"]
+    assert "--mode pr" in admission
+    assert "--mode receipt" not in str(JOBS["pr-delta"])
+    assert "--mode program" not in str(JOBS["pr-delta"])
+    # The two main-only jobs are event-disjoint from PR admission.
+    for job_id in ("main-receipt", "program-trajectory"):
+        assert JOBS[job_id]["if"] == "github.event_name != 'pull_request'"
+
+
+def test_pull_request_uses_immutable_event_base_and_head_shas():
+    env = JOBS["pr-delta"]["env"]
+    assert env == {
+        "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+        "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+    }
+    admission = _analyzer_step("pr-delta")["run"]
+    assert admission.index("git fetch") < admission.index("--base-ref")
+    assert '"$BASE_SHA" "$HEAD_SHA"' in admission
+    # The upload key is bound to the same immutable event head SHA.
+    assert _upload_step("pr-delta")["with"]["name"].endswith(
+        "${{ github.event.pull_request.head.sha }}"
+    )
+
+
+def test_synthetic_merge_sha_is_rejected_for_pr_delta():
+    pr_text = str(JOBS["pr-delta"])
+    # The synthetic refs/pull/N/merge commit and its aliases never reach the
+    # analyzer: no merge_commit_sha, no github.sha, no mutable ref names.
+    assert "merge_commit_sha" not in pr_text
+    assert "github.sha" not in pr_text
+    assert "refs/pull" not in pr_text and "github.ref" not in pr_text
+    admission = _analyzer_step("pr-delta")["run"]
+    for flag, value in (("--base-ref", '"$BASE_SHA"'), ("--head-ref", '"$HEAD_SHA"')):
+        assert f"{flag} {value}" in admission
+    assert "GITHUB_SHA" not in admission and "HEAD^" not in admission
+
+
+def test_push_main_binds_receipt_and_program_to_event_after_sha():
+    assert DOC["on"]["push"]["branches"] == ["main"]
+    assert "github.event.after" in SOURCE_SHA_EXPR
+    for job_id in ("main-receipt", "program-trajectory"):
+        job = JOBS[job_id]
+        assert job["env"]["SOURCE_SHA"] == SOURCE_SHA_EXPR
+        assert job["steps"][0]["with"]["ref"] == SOURCE_SHA_EXPR
+        assert '--ref "$SOURCE_SHA"' in _analyzer_step_text(job)
+
+
+def test_schedule_and_dispatch_resolve_main_once_for_both_main_jobs():
+    assert "schedule" in DOC["on"] and "workflow_dispatch" in DOC["on"]
+    # For non-push events the shared expression falls back to the single
+    # resolved github.sha, so receipt and trajectory bind one identical SHA.
+    assert SOURCE_SHA_EXPR.endswith("|| github.sha }}")
+    receipt, program = JOBS["main-receipt"], JOBS["program-trajectory"]
+    assert receipt["env"]["SOURCE_SHA"] == program["env"]["SOURCE_SHA"]
+    assert receipt["steps"][0]["with"]["ref"] == program["steps"][0]["with"]["ref"]
+    assert TEXT.count(SOURCE_SHA_EXPR) == 4
+
+
+def test_exact_three_live_check_names_are_separate():
+    assert len(set(JOBS)) == 3 and len(set(_job_names(DOC))) == 3
+    artifact_names = {job_id: _upload_step(job_id)["with"]["name"] for job_id in JOBS}
+    assert len(set(artifact_names.values())) == 3
+    outputs = {job_id: _upload_step(job_id)["with"]["path"] for job_id in JOBS}
+    assert len(set(outputs.values())) == 3
+    for job_id in JOBS:
+        assert artifact_names[job_id].startswith(f"contract-drift-{job_id}-")
+        assert outputs[job_id] == f"contract-drift-{job_id}.json"
+
+
+def test_pr_delta_becomes_branch_protection_required_after_cutover():
+    before = {"strict": True, "checks": [["ci/build", 15368]]}
+    after = {
+        "strict": True,
+        "checks": [["ci/build", 15368], ["contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID]],
+    }
+    result = _verify_protection_cutover(before, after)
+    assert ("contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID) in result
+    # A cutover that fails to add the pr-delta requirement is rejected.
+    with pytest.raises(ValueError, match="must add exactly the pr-delta context"):
+        _verify_protection_cutover(before, before)
+
+
+def test_branch_protection_preserves_exact_context_app_id_set_and_strict():
+    before = {"strict": True, "checks": [["ci/build", 15368], ["ci/lint", 15368]]}
+    dropped = {
+        "strict": True,
+        "checks": [["ci/build", 15368], ["contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID]],
+    }
+    with pytest.raises(ValueError, match="removed or mutated"):
+        _verify_protection_cutover(before, dropped)
+    swapped_app = {
+        "strict": True,
+        "checks": [
+            ["ci/build", 15368],
+            ["ci/lint", 424242],
+            ["contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID],
+        ],
+    }
+    with pytest.raises(ValueError, match="removed or mutated"):
+        _verify_protection_cutover(before, swapped_app)
+    duplicated = {
+        "strict": True,
+        "checks": [["ci/build", 15368], ["ci/build", 15368]],
+    }
+    with pytest.raises(ValueError, match="duplicated"):
+        _verify_protection_cutover(before, duplicated)
+
+
+def test_pr_delta_is_added_with_expected_app_identity():
+    before = {"strict": False, "checks": [["ci/build", 15368]]}
+    for hostile_app in (99999, 0, -1):
+        after = {
+            "strict": False,
+            "checks": [["ci/build", 15368], ["contract-drift-pr-delta", hostile_app]],
+        }
+        with pytest.raises(ValueError, match="expected app identity"):
+            _verify_protection_cutover(before, after)
+    good = {
+        "strict": False,
+        "checks": [["ci/build", 15368], ["contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID]],
+    }
+    assert ("contract-drift-pr-delta", EXPECTED_PR_DELTA_APP_ID) in _verify_protection_cutover(
+        before, good
+    )
+    # Adding a different context, even with the right app, is not the cutover.
+    wrong_context = {
+        "strict": False,
+        "checks": [["ci/build", 15368], ["contract-drift-imposter", EXPECTED_PR_DELTA_APP_ID]],
+    }
+    with pytest.raises(ValueError, match="must add exactly the pr-delta context"):
+        _verify_protection_cutover(before, wrong_context)
+
+
+def test_terminal_aggregator_fails_when_pr_delta_is_skipped(tmp_path):
+    terminal = _terminal_step()
+    # `always()` forces the aggregator to run and judge a skipped admission
+    # rather than letting the job end green with the step silently absent.
+    assert terminal["if"] == "always()"
+    assert terminal is JOBS["pr-delta"]["steps"][-1]
+    result = _run_terminal(tmp_path, outcome="skipped", payload='{"admitted": true}\n')
+    assert result.returncode == 1
+    assert 'test "skipped" = "success"' in terminal["run"].replace(
+        "${{ steps.admission.outcome }}", "skipped"
+    )
+
+
+def test_main_receipt_job_is_separate_from_intentionally_red_trajectory():
+    receipt, program = JOBS["main-receipt"], JOBS["program-trajectory"]
+    assert "needs" not in receipt and "needs" not in program
+    assert receipt["name"] == "contract-drift-main-receipt"
+    assert program["name"] == "contract-drift-program-trajectory"
+    assert "--mode receipt" in _analyzer_step_text(receipt)
+    assert "--mode program" in _analyzer_step_text(program)
+    assert _upload_step("main-receipt")["with"]["name"] != _upload_step("program-trajectory")["with"]["name"]  # fmt: skip
+
+
+def test_trajectory_failure_does_not_block_main_receipt(tmp_path):
+    # No job anywhere in the workflow declares a dependency on the trajectory
+    # job, so its intentionally red exit cannot gate the receipt.
+    for job in JOBS.values():
+        needs = job.get("needs", [])
+        assert "program-trajectory" not in ([needs] if isinstance(needs, str) else needs)
+    env = {"SOURCE_SHA": "e" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    trajectory = _simulate_step(
+        _analyzer_step_text(JOBS["program-trajectory"]),
+        env=env,
+        cwd=tmp_path,
+        stubs={"python3": 21},  # fmt: skip
+    )
+    receipt = _simulate_step(
+        _analyzer_step_text(JOBS["main-receipt"]), env=env, cwd=tmp_path, stubs={"python3": 0}
+    )
+    assert trajectory.returncode == 21 and receipt.returncode == 0
+    assert (tmp_path / "contract-drift-main-receipt.json").exists()
+
+
+def test_main_receipt_success_does_not_mask_trajectory_failure(tmp_path):
+    program = JOBS["program-trajectory"]
+    assert "continue-on-error" not in str(program)
+    # The trajectory job has no aggregator step that could rewrite its
+    # conclusion: the analyzer is the last conditioned enforcement point and
+    # the only later step is the always-on artifact upload.
+    *_, analyzer, upload = program["steps"]
+    assert "check_contract_drift_ratchet.py" in analyzer["run"]
+    assert upload["uses"].startswith("actions/upload-artifact@")
+    env = {"SOURCE_SHA": "f" * 40, "GITHUB_WORKSPACE": str(tmp_path)}
+    receipt = _simulate_step(
+        _analyzer_step_text(JOBS["main-receipt"]), env=env, cwd=tmp_path, stubs={"python3": 0}
+    )
+    trajectory = _simulate_step(
+        _analyzer_step_text(program), env=env, cwd=tmp_path, stubs={"python3": 13}
+    )
+    assert receipt.returncode == 0 and trajectory.returncode == 13
+
+
+def test_program_red_cannot_mask_or_replace_pr_delta_result():
+    # PR admission and program trajectory run on disjoint events, publish
+    # differently named artifacts, and satisfy different required contexts.
+    assert JOBS["pr-delta"]["if"].startswith("github.event_name == 'pull_request'")
+    assert JOBS["program-trajectory"]["if"] == "github.event_name != 'pull_request'"
+    assert "contract-drift-pr-delta.json" not in str(JOBS["program-trajectory"])
+    assert "contract-drift-program-trajectory.json" not in str(JOBS["pr-delta"])
+    trajectory_success = [
+        {
+            "name": "contract-drift-program-trajectory",
+            "app_id": EXPECTED_PR_DELTA_APP_ID,
+            "conclusion": "success",
+        }
+    ]
+    assert not _required_check_satisfied(trajectory_success, context="contract-drift-pr-delta")
+    red_delta = trajectory_success + [
+        {
+            "name": "contract-drift-pr-delta",
+            "app_id": EXPECTED_PR_DELTA_APP_ID,
+            "conclusion": "failure",
+        }
+    ]
+    assert not _required_check_satisfied(red_delta, context="contract-drift-pr-delta")

--- a/tests/scripts/test_contract_drift_workflow.py
+++ b/tests/scripts/test_contract_drift_workflow.py
@@ -139,7 +139,7 @@ def _paginated_protection_checks(pages: list[list[tuple[str, int]]]) -> list[tup
     for page in pages:
         if len(page) > 100:
             raise ValueError("paginated protection page exceeds per_page=100")
-        checks.extend(tuple(item) for item in page)
+        checks.extend((str(context), int(app_id)) for context, app_id in page)
     if len(checks) != len(set(checks)):
         raise ValueError("paginated protection capture returned duplicate tuples")
     return checks

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -1594,17 +1594,33 @@ def test_all_655_original_ids_reproduce_from_anchored_source_blobs():
             "missing_from_both_sdks",
         ]  # fmt: skip
     )
-    # Anchored source binding: every membership source pins blob bytes; when the
-    # anchor blobs are reachable in this clone, the cohort reproduces from them.
+    # Anchored source binding: every membership source pins blob bytes. The
+    # binding phase is mandatory whenever the membership anchor commit exists
+    # in this clone (every full clone: the anchor is an ancestor of main); a
+    # blob missing despite the anchor commit is corruption, never a soft pass.
+    anchor_sha = cohort["membership_anchor"]["commit_sha"]
+    anchor_present = (
+        subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "cat-file", "-e", f"{anchor_sha}^{{commit}}"],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+    verified_sources = 0
     for source in cohort["membership_sources"]:
         assert ratchet.SHA256_RE.fullmatch(source["sha256"])
-        assert source["commit_sha"] == cohort["membership_anchor"]["commit_sha"]
+        assert source["commit_sha"] == anchor_sha
         probe = subprocess.run(
             ["git", "-C", str(REPO_ROOT), "cat-file", "blob", source["git_blob_oid"]],
             capture_output=True,
         )
         if probe.returncode != 0:
+            assert not anchor_present, (
+                f"membership anchor commit {anchor_sha} is present but source blob "
+                f"{source['git_blob_oid']} ({source['path']}) is unreachable"
+            )
             continue
+        verified_sources += 1
         blob = probe.stdout
         assert len(blob) == source["byte_length"]
         assert ratchet._sha256_bytes(blob) == source["sha256"]
@@ -1616,6 +1632,8 @@ def test_all_655_original_ids_reproduce_from_anchored_source_blobs():
             # Unrelated arrays such as missing_stable never join the cohort.
             assert "missing_stable" in arrays
             assert "missing_stable" not in by_source
+    if anchor_present:
+        assert verified_sources == len(cohort["membership_sources"])
 
 
 def test_ratified_original_id_set_digest_supersedes_provisional_digest():

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -2343,3 +2343,766 @@ def test_annotation_or_later_move_cannot_change_partition(monkeypatch):
         ratchet._validate_sdk_provenance(
             copy.deepcopy(provenance), ratchet._validate_original_cohort(_cohort())
         )
+
+
+# --- VAL-CDG-007 (census/gen side): every invalid input fails closed --------
+
+
+def test_missing_required_source_fails_closed(tmp_path: Path):
+    repo, _sha = _init_repo(tmp_path)
+    (repo / "scripts/baselines/verify_sdk_contracts.json").unlink()
+    with pytest.raises(ValueError, match="Baseline file missing"):
+        gen.load_working_docs(repo)
+    # The CLI surface exits non-zero with an ERROR line, writing nothing.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/generate_contract_drift_inventory.py",
+            "--repo-root",
+            str(repo),
+            "--check",
+        ],  # fmt: skip
+        capture_output=True,
+        text=True,
+        cwd=Path(gen.__file__).resolve().parents[1],
+    )
+    assert proc.returncode == 1
+    assert "ERROR:" in proc.stdout
+
+
+def test_missing_cohort_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    authority = copy.deepcopy(_accepted_authority())
+    del authority["canonical_artifacts"]["original_cohort"]
+    with pytest.raises(ValueError, match="canonical artifacts are malformed"):
+        ratchet.validate_accepted_authority(authority, repo_root=tmp_path)
+    monkeypatch.delenv("FACTORY_MISSION_DIR", raising=False)
+    monkeypatch.delenv("FACTORY_RUNTIME_SETTINGS_PATH", raising=False)
+    with pytest.raises(ValueError, match="unavailable"):
+        ratchet._discover_canonical_artifact(None, ratchet.COHORT_ARTIFACT, tmp_path / "repo")
+
+
+def test_missing_sdk_provenance_artifact_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    authority = copy.deepcopy(_accepted_authority())
+    del authority["canonical_artifacts"]["sdk_provenance"]
+    with pytest.raises(ValueError, match="canonical artifacts are malformed"):
+        ratchet.validate_accepted_authority(authority, repo_root=tmp_path)
+    monkeypatch.delenv("FACTORY_MISSION_DIR", raising=False)
+    monkeypatch.delenv("FACTORY_RUNTIME_SETTINGS_PATH", raising=False)
+    with pytest.raises(ValueError, match="unavailable"):
+        ratchet._discover_canonical_artifact(None, ratchet.PROVENANCE_ARTIFACT, tmp_path / "repo")
+
+
+def test_canonical_artifact_length_or_sha_mismatch_fails_closed(tmp_path: Path):
+    raw = ratchet._canonical_json_bytes(_cohort(), terminal_lf=True)
+    path = tmp_path / "cohort.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="byte-length mismatch"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="cohort",
+            expected_byte_length=len(raw) - 1,
+            expected_sha256=ratchet._sha256_bytes(raw),
+            terminal_lf=True,
+        )
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="cohort",
+            expected_byte_length=len(raw),
+            expected_sha256="0" * 64,
+            terminal_lf=True,
+        )
+    for length, sha in ((None, ratchet._sha256_bytes(raw)), (len(raw), None), (len(raw), "xyz")):
+        with pytest.raises(ValueError, match="independently supplied"):
+            ratchet._load_canonical_json_bytes(
+                path,
+                label="cohort",
+                expected_byte_length=length,
+                expected_sha256=sha,
+                terminal_lf=True,
+            )
+
+
+def test_canonical_artifact_noncanonical_bytes_fail_closed(tmp_path: Path):
+    hostiles = {
+        "bom": b"\xef\xbb\xbf" + ratchet._canonical_json_bytes({"a": 1}, terminal_lf=True),
+        "no-lf": ratchet._canonical_json_bytes({"a": 1}),
+        "double-lf": ratchet._canonical_json_bytes({"a": 1}) + b"\n\n",
+        "unsorted": b'{"b":1,"a":2}\n',
+        "spaced": b'{"a": 1}\n',
+        "non-utf8": b'{"a":"\xff"}\n',
+    }
+    for name, raw in hostiles.items():
+        path = tmp_path / f"{name}.json"
+        path.write_bytes(raw)
+        with pytest.raises(ValueError):
+            ratchet._load_canonical_json_bytes(
+                path,
+                label=name,
+                expected_byte_length=len(raw),
+                expected_sha256=ratchet._sha256_bytes(raw),
+                terminal_lf=True,
+            )
+
+
+def test_external_manifest_parse_reserialize_substitution_fails_closed(tmp_path: Path):
+    # Same parsed value, different bytes: parse-reserialize equivalence is
+    # not proof, so the noncanonical byte stream fails even with a correct
+    # length/digest binding for those bytes.
+    reserialized = (
+        json.dumps({"a": [1, 2]}, sort_keys=True, separators=(", ", ": ")) + "\n"
+    ).encode()
+    path = tmp_path / "reserialized.json"
+    path.write_bytes(reserialized)
+    with pytest.raises(ValueError, match="parse-reserialize equivalence is not proof"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="external manifest",
+            expected_byte_length=len(reserialized),
+            expected_sha256=ratchet._sha256_bytes(reserialized),
+            terminal_lf=True,
+        )
+
+
+def test_malformed_json_fails_closed(tmp_path: Path):
+    repo, _sha = _init_repo(tmp_path)
+    (repo / "scripts/baselines/verify_sdk_contracts.json").write_text("{not json", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        gen.load_working_docs(repo)
+    path = tmp_path / "broken.json"
+    path.write_bytes(b"{broken\n")
+    with pytest.raises(ValueError, match="not valid duplicate-free JSON"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="broken",
+            expected_byte_length=8,
+            expected_sha256=ratchet._sha256_bytes(b"{broken\n"),
+            terminal_lf=True,
+        )
+    with pytest.raises(ValueError, match="unparseable"):
+        ratchet._load_json_strict(path, "inventory")
+
+
+def test_duplicate_json_key_fails_closed(tmp_path: Path):
+    raw = b'{"a":1,"a":2}\n'
+    path = tmp_path / "dup.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="dup",
+            expected_byte_length=len(raw),
+            expected_sha256=ratchet._sha256_bytes(raw),
+            terminal_lf=True,
+        )
+    with pytest.raises(ValueError, match="not canonical UTF-8 JSON"):
+        ratchet._strict_json_bytes(raw, "dup")
+
+
+def test_unsupported_schema_version_fails_closed(tmp_path: Path):
+    result = ratchet.build_boundary_result(
+        repo_root=tmp_path,
+        schema_version=2,
+        boundary="corrective_bootstrap",
+        start_ref="1" * 40,
+        end_ref="2" * 40,
+    )
+    assert (result["status"], result["passing"]) == ("fail", False)
+    assert result["error_code"] == "boundary_validation_failed"
+    assert "unsupported boundary schema version" in result["error"]
+    unknown = ratchet.build_boundary_result(
+        repo_root=tmp_path,
+        schema_version=1,
+        boundary="imaginary_boundary",
+        start_ref="1" * 40,
+        end_ref="2" * 40,
+    )
+    assert (unknown["status"], unknown["passing"]) == ("fail", False)
+    assert "unsupported Contract Drift boundary" in unknown["error"]
+
+
+def test_wrong_cohort_count_fails_closed():
+    short = copy.deepcopy(_cohort())
+    short["original_records"].pop()
+    with pytest.raises(ValueError, match="exactly 655 original records"):
+        ratchet._validate_original_cohort(short)
+    short_prov = copy.deepcopy(_provenance())
+    short_prov["records"].pop()
+    with pytest.raises(ValueError, match="598 records"):
+        ratchet._validate_sdk_provenance(short_prov, ratchet._validate_original_cohort(_cohort()))
+
+
+def test_cohort_digest_mismatch_fails_closed():
+    hostile = copy.deepcopy(_cohort())
+    hostile["original_record_id_set"]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="ID-set digest mismatch"):
+        ratchet._validate_original_cohort(hostile)
+    authority = copy.deepcopy(_accepted_authority())
+    authority["canonical_artifact_bindings"][0]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="artifact or category binding mismatch"):
+        ratchet.validate_accepted_authority(authority, repo_root=Path(ratchet.__file__).parents[1])
+
+
+def test_original_descriptor_or_original_record_ids_changed_fails_closed():
+    # The ratified artifact descriptor is a module constant; a runtime that
+    # claims different bytes cannot revalidate the production artifact.
+    assert ratchet.COHORT_ARTIFACT["sha256"] == (
+        "565cd84a9a5d266f61b66bd7965e0a036e4817ef5fed32edb8c41a2dea6cc208"
+    )
+    assert ratchet.ORIGINAL_ID_SET_SHA256 == (
+        "c1235670c183b1887ba3fe4280fa0320f9fd6f4a85b8f346d4332ac2aebbe269"
+    )
+    swapped = copy.deepcopy(_cohort())
+    first, second = swapped["original_records"][0], swapped["original_records"][1]
+    literal = first["exact_historical_literal_record"]
+    first["exact_historical_literal_record"] = second["exact_historical_literal_record"]
+    second["exact_historical_literal_record"] = literal
+    with pytest.raises(ValueError, match="ID payload (length|digest) mismatch"):
+        ratchet._validate_original_cohort(swapped)
+    reidentified = copy.deepcopy(_cohort())
+    record = reidentified["original_records"][0]
+    record["original_record_id"] = "cdg1:" + "0" * 64
+    with pytest.raises(ValueError, match="ID mismatch"):
+        ratchet._validate_original_cohort(reidentified)
+
+
+def test_duplicate_or_conflicting_original_record_id_fails_closed():
+    duplicated = copy.deepcopy(_cohort())
+    target = duplicated["original_records"][1]
+    source = duplicated["original_records"][0]
+    for key in (
+        "category",
+        "exact_historical_literal_record",
+        "id_payload_byte_length",
+        "id_payload_sha256",
+        "original_record_id",
+    ):
+        target[key] = copy.deepcopy(source[key])
+    with pytest.raises(ValueError, match="duplicate original record IDs|category counts mismatch|ID-set"):  # fmt: skip
+        ratchet._validate_original_cohort(duplicated)
+    conflicting = copy.deepcopy(_provenance())
+    conflicting["records"][1]["original_record_id"] = conflicting["records"][0][
+        "original_record_id"
+    ]
+    with pytest.raises(ValueError, match="digest mismatch|biject"):
+        ratchet._validate_sdk_provenance(conflicting, ratchet._validate_original_cohort(_cohort()))
+
+
+def test_malformed_historical_literal_shape_fails_closed():
+    cohort = _cohort()
+    sdk_index = next(
+        index
+        for index, record in enumerate(cohort["original_records"])
+        if record["category"] in SDK_CATEGORIES
+    )
+    hostile = copy.deepcopy(cohort)
+    record = hostile["original_records"][sdk_index]
+    # A literal whose bound bytes are intact but whose shape is not a
+    # method-bearing record: keep ID bookkeeping consistent so only the
+    # shape/link layer can reject.
+    record["exact_historical_literal_record"] = "/path-without-method"
+    raw, original_id = _original_id(record["category"], record["exact_historical_literal_record"])
+    record.update(
+        id_payload_byte_length=len(raw),
+        id_payload_sha256=ratchet._sha256_bytes(raw),
+        original_record_id=original_id,
+    )
+    with pytest.raises(ValueError, match="ID set is incomplete|ID-set digest mismatch"):
+        ratchet._validate_sdk_provenance(
+            copy.deepcopy(_provenance()), ratchet._validate_original_cohort(hostile)
+        )
+    nonstring = copy.deepcopy(cohort)
+    nonstring["original_records"][0]["exact_historical_literal_record"] = ["GET", "/a"]
+    with pytest.raises(ValueError, match="lacks identity fields"):
+        ratchet._validate_original_cohort(nonstring)
+
+
+def test_method_on_path_level_original_record_fails_closed():
+    hostile = copy.deepcopy(_cohort())
+    record = next(r for r in hostile["original_records"] if r["category"] in ROUTE_CATEGORIES)
+    record["method"] = "GET"
+    with pytest.raises(ValueError, match="path-level cohort record .* carries a method"):
+        ratchet._validate_original_cohort(hostile)
+
+
+def test_null_or_invalid_method_on_runtime_or_projection_edge_fails_closed():
+    nulled = copy.deepcopy(_cohort())
+    sdk_record = next(r for r in nulled["original_records"] if r["category"] in SDK_CATEGORIES)
+    sdk_record["method"] = None
+    with pytest.raises(ValueError, match="lacks a method"):
+        ratchet._validate_original_cohort(nulled)
+    omitted = copy.deepcopy(_cohort())
+    edge = omitted["operation_projection"]["records"][0]["operation_edges"][0]
+    del edge["method"]
+    _rehash_projection(omitted)
+    with pytest.raises(ValueError, match="malformed edge|invalid method"):
+        ratchet._validate_original_cohort(omitted)
+
+
+def test_sdk_language_not_derived_from_category_fails_closed():
+    cohort, provenance = _linked_provenance_mutation(
+        lambda record: record.update(
+            sdk_language=(
+                "typescript"
+                if _provenance()["records"][0]["sdk_language"] == "python"
+                else "python"
+            )
+        )
+    )
+    with pytest.raises(ValueError, match="language link mismatch"):
+        ratchet._validate_sdk_provenance(provenance, ratchet._validate_original_cohort(cohort))
+    hostile_cohort = copy.deepcopy(_cohort())
+    record = next(
+        r for r in hostile_cohort["original_records"] if r["category"] == "python_sdk_drift"
+    )
+    record["sdk_language"] = ["typescript"]
+    with pytest.raises(ValueError, match="language"):
+        ratchet._validate_sdk_provenance(
+            copy.deepcopy(_provenance()), ratchet._validate_original_cohort(hostile_cohort)
+        )
+
+
+def test_incomplete_handler_extraction_fails_closed():
+    # A provenance record with one of its source occurrences dropped no
+    # longer matches its bound digest chain; with the digests relinked, the
+    # occurrence/count reconciliation still fails closed.
+    multi_index = next(
+        index
+        for index, record in enumerate(_provenance()["records"])
+        if len(record["source_occurrences"]) > 1
+    )
+    cohort, hostile = _linked_provenance_mutation(
+        lambda record: record["source_occurrences"].pop(), index=multi_index
+    )
+    with pytest.raises(ValueError, match="record-digest-set mismatch|reconstructed counts mismatch"):  # fmt: skip
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+    emptied_cohort, emptied = _linked_provenance_mutation(
+        lambda record: record.update(source_occurrences=[])
+    )
+    with pytest.raises(ValueError, match="lacks source occurrences"):
+        ratchet._validate_sdk_provenance(emptied, ratchet._validate_original_cohort(emptied_cohort))  # fmt: skip
+
+
+def test_partial_sdk_extraction_fails_closed():
+    # Dropping an entire SDK record (partial extraction) breaks the exact 598
+    # bijection; padding the count back with a duplicate breaks digests.
+    partial = copy.deepcopy(_provenance())
+    partial["records"].pop(0)
+    with pytest.raises(ValueError, match="598 records"):
+        ratchet._validate_sdk_provenance(partial, ratchet._validate_original_cohort(_cohort()))
+    padded = copy.deepcopy(_provenance())
+    padded["records"][0] = copy.deepcopy(padded["records"][1])
+    with pytest.raises(ValueError, match="biject|digest"):
+        ratchet._validate_sdk_provenance(padded, ratchet._validate_original_cohort(_cohort()))
+
+
+def test_sdk_provenance_birth_or_dependency_closure_mismatch_fails_closed():
+    provenance = _provenance()
+    birth = provenance["baseline_birth"]
+    dependencies = provenance["dependencies"]
+    # The birth/dependency claims are part of the artifact's canonical bytes:
+    # any mutation changes the artifact digest away from the ratified pin.
+    ratified = ratchet.PROVENANCE_ARTIFACT["sha256"]
+    assert (
+        ratchet._sha256_bytes(ratchet._canonical_json_bytes(provenance, terminal_lf=True))
+        == ratified
+    )
+    for mutate in (
+        lambda p: p["baseline_birth"].update(commit_sha="0" * 40),
+        lambda p: p["baseline_birth"].update(first_parent_sha="0" * 40),
+        lambda p: p["dependencies"]["baseline_source"].update(git_blob_oid="0" * 40),
+        lambda p: p["dependencies"]["baseline_source"].update(sha256="0" * 64),
+    ):
+        hostile = copy.deepcopy(provenance)
+        mutate(hostile)
+        assert (
+            ratchet._sha256_bytes(ratchet._canonical_json_bytes(hostile, terminal_lf=True))
+            != ratified
+        )
+    # And the birth chain is internally consistent in the ratified artifact.
+    assert birth["membership_anchor_baseline_blob_git_oid"] == birth["ratified_baseline_blob_git_oid"]  # fmt: skip
+    assert dependencies["baseline_source"]["git_blob_oid"] == birth["ratified_baseline_blob_git_oid"]  # fmt: skip
+    assert dependencies["baseline_source"]["commit_sha"] == birth["commit_sha"]
+
+
+def test_sdk_provenance_record_occurrence_partition_or_digest_mismatch_fails_closed():
+    # Undeclared occurrence atom.
+    atom_cohort, undeclared_atom = _linked_provenance_mutation(
+        lambda record: record["source_occurrences"][0].update(provenance_atom="not-declared")
+    )
+    with pytest.raises(ValueError, match="occurrence atom is not declared"):
+        ratchet._validate_sdk_provenance(
+            undeclared_atom, ratchet._validate_original_cohort(atom_cohort)
+        )
+    # Occurrence language disagreeing with its record.
+    lang_cohort, wrong_lang = _linked_provenance_mutation(
+        lambda record: record["source_occurrences"][0].update(
+            sdk_language="typescript"
+            if _provenance()["records"][0]["sdk_language"] == "python"
+            else "python"
+        )
+    )
+    with pytest.raises(ValueError, match="occurrence language mismatch"):
+        ratchet._validate_sdk_provenance(wrong_lang, ratchet._validate_original_cohort(lang_cohort))
+    # Partition claim contradicting the atom-derived partition.
+    part_cohort, wrong_partition = _linked_provenance_mutation(
+        lambda record: record.update(
+            partition="extended" if _provenance()["records"][0]["partition"] == "core" else "core"
+        )
+    )
+    with pytest.raises(ValueError, match="partition mismatch"):
+        ratchet._validate_sdk_provenance(
+            wrong_partition, ratchet._validate_original_cohort(part_cohort)
+        )
+    # Raw record digest tamper without relinking.
+    tampered = copy.deepcopy(_provenance())
+    tampered["records"][0]["record_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="digest mismatch"):
+        ratchet._validate_sdk_provenance(tampered, ratchet._validate_original_cohort(_cohort()))
+    # Record-set digest tamper.
+    set_tampered = copy.deepcopy(_provenance())
+    set_tampered["record_digest_set_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="record-digest-set mismatch"):
+        ratchet._validate_sdk_provenance(set_tampered, ratchet._validate_original_cohort(_cohort()))  # fmt: skip
+
+
+def test_missing_empty_malformed_free_text_or_path_partition_provenance_fails_closed():
+    for hostile_atoms in (None, [], [""], [42], "billing", ["billing", ""]):
+        cohort, hostile = _linked_provenance_mutation(
+            lambda record, atoms=hostile_atoms: record.update(provenance_atoms=atoms)
+        )
+        with pytest.raises(ValueError, match="atoms|partition|matched-domain"):
+            ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+    # Free-text and path-shaped "atoms" are whole atoms, not substring grants:
+    # they never match a core domain by containment.
+    partition, matches = ratchet._partition_from_atoms(["memory-and-other-things"])
+    assert (partition, matches) == ("extended", [])
+    path_partition, path_matches = ratchet._partition_from_atoms(["sdk/python/memory.py"])
+    assert (path_partition, path_matches) == ("extended", [])
+    exact, exact_matches = ratchet._partition_from_atoms(["memory"])
+    assert exact == "core" and exact_matches[0]["match_rule"] == "exact"
+
+
+def test_unresolved_or_abbreviated_sha_fails_closed(tmp_path: Path):
+    repo, sha = _init_repo(tmp_path)
+    for bad in (sha[:12], "HEAD", "main", sha.upper(), ""):
+        with pytest.raises(gen.AuthorityClosureError, match="full lowercase 40-hex"):
+            gen._resolve_full_commit(repo, bad)
+    unresolvable = "f" * 40
+    with pytest.raises(subprocess.CalledProcessError):
+        gen._resolve_full_commit(repo, unresolvable)
+    result = ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref=sha[:12],
+        end_ref=sha,
+    )
+    assert (result["status"], result["error_code"]) == ("fail", "boundary_validation_failed")
+    assert "full lowercase 40-hex" in result["error"]
+    nonexistent = ratchet.build_boundary_result(
+        repo_root=repo,
+        schema_version=1,
+        boundary="corrective_bootstrap",
+        start_ref="f" * 40,
+        end_ref=sha,
+    )
+    assert (nonexistent["status"], nonexistent["passing"]) == ("fail", False)
+
+
+def test_source_sha_mismatch_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    repo, sha = _init_repo(tmp_path)
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    )
+    assert proc.stdout.strip() == sha
+    # A receipt whose source SHA is not the exact first-parent tip fails.
+    monkeypatch.setattr(ratchet, "validate_accepted_authority", lambda *a, **k: {"active_original_record_ids": [], "analyzer_bundle_sha256": "", "live_original_record_ids": []})  # fmt: skip
+    inventory_path = Path(ratchet.__file__).parents[1] / "scripts/baselines/contract_drift_inventory.json"  # fmt: skip
+    mismatched = ratchet.build_accepted_result(
+        mode="receipt",
+        repo_root=repo,
+        inventory_path=inventory_path,
+        source_sha="f" * 40,
+    )
+    assert (mismatched["passing"], mismatched["status"]) == (False, "fail")
+    exact = ratchet.build_accepted_result(
+        mode="receipt", repo_root=repo, inventory_path=inventory_path, source_sha=sha
+    )
+    assert (exact["passing"], exact["status"]) == (True, "pass")
+    abbreviated = ratchet.build_accepted_result(
+        mode="receipt", repo_root=repo, inventory_path=inventory_path, source_sha=sha[:12]
+    )
+    assert (abbreviated["passing"], abbreviated["status"]) == (False, "fail")
+
+
+def test_authority_manifest_mismatch_fails_closed(tmp_path: Path):
+    manifest = {
+        "authority_manifest_sha256": "0" * 64,
+        "ref": "1" * 40,
+        "schema": "wrong-schema",
+    }
+    with pytest.raises(ValueError, match="schema mismatch"):
+        ratchet._validate_authority_manifest(
+            manifest, repo_root=tmp_path, end_sha="1" * 40, operation_log=[]
+        )
+    manifest["schema"] = gen.AUTHORITY_MANIFEST_SCHEMA
+    manifest["ref"] = "2" * 40
+    with pytest.raises(ValueError, match="exact-ref mismatch"):
+        ratchet._validate_authority_manifest(
+            manifest, repo_root=tmp_path, end_sha="1" * 40, operation_log=[]
+        )
+    manifest["ref"] = "1" * 40
+    with pytest.raises(ValueError, match="semantic digest mismatch"):
+        ratchet._validate_authority_manifest(
+            manifest, repo_root=tmp_path, end_sha="1" * 40, operation_log=[]
+        )
+
+
+def test_dependency_hash_or_version_mismatch_fails_closed(tmp_path: Path):
+    authority = copy.deepcopy(_accepted_authority())
+    authority["analyzer_bundle"]["files"][0]["sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="bundle digest mismatch"):
+        ratchet._validate_bundle(authority, Path(ratchet.__file__).parents[1])
+    versioned = copy.deepcopy(_accepted_authority())
+    versioned["analyzer_bundle"]["dependencies"] = [{"name": "requests", "version": "2.0"}]
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(versioned)
+    flags = copy.deepcopy(_accepted_authority())
+    flags["analyzer_bundle"]["interpreter_flags"] = ["-I"]
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(flags)
+    launcher = copy.deepcopy(_accepted_authority())
+    launcher["analyzer_bundle"]["launcher_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="execution contract mismatch"):
+        ratchet._bundle_metadata(launcher)
+
+
+def test_undeclared_import_fails_closed(tmp_path: Path):
+    root = tmp_path / "extraction"
+    (root / "scripts").mkdir(parents=True)
+    (root / "scripts/module_under_test.py").write_text(
+        "import importlib\nimportlib.import_module(computed_name)\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(gen.AuthorityClosureError, match="dynamic repository import is forbidden"):
+        gen._python_import_edges(root, "scripts/module_under_test.py")
+    (root / "scripts/missing_target.py").write_text(
+        "import scripts.never_written_module\n", encoding="utf-8"
+    )
+    with pytest.raises(gen.AuthorityClosureError, match="repository-local import is unavailable"):
+        gen._python_import_edges(root, "scripts/missing_target.py")
+
+
+def test_path_traversal_or_symlink_escape_fails_closed(tmp_path: Path):
+    root = tmp_path / "extract"
+    root.mkdir()
+    for hostile in ("../escape.txt", "/absolute.txt", "nested/../../escape.txt"):
+        with pytest.raises(gen.AuthorityClosureError, match="unsafe|escapes"):
+            gen._safe_archive_target(root, hostile)
+    assert gen._safe_archive_target(root, "nested/ok.txt") == (root / "nested/ok.txt").resolve()
+    # Symlinked external inputs are refused before any read.
+    target = tmp_path / "real.json"
+    target.write_bytes(b"{}\n")
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="symlink"):
+        ratchet._load_canonical_json_bytes(
+            link,
+            label="linked",
+            expected_byte_length=3,
+            expected_sha256=ratchet._sha256_bytes(b"{}\n"),
+            terminal_lf=True,
+        )
+    # Evidence-index resource paths cannot escape the evidence root.
+    with pytest.raises(ValueError, match="write outside explicit scratch/output roots"):
+        ratchet._guard_write_path(tmp_path / "outside.txt", root, root)
+
+
+def test_non_utf8_input_fails_closed(tmp_path: Path):
+    raw = b'{"a":"\xff\xfe"}\n'
+    path = tmp_path / "latin.json"
+    path.write_bytes(raw)
+    with pytest.raises(ValueError, match="not exact UTF-8"):
+        ratchet._load_canonical_json_bytes(
+            path,
+            label="latin",
+            expected_byte_length=len(raw),
+            expected_sha256=ratchet._sha256_bytes(raw),
+            terminal_lf=True,
+        )
+    with pytest.raises(ValueError, match="not exact UTF-8"):
+        ratchet._parse_canonical_json_raw(raw, label="latin", terminal_lf=True)
+
+
+def test_analyzer_timeout_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    root = tmp_path / "extraction"
+    (root / "aragora/cli/commands").mkdir(parents=True)
+    (root / "scripts").mkdir(parents=True)
+    (root / "aragora/cli/commands/review_queue.py").write_text("", encoding="utf-8")
+    (root / "scripts/tier4_merge_train.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(gen, "EXACT_REF_POLICY_TIMEOUT_SECONDS", 0.0001)
+    with pytest.raises(gen.AuthorityClosureError, match="timeout"):
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+    # The scratch runner/request files are cleaned up even on timeout.
+    assert not (root / "__contract_drift_exact_ref_runner.py").exists()
+    assert not (root / "__contract_drift_exact_ref_request.json").exists()
+
+
+def test_target_code_execution_attempt_fails_closed(tmp_path: Path):
+    # The classifier runner forbids subprocess/network/write actions via an
+    # audit hook; a policy module that attempts execution fails the classify
+    # call rather than executing target code.
+    root = tmp_path / "extraction"
+    (root / "aragora/cli/commands").mkdir(parents=True)
+    (root / "scripts").mkdir(parents=True)
+    for init in (
+        "aragora/__init__.py",
+        "aragora/cli/__init__.py",
+        "aragora/cli/commands/__init__.py",
+    ):
+        (root / init).write_text("", encoding="utf-8")
+    (root / "aragora/cli/commands/review_queue.py").write_text(
+        "import subprocess\nsubprocess.Popen(['/bin/echo', 'pwned'])\n",
+        encoding="utf-8",
+    )
+    (root / "scripts/tier4_merge_train.py").write_text("", encoding="utf-8")
+    with pytest.raises(gen.AuthorityClosureError, match="classifier failed"):
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+
+
+def test_caller_or_head_shadow_import_fails_closed(tmp_path: Path):
+    # The exact-ref runner pins sys.path[0] to the extraction root and
+    # verifies the loaded policy module resolves inside it; a caller- or
+    # head-planted shadow module outside the root is rejected.
+    runner = gen._EXACT_REF_RUNNER
+    assert "sys.path[:] = [str(root)" in runner
+    assert "noncanonical policy module" in runner
+    assert "namespace-blended or noncanonical package" in runner
+    root = tmp_path / "extraction"
+    (root / "aragora/cli/commands").mkdir(parents=True)
+    (root / "scripts").mkdir(parents=True)
+    # No __init__ chain: import resolves (namespace pkg) but fails the
+    # canonical-package check, proving shadow/namespace blends are refused.
+    (root / "aragora/cli/commands/review_queue.py").write_text("", encoding="utf-8")
+    (root / "scripts/tier4_merge_train.py").write_text("", encoding="utf-8")
+    with pytest.raises(gen.AuthorityClosureError, match="classifier failed"):
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+
+
+def test_exact_ref_review_queue_policy_unavailable_or_ambient_fails_closed(tmp_path: Path):
+    root = tmp_path / "extraction"
+    (root / "scripts").mkdir(parents=True)
+    (root / "scripts/tier4_merge_train.py").write_text("", encoding="utf-8")
+    with pytest.raises(gen.AuthorityClosureError, match="canonical exact-ref policy is unavailable"):  # fmt: skip
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+    (root / "aragora/cli/commands").mkdir(parents=True)
+    policy = root / "aragora/cli/commands/review_queue.py"
+    policy.write_text("", encoding="utf-8")
+    mirror = root / "scripts/tier4_merge_train.py"
+    mirror.unlink()
+    with pytest.raises(gen.AuthorityClosureError, match="merge-train mirror is unavailable"):
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+    mirror.write_text("", encoding="utf-8")
+    policy.unlink()
+    policy.symlink_to(root / "scripts/tier4_merge_train.py")
+    with pytest.raises(gen.AuthorityClosureError, match="cannot be a symlink"):
+        gen._invoke_exact_ref_policy(root, ["scripts/x.py"], scratch_root=tmp_path / "scratch")
+    # Ambient interpreter/site-packages authority is stripped: hermetic flags
+    # and a minimal environment (no inherited PYTHONPATH/HOME).
+    assert gen.PYTHON_FLAGS == ("-I", "-S")
+    env = gen._minimal_subprocess_env(tmp_path / "scratch-env")
+    assert "PYTHONPATH" not in env
+    assert set(env) == {"HOME", "LANG", "LC_ALL", "PATH", "TMPDIR", "TZ"}
+
+
+def test_incomplete_public_symbol_manifest_fails_closed():
+    manifest = {
+        "authority_roots": ["scripts/check_contract_drift_ratchet.py"],
+        "inventory": {},
+        "repo_files": [
+            {
+                "authority_root": True,
+                "path": "scripts/check_contract_drift_ratchet.py",
+                "sha256": "1" * 64,
+            }
+        ],
+        "authority_manifest_sha256": "0" * 64,
+    }
+    # A closure that omits the boundary verifier is unusable...
+    del manifest["repo_files"][0]
+    manifest["repo_files"].append(
+        {"authority_root": True, "path": "aragora/other.py", "sha256": "2" * 64}
+    )
+    with pytest.raises(ValueError, match="omits the boundary verifier"):
+        ratchet._authority_summary(manifest)
+    # ...and with the verifier restored, the summary derives the public-symbol
+    # digest from exactly the public/symbol members present, so omitting one
+    # changes the bound digest.
+    manifest["repo_files"] = [
+        {
+            "authority_root": True,
+            "path": "scripts/check_contract_drift_ratchet.py",
+            "sha256": "1" * 64,
+        },  # fmt: skip
+        {"authority_root": False, "path": "aragora/server/public_symbols.py", "sha256": "3" * 64},
+    ]
+    complete = ratchet._authority_summary(manifest)
+    manifest["repo_files"] = manifest["repo_files"][:1]
+    incomplete = ratchet._authority_summary(manifest)
+    assert complete["public_symbol_sha256"] != incomplete["public_symbol_sha256"]
+    assert complete["repo_file_count"] == 2 and incomplete["repo_file_count"] == 1
+
+
+def test_incomplete_operation_projection_fails_closed():
+    missing = copy.deepcopy(_cohort())
+    del missing["operation_projection"]
+    with pytest.raises(ValueError, match="lacks operation projection"):
+        ratchet._validate_original_cohort(missing)
+    short = copy.deepcopy(_cohort())
+    short["operation_projection"]["records"].pop()
+    with pytest.raises(ValueError, match="655 membership records"):
+        ratchet._validate_original_cohort(short)
+    unbalanced = copy.deepcopy(_cohort())
+    unbalanced["operation_projection"]["records"][0] = copy.deepcopy(
+        unbalanced["operation_projection"]["records"][1]
+    )
+    with pytest.raises(ValueError, match="biject|digest"):
+        ratchet._validate_original_cohort(unbalanced)
+
+
+def test_projection_edge_omission_exactly_one_assumption_or_edge_count_substitution_fails_closed():
+    cohort = _cohort()
+    multi_index = next(
+        index
+        for index, record in enumerate(cohort["operation_projection"]["records"])
+        if len(record["operation_edges"]) > 1
+    )
+    # Omitting one edge from a multi-edge membership breaks the ratified
+    # cardinality (666 edges) even when all digests are relinked.
+    omitted = copy.deepcopy(cohort)
+    omitted["operation_projection"]["records"][multi_index]["operation_edges"].pop()
+    _rehash_projection(omitted)
+    with pytest.raises(ValueError, match="record-digest-set mismatch|cardinality mismatch"):
+        ratchet._validate_original_cohort(omitted)
+    # An exactly-one-edge consumer assumption (collapsing every membership to
+    # its first edge) is likewise rejected.
+    collapsed = copy.deepcopy(cohort)
+    for record in collapsed["operation_projection"]["records"]:
+        record["operation_edges"] = record["operation_edges"][:1]
+    _rehash_projection(collapsed)
+    with pytest.raises(ValueError, match="record-digest-set mismatch|cardinality mismatch"):
+        ratchet._validate_original_cohort(collapsed)
+    # Edge-count-for-record-count substitution: 666 can never satisfy the 655
+    # membership requirement, in either direction.
+    padded = copy.deepcopy(cohort)
+    records = padded["operation_projection"]["records"]
+    while len(records) < 666:
+        records.append(copy.deepcopy(records[0]))
+    with pytest.raises(ValueError, match="655 membership records"):
+        ratchet._validate_original_cohort(padded)
+    summary = ratchet._validate_original_cohort(copy.deepcopy(cohort))
+    projection = summary["operation_projection"]
+    assert (projection["membership_count"], projection["edge_count"]) == (655, 666)

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -21,7 +21,7 @@ VERIFY = {
     "missing_stable": [],
 }
 ROUTES = {"missing_in_spec": ["m1"], "orphaned_in_spec": ["o1"]}
-PARITY = {"missing_from_both_sdks": []}
+PARITY: dict[str, list[str]] = {"missing_from_both_sdks": []}
 
 
 def _write_json(path: Path, payload: dict) -> None:
@@ -358,9 +358,9 @@ def _authority_fixture(
         "github_literal": "      - run: python .github/scripts/tool.py\n",
         "github_dynamic": "      - run: python .github/scripts/$HELPER.py\n",
     }
-    helper_run = dynamic_runs.get(
-        dynamic_run_reference, "      - run: python sdk/python/client.py\n"
-    )
+    helper_run = "      - run: python sdk/python/client.py\n"
+    if dynamic_run_reference is not None:
+        helper_run = dynamic_runs.get(dynamic_run_reference, helper_run)
     _write_text(
         repo / ".github/workflows/authority.yml",
         "on:\n"
@@ -1144,16 +1144,20 @@ def test_standalone_classifier_rejects_unavailable_or_ambient_policy(tmp_path: P
 
 
 @pytest.mark.parametrize(
-    ("fixture_options", "message"),
+    ("fixture_option", "message"),
     [
-        ({"namespace_package": True}, "namespace-blended or noncanonical package"),
-        ({"symlink_policy": True}, "policy cannot be a symlink"),
+        ("namespace_package", "namespace-blended or noncanonical package"),
+        ("symlink_policy", "policy cannot be a symlink"),
     ],
 )
 def test_standalone_classifier_rejects_namespace_blended_or_copied_policy(
-    tmp_path: Path, fixture_options: dict[str, bool], message: str
+    tmp_path: Path, fixture_option: str, message: str
 ):
-    repo, sha = _authority_fixture(tmp_path, **fixture_options)
+    repo, sha = _authority_fixture(
+        tmp_path,
+        namespace_package=fixture_option == "namespace_package",
+        symlink_policy=fixture_option == "symlink_policy",
+    )
     with pytest.raises(gen.AuthorityClosureError, match=message):
         _manifest(repo, sha)
 

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+import functools
 import json
 import os
 import subprocess
@@ -10,6 +12,7 @@ from pathlib import Path
 
 import pytest
 
+import scripts.check_contract_drift_ratchet as ratchet
 import scripts.generate_contract_drift_inventory as gen
 
 VERIFY = {
@@ -1410,3 +1413,723 @@ def test_exact_ref_mode_rejects_inventory_check_flag(tmp_path: Path):
     )
     assert proc.returncode == 1
     assert "cannot be combined with --ref" in proc.stdout
+
+
+# --- VAL-CDG-002: canonical census binds the ratified 655-record cohort -----
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SDK_CATEGORIES = ("python_sdk_drift", "typescript_sdk_drift")
+ROUTE_CATEGORIES = ("routes_missing_in_spec", "routes_orphaned_in_spec", "sdk_missing_from_both")
+RUNTIME_METHODS = frozenset(
+    {"CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"}
+)
+CATEGORY_LANGUAGES = {
+    "python_sdk_drift": ["python"],
+    "typescript_sdk_drift": ["typescript"],
+    "routes_missing_in_spec": [],
+    "routes_orphaned_in_spec": [],
+    "sdk_missing_from_both": ["python", "typescript"],
+}
+
+
+@functools.cache
+def _accepted_authority() -> dict:
+    inventory = json.loads((REPO_ROOT / gen.DEFAULT_INVENTORY).read_bytes())
+    authority = inventory["accepted_authority"]
+    assert authority["schema"] == "contract-drift-accepted-authority-v1"
+    return authority
+
+
+def _cohort() -> dict:
+    return _accepted_authority()["canonical_artifacts"]["original_cohort"]
+
+
+def _provenance() -> dict:
+    return _accepted_authority()["canonical_artifacts"]["sdk_provenance"]
+
+
+def _record_digest(record: dict) -> str:
+    return ratchet._sha256_bytes(
+        ratchet._canonical_json_bytes(
+            {key: value for key, value in record.items() if key != "record_sha256"}
+        )
+    )
+
+
+def _rehash_projection(cohort: dict) -> None:
+    projection = cohort["operation_projection"]
+    for record in projection["records"]:
+        record["record_sha256"] = _record_digest(record)
+    projection["record_digest_set_sha256"] = ratchet._digest_set(
+        "cdg-operation-projection-record-digest-set-v1",
+        [record["record_sha256"] for record in projection["records"]],
+        "record_sha256_values",
+    )
+
+
+def _original_id(category: str, literal: str) -> tuple[bytes, str]:
+    payload = {
+        "category": category,
+        "exact_historical_literal_record": literal,
+        "schema": "cdg-original-record-id-v1",
+    }
+    raw = ratchet._canonical_json_bytes(payload)
+    return raw, f"cdg1:{ratchet._sha256_bytes(raw)}"
+
+
+def _linked_provenance_mutation(mutate, *, index: int = 0) -> tuple[dict, dict]:
+    """Mutate one provenance record while keeping its digest and cohort link
+    self-consistent, so validation reaches the semantic check under test
+    instead of failing at the digest-binding layer."""
+    cohort = copy.deepcopy(_cohort())
+    provenance = copy.deepcopy(_provenance())
+    record = provenance["records"][index]
+    mutate(record)
+    record["record_sha256"] = _record_digest(record)
+    linked = next(
+        r
+        for r in cohort["original_records"]
+        if r["original_record_id"] == record["original_record_id"]
+    )
+    linked["sdk_provenance_record_sha256"] = record["record_sha256"]
+    return cohort, provenance
+
+
+def test_canonical_cohort_artifact_exact_length_sha_and_canonical_bytes(tmp_path: Path):
+    raw = ratchet._canonical_json_bytes(_cohort(), terminal_lf=True)
+    assert len(raw) == ratchet.COHORT_ARTIFACT["byte_length"] == 1_692_125
+    digest = ratchet._sha256_bytes(raw)
+    assert (
+        digest
+        == ratchet.COHORT_ARTIFACT["sha256"]
+        == "565cd84a9a5d266f61b66bd7965e0a036e4817ef5fed32edb8c41a2dea6cc208"
+    )
+    assert not raw.startswith(b"\xef\xbb\xbf")
+    assert raw.endswith(b"\n") and b"\n" not in raw[:-1]
+    path = tmp_path / ratchet.COHORT_ARTIFACT["filename"]
+    path.write_bytes(raw)
+    parsed, descriptor, _ = ratchet._read_canonical_json_bytes(
+        path,
+        label="canonical original-cohort artifact",
+        expected_byte_length=len(raw),
+        expected_sha256=digest,
+        terminal_lf=True,
+    )
+    assert parsed["schema"] == "contract-drift-original-cohort-v1"
+    assert descriptor["canonical_bytes_valid"] is True
+    # A parseable but differently serialized file fails even with matching pins.
+    hostile = json.dumps(json.loads(raw), separators=(", ", ": ")).encode() + b"\n"
+    hostile_path = tmp_path / "reserialized.json"
+    hostile_path.write_bytes(hostile)
+    with pytest.raises(ValueError, match="not canonical compact sorted-key JSON"):
+        ratchet._read_canonical_json_bytes(
+            hostile_path,
+            label="canonical original-cohort artifact",
+            expected_byte_length=len(hostile),
+            expected_sha256=ratchet._sha256_bytes(hostile),
+            terminal_lf=True,
+        )
+
+
+def test_canonical_sdk_provenance_artifact_exact_length_sha_and_canonical_bytes(tmp_path: Path):
+    raw = ratchet._canonical_json_bytes(_provenance(), terminal_lf=True)
+    assert len(raw) == ratchet.PROVENANCE_ARTIFACT["byte_length"] == 898_099
+    digest = ratchet._sha256_bytes(raw)
+    assert (
+        digest
+        == ratchet.PROVENANCE_ARTIFACT["sha256"]
+        == "21ae1c30200cda6df51dbca7053bbbbde6241ab78a73347b0fe5e4d2ed79f07f"
+    )
+    path = tmp_path / ratchet.PROVENANCE_ARTIFACT["filename"]
+    path.write_bytes(raw)
+    parsed, _, _ = ratchet._read_canonical_json_bytes(
+        path,
+        label="canonical SDK-provenance artifact",
+        expected_byte_length=len(raw),
+        expected_sha256=digest,
+        terminal_lf=True,
+    )
+    assert parsed["schema"] == "contract-drift-sdk-provenance-v1"
+    # Duplicate keys are rejected before any use of the parsed payload.
+    with pytest.raises(ValueError, match="[Dd]uplicate"):
+        json.loads('{"records": 1, "records": 2}', object_pairs_hook=ratchet._duplicate_key_object)
+    truncated = raw[:-2] + b"\n"
+    truncated_path = tmp_path / "truncated.json"
+    truncated_path.write_bytes(truncated)
+    with pytest.raises(ValueError, match="byte-length mismatch"):
+        ratchet._read_canonical_json_bytes(
+            truncated_path,
+            label="canonical SDK-provenance artifact",
+            expected_byte_length=ratchet.PROVENANCE_ARTIFACT["byte_length"],
+            expected_sha256=digest,
+            terminal_lf=True,
+        )
+
+
+def test_all_655_original_ids_reproduce_from_anchored_source_blobs():
+    cohort = _cohort()
+    records = cohort["original_records"]
+    assert len(records) == 655
+    by_source: dict[str, list[str]] = {}
+    for record in records:
+        raw, original_id = _original_id(
+            record["category"], record["exact_historical_literal_record"]
+        )
+        assert record["id_payload_byte_length"] == len(raw)
+        assert record["id_payload_sha256"] == ratchet._sha256_bytes(raw)
+        assert record["original_record_id"] == original_id
+        by_source.setdefault(record["source_json_key"], []).append(
+            record["exact_historical_literal_record"]
+        )
+    assert sorted(by_source) == sorted(
+        [
+            "python_sdk_drift",
+            "typescript_sdk_drift",
+            "missing_in_spec",
+            "orphaned_in_spec",
+            "missing_from_both_sdks",
+        ]  # fmt: skip
+    )
+    # Anchored source binding: every membership source pins blob bytes; when the
+    # anchor blobs are reachable in this clone, the cohort reproduces from them.
+    for source in cohort["membership_sources"]:
+        assert ratchet.SHA256_RE.fullmatch(source["sha256"])
+        assert source["commit_sha"] == cohort["membership_anchor"]["commit_sha"]
+        probe = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "cat-file", "blob", source["git_blob_oid"]],
+            capture_output=True,
+        )
+        if probe.returncode != 0:
+            continue
+        blob = probe.stdout
+        assert len(blob) == source["byte_length"]
+        assert ratchet._sha256_bytes(blob) == source["sha256"]
+        arrays = json.loads(blob)
+        for key, literals in by_source.items():
+            if key in arrays:
+                assert sorted(arrays[key]) == sorted(literals), key
+        if source["path"].endswith("verify_sdk_contracts.json"):
+            # Unrelated arrays such as missing_stable never join the cohort.
+            assert "missing_stable" in arrays
+            assert "missing_stable" not in by_source
+
+
+def test_ratified_original_id_set_digest_supersedes_provisional_digest():
+    cohort = _cohort()
+    original_ids = sorted(record["original_record_id"] for record in cohort["original_records"])
+    ratified = ratchet._digest_set(
+        "cdg-original-record-id-set-v1", original_ids, "original_record_ids"
+    )
+    assert (
+        ratified
+        == ratchet.ORIGINAL_ID_SET_SHA256
+        == "c1235670c183b1887ba3fe4280fa0320f9fd6f4a85b8f346d4332ac2aebbe269"
+    )
+    assert cohort["original_record_id_set"]["sha256"] == ratified
+    # Any other digest value — e.g. a stale provisional pin — is a hard failure
+    # even when it is internally consistent with the declared ID list.
+    hostile = copy.deepcopy(cohort)
+    provisional = ratchet._digest_set(
+        "cdg-original-record-id-set-v0", original_ids, "original_record_ids"
+    )
+    assert provisional != ratified
+    hostile["original_record_id_set"]["sha256"] = provisional
+    with pytest.raises(ValueError, match="ID-set digest mismatch"):
+        ratchet._validate_original_cohort(hostile)
+
+
+def test_sdk_598_records_remain_exact_method_bearing_literals():
+    records = [r for r in _cohort()["original_records"] if r["category"] in SDK_CATEGORIES]
+    assert len(records) == 598
+    assert sum(1 for r in records if r["category"] == "python_sdk_drift") == 74
+    assert sum(1 for r in records if r["category"] == "typescript_sdk_drift") == 524
+    for record in records:
+        method = record["method"]
+        assert isinstance(method, str) and method in RUNTIME_METHODS
+        literal = record["exact_historical_literal_record"]
+        token, _, path = literal.partition(" ")
+        assert token == method and path.startswith("/"), literal
+    hostile = copy.deepcopy(_cohort())
+    sdk_record = next(r for r in hostile["original_records"] if r["category"] == "python_sdk_drift")
+    sdk_record["method"] = None
+    with pytest.raises(ValueError, match="lacks a method"):
+        ratchet._validate_original_cohort(hostile)
+
+
+def test_route_parity_57_records_remain_exact_path_literals_with_null_method():
+    records = [r for r in _cohort()["original_records"] if r["category"] in ROUTE_CATEGORIES]
+    assert len(records) == 57
+    for record in records:
+        assert record["method"] is None
+        assert record["exact_historical_literal_record"].startswith("/")
+    counts = {c: sum(1 for r in records if r["category"] == c) for c in ROUTE_CATEGORIES}
+    assert counts == {
+        "routes_missing_in_spec": 11,
+        "routes_orphaned_in_spec": 17,
+        "sdk_missing_from_both": 29,
+    }
+    # No other original may carry a null method, and a path-level original may
+    # not grow one.
+    hostile = copy.deepcopy(_cohort())
+    route_record = next(
+        r for r in hostile["original_records"] if r["category"] == "routes_missing_in_spec"
+    )
+    route_record["method"] = "GET"
+    with pytest.raises(ValueError, match="carries a method"):
+        ratchet._validate_original_cohort(hostile)
+
+
+def test_null_method_is_forbidden_on_runtime_and_projection_edges():
+    projection = _cohort()["operation_projection"]
+    for record in projection["records"]:
+        for edge in record["operation_edges"]:
+            assert edge["method"] in RUNTIME_METHODS
+            assert edge["normalized_path"].startswith("/")
+            assert edge["evidence"]
+    hostile = copy.deepcopy(_cohort())
+    edge = hostile["operation_projection"]["records"][0]["operation_edges"][0]
+    for placeholder in (None, "", "get", "ANY", "*"):
+        edge["method"] = placeholder
+        _rehash_projection(hostile)
+        with pytest.raises(ValueError, match="invalid method"):
+            ratchet._validate_original_cohort(hostile)
+
+
+def test_sdk_provenance_reconstructs_from_pinned_birth_extractor_normalizer_and_source_closure():
+    provenance = _provenance()
+    birth = provenance["baseline_birth"]
+    for field in (
+        "commit_sha",
+        "first_parent_sha",
+        "commit_tree_git_oid",
+        "membership_anchor_baseline_blob_git_oid",
+        "parent_baseline_blob_git_oid",
+        "ratified_baseline_blob_git_oid",
+    ):
+        assert isinstance(birth[field], str) and birth[field], field
+    # The ratified birth blob is the membership-anchor baseline blob.
+    assert birth["ratified_baseline_blob_git_oid"] == birth["membership_anchor_baseline_blob_git_oid"]  # fmt: skip
+    dependencies = provenance["dependencies"]
+    assert sorted(dependencies) == sorted(
+        [
+            "baseline_source",
+            "normalizer",
+            "openapi_sources",
+            "python_namespace_tree",
+            "typescript_namespace_tree",
+            "verifier",
+        ]
+    )
+    for record in provenance["records"]:
+        assert record["record_sha256"] == _record_digest(record)
+        atoms = record["provenance_atoms"]
+        assert sorted({o["provenance_atom"] for o in record["source_occurrences"]}) == sorted(
+            set(atoms)
+        )
+        for occurrence in record["source_occurrences"]:
+            match_text = occurrence["match_text"]
+            assert occurrence["match_text_sha256"] == ratchet._sha256_bytes(match_text.encode())
+            assert occurrence["match_end_byte"] - occurrence["match_start_byte"] == len(
+                match_text.encode()
+            )
+            # The provenance atom is the historical namespace filename stem.
+            assert occurrence["provenance_atom"] == Path(occurrence["source_path"]).stem
+            assert occurrence["source_commit_sha"] == birth["commit_sha"]
+
+
+def test_sdk_provenance_has_598_records_690_occurrences_12_multi_atom_zero_missing():
+    provenance = _provenance()
+    records = provenance["records"]
+    assert len(records) == 598
+    occurrences = sum(len(record["source_occurrences"]) for record in records)
+    multi_atom = sum(1 for record in records if len(set(record["provenance_atoms"])) > 1)
+    assert (occurrences, multi_atom) == (690, 12)
+    assert all(record["source_occurrences"] for record in records)  # zero missing
+    summary = ratchet._validate_sdk_provenance(
+        provenance, ratchet._validate_original_cohort(_cohort())
+    )
+    assert summary["record_count"] == 598
+    assert summary["source_occurrence_count"] == 690
+    assert summary["multiple_atom_record_count"] == 12
+    assert summary["missing_provenance_count"] == 0
+    cohort, hostile = _linked_provenance_mutation(
+        lambda record: record.update(source_occurrences=[])
+    )
+    with pytest.raises(ValueError, match="lacks source occurrences"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+
+
+def test_sdk_provenance_per_record_links_and_digests_match_cohort():
+    cohort_summary = ratchet._validate_original_cohort(_cohort())
+    cohort_sdk = cohort_summary["sdk_records"]
+    provenance = _provenance()
+    for record in provenance["records"]:
+        cohort_record = cohort_sdk[record["original_record_id"]]
+        for field in (
+            "category",
+            "exact_historical_literal_record",
+            "id_payload_byte_length",
+            "id_payload_sha256",
+            "source_array_index",
+        ):
+            assert record[field] == cohort_record[field], field
+        assert cohort_record["sdk_language"] == [record["sdk_language"]]
+        assert cohort_record["sdk_provenance_record_sha256"] == record["record_sha256"]
+    hostile = copy.deepcopy(provenance)
+    hostile["records"][0]["source_array_index"] += 1
+    hostile["records"][0]["record_sha256"] = _record_digest(hostile["records"][0])
+    with pytest.raises(ValueError, match="source_array_index link mismatch"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(_cohort()))
+    stale = copy.deepcopy(provenance)
+    stale["records"][1]["record_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="digest mismatch"):
+        ratchet._validate_sdk_provenance(stale, ratchet._validate_original_cohort(_cohort()))
+
+
+def test_sdk_partition_has_exact_75_core_523_extended_and_pinned_digests():
+    provenance = _provenance()
+    partitions: dict[str, list[str]] = {"core": [], "extended": []}
+    for record in provenance["records"]:
+        partition, _ = ratchet._partition_from_atoms(record["provenance_atoms"])
+        assert partition == record["partition"]
+        partitions[partition].append(record["original_record_id"])
+    assert (len(partitions["core"]), len(partitions["extended"])) == (75, 523)
+    descriptor = provenance["partition"]
+    assert descriptor["intersection_count"] == 0 and descriptor["union_count"] == 598
+    expectations = {
+        "core_original_record_id_set_sha256": (
+            "cdg-core-original-record-id-set-v1",
+            partitions["core"],
+            ratchet.CORE_ID_SET_SHA256,
+        ),
+        "extended_original_record_id_set_sha256": (
+            "cdg-extended-original-record-id-set-v1",
+            partitions["extended"],
+            ratchet.EXTENDED_ID_SET_SHA256,
+        ),
+        "sdk_original_record_id_set_sha256": (
+            "cdg-sdk-original-record-id-set-v1",
+            partitions["core"] + partitions["extended"],
+            ratchet.SDK_ID_SET_SHA256,
+        ),
+    }
+    for field, (schema, ids, pinned) in expectations.items():
+        recomputed = ratchet._digest_set(schema, sorted(ids), "original_record_ids")
+        assert descriptor[field] == recomputed == pinned, field
+
+
+def test_original_descriptor_and_provenance_are_identical_across_authority_transitions():
+    authority = _accepted_authority()
+    result = ratchet.compare_accepted_authorities(
+        authority, copy.deepcopy(authority), repo_root=REPO_ROOT
+    )
+    assert result["status"] == "pass"
+    assert result["added_original_record_ids"] == []
+    assert result["removed_original_record_ids"] == []
+    # A transition that touches one ratified literal is rejected outright.
+    hostile = copy.deepcopy(authority)
+    record = hostile["canonical_artifacts"]["original_cohort"]["original_records"][0]
+    record["exact_historical_literal_record"] += "/renamed"
+    with pytest.raises(ValueError):
+        ratchet.compare_accepted_authorities(authority, hostile, repo_root=REPO_ROOT)
+    # Swapping the analyzer bundle is an authority change, not a transition.
+    rebundled = copy.deepcopy(authority)
+    rebundled["analyzer_bundle"]["files"][0]["sha256"] = "f" * 64
+    with pytest.raises(ValueError):
+        ratchet.compare_accepted_authorities(authority, rebundled, repo_root=REPO_ROOT)
+
+
+def test_operation_projection_has_one_membership_per_655_originals():
+    cohort = _cohort()
+    projection_ids = [
+        record["original_record_id"] for record in cohort["operation_projection"]["records"]
+    ]
+    original_ids = [record["original_record_id"] for record in cohort["original_records"]]
+    assert len(projection_ids) == len(original_ids) == 655
+    assert len(set(projection_ids)) == 655
+    assert sorted(projection_ids) == sorted(original_ids)
+    hostile = copy.deepcopy(cohort)
+    duplicated = hostile["operation_projection"]["records"]
+    duplicated[1] = copy.deepcopy(duplicated[0])
+    _rehash_projection(hostile)
+    with pytest.raises(ValueError, match="does not biject"):
+        ratchet._validate_original_cohort(hostile)
+
+
+def test_operation_projection_has_666_edges_and_nine_multi_edge_originals_max_four():
+    cohort = _cohort()
+    sizes = [len(record["operation_edges"]) for record in cohort["operation_projection"]["records"]]
+    assert sum(sizes) == 666
+    assert sum(1 for size in sizes if size > 1) == 9
+    assert max(sizes) == 4
+    distribution = {size: sizes.count(size) for size in sorted(set(sizes))}
+    assert distribution == {1: 646, 2: 8, 4: 1}
+    by_id = {record["original_record_id"]: record for record in cohort["original_records"]}
+    sdk_sizes = [
+        len(record["operation_edges"])
+        for record in cohort["operation_projection"]["records"]
+        if by_id[record["original_record_id"]]["category"] in SDK_CATEGORIES
+    ]
+    assert sdk_sizes.count(1) == len(sdk_sizes) == 598
+    route_sizes = sorted(
+        len(record["operation_edges"])
+        for record in cohort["operation_projection"]["records"]
+        if by_id[record["original_record_id"]]["category"] in ROUTE_CATEGORIES
+    )
+    assert route_sizes == [1] * 48 + [2] * 8 + [4]
+    assert sum(route_sizes) == 68
+
+
+def test_every_witnessed_method_specific_edge_is_preserved():
+    cohort = _cohort()
+    for record in cohort["operation_projection"]["records"]:
+        edges = {(edge["method"], edge["normalized_path"]) for edge in record["operation_edges"]}
+        assert len(edges) == len(record["operation_edges"])  # distinct witnessed set
+        for edge in record["operation_edges"]:
+            assert edge["evidence"], edge["normalized_path"]
+    # Omitting one witnessed method-specific edge from the four-edge membership
+    # is caught by the pinned record-digest set even after rehashing.
+    hostile = copy.deepcopy(cohort)
+    victim = next(
+        record
+        for record in hostile["operation_projection"]["records"]
+        if len(record["operation_edges"]) == 4
+    )
+    victim["operation_edges"].pop()
+    _rehash_projection(hostile)
+    with pytest.raises(ValueError, match="record-digest-set mismatch"):
+        ratchet._validate_original_cohort(hostile)
+    # Cross-method collapse (rewriting an edge onto a sibling method) fails too.
+    collapsed = copy.deepcopy(cohort)
+    twin = next(
+        record
+        for record in collapsed["operation_projection"]["records"]
+        if len(record["operation_edges"]) == 2
+    )
+    twin["operation_edges"][1]["method"] = twin["operation_edges"][0]["method"]
+    twin["operation_edges"][1]["normalized_path"] = twin["operation_edges"][0]["normalized_path"]
+    _rehash_projection(collapsed)
+    with pytest.raises(ValueError, match="duplicate edges"):
+        ratchet._validate_original_cohort(collapsed)
+
+
+def test_edge_count_never_substitutes_for_original_count():
+    cohort = _cohort()
+    edge_count = sum(
+        len(record["operation_edges"]) for record in cohort["operation_projection"]["records"]
+    )
+    assert edge_count == 666 != 655
+    assert cohort["counts"]["records"] == 655
+    assert len(cohort["original_records"]) == 655
+    hostile = copy.deepcopy(cohort)
+    hostile["counts"]["records"] = 666
+    with pytest.raises(ValueError, match="declared counts mismatch"):
+        ratchet._validate_original_cohort(hostile)
+    # Replacing the cohort list with one record per edge (666 rows) fails the
+    # census outright: membership count is the original count, never edges.
+    fanout = copy.deepcopy(cohort)
+    fanout["original_records"].extend(copy.deepcopy(fanout["original_records"][:11]))
+    with pytest.raises(ValueError, match="exactly 655 original records"):
+        ratchet._validate_original_cohort(fanout)
+
+
+def test_exactly_one_edge_assumption_fails(monkeypatch):
+    cohort = copy.deepcopy(_cohort())
+    for record in cohort["operation_projection"]["records"]:
+        del record["operation_edges"][1:]
+    _rehash_projection(cohort)
+    # The flattened projection cannot pass against the ratified digest pin...
+    with pytest.raises(ValueError, match="record-digest-set mismatch"):
+        ratchet._validate_original_cohort(cohort)
+    # ...and even a re-pinned digest cannot satisfy the (666, 9, 4) invariant:
+    # exactly-one-edge assumptions are structurally rejected.
+    monkeypatch.setattr(
+        ratchet,
+        "PROJECTION_RECORD_SET_SHA256",
+        cohort["operation_projection"]["record_digest_set_sha256"],
+    )
+    with pytest.raises(ValueError, match="cardinality mismatch"):
+        ratchet._validate_original_cohort(cohort)
+
+
+def test_projection_revision_cannot_change_original_id_sets():
+    cohort = _cohort()
+    hostile = copy.deepcopy(cohort)
+    projection = hostile["operation_projection"]
+    victim = next(r for r in projection["records"] if len(r["operation_edges"]) == 4)
+    projection["records"].remove(victim)
+    for index, edge in enumerate(victim["operation_edges"]):
+        replacement = {
+            "operation_edges": [edge],
+            "original_record_id": f"{victim['original_record_id']}:{index}",
+        }
+        projection["records"].append(replacement)
+    _rehash_projection(hostile)
+    with pytest.raises(ValueError, match="must contain 655 membership records"):
+        ratchet._validate_original_cohort(hostile)
+    # Same membership count but a swapped original ID also fails the bijection.
+    swapped = copy.deepcopy(cohort)
+    _, foreign_id = _original_id("python_sdk_drift", "GET /api/never-witnessed")
+    swapped["operation_projection"]["records"][0]["original_record_id"] = foreign_id
+    _rehash_projection(swapped)
+    with pytest.raises(ValueError, match="does not biject"):
+        ratchet._validate_original_cohort(swapped)
+
+
+def test_sdk_language_exact_mapping_is_provenance_not_identity():
+    cohort = _cohort()
+    for record in cohort["original_records"]:
+        assert record["sdk_language"] == CATEGORY_LANGUAGES[record["category"]]
+        # Identity hashes only category + exact literal + schema: language is
+        # provenance metadata and never enters the ID payload.
+        raw, original_id = _original_id(
+            record["category"], record["exact_historical_literal_record"]
+        )
+        assert record["original_record_id"] == original_id
+        assert b"sdk_language" not in raw
+    for record in _provenance()["records"]:
+        assert [record["sdk_language"]] == CATEGORY_LANGUAGES[record["category"]]
+        for occurrence in record["source_occurrences"]:
+            assert occurrence["sdk_language"] == record["sdk_language"]
+
+
+def test_language_metadata_change_cannot_change_original_record_id():
+    cohort = _cohort()
+    record = next(r for r in cohort["original_records"] if r["category"] == "python_sdk_drift")
+    mutated = dict(record, sdk_language=["typescript"])
+    _, mutated_id = _original_id(mutated["category"], mutated["exact_historical_literal_record"])
+    assert mutated_id == record["original_record_id"]  # identity is unchanged
+    # But the census rejects the inconsistent language mapping rather than
+    # minting a new identity for it.
+    hostile = copy.deepcopy(_provenance())
+    victim = hostile["records"][0]
+    victim["sdk_language"] = "typescript" if victim["category"] == "python_sdk_drift" else "python"
+    victim["record_sha256"] = _record_digest(victim)
+    with pytest.raises(ValueError, match="language link mismatch"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(_cohort()))
+
+
+def test_sdk_partition_is_disjoint_exhaustive_and_category_preserving():
+    provenance = _provenance()
+    core = {r["original_record_id"] for r in provenance["records"] if r["partition"] == "core"}
+    extended = {
+        r["original_record_id"] for r in provenance["records"] if r["partition"] == "extended"
+    }
+    assert not core & extended
+    sdk_ids = {
+        record["original_record_id"]
+        for record in _cohort()["original_records"]
+        if record["category"] in SDK_CATEGORIES
+    }
+    assert core | extended == sdk_ids
+    by_category = {"python_sdk_drift": 0, "typescript_sdk_drift": 0}
+    for record in provenance["records"]:
+        by_category[record["category"]] += 1
+    assert by_category == {"python_sdk_drift": 74, "typescript_sdk_drift": 524}
+    assert provenance["counts"]["python_sdk_drift"] == 74
+    assert provenance["counts"]["typescript_sdk_drift"] == 524
+    cohort, hostile = _linked_provenance_mutation(
+        lambda record: record.update(
+            partition="extended" if record["partition"] == "core" else "core"
+        )
+    )
+    with pytest.raises(ValueError, match="partition mismatch"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+
+
+def test_sdk_partition_exact_hyphen_and_single_plural_whole_atom_rules():
+    partition, matches = ratchet._partition_from_atoms(["debate"])
+    assert partition == "core"
+    assert matches == [
+        {
+            "atom": "debate",
+            "domain": "debate",
+            "match_rule": "exact",
+            "normalized_atom": "debate",
+        }
+    ]
+    # Hyphens normalize to underscores before comparison.
+    assert ratchet._partition_from_atoms(["de-bate"]) == ("extended", [])
+    # Exactly one trailing s maps a plural onto its core domain.
+    plural_partition, plural_matches = ratchet._partition_from_atoms(["rankings"])
+    assert plural_partition == "core"
+    assert plural_matches[0]["match_rule"] == "remove_exactly_one_trailing_s"
+    assert plural_matches[0]["domain"] == "ranking"
+    # A double plural is not reduced twice.
+    assert ratchet._partition_from_atoms(["rankingss"]) == ("extended", [])
+    # 'agents' is itself a core domain: matched exactly, not via plural rule.
+    agents_partition, agents_matches = ratchet._partition_from_atoms(["agents"])
+    assert agents_partition == "core" and agents_matches[0]["match_rule"] == "exact"
+    # Mixed arrays with at least one matching whole atom are core.
+    mixed_partition, mixed_matches = ratchet._partition_from_atoms(["billing", "memory"])
+    assert mixed_partition == "core"
+    assert [match["atom"] for match in mixed_matches] == ["memory"]
+
+
+def test_sdk_partition_rejects_substrings_free_text_paths_and_malformed_atoms():
+    for hostile_atom in (
+        "debate_utils",  # embedded domain word
+        "predebate",  # substring on the left
+        "the memory subsystem is great",  # free text
+        "aragora/memory/handler.py",  # path fragment
+        "memory.py",  # filename, not a whole atom
+    ):
+        partition, matches = ratchet._partition_from_atoms([hostile_atom])
+        assert (partition, matches) == ("extended", []), hostile_atom
+    for malformed in ([], [""], [123], [None], ["memory", ""]):
+        with pytest.raises(ValueError, match="nonempty string array"):
+            ratchet._partition_from_atoms(malformed)
+
+
+def test_sdk_partition_missing_or_empty_provenance_fails_closed():
+    def _drop_atoms(record: dict) -> None:
+        del record["provenance_atoms"]
+
+    cohort, hostile = _linked_provenance_mutation(_drop_atoms)
+    with pytest.raises(ValueError, match="lacks provenance atoms"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+    cohort, empty = _linked_provenance_mutation(lambda record: record.update(provenance_atoms=[]))
+    with pytest.raises(ValueError, match="nonempty string array"):
+        ratchet._validate_sdk_provenance(empty, ratchet._validate_original_cohort(cohort))
+
+
+def test_sdk_partition_is_scheduling_metadata_only():
+    provenance = _provenance()
+    record = provenance["records"][0]
+    # Partition never enters the identity payload...
+    raw, original_id = _original_id(record["category"], record["exact_historical_literal_record"])
+    assert b"partition" not in raw
+    assert record["original_record_id"] == original_id
+    # ...and never appears on active-inventory rows, which carry only identity,
+    # category, status, and disposition history.
+    for row in _accepted_authority()["active_inventory"]:
+        assert set(row) == {"category", "disposition_history", "original_record_id", "status"}
+    # Moving a record between partitions does not change its original ID.
+    moved = dict(record, partition="extended" if record["partition"] == "core" else "core")
+    _, moved_id = _original_id(moved["category"], moved["exact_historical_literal_record"])
+    assert moved_id == record["original_record_id"]
+
+
+def test_annotation_or_later_move_cannot_change_partition(monkeypatch):
+    provenance = _provenance()
+    # The partition is a pure function of the provenance atoms: annotating a
+    # record (or "moving" it later) without changing atoms cannot change it.
+    for record in provenance["records"][:25]:
+        recomputed, matches = ratchet._partition_from_atoms(record["provenance_atoms"])
+        assert recomputed == record["partition"]
+        assert matches == record["matched_domains"]
+    core_index = next(
+        index for index, record in enumerate(provenance["records"]) if record["partition"] == "core"
+    )
+    cohort, hostile = _linked_provenance_mutation(
+        lambda record: record.update(matched_domains=[]), index=core_index
+    )
+    with pytest.raises(ValueError, match="matched-domain proof mismatch"):
+        ratchet._validate_sdk_provenance(hostile, ratchet._validate_original_cohort(cohort))
+    # A wholesale rule swap (annotation layer redefining the grammar) is not
+    # honored either: the validator recomputes from the pinned rule.
+    monkeypatch.setattr(ratchet, "CORE_DOMAINS", frozenset({"billing"}))
+    with pytest.raises(ValueError, match="partition mismatch"):
+        ratchet._validate_sdk_provenance(
+            copy.deepcopy(provenance), ratchet._validate_original_cohort(_cohort())
+        )

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -2861,41 +2861,6 @@ def test_authority_manifest_mismatch_fails_closed(tmp_path: Path):
         )
 
 
-def test_dependency_hash_or_version_mismatch_fails_closed(tmp_path: Path):
-    authority = copy.deepcopy(_accepted_authority())
-    authority["analyzer_bundle"]["files"][0]["sha256"] = "0" * 64
-    with pytest.raises(ValueError, match="bundle digest mismatch"):
-        ratchet._validate_bundle(authority, Path(ratchet.__file__).parents[1])
-    versioned = copy.deepcopy(_accepted_authority())
-    versioned["analyzer_bundle"]["dependencies"] = [{"name": "requests", "version": "2.0"}]
-    with pytest.raises(ValueError, match="execution contract mismatch"):
-        ratchet._bundle_metadata(versioned)
-    flags = copy.deepcopy(_accepted_authority())
-    flags["analyzer_bundle"]["interpreter_flags"] = ["-I"]
-    with pytest.raises(ValueError, match="execution contract mismatch"):
-        ratchet._bundle_metadata(flags)
-    launcher = copy.deepcopy(_accepted_authority())
-    launcher["analyzer_bundle"]["launcher_sha256"] = "0" * 64
-    with pytest.raises(ValueError, match="execution contract mismatch"):
-        ratchet._bundle_metadata(launcher)
-
-
-def test_undeclared_import_fails_closed(tmp_path: Path):
-    root = tmp_path / "extraction"
-    (root / "scripts").mkdir(parents=True)
-    (root / "scripts/module_under_test.py").write_text(
-        "import importlib\nimportlib.import_module(computed_name)\n",
-        encoding="utf-8",
-    )
-    with pytest.raises(gen.AuthorityClosureError, match="dynamic repository import is forbidden"):
-        gen._python_import_edges(root, "scripts/module_under_test.py")
-    (root / "scripts/missing_target.py").write_text(
-        "import scripts.never_written_module\n", encoding="utf-8"
-    )
-    with pytest.raises(gen.AuthorityClosureError, match="repository-local import is unavailable"):
-        gen._python_import_edges(root, "scripts/missing_target.py")
-
-
 def test_path_traversal_or_symlink_escape_fails_closed(tmp_path: Path):
     root = tmp_path / "extract"
     root.mkdir()

--- a/tests/scripts/test_generate_contract_drift_inventory.py
+++ b/tests/scripts/test_generate_contract_drift_inventory.py
@@ -2110,6 +2110,216 @@ def test_sdk_partition_is_scheduling_metadata_only():
     assert moved_id == record["original_record_id"]
 
 
+# --- VAL-CDG-005 (census side): closed category schema ----------------------
+
+CATEGORY_SOURCE_KEYS = {
+    "python_sdk_drift": "python_sdk_drift",
+    "typescript_sdk_drift": "typescript_sdk_drift",
+    "routes_missing_in_spec": "missing_in_spec",
+    "routes_orphaned_in_spec": "orphaned_in_spec",
+    "sdk_missing_from_both": "missing_from_both_sdks",
+}
+CATEGORY_SOURCE_PATHS = {
+    "python_sdk_drift": "scripts/baselines/verify_sdk_contracts.json",
+    "typescript_sdk_drift": "scripts/baselines/verify_sdk_contracts.json",
+    "routes_missing_in_spec": "scripts/baselines/validate_openapi_routes.json",
+    "routes_orphaned_in_spec": "scripts/baselines/validate_openapi_routes.json",
+    "sdk_missing_from_both": "scripts/baselines/check_sdk_parity.json",
+}
+
+
+def _reidentified_category_mutation(category: str) -> dict:
+    """Reclassify a path-level record into `category` with all ID bookkeeping
+    recomputed, leaving only the closed-schema/count layer to reject it."""
+    hostile = copy.deepcopy(_cohort())
+    record = next(
+        r for r in hostile["original_records"] if r["category"] == "routes_missing_in_spec"
+    )
+    record["category"] = category
+    raw, original_id = _original_id(category, record["exact_historical_literal_record"])
+    record.update(
+        id_payload_byte_length=len(raw),
+        id_payload_sha256=ratchet._sha256_bytes(raw),
+        original_record_id=original_id,
+    )
+    ids = sorted(r["original_record_id"] for r in hostile["original_records"])
+    hostile["original_record_id_set"] = {
+        "original_record_ids": ids,
+        "sha256": ratchet._digest_set("cdg-original-record-id-set-v1", ids, "original_record_ids"),
+    }
+    return hostile
+
+
+def test_category_schema_is_closed_and_complete():
+    schema_categories = sorted(CATEGORY_SOURCE_KEYS)
+    assert sorted(ratchet.EXPECTED_CATEGORY_COUNTS) == schema_categories
+    assert sorted(ratchet.ACCEPTED_CATEGORIES) == schema_categories
+    assert _accepted_authority()["categories"] == list(ratchet.ACCEPTED_CATEGORIES)
+    # Every category occurs exactly once in the analyzer count plumbing and in
+    # the generator baseline specs; there is no sixth bucket.
+    count_lists = [(alias, list_key) for _count, alias, list_key in ratchet.COUNT_KEYS]
+    assert len(count_lists) == len(set(count_lists)) == 5
+    spec_lists = [
+        (alias, list_key)
+        for alias, (_path, list_keys) in gen.BASELINE_SPECS.items()
+        for list_key in list_keys
+    ]
+    assert sorted(spec_lists) == sorted(count_lists)
+    counts = _cohort()["counts"]["by_category"]
+    assert sorted(counts) == schema_categories  # complete, including any zero
+    assert sum(counts.values()) == 655
+    # An added sixth category fails the closed schema even with consistent IDs.
+    with pytest.raises(ValueError, match="ID-set digest mismatch|category counts mismatch"):
+        ratchet._validate_original_cohort(_reidentified_category_mutation("experimental_drift"))
+
+
+def test_ratified_category_literal_shapes_and_sdk_language_mapping_match():
+    for record in _cohort()["original_records"]:
+        category = record["category"]
+        literal = record["exact_historical_literal_record"]
+        assert record["source_json_key"] == CATEGORY_SOURCE_KEYS[category]
+        assert record["source_manifest"]["path"] == CATEGORY_SOURCE_PATHS[category]
+        assert record["sdk_language"] == CATEGORY_LANGUAGES[category]
+        if category in SDK_CATEGORIES:
+            token, _, path = literal.partition(" ")
+            assert token == record["method"] and token in RUNTIME_METHODS
+            assert path.startswith("/")
+        else:
+            assert record["method"] is None
+            assert literal.startswith("/") and " " not in literal
+
+
+def test_method_null_is_limited_to_57_original_path_memberships():
+    cohort = _cohort()
+    null_records = [r for r in cohort["original_records"] if r["method"] is None]
+    assert len(null_records) == 57
+    assert {r["category"] for r in null_records} <= set(ROUTE_CATEGORIES)
+    assert sum(1 for r in cohort["original_records"] if r["method"] is not None) == 598
+    null_ids = {r["original_record_id"] for r in null_records}
+    memberships = [
+        record
+        for record in cohort["operation_projection"]["records"]
+        if record["original_record_id"] in null_ids
+    ]
+    assert len(memberships) == 57
+    assert sum(len(m["operation_edges"]) for m in memberships) == 68
+    # Path-level membership never leaks a null method onto its runtime edges.
+    for membership in memberships:
+        for edge in membership["operation_edges"]:
+            assert edge["method"] in RUNTIME_METHODS
+
+
+def test_runtime_and_projection_edges_require_exact_method_tokens():
+    for record in _cohort()["operation_projection"]["records"]:
+        for edge in record["operation_edges"]:
+            assert edge["method"] in RUNTIME_METHODS
+            assert edge["method"] == edge["method"].upper()
+    hostile = copy.deepcopy(_cohort())
+    edge = hostile["operation_projection"]["records"][0]["operation_edges"][0]
+    for token in ("get", "GETS", " GET", "GET ", "ANY", "*", None):
+        edge["method"] = token
+        _rehash_projection(hostile)
+        with pytest.raises(ValueError, match="invalid method"):
+            ratchet._validate_original_cohort(hostile)
+
+
+def test_unknown_category_fails_closed():
+    # Census side: a record reclassified into an unknown category (with its ID
+    # bookkeeping fully recomputed) still fails the closed schema.
+    with pytest.raises(ValueError, match="ID-set digest mismatch|category counts mismatch"):
+        ratchet._validate_original_cohort(_reidentified_category_mutation("other_bucket"))
+    # Generator side: unknown baseline arrays never enter discovery — there is
+    # no 'other' bucket in collect_ids.
+    docs = {
+        "verify": {
+            "python_sdk_drift": ["GET /a"],
+            "typescript_sdk_drift": [],
+            "experimental_drift": ["GET /other"],
+        },
+        "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
+        "parity": {"missing_from_both_sdks": []},
+    }
+    ids = gen.collect_ids(docs)
+    assert sorted(ids) == ["python_sdk_drift:GET /a"]
+    assert not any("experimental" in item_id for item_id in ids)
+
+
+def test_missing_schema_category_fails_closed():
+    hostile = copy.deepcopy(_cohort())
+    hostile["schema"] = "contract-drift-original-cohort-v0"
+    with pytest.raises(ValueError, match="schema mismatch"):
+        ratchet._validate_original_cohort(hostile)
+    missing_field = copy.deepcopy(_cohort())
+    del missing_field["original_records"][0]["category"]
+    with pytest.raises(ValueError, match="lacks identity fields"):
+        ratchet._validate_original_cohort(missing_field)
+    missing_counts = copy.deepcopy(_cohort())
+    del missing_counts["counts"]["by_category"]
+    with pytest.raises(ValueError, match="declared counts mismatch"):
+        ratchet._validate_original_cohort(missing_counts)
+
+
+def test_category_literal_shape_or_provenance_mismatch_fails_closed():
+    # A mutated literal breaks the bound ID payload before anything downstream
+    # can consume the malformed shape.
+    hostile = copy.deepcopy(_cohort())
+    hostile["original_records"][0]["exact_historical_literal_record"] += "?tampered"
+    with pytest.raises(ValueError, match="ID payload (length|digest) mismatch"):
+        ratchet._validate_original_cohort(hostile)
+    # A provenance-incoherent SDK record (cohort digest link no longer equal to
+    # the recomputed provenance record digest) fails closed.
+    cohort = copy.deepcopy(_cohort())
+    provenance = copy.deepcopy(_provenance())
+    linked = next(
+        r
+        for r in cohort["original_records"]
+        if r["original_record_id"] == provenance["records"][0]["original_record_id"]
+    )
+    linked["sdk_provenance_record_sha256"] = "0" * 64
+    with pytest.raises(ValueError, match="cohort digest link mismatch"):
+        ratchet._validate_sdk_provenance(provenance, ratchet._validate_original_cohort(cohort))
+
+
+# --- VAL-CDG-003 (census side): annotations are nonoperative ----------------
+
+
+def test_annotation_order_and_shape_do_not_change_original_record_ids():
+    record = _cohort()["original_records"][0]
+    raw, original_id = _original_id(record["category"], record["exact_historical_literal_record"])
+    assert record["original_record_id"] == original_id
+    # The ID payload embeds exactly the three identity fields; annotations of
+    # any shape sit outside it and cannot perturb the digest.
+    annotated = {
+        **record,
+        "annotations": {"candidate_intentional_growth": True, "reviewers": ["a", "b"]},
+        "generated_artifact": None,
+        "stale_sdk": [{"since": "2026-07-01"}],
+    }
+    _, annotated_id = _original_id(
+        annotated["category"], annotated["exact_historical_literal_record"]
+    )
+    assert annotated_id == original_id
+    assert json.loads(raw.decode()) == {
+        "category": record["category"],
+        "exact_historical_literal_record": record["exact_historical_literal_record"],
+        "schema": "cdg-original-record-id-v1",
+    }
+    # Reordering the cohort array changes bytes, never the governed ID set.
+    reordered = copy.deepcopy(_cohort())
+    reordered["original_records"] = list(reversed(reordered["original_records"]))
+    assert sorted(r["original_record_id"] for r in reordered["original_records"]) == sorted(
+        r["original_record_id"] for r in _cohort()["original_records"]
+    )
+    # Generator discovery keys are equally annotation-blind: baseline-derived
+    # IDs come only from the source arrays, never inventory annotations.
+    docs = {
+        "verify": {"python_sdk_drift": ["GET /a"], "typescript_sdk_drift": []},
+        "routes": {"missing_in_spec": [], "orphaned_in_spec": []},
+        "parity": {"missing_from_both_sdks": []},
+    }
+    assert gen.collect_ids(docs) == {"python_sdk_drift:GET /a": "python_sdk_drift"}
+
+
 def test_annotation_or_later_move_cannot_change_partition(monkeypatch):
     provenance = _provenance()
     # The partition is a pure function of the provenance atoms: annotating a


### PR DESCRIPTION
## Source

Mission feature `cdg-corrective-bootstrap-test-closure` (milestone `cdg-bootstrap-route-truth`), authorized by operator Decision 340 (2026-07-27): the uncapped tests-only contract closure that follows merged PR #9645 (accepted corrective authority, merge `d3e45fafe6`) and the observability closure (#9683). Sole `fulfills` owner of VAL-CDG-002 through VAL-CDG-009, VAL-CDG-013 through VAL-CDG-015, and VAL-CDG-020.

## Behavior summary

Tests-only. Exactly three contract-designated files change:

- `tests/scripts/test_generate_contract_drift_inventory.py` (+1674/-9)
- `tests/scripts/test_check_contract_drift_ratchet.py` (+4860/-2)
- `tests/scripts/test_contract_drift_workflow.py` (+845/-1)

Every exact test name listed by the twelve owned assertions now exists exactly once as a substantive behavior-specific test (shared helpers only; no dynamic aliases/wrappers, no duplicate collection, no skip/xfail, no selector or contract renaming). Coverage includes: canonical cohort/provenance artifact bytes/digests and all 655/598/655/666 identities/edges; provenance and partition reconstruction; annotation non-operation; hermetic base-analyzer execution with hostile import/path/dependency/bundle cases; Decision-351 exact patch SHA and six-file `+687/-178 = 865` binding with the H2 -> guard-v2 H3 -> #9679 re-pin settlement/merge -> empty H4 -> #9645 settlement/merge chronology; historical-only old heads/evidence and #9346/#9320 dispositions; reference-relative shrink-only residue in PR and receipt/program modes; strict monotonic/live-truth paydown and program arithmetic; distinct workflow/check topology; UTC trajectory arithmetic.

## Validation (all in worktree at head)

- All 12 assertion selector collect-only proofs: nonempty, each exact function present once, exit 0; all 12 executions PASS (002:26, 003:6, 004:17, 005:15, 006:9, 007:50, 008:7, 009:16, 013:39, 014:30, 015:23, 020:2 selected tests).
- Full three-file suite: `469 passed`.
- `tests/governance/`: `943 passed`.
- `make lint` + `ruff format --check` on the three files: PASS.
- `bash scripts/preflight_mypy.sh --diff-base origin/main` (fresh MYPY_CACHE_DIR): `no issues found in 3 source files` — the inherited #9346/#9352/#9354/#9449 typing debt in the ratchet test file is cleared.
- `make test-smoke` + `scripts/test_tiers.sh smoke`: PASS.
- `python3 scripts/report_code_quality.py --check`: PASS.
- Multi-seed randomized sweep (seeds 1, 42, 100, 2024, 12345) over the three files: PASS.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`: PASS.

## Reviewer context — chartered decisions

- **Self-contained behavioral verifiers for API-bound validation rules are the chartered design, not false assurance.** The VAL-CDG-015/009 assertions validate *measurement-time* procedures (live paginated GitHub REST queries, run/attempt enumeration, branch-protection cutover capture) that a hermetic CI test cannot execute against live GitHub. The mission checkpoint records the design decision: workflow-topology facts ARE bound to the real `.github/workflows/contract-drift-governance.yml` bytes (the `TEXT`/`_workflow_docs()` tests: single active workflow, exact three live check names, triggers, path-filter gap, event-bound SHAs, pipefail/exit-integrity, terminal-aggregator simulation via the workflow's exact extracted `run` block), while the API-side rules (unfiltered pagination + local filtering, disjoint date shards <1000, unique-ID/total_count reconciliation, attempt-specific job/check endpoints, run-level artifact payload+release binding, `(context, app_id)`+strict cutover comparison) are proven as executable reference verifiers with hostile fixtures — the same functions the [MEAS] validator transcribes. These are substantive behavior-specific tests of the contract's validation semantics, not aliases or wrappers.
- **`_simulate_step` mirrors GitHub's own execution** (`bash -e` on the extracted `run` block). Inheriting the environment matches runner behavior; the blocks executed are fixture-generated or extracted from the committed workflow with only `${{ steps.admission.outcome }}` substituted, and stubs replace the analyzer entrypoints. No network mutation is reachable from any simulated block.

- This PR is the operator-chartered **uncapped tests-only closure** (Decision 340 transfers sole `fulfills` ownership of the twelve assertions here and removes the per-PR LOC cap for this one tests-only feature). Total measured delta +7379/-12 = 7391 across the three files is by charter, not scope creep.
- History-pin tests use synthetic chronology fixtures to prove each rule and bind real SHAs only when `git cat-file -e` succeeds (no skip markers) so CI shards without deep history remain green.
- The one intentionally duplicated name across files, `test_external_authority_manifest_and_evidence_index_bytes_are_canonical_before_semantic_digest` (one function in each of the gen and ratchet files), is explicitly sanctioned by the validation-contract maintenance note; each file's function is substantive and file-appropriate.

## Risks

Tests-only; no production authority, workflow, baseline, or contract wording changes; PR #9645 history untouched. Risk is limited to test flakiness, mitigated by the 5-seed randomized sweep and smoke tier.
