### PR TITLE
fix(swarm): derive diagnostic western-frontier advice from genuine reviewer signals

### DIFF
--- a/aragora/swarm/merge_quorum_io.py
+++ b/aragora/swarm/merge_quorum_io.py
@@ -347,6 +347,52 @@ def fetch_quorum_run_packet_classification(
     return parse_ci_packet_classification(proc.stdout, pr_number=pr, head_sha=head_sha)
 
 
+# Hard identity problems that stop one reviewer-signal item from counting.
+# Mirrors ``review_queue.IDENTITY_COUNT_BLOCKERS`` — the swarm layer cannot
+# import the CLI module (upward layer edge, and a circular import via
+# quorum_evidence), so the four blocker strings are duplicated here and pinned
+# against the CLI set by
+# tests/swarm/test_merge_quorum_reconcile.py::TestSignalFamiliesFromLint.
+_SIGNAL_IDENTITY_BLOCKERS: frozenset[str] = frozenset(
+    (
+        "missing_model_family_disclosure",
+        "unknown_model_family",
+        "heading_model_family_conflict",
+        "unknown_surface_reviewer",
+    )
+)
+
+
+def _signal_families_from_lint(lint: dict[str, Any]) -> tuple[str, ...]:
+    """Counted families backed by GENUINE model-review signal items.
+
+    Derives ``EvidenceComment.reviewer_signals`` provenance from the lint's
+    ``reviewer_signals`` list ONLY — never ``dogfood_evidence`` — mirroring the
+    live gate's signal-only western-frontier derivation (review_queue computes
+    ``has_western_frontier_signal`` from reviewer signals with an EMPTY dogfood
+    list). Families are intersected with ``counted_reviewer_ids`` so the result
+    is always a subset of the counted families (advisory-only exclusions carry
+    over), and items with hard identity blockers never contribute, keeping this
+    at-most-as-permissive as the gate.
+    """
+    counted = {
+        str(rid).strip().lower()
+        for rid in (lint.get("counted_reviewer_ids") or [])
+        if str(rid).strip()
+    }
+    families: set[str] = set()
+    for item in lint.get("reviewer_signals") or []:
+        if not isinstance(item, dict):
+            continue
+        problems = {str(problem) for problem in (item.get("identity_problems") or [])}
+        if problems & _SIGNAL_IDENTITY_BLOCKERS:
+            continue
+        family = str(item.get("model_family") or "").strip().lower()
+        if family and family in counted:
+            families.add(family)
+    return tuple(sorted(families))
+
+
 def fetch_evidence_comments(
     repo: str, pr: int, head_sha: str, head_committed_at: str
 ) -> list[EvidenceComment]:
@@ -371,6 +417,7 @@ def fetch_evidence_comments(
                 would_count=bool(lint.get("would_count")),
                 reviewer_id=str(counted[0]) if counted else "",
                 is_dogfood=bool(lint.get("dogfood_evidence")),
+                reviewer_signals=_signal_families_from_lint(lint),
             )
         )
     return results

--- a/aragora/swarm/merge_quorum_reconcile.py
+++ b/aragora/swarm/merge_quorum_reconcile.py
@@ -97,12 +97,22 @@ class EvidenceComment:
             or ``""`` when the comment does not count.
         is_dogfood: Whether the comment contributes adversarial-dogfood
             evidence (``evidence-lint`` returned non-empty ``dogfood_evidence``).
