### PR TITLE
ci(governance): add the contract-drift boundary attestation signer workflow [Tier 4]

### DIFF
--- a/.github/workflows/contract-drift-boundary.yml
+++ b/.github/workflows/contract-drift-boundary.yml
@@ -1,0 +1,61 @@
+name: Contract Drift Boundary
+
+# Operator-authorized Tier-4 signer workflow (validation-contract review-history
+# entry 30; operator ledger decision 2026-08-01; seal blocker B1). Produces the
+# actions/attest@v4 Sigstore provenance over the three immutable boundary
+# capsule assets (manifest.json, payload.json, checksums.txt) so that the
+# pinned verification argv in scripts/check_contract_drift_ratchet.py
+# (_attestation_verify_argv) succeeds:
+#
+#   gh attestation verify <asset> -R <owner>/<repo>
+#     --signer-workflow <owner>/<repo>/.github/workflows/contract-drift-boundary.yml
+#     --source-digest <end_sha> --format json
+#
+# Dispatch this workflow AT the boundary capsule tag
+# (cdg-<boundary>-<end_sha>) so the certificate's source digest equals the
+# boundary end SHA the checker binds with --source-digest. No other trigger
+# surface, no other jobs, and no repository mutations are authorized.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Boundary capsule tag (cdg-<boundary>-<end_sha>). Must equal the tag
+          ref this run is dispatched on.
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: read
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      TAG: ${{ inputs.tag }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Download and authenticate the capsule assets at the boundary tag
+        run: |
+          set -euo pipefail
+          [[ "$TAG" =~ ^cdg-(corrective_bootstrap|route_truth|core_sdk|extended_sdk|final_seal)-[0-9a-f]{40}$ ]]
+          test "refs/tags/$TAG" = "$GITHUB_REF"
+          test "${TAG##*-}" = "$GITHUB_SHA"
+          mkdir assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir assets
+          test "$(find assets -mindepth 1 | wc -l)" -eq 3
+          test -s assets/manifest.json
+          test -s assets/payload.json
+          test -s assets/checksums.txt
+          (cd assets && sha256sum --check --strict checksums.txt)
+      - name: Attest the capsule assets
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            assets/manifest.json
+            assets/payload.json
+            assets/checksums.txt

--- a/.github/workflows/contract-drift-boundary.yml
+++ b/.github/workflows/contract-drift-boundary.yml
@@ -53,7 +53,7 @@ jobs:
           test -s assets/checksums.txt
           (cd assets && sha256sum --check --strict checksums.txt)
       - name: Attest the capsule assets
-        uses: actions/attest@v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: |
             assets/manifest.json


### PR DESCRIPTION
## Tier-4 PARKED DRAFT — operator-review-required. Do NOT merge without exact-head operator settlement.

**Source authority:** validation-contract review-history **entry 30** + operator ledger Decision 2026-08-01 (`library/operator-approvals.md`), item (b): "one parked Tier-4 draft adding `.github/workflows/contract-drift-boundary.yml` (actions/attest@v4 over manifest.json/payload.json/checksums.txt, permissions id-token:write + attestations:write, runnable at the boundary tag, no other trigger surface)". Resolves `corrective_bootstrap` seal blocker **B1** (`library/cdg-corrective-bootstrap-boundary-blocked-2026-08-01.md`): the checker-pinned signer workflow has never existed, so `actions/attest@v4` Sigstore provenance cannot be produced for any boundary capsule.

### Behavior

One new workflow file, nothing else. It exactly matches the pinned verification argv in `scripts/check_contract_drift_ratchet.py::_attestation_verify_argv` (lines ~1815-1834 on main):

```
gh attestation verify <asset> -R synaptent/aragora \
  --signer-workflow synaptent/aragora/.github/workflows/contract-drift-boundary.yml \
  --source-digest <end_sha> --format json
```

- **Trigger:** `workflow_dispatch` only, with a required `tag` input — dispatched AT the boundary capsule tag `cdg-<boundary>-<end_sha>` so the signing certificate's source digest equals the boundary `end_sha` the checker binds via `--source-digest`. No push/PR/schedule surface.
- **Permissions:** `id-token: write` (OIDC for Sigstore), `attestations: write` (persist), `contents: read` (release asset download). Nothing else.
- **Single job `attest`:** validates the dispatched ref IS the capsule tag for the run's `GITHUB_SHA`, downloads the exactly-three released capsule assets, authenticates `manifest.json`/`payload.json` against `checksums.txt` (`sha256sum --check --strict`), then runs `actions/attest@v4` provenance (no predicate inputs → SLSA build provenance) over the three assets. `--signer-workflow` matches on the workflow path from the certificate's job workflow ref, so dispatching at the tag ref keeps the pinned argv valid.
- **No repository mutations:** no checkout, no `git push`, no writes outside the runner scratch dir.

### Validation (exact commands + results)

| Command | Result |
|---|---|
| `actionlint .github/workflows/contract-drift-boundary.yml` (v1.7.11) | clean, exit 0 |
| workflow_dispatch structure check (trigger surface == {workflow_dispatch}, permissions exactly id-token/attestations/contents, single `attest` job, only `uses` = `actions/attest@v4`, subjects exactly assets/manifest.json + assets/payload.json + assets/checksums.txt, no `git push`/checkout/pull_request/schedule text) | PASS (red before file existed) |
| checker argv match: `_attestation_verify_argv(...)` `--signer-workflow` value resolves to an existing repo file | PASS (red-first: failed on origin/main where the file is absent) |
| `bash -n` on the extracted run block | PASS |
| `python3 scripts/check_branch_mutation_policy.py` | "Branch mutation policy check passed" |
| `python3 -m pytest tests/scripts/test_contract_drift_workflow.py -q` (workflow-glob topology census: producer set unchanged) | 40 passed |
| `python3 -m pytest tests/ci/test_live_node_runtime_workflows.py -q` | 4 passed |
| `make lint` + `ruff format --check aragora/ tests/ scripts/` | pass / 10792 files already formatted |
| `make test-smoke` (AWS-neutralized) | Core/Server/Memory imports OK, smoke passed |

LOC: +61/-0, one file. No Python changed → no mypy/pytest-red-first surface beyond the two structure/argv checks above (config-only variant).

### Risks

- Workflow-file-only change; inert until an operator dispatches it at a capsule tag. The `attestations: write` permission is scoped to this dispatch-only workflow.
- The checker's capsule attestation claim shape (`workflow: actions/attest@v4`, stable identity fields) is owned by the sibling checker amendment PR #9695; this PR intentionally adds no checker/test changes.
- Settlement is a separate delegated feature per the ledger decision; this PR stays parked draft at frozen head until then.


---

## Commit 2 (head `9ae5bd2fd4aed10f752f1b047898851486a2f812`): SHA-pin `actions/attest` (operator-adjudicated claude-P2 response)

Per the operator ledger Decision 2026-08-02 (`library/operator-approvals.md`, "PR #9696 dissents adjudicated - SHA-pin route authorized"): the claude P2 (unpinned mutable `actions/attest@v4` major tag in a workflow holding `id-token: write` + `attestations: write`) was SUSTAINED; the authorized response is this ONE additional commit pinning the action to the exact upstream v4 release commit SHA. No other workflow change:

```diff
-        uses: actions/attest@v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
```

### Pin resolution chain (resolved live 2026-08-02 from the actions/attest repository; raw `gh api -i` captures)

**1. Latest v4 release** — `gh api -i repos/actions/attest/releases/latest`:

```
HTTP/2.0 200 OK
Date: Sun, 02 Aug 2026 08:27:06 GMT
Etag: W/"d8ed2f23d54b4615724cf1678bfd2f1d0830cb32d9f4544c5020c30872f48ba1"
Last-Modified: Wed, 29 Jul 2026 20:14:43 GMT
X-Github-Request-Id: F9E8:771C8:1E966:6B73D:6A6EFF5A
...
"tag_name":"v4.2.1"
```

(`repos/actions/attest/releases?per_page=10` cross-check: v4.2.1 published 2026-07-29T20:14:43Z is the newest release; the full v4 line is v4.0.0, v4.1.0, v4.1.1, v4.2.0, v4.2.1, none prerelease.)

**2. Tag ref dereference** — `gh api -i repos/actions/attest/git/ref/tags/v4.2.1`:

```
HTTP/2.0 200 OK
Date: Sun, 02 Aug 2026 08:27:07 GMT
Etag: W/"8eeaea747b8e3a9d6b14688b9dfda7a4fdd324a670eaa8dee9a8a3bab224f73c"
X-Github-Request-Id: F9E9:1CBDCB:2CFF0:9D0BC:6A6EFF5A

{"ref":"refs/tags/v4.2.1","node_id":"REF_kwDOLVdghbByZWZzL3RhZ3MvdjQuMi4x","url":"https://api.github.com/repos/actions/attest/git/refs/tags/v4.2.1","object":{"sha":"508db95dd578ae2727ebd6217d5ba78e4fbda05d","type":"commit","url":"https://api.github.com/repos/actions/attest/git/commits/508db95dd578ae2727ebd6217d5ba78e4fbda05d"}}
```

`object.type == "commit"` — v4.2.1 is a lightweight tag pointing directly at the commit; no annotated-tag-object dereference step exists.

**3. Commit object authentication** — `gh api -i repos/actions/attest/git/commits/508db95dd578ae2727ebd6217d5ba78e4fbda05d`:

```
HTTP/2.0 200 OK
Date: Sun, 02 Aug 2026 08:27:07 GMT
Etag: W/"9ee2ce4531615929c14f5f86615ad6e9629da8053fa2c824f8e9488165aee221"
X-Github-Request-Id: F9EB:22916C:21457:74FB6:6A6EFF5B

"sha": "508db95dd578ae2727ebd6217d5ba78e4fbda05d"
"author": {"name": "Brian DeHamer", "email": "bdehamer@github.com", "date": "2026-07-29T20:11:36Z"}
"committer": {"name": "GitHub", "email": "noreply@github.com", "date": "2026-07-29T20:11:36Z"}
"message": "fix: strip OCI image tag when pushing attestation to registry (#464)"
"parents": ["dda48f2935afea63fd4651871c16233251f9d06c"]
```

**4. Floating-tag equality check** — `gh api -i repos/actions/attest/git/ref/tags/v4`:

```
HTTP/2.0 200 OK
Date: Sun, 02 Aug 2026 08:27:07 GMT
Etag: W/"28967ccaa7aa5520e4fcf9d1fa9497087ee1f3f45d9114074a1b0116607cd0b9"

{"ref":"refs/tags/v4","node_id":"REF_kwDOLVdghaxyZWZzL3RhZ3MvdjQ","url":"https://api.github.com/repos/actions/attest/git/refs/tags/v4","object":{"sha":"508db95dd578ae2727ebd6217d5ba78e4fbda05d","type":"commit","url":"https://api.github.com/repos/actions/attest/git/commits/508db95dd578ae2727ebd6217d5ba78e4fbda05d"}}
```

The floating `v4` tag currently resolves to the same commit — the pin changes the trust model (immutable SHA instead of mutable tag), not the executed bytes today.

Note: the checker-side capsule claim field `workflow: actions/attest@v4` (checker L2589/L3473) is derived from the verified Sigstore certificate's workflow identity, not parsed from this YAML file — SHA-pinning the `uses:` line does not change that claim value.

### Re-validation at head `9ae5bd2f` (config-only matrix)

| Command | Result |
|---|---|
| `actionlint .github/workflows/contract-drift-boundary.yml` (v1.7.11) | clean, exit 0 |
| `bash -n` on the extracted run block | PASS |
| workflow_dispatch structure check (trigger surface == {workflow_dispatch}, exact permissions, single `attest` job, only `uses` step is full-40-hex-pinned `actions/attest@508db95d... # v4.2.1`, subjects exactly the 3 assets, no predicate inputs, no mutation text) | PASS |
| checker argv match: `_attestation_verify_argv` `--signer-workflow` value resolves to an existing repo file | PASS |
| `python3 scripts/check_branch_mutation_policy.py` | passed |
| `python3 -m pytest tests/scripts/test_contract_drift_workflow.py tests/ci/test_live_node_runtime_workflows.py -q` | 44 passed |
| `python3 -m pytest tests/scripts/test_check_contract_drift_ratchet.py -k "signer or attestation_source_digest" -q` | 2 passed |
| `make lint` | All checks passed |
| `make test-smoke` (AWS-neutralized) | Core/Server/Memory imports OK, smoke passed |

LOC (cumulative vs main): +61/-0 → one file, `+61/-0` net unchanged file count; commit 2 is `+1/-1` within the same file. The old `bb74ee57` settlement delegation half (ledger line 365) is VOID per the 2026-08-02 adjudication; a fresh exact-head settlement delegation follows at this new frozen head.