+        reviewer_signals: Distinct model families carried by GENUINE
+            model-review signal items (``evidence-lint``'s ``reviewer_signals``
+            list, never ``dogfood_evidence``). ``reviewer_id`` can be
+            dogfood-attributed, so it must not feed requirements that the live
+            gate derives from review signals only (the western-frontier check).
+            ``None`` means provenance is unknown (legacy/hand-built records):
+            consumers fall back to ``reviewer_id`` so pre-provenance callers
+            keep their behavior; ``()`` affirmatively means "no genuine
+            reviewer signal" (e.g. a dogfood-only comment).
     """
 
     created_at: str
     would_count: bool
     reviewer_id: str = ""
     is_dogfood: bool = False
+    reviewer_signals: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True)
@@ -184,6 +194,29 @@ def counted_reviewer_ids(comments: list[EvidenceComment]) -> list[str]:
         if comment.would_count and comment.reviewer_id:
             ids.add(comment.reviewer_id)
     return sorted(ids)
+
+
+def counted_reviewer_signal_families(comments: list[EvidenceComment]) -> set[str]:
+    """Distinct counted families backed by GENUINE model-review signals.
+
+    Mirrors the live gate's signal-only derivation (review_queue computes
+    ``has_western_frontier_signal`` from ``reviewer_signals`` with an EMPTY
+    dogfood list), so a dogfood-only counted identity never satisfies a
+    review-signal requirement. Provenance-unaware records
+    (``reviewer_signals is None`` — legacy or hand-built) fall back to
+    ``reviewer_id`` so existing callers keep their behavior; an explicit empty
+    tuple affirmatively means "no genuine reviewer signal".
+    """
+    families: set[str] = set()
+    for comment in comments:
+        if not comment.would_count:
+            continue
+        if comment.reviewer_signals is None:
+            if comment.reviewer_id:
+                families.add(comment.reviewer_id)
+            continue
+        families.update(family for family in comment.reviewer_signals if family)
+    return families
 
 
 def plan_rerun(
@@ -437,9 +470,14 @@ def summarize_settlement(
     advisory_only = bool(set(ids) - counted)
     # Tiered gate ON: a Tier 1-2 PR settles on ONE western-frontier signal (claude/openai),
     # so a lone non-frontier signal must not be reported as sufficient (mirrors the gate's
-    # western_frontier_satisfied check).
+    # western_frontier_satisfied check). Like the gate, the frontier requirement is
+    # derived from GENUINE model-review signals only (review_queue computes
+    # has_western_frontier_signal from reviewer_signals with an EMPTY dogfood list):
+    # a dogfood-only counted identity satisfies the dogfood leg below but must not
+    # advance the western-frontier advice (VAL-P4A-024).
+    counted_signal_families = rule.counted_families(counted_reviewer_signal_families(comments))
     needs_western_frontier = rule.requires_western_frontier and not (
-        counted & WESTERN_FRONTIER_FAMILIES
+        counted_signal_families & WESTERN_FRONTIER_FAMILIES
     )
     needs_western = rule.requires_at_least_one_western and not (counted & WESTERN_FAMILIES)
 

--- a/tests/governance/test_tiered_merge_gate_quorum_policy.py
+++ b/tests/governance/test_tiered_merge_gate_quorum_policy.py
@@ -321,3 +321,89 @@ def test_review_queue_reexports_canonical_jurisdiction_sets():
 
     assert rq.WESTERN_FAMILIES is WESTERN_FAMILIES
     assert rq.WESTERN_FRONTIER_FAMILIES is WESTERN_FRONTIER_FAMILIES
+
+
+# --- VAL-P4A-024: signal-only western-frontier advice in the read-only diagnostic
+
+
+def test_diagnostic_dogfood_only_identity_does_not_advance_frontier_advice(monkeypatch):
+    # VAL-P4A-024: a dogfood-only record attributed to a western-frontier family
+    # (claude/openai) may satisfy the separate dogfood requirement, but it
+    # carries NO genuine model-review signal, so the read-only settlement
+    # diagnostic must keep asking for a western-frontier review signal instead
+    # of reporting the frontier requirement as met. Mirrors the live gate's
+    # signal-only derivation (review_queue._build_model_review_quorum computes
+    # has_western_frontier_signal from reviewer signals with an EMPTY dogfood
+    # list: "The WF requirement must be met by a model-review signal, not by
+    # dogfood-only metadata").
+    from aragora.swarm.merge_quorum_reconcile import EvidenceComment, summarize_settlement
+
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "1")
+    for tier in (1, 2):
+        for family in ("claude", "openai"):
+            dogfood_only = [
+                EvidenceComment(
+                    created_at="2026-07-15T00:00:00Z",
+                    would_count=True,
+                    # Counted identity attributed via dogfood evidence only.
+                    reviewer_id=family,
+                    is_dogfood=True,
+                    # Provenance: affirmatively NO genuine reviewer signal.
+                    reviewer_signals=(),
+                )
+            ]
+            status = summarize_settlement(
+                pr_number=1,
+                head_sha="deadbeef",
+                tier=tier,
+                comments=dogfood_only,
+                human_settlement_present=False,
+                quorum_conclusion="FAILURE",
+            )
+            # The dogfood leg is satisfied by the dogfood-only record...
+            assert status.has_dogfood is True
+            # ...but the western-frontier review-signal requirement is NOT:
+            # the diagnostic must still ask for a western-frontier signal.
+            assert "western-frontier" in status.next_action
+
+
+def test_diagnostic_genuine_reviewer_signal_advances_frontier_advice(monkeypatch):
+    # VAL-P4A-024 companion: adding ONE genuine current-head claude/openai
+    # reviewer signal (on top of the same dogfood-only record) satisfies the
+    # western-frontier requirement, so the advice advances past it to the next
+    # step (here the stale-quorum re-run hint) instead of asking for a signal.
+    from aragora.swarm.merge_quorum_reconcile import EvidenceComment, summarize_settlement
+
+    monkeypatch.setenv("ARAGORA_ENABLE_TIERED_MERGE_GATE", "1")
+    for tier in (1, 2):
+        comments = [
+            # The dogfood-only record from the companion test...
+            EvidenceComment(
+                created_at="2026-07-15T00:00:00Z",
+                would_count=True,
+                reviewer_id="claude",
+                is_dogfood=True,
+                reviewer_signals=(),
+            ),
+            # ...plus one genuine current-head claude reviewer signal.
+            EvidenceComment(
+                created_at="2026-07-15T00:05:00Z",
+                would_count=True,
+                reviewer_id="claude",
+                is_dogfood=False,
+                reviewer_signals=("claude",),
+            ),
+        ]
+        status = summarize_settlement(
+            pr_number=1,
+            head_sha="deadbeef",
+            tier=tier,
+            comments=comments,
+            human_settlement_present=False,
+            quorum_conclusion="FAILURE",
+        )
+        assert tier_quorum_rule(tier, tiered_gate=True).is_satisfied_by(["claude"]) is True
+        assert status.has_dogfood is True
+        assert "western-frontier" not in status.next_action
+        # Advice advanced past every quorum leg to the stale-check recovery hint.
+        assert "re-run aragora-merge-quorum" in status.next_action

--- a/tests/swarm/test_merge_quorum_reconcile.py
+++ b/tests/swarm/test_merge_quorum_reconcile.py
@@ -4,6 +4,8 @@ Covers:
 
 - ``parse_iso8601`` (Z form, naive, empty, invalid).
 - ``counted_reviewer_ids`` aggregation (distinct, ignores non-counting).
+- ``counted_reviewer_signal_families`` provenance (signal-only, ``None`` fallback).
+- ``_signal_families_from_lint`` (lint ``reviewer_signals`` -> provenance tuple).
 - ``plan_rerun`` — every safety guard and the happy path.
 - ``summarize_settlement`` — every ``next_action`` branch.
 """
@@ -13,15 +15,18 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from aragora.swarm.merge_quorum_io import (
+    _SIGNAL_IDENTITY_BLOCKERS,
     _could_count,
     _evidence_lint_args,
     _looks_like_shadow,
+    _signal_families_from_lint,
 )
 from aragora.swarm.merge_quorum_reconcile import (
     EvidenceComment,
     PacketClassification,
     QuorumRun,
     counted_reviewer_ids,
+    counted_reviewer_signal_families,
     guard_rerun_classification_divergence,
     parse_ci_packet_classification,
     parse_iso8601,
@@ -79,6 +84,95 @@ class TestCountedReviewerIds:
 
     def test_empty(self) -> None:
         assert counted_reviewer_ids([]) == []
+
+
+class TestCountedReviewerSignalFamilies:
+    def test_signal_backed_families_counted(self) -> None:
+        comments = [
+            EvidenceComment(
+                created_at=_ts(-10),
+                would_count=True,
+                reviewer_id="claude",
+                reviewer_signals=("claude",),
+            ),
+            EvidenceComment(
+                created_at=_ts(-5),
+                would_count=True,
+                reviewer_id="openai",
+                reviewer_signals=("openai",),
+            ),
+        ]
+        assert counted_reviewer_signal_families(comments) == {"claude", "openai"}
+
+    def test_dogfood_only_comment_contributes_no_signal_family(self) -> None:
+        # Explicit empty tuple = affirmatively no genuine reviewer signal:
+        # the counted identity must not leak into the signal-only set.
+        dogfood_only = EvidenceComment(
+            created_at=_ts(-10),
+            would_count=True,
+            reviewer_id="claude",
+            is_dogfood=True,
+            reviewer_signals=(),
+        )
+        assert counted_reviewer_signal_families([dogfood_only]) == set()
+
+    def test_legacy_none_falls_back_to_reviewer_id(self) -> None:
+        # Provenance-unaware records (hand-built/legacy) keep prior behavior.
+        legacy = EvidenceComment(created_at=_ts(-10), would_count=True, reviewer_id="claude")
+        assert legacy.reviewer_signals is None
+        assert counted_reviewer_signal_families([legacy]) == {"claude"}
+
+    def test_non_counting_comment_never_contributes(self) -> None:
+        rejected = EvidenceComment(
+            created_at=_ts(-10),
+            would_count=False,
+            reviewer_id="claude",
+            reviewer_signals=("claude",),
+        )
+        assert counted_reviewer_signal_families([rejected]) == set()
+
+
+class TestSignalFamiliesFromLint:
+    def test_blockers_pin_review_queue_identity_count_blockers(self) -> None:
+        # The swarm layer cannot import the CLI module (upward edge + circular
+        # import via quorum_evidence), so the blocker set is duplicated; this
+        # pins the copy against the canonical CLI set so they cannot drift.
+        from aragora.cli.commands.review_queue import IDENTITY_COUNT_BLOCKERS
+
+        assert _SIGNAL_IDENTITY_BLOCKERS == IDENTITY_COUNT_BLOCKERS
+
+    def test_signal_families_subset_of_counted(self) -> None:
+        lint = {
+            "counted_reviewer_ids": ["claude"],
+            "reviewer_signals": [
+                {"model_family": "claude", "identity_problems": []},
+                # Not in counted ids -> excluded (e.g. advisory-only family).
+                {"model_family": "gemini", "identity_problems": []},
+            ],
+        }
+        assert _signal_families_from_lint(lint) == ("claude",)
+
+    def test_dogfood_evidence_never_contributes(self) -> None:
+        # A dogfood-only lint result has a counted id but NO reviewer_signals
+        # item: provenance is affirmatively empty, not the counted id.
+        lint = {
+            "counted_reviewer_ids": ["claude"],
+            "reviewer_signals": [],
+            "dogfood_evidence": [{"model_family": "claude", "identity_problems": []}],
+        }
+        assert _signal_families_from_lint(lint) == ()
+
+    def test_identity_blockers_exclude_item(self) -> None:
+        lint = {
+            "counted_reviewer_ids": ["claude"],
+            "reviewer_signals": [
+                {
+                    "model_family": "claude",
+                    "identity_problems": ["heading_model_family_conflict"],
+                }
+            ],
+        }
+        assert _signal_families_from_lint(lint) == ()
 
 
 class TestPlanRerun:


### PR DESCRIPTION
## Source

Mission feature `p4a-tiered-gate-diagnostic-signal-repair` (VAL-P4A-024), operator-authorized diagnostic-only Tier-4 repair (Decisions of 2026-07-15 in the mission ledger: governance-test path-freeze lift; exact-head coordination with draft PR #9081 for `aragora/swarm/merge_quorum_io.py`, verified open at `622d158e5f2b9c6270463881691211746423bfe0`).

## Behavior

The read-only settlement diagnostic (`merge_quorum_reconcile.summarize_settlement`) satisfied the tiered-gate western-frontier requirement from counted reviewer identities, which include dogfood-attributed families. A dogfood-only Claude/OpenAI record therefore advanced the western-frontier advice even though the live gate derives that requirement from genuine model-review signals only (`review_queue._build_model_review_quorum` computes `has_western_frontier_signal` from `reviewer_signals` with an empty dogfood list).

This diagnostic-only repair:

- adds `reviewer_signals` provenance to the diagnostic `EvidenceComment` I/O model (`None` = legacy/unknown, falls back to `reviewer_id`; `()` = affirmatively no genuine signal),
- populates it in `merge_quorum_io.fetch_evidence_comments` from the lint's `reviewer_signals` list only (never `dogfood_evidence`), intersected with counted ids and filtered by the identity-blocker set (pinned against `review_queue.IDENTITY_COUNT_BLOCKERS` by test),
- derives the diagnostic's western-frontier advice from signal-only families via `counted_reviewer_signal_families`.

Dogfood provenance remains distinct from reviewer-signal provenance. Live gate policy and evidence collection are unchanged: `aragora/swarm/quorum_evidence.py`, `aragora/cli/commands/review_queue.py`, and `.github/workflows/aragora-merge-quorum.yml` are untouched.

## Validation

```
python3 -m pytest tests/governance/test_tiered_merge_gate_quorum_policy.py -q \
  -k 'test_diagnostic_dogfood_only_identity_does_not_advance_frontier_advice or test_diagnostic_genuine_reviewer_signal_advances_frontier_advice'
# 2 passed (red-first: 2 failed before implementation)
python3 -m pytest tests/swarm/test_merge_quorum_reconcile.py -q          # 53 passed
python3 -m pytest tests/governance/test_tiered_merge_gate_quorum_policy.py tests/swarm/test_merge_quorum_io.py tests/swarm/test_merge_quorum_reconcile.py tests/swarm/test_merge_arbiter.py tests/scripts/test_reconcile_merge_quorum_budget.py -q   # 170 passed
make lint; ruff format --check <touched>                                  # clean
bash scripts/preflight_mypy.sh --diff-base origin/main                    # no issues in 4 files
make test-smoke; test_tiers.sh smoke                                      # 138 passed
5-seed randomized sweep of both touched test files                        # 97 passed x5
```

## Risks

Diagnostic-only surfaces (A1/A2 reconcile CLIs, merge arbiter freshness read). The signal-only set is derived as a subset of counted families, so the diagnostic can only become stricter, never more permissive, and legacy `reviewer_signals=None` records keep byte-identical prior behavior. LOC: +267/-2 (269 total).
