### PR TITLE
feat(scripts): add mounted-FastAPI-router evidence plane to route-truth validator [Tier 4]

### DIFF
--- a/scripts/baselines/validate_openapi_routes.json
+++ b/scripts/baselines/validate_openapi_routes.json
@@ -1,12 +1,4 @@
 {
   "missing_in_spec": [],
-  "orphaned_in_spec": [
-    "/api/v2/marketplace/categories",
-    "/api/v2/marketplace/status",
-    "/api/v2/marketplace/templates",
-    "/api/v2/marketplace/templates/import",
-    "/api/v2/orchestration/deliberate",
-    "/api/v2/orchestration/deliberate/sync",
-    "/api/v2/orchestration/templates"
-  ]
+  "orphaned_in_spec": []
 }

--- a/scripts/validate_openapi_routes.py
+++ b/scripts/validate_openapi_routes.py
@@ -5,7 +5,14 @@ This script ensures the OpenAPI specification stays in sync with actual
 handler implementations by comparing:
 1. Routes defined in handler ROUTES attributes
 2. Literal routes in server-wired aiohttp registration functions
-3. Routes in the OpenAPI spec paths
+3. Literal routes on APIRouters mounted in the opt-in FastAPI app factory
+4. Routes in the OpenAPI spec paths
+
+"Served" means reachable on the default ``aragora serve`` dispatcher plane
+(handler ROUTES / wired registrations / can_handle probes) OR on the mounted
+opt-in FastAPI plane (``ARAGORA_USE_FASTAPI``) — routers mounted in
+``aragora/server/fastapi/factory.py`` back shipped SDK operations, so their
+spec entries are not orphans.
 
 Usage:
     python scripts/validate_openapi_routes.py
@@ -58,6 +65,8 @@ _SERVER_ROUTE_REGISTRATION = (
 _LITERAL_ROUTER_METHODS = frozenset(
     {"add_get", "add_post", "add_put", "add_patch", "add_delete", "add_head", "add_options"}
 )
+_FASTAPI_FACTORY = _REPO_ROOT / "aragora" / "server" / "fastapi" / "factory.py"
+_FASTAPI_DECORATOR_METHODS = frozenset({"get", "post", "put", "patch", "delete", "head", "options"})
 
 # ---------------------------------------------------------------------------
 # Method-aware operation plane (VAL-CDG-011)
@@ -1117,6 +1126,176 @@ def get_wired_function_routes(
         operation["path"]
         for operation in get_wired_function_operations(registration_path, repo_root)
     }
+
+
+def _fastapi_route_module_imports(
+    factory_tree: ast.Module,
+    factory_path: Path,
+    repo_root: Path,
+) -> dict[str, Path]:
+    """Map local names of locally-imported modules in the factory to source paths.
+
+    Only imports that resolve to an existing local package directory are
+    recorded. A recognized package whose submodule source file is missing is
+    still recorded (pointing at the nonexistent path) so a mounted-but-
+    uninspectable module fails closed downstream instead of silently dropping
+    its serve evidence.
+    """
+    modules: dict[str, Path] = {}
+    for node in ast.walk(factory_tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            base_dir = factory_path.parent
+            for _ in range(node.level - 1):
+                base_dir = base_dir.parent
+            if node.module:
+                base_dir = base_dir.joinpath(*node.module.split("."))
+        elif node.module:
+            base_dir = repo_root.joinpath(*node.module.split("."))
+        else:
+            continue
+        for imported in node.names:
+            local_name = imported.asname or imported.name
+            candidates = (
+                base_dir / f"{imported.name}.py",
+                base_dir / imported.name / "__init__.py",
+            )
+            module_path = next((c for c in candidates if c.is_file()), None)
+            if module_path is not None:
+                modules[local_name] = module_path
+            elif base_dir.is_dir():
+                modules[local_name] = candidates[0]
+    return modules
+
+
+def _fastapi_router_prefix(
+    module_tree: ast.Module, router_name: str, module_path: Path
+) -> str | None:
+    """Return the mounted router's literal prefix.
+
+    Returns ``None`` when the prefix is present but not a literal string
+    (unverifiable — the whole module contributes nothing). Raises
+    ``RouteRegistrationScanError`` when the mounted name has no module-level
+    ``APIRouter(...)`` assignment at all: a recognized mount we cannot inspect
+    is a scan-integrity failure, not silent under-crediting.
+    """
+    assignment: ast.Call | None = None
+    for node in module_tree.body:
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            if any(isinstance(t, ast.Name) and t.id == router_name for t in node.targets):
+                value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == router_name:
+                value = node.value
+        if value is None or not isinstance(value, ast.Call):
+            continue
+        func = value.func
+        func_name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if func_name == "APIRouter":
+            assignment = value
+    if assignment is None:
+        raise RouteRegistrationScanError(
+            f"mounted router {router_name!r} has no module-level APIRouter "
+            f"assignment in {module_path}"
+        )
+    for keyword in assignment.keywords:
+        if keyword.arg != "prefix":
+            continue
+        if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+            return keyword.value.value
+        return None
+    return ""
+
+
+def _iter_fastapi_decorator_paths(module_tree: ast.Module, router_name: str) -> Iterator[str]:
+    """Yield literal paths from ``@<router>.<method>("/path")`` decorators."""
+    for node in module_tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call):
+                continue
+            func = decorator.func
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr in _FASTAPI_DECORATOR_METHODS
+                and isinstance(func.value, ast.Name)
+                and func.value.id == router_name
+            ):
+                continue
+            if not decorator.args:
+                continue
+            path_argument = decorator.args[0]
+            if isinstance(path_argument, ast.Constant) and isinstance(path_argument.value, str):
+                yield path_argument.value
+
+
+def get_fastapi_mounted_routes(
+    factory_path: Path | None = None,
+    repo_root: Path | None = None,
+) -> set[str]:
+    """Statically extract literal routes from APIRouters mounted in the FastAPI factory.
+
+    The opt-in FastAPI surface (``ARAGORA_USE_FASTAPI`` / standalone uvicorn)
+    mounts routers in ``aragora/server/fastapi/factory.py``. Every
+    ``<x>.include_router(<module>.<router>[, prefix=...])`` call whose module
+    was imported from a local package is mounted serve evidence: the module's
+    module-level ``<router> = APIRouter(prefix=...)`` definition plus its
+    literal ``@<router>.<method>("/path")`` decorators yield full paths
+    (include prefix + router prefix + decorator path), kept when they start
+    with ``/api/``. A recognized mount whose module source or router
+    definition cannot be inspected fails closed. Computed include/router
+    prefixes, computed decorator paths, and unrecognized mount forms remain
+    unverified and contribute nothing — the plane can under-credit but never
+    over-credit.
+    """
+    root = repo_root or _REPO_ROOT
+    path = factory_path or _FASTAPI_FACTORY
+    factory_tree = _parse_python_source(path)
+    modules = _fastapi_route_module_imports(factory_tree, path, root)
+
+    mounts: list[tuple[str, str, str]] = []
+    for call in ast.walk(factory_tree):
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "include_router"):
+            continue
+        if not call.args:
+            continue
+        target = call.args[0]
+        if not (
+            isinstance(target, ast.Attribute)
+            and isinstance(target.value, ast.Name)
+            and target.value.id in modules
+        ):
+            continue
+        include_prefix = ""
+        unverifiable = False
+        for keyword in call.keywords:
+            if keyword.arg != "prefix":
+                continue
+            if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                include_prefix = keyword.value.value
+            else:
+                unverifiable = True
+        if unverifiable:
+            continue
+        mounts.append((target.value.id, target.attr, include_prefix))
+
+    routes: set[str] = set()
+    for module_name, router_attr, include_prefix in mounts:
+        module_tree = _parse_python_source(modules[module_name])
+        router_prefix = _fastapi_router_prefix(module_tree, router_attr, modules[module_name])
+        if router_prefix is None:
+            continue
+        for path_suffix in _iter_fastapi_decorator_paths(module_tree, router_attr):
+            route = f"{include_prefix}{router_prefix}{path_suffix}"
+            if route.startswith("/api/"):
+                routes.add(route)
+    return routes
 
 
 def get_handler_routes() -> set[str]:
@@ -2458,6 +2637,36 @@ def load_wired_routes_for_validation() -> set[str]:
         sys.exit(1)
 
 
+def load_fastapi_routes_for_validation() -> set[str]:
+    """Load literal mounted-FastAPI routes with exact API-version semantics."""
+    try:
+        return {
+            normalize_route(route, normalize_version=False)
+            for route in get_fastapi_mounted_routes()
+        }
+    except RouteRegistrationScanError as exc:
+        print(f"Error: {exc}. Refusing to validate partial FastAPI mounting.", file=sys.stderr)
+        sys.exit(1)
+
+
+def filter_fastapi_orphans(
+    candidates: set[str], fastapi_routes: set[str] | None = None
+) -> tuple[set[str], set[str]]:
+    """Split orphan candidates by literal evidence from mounted FastAPI routers."""
+    if fastapi_routes is None:
+        fastapi_routes = load_fastapi_routes_for_validation()
+
+    served = candidates & fastapi_routes
+    if served:
+        print(
+            f"Spec-orphan suppressions via mounted FastAPI routers ({len(served)}):",
+            file=sys.stderr,
+        )
+        for path in sorted(served):
+            print(f"  - {path}", file=sys.stderr)
+    return candidates - served, served
+
+
 def filter_wired_orphans(
     candidates: set[str], wired_routes: set[str] | None = None
 ) -> tuple[set[str], set[str]]:
@@ -2497,6 +2706,7 @@ def validate_coverage(
     handler_routes = get_handler_routes()
     openapi_routes = get_openapi_routes(spec_path)
     wired_routes = load_wired_routes_for_validation()
+    fastapi_routes = load_fastapi_routes_for_validation()
 
     # Normalize routes for comparison
     normalized_handler = {normalize_route(r) for r in handler_routes}
@@ -2519,6 +2729,12 @@ def validate_coverage(
         wired_routes = {
             r
             for r in wired_routes
+            if not is_internal_route(r, internal_prefixes)
+            and not is_internal_route(normalize_route(r), internal_prefixes)
+        }
+        fastapi_routes = {
+            r
+            for r in fastapi_routes
             if not is_internal_route(r, internal_prefixes)
             and not is_internal_route(normalize_route(r), internal_prefixes)
         }
@@ -2566,8 +2782,11 @@ def validate_coverage(
     orphan_candidates, served_wired_registration = filter_wired_orphans(
         orphan_candidates, wired_routes
     )
+    orphan_candidates, served_fastapi_mounted = filter_fastapi_orphans(
+        orphan_candidates, fastapi_routes
+    )
     orphaned_in_spec, served_can_handle = filter_served_orphans(orphan_candidates)
-    served_undeclared = served_wired_registration | served_can_handle
+    served_undeclared = served_wired_registration | served_fastapi_mounted | served_can_handle
 
     baseline_missing: set[str] = set()
     baseline_orphaned: set[str] = set()
@@ -2596,6 +2815,9 @@ def validate_coverage(
         "served_undeclared_count": len(served_undeclared),
         "served_wired_registration": sorted(served_wired_registration),
         "served_wired_registration_count": len(served_wired_registration),
+        "served_fastapi_mounted": sorted(served_fastapi_mounted),
+        "served_fastapi_mounted_count": len(served_fastapi_mounted),
+        "fastapi_mounted_routes_count": len(fastapi_routes),
         "new_orphaned_in_spec": new_orphaned_in_spec,
         "new_orphaned_in_spec_count": len(new_orphaned_in_spec),
         "dynamic_routes_skipped": len(known_dynamic_patterns),
@@ -2612,6 +2834,7 @@ def validate_coverage(
         print("=" * 60)
         print(f"Handler metadata routes: {results['handler_routes_count']}")
         print(f"Wired function routes:   {results['wired_function_routes_count']}")
+        print(f"FastAPI mounted routes:  {results['fastapi_mounted_routes_count']}")
         print(f"Effective handler routes: {results['effective_handler_routes_count']}")
         print(f"OpenAPI routes:          {results['openapi_routes_count']}")
         print(f"Coverage:                {results['coverage_percentage']}%")

--- a/tests/scripts/test_validate_openapi_routes.py
+++ b/tests/scripts/test_validate_openapi_routes.py
@@ -589,6 +589,348 @@ def test_is_internal_route_matches_exact_family_not_sibling_names():
 
 
 # ---------------------------------------------------------------------------
+# Mounted-FastAPI-router evidence plane (additive; ledger 397 point 3)
+# ---------------------------------------------------------------------------
+
+
+def _write_fastapi_tree(
+    tmp_path: Path,
+    factory_source: str,
+    route_modules: dict[str, str],
+) -> Path:
+    """Lay out a synthetic aragora/server/fastapi tree and return factory path."""
+    fastapi_dir = tmp_path / "aragora" / "server" / "fastapi"
+    routes_dir = fastapi_dir / "routes"
+    routes_dir.mkdir(parents=True)
+    (routes_dir / "__init__.py").write_text("", encoding="utf-8")
+    factory = fastapi_dir / "factory.py"
+    factory.write_text(factory_source, encoding="utf-8")
+    for name, source in route_modules.items():
+        (routes_dir / f"{name}.py").write_text(source, encoding="utf-8")
+    return factory
+
+
+def test_get_fastapi_mounted_routes_extracts_mounted_router_paths(tmp_path: Path):
+    factory = _write_fastapi_tree(
+        tmp_path,
+        """
+from .routes import shop, ghost
+
+def create_app():
+    app = object()
+    app.include_router(shop.router)
+    return app
+""".lstrip(),
+        {
+            "shop": """
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/v2/shop", tags=["Shop"])
+
+@router.get("/items")
+async def list_items():
+    return []
+
+@router.post("/items")
+async def create_item():
+    return {}
+
+@router.get("/items/{item_id}")
+async def get_item(item_id: str):
+    return {}
+""".lstrip(),
+            # Imported in the factory but never mounted: contributes nothing.
+            "ghost": """
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/v2/ghost")
+
+@router.get("/status")
+async def ghost_status():
+    return {}
+""".lstrip(),
+        },
+    )
+
+    routes = validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+    assert routes == {
+        "/api/v2/shop/items",
+        "/api/v2/shop/items/{item_id}",
+    }
+
+
+def test_get_fastapi_mounted_routes_combines_include_router_prefix(tmp_path: Path):
+    factory = _write_fastapi_tree(
+        tmp_path,
+        """
+from .routes import things
+
+def create_app(app):
+    app.include_router(things.router, prefix="/api/v2")
+""".lstrip(),
+        {
+            "things": """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/things")
+async def list_things():
+    return []
+""".lstrip(),
+        },
+    )
+
+    routes = validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+    assert routes == {"/api/v2/things"}
+
+
+def test_get_fastapi_mounted_routes_skips_non_literal_paths(tmp_path: Path):
+    factory = _write_fastapi_tree(
+        tmp_path,
+        """
+from .routes import mixed, computed_prefix
+
+PREFIX = "/api/v2"
+
+def create_app(app):
+    app.include_router(mixed.router)
+    app.include_router(computed_prefix.router, prefix=PREFIX)
+""".lstrip(),
+        {
+            "mixed": """
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/v2/mixed")
+_computed = "/computed"
+
+@router.get("/literal")
+async def literal():
+    return {}
+
+@router.get(_computed)
+async def computed():
+    return {}
+""".lstrip(),
+            # Mount uses a computed prefix: unverifiable, contributes nothing.
+            "computed_prefix": """
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/whatever")
+async def whatever():
+    return {}
+""".lstrip(),
+        },
+    )
+
+    routes = validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+    assert routes == {"/api/v2/mixed/literal"}
+
+
+def test_get_fastapi_mounted_routes_fails_closed_on_unparseable_factory(tmp_path: Path):
+    factory = tmp_path / "aragora" / "server" / "fastapi" / "factory.py"
+    factory.parent.mkdir(parents=True)
+    factory.write_text("def broken(:\n", encoding="utf-8")
+
+    with pytest.raises(validate_openapi_routes.RouteRegistrationScanError):
+        validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+
+def test_get_fastapi_mounted_routes_fails_closed_on_missing_mounted_module(tmp_path: Path):
+    factory = _write_fastapi_tree(
+        tmp_path,
+        """
+from .routes import shop
+
+def create_app(app):
+    app.include_router(shop.router)
+""".lstrip(),
+        {
+            "shop": """
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/v2/shop")
+
+@router.get("/items")
+async def list_items():
+    return []
+""".lstrip(),
+        },
+    )
+    (tmp_path / "aragora" / "server" / "fastapi" / "routes" / "shop.py").unlink()
+
+    with pytest.raises(validate_openapi_routes.RouteRegistrationScanError):
+        validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+
+def test_get_fastapi_mounted_routes_fails_closed_on_missing_router_definition(tmp_path: Path):
+    factory = _write_fastapi_tree(
+        tmp_path,
+        """
+from .routes import broken
+
+def create_app(app):
+    app.include_router(broken.router)
+""".lstrip(),
+        {
+            # Mounted, but no module-level `router = APIRouter(...)` to inspect.
+            "broken": """
+def make_router():
+    from fastapi import APIRouter
+
+    router = APIRouter(prefix="/api/v2/broken")
+    return router
+""".lstrip(),
+        },
+    )
+
+    with pytest.raises(validate_openapi_routes.RouteRegistrationScanError):
+        validate_openapi_routes.get_fastapi_mounted_routes(factory, tmp_path)
+
+
+def test_validate_coverage_credits_fastapi_mounted_routes(monkeypatch, tmp_path: Path):
+    """Positive + negative: a mounted path is served, an unmounted one stays orphaned."""
+    monkeypatch.setattr(validate_openapi_routes, "get_handler_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_openapi_routes",
+        lambda _spec: {"/api/v2/shop/items", "/api/v2/zz-truly-unmounted"},
+    )
+    monkeypatch.setattr(validate_openapi_routes, "get_wired_function_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_fastapi_mounted_routes",
+        lambda: {"/api/v2/shop/items"},
+    )
+    fake_registry = types.SimpleNamespace(HANDLER_REGISTRY=[])
+    monkeypatch.setitem(sys.modules, "aragora.server.handler_registry", fake_registry)
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"missing_in_spec": [], "orphaned_in_spec": []}\n', encoding="utf-8")
+
+    results = validate_openapi_routes.validate_coverage(
+        "ignored.json",
+        baseline_path=str(baseline),
+        include_internal=True,
+    )
+
+    assert results["orphaned_in_spec"] == ["/api/v2/zz-truly-unmounted"]
+    assert results["served_fastapi_mounted"] == ["/api/v2/shop/items"]
+    assert "/api/v2/shop/items" in results["served_undeclared"]
+
+
+def test_validate_coverage_fastapi_plane_does_not_feed_missing_in_spec(monkeypatch, tmp_path: Path):
+    """The FastAPI plane is serve evidence only: a mounted route absent from the
+    spec must NOT become missing_in_spec (the mounted surface is opt-in, so it
+    carries no declaration obligation), and the existing planes' missing_in_spec
+    arithmetic stays untouched."""
+    monkeypatch.setattr(validate_openapi_routes, "get_handler_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_openapi_routes",
+        lambda _spec: {"/api/v2/shop/items"},
+    )
+    monkeypatch.setattr(validate_openapi_routes, "get_wired_function_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_fastapi_mounted_routes",
+        lambda: {"/api/v2/shop/items", "/api/v2/shop/absent-from-spec"},
+    )
+    fake_registry = types.SimpleNamespace(HANDLER_REGISTRY=[])
+    monkeypatch.setitem(sys.modules, "aragora.server.handler_registry", fake_registry)
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"missing_in_spec": [], "orphaned_in_spec": []}\n', encoding="utf-8")
+
+    results = validate_openapi_routes.validate_coverage(
+        "ignored.json",
+        baseline_path=str(baseline),
+        include_internal=True,
+    )
+
+    assert results["missing_in_spec"] == []
+    assert results["orphaned_in_spec"] == []
+    assert results["served_fastapi_mounted"] == ["/api/v2/shop/items"]
+
+
+def test_validate_coverage_excludes_internal_fastapi_routes(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(validate_openapi_routes, "get_handler_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_openapi_routes",
+        lambda _spec: {"/api/v1/control-plane/private"},
+    )
+    monkeypatch.setattr(validate_openapi_routes, "get_wired_function_routes", lambda: set())
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "get_fastapi_mounted_routes",
+        lambda: {"/api/v1/control-plane/private"},
+    )
+    fake_registry = types.SimpleNamespace(HANDLER_REGISTRY=[])
+    monkeypatch.setitem(sys.modules, "aragora.server.handler_registry", fake_registry)
+
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"missing_in_spec": [], "orphaned_in_spec": []}\n', encoding="utf-8")
+
+    results = validate_openapi_routes.validate_coverage(
+        "ignored.json",
+        baseline_path=str(baseline),
+    )
+
+    # Internal families are excluded from BOTH the candidates and the plane, so
+    # nothing is orphaned and nothing is credited to the FastAPI plane.
+    assert results["orphaned_in_spec"] == []
+    assert results["served_fastapi_mounted"] == []
+
+
+def test_filter_fastapi_orphans_logs_suppressions(monkeypatch, capsys):
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "load_fastapi_routes_for_validation",
+        lambda: {"/api/v2/shop/items"},
+    )
+
+    orphaned, served = validate_openapi_routes.filter_fastapi_orphans(
+        {"/api/v2/shop/items", "/api/v2/dark"}
+    )
+
+    assert served == {"/api/v2/shop/items"}
+    assert orphaned == {"/api/v2/dark"}
+    err = capsys.readouterr().err
+    assert "mounted FastAPI routers" in err
+    assert "/api/v2/shop/items" in err
+
+
+def test_real_factory_mounts_v2_marketplace_and_orchestration_paths():
+    """The real factory mounts the v2 marketplace/orchestration routers whose
+    spec entries were re-added by PR #9724 (ledger 397 point 1)."""
+    routes = validate_openapi_routes.get_fastapi_mounted_routes()
+
+    assert {
+        "/api/v2/marketplace/categories",
+        "/api/v2/marketplace/status",
+        "/api/v2/marketplace/templates",
+        "/api/v2/marketplace/templates/import",
+        "/api/v2/orchestration/deliberate",
+        "/api/v2/orchestration/deliberate/sync",
+        "/api/v2/orchestration/templates",
+    } <= routes
+
+
+def test_real_factory_does_not_credit_unmounted_swarm_status_router():
+    """swarm_status.py defines an APIRouter but is not imported/mounted by the
+    factory, so its paths must never enter the evidence plane."""
+    routes = validate_openapi_routes.get_fastapi_mounted_routes()
+
+    assert not any(route.startswith("/api/v1/swarm") for route in routes)
+
+
+# ---------------------------------------------------------------------------
 # VAL-CDG-011: method-aware operation plane
 # ---------------------------------------------------------------------------
 

--- a/tests/server/handlers/test_serve_side_orphan_dispatch.py
+++ b/tests/server/handlers/test_serve_side_orphan_dispatch.py
@@ -52,17 +52,10 @@ SERVED_ORPHANS = [
     "/api/v1/review-queue/triage-metrics",
 ]
 
-# The only paths that may remain orphaned after this PR: the 7 re-added
-# v2 FastAPI-plane paths owned by cdg-route-validator-fastapi-plane.
-V2_REMAINDER = [
-    "/api/v2/marketplace/categories",
-    "/api/v2/marketplace/status",
-    "/api/v2/marketplace/templates",
-    "/api/v2/marketplace/templates/import",
-    "/api/v2/orchestration/deliberate",
-    "/api/v2/orchestration/deliberate/sync",
-    "/api/v2/orchestration/templates",
-]
+# After cdg-route-validator-fastapi-plane landed the mounted-FastAPI evidence
+# plane, the 7 re-added v2 marketplace/orchestration paths count as served and
+# the orphan baseline is terminal-empty.
+V2_REMAINDER: list[str] = []
 
 
 def _load_validator_module():


### PR DESCRIPTION
## Source

PR-3 of the route-debt orphan reconciliation — ledger 397 point 3 (2026-08-08): the operator accepted the claude dissent on PR #9724 that the route-truth validator is blind to the mounted FastAPI surface, ordered the 7 v2 paths re-added (PR #9724), scoped PR-2 to the serve-side 12 (PR #9725), and split this validator-plane feature out.

## Behavior summary

**Additive mounted-FastAPI-router evidence plane** in `scripts/validate_openapi_routes.py`:

- `get_fastapi_mounted_routes()` statically parses `aragora/server/fastapi/factory.py`, resolves locally-imported route modules, and extracts literal routes from every `include_router(<module>.router[, prefix=...])` mount: include prefix + `APIRouter(prefix=...)` + `@router.<method>("<path>")`, keeping `/api/`-rooted literals only.
- Fail-closed: unreadable/unparseable factory or mounted module source, and a mounted name with no module-level `APIRouter` assignment, raise `RouteRegistrationScanError` (validator exits 1). Computed prefixes/paths and unrecognized mount forms contribute nothing (under-credit, never over-credit).
- `filter_fastapi_orphans()` suppresses orphan candidates with stderr logging, between the wired-registration filter and the can_handle probes. New JSON fields: `served_fastapi_mounted`, `served_fastapi_mounted_count`, `fastapi_mounted_routes_count`.
- **Existing planes unweakened**: handler ROUTES, wired registrations, and can_handle probes are untouched; the new plane only shrinks orphan candidates and never feeds `missing_in_spec` (the mounted surface is opt-in and carries no declaration obligation).

**Contract-scope revision (for settlement record):** *served* = reachable on the default `aragora serve` dispatcher plane OR on the mounted opt-in FastAPI plane (`ARAGORA_USE_FASTAPI`), because routers mounted in `aragora/server/fastapi/factory.py` back shipped SDK operations.

**Baseline shrink:** `scripts/baselines/validate_openapi_routes.json` `orphaned_in_spec` 7 → `[]` (exactly the PR #9724 re-added v2 marketplace/orchestration paths; shrink-only). The PR-2 pin `V2_REMAINDER` in `tests/server/handlers/test_serve_side_orphan_dispatch.py` updated to the terminal-empty state.

## Validation

- `python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json --fail-on-missing --baseline scripts/baselines/validate_openapi_routes.json --internal-prefixes scripts/baselines/internal_route_prefixes.json --json` → rc=0, missing=0, orphaned=0, new_missing=0, new_orphaned=0, coverage=100.0; stderr logs the 7 v2 suppressions via "mounted FastAPI routers".
- Red-first: with the shrunk baseline and no plane, rc=1 with new_orphaned=7 (captured before implementation).
- `python3 -m pytest tests/scripts/test_validate_openapi_routes.py -q` → 102 passed (17 new: synthetic mount extraction, include-prefix composition, non-literal skips, 3 fail-closed negatives, coverage integration positive+negative, no-missing-feed, internal exclusion, suppression logging, real-repo 7-path positive, real-repo unmounted swarm_status negative). Multi-seed sweep (1/42/100/2024/12345) all green.
- `python3 -m pytest tests/server/handlers/test_serve_side_orphan_dispatch.py tests/scripts/test_openapi_workflow_contract.py tests/governance/test_contract_drift_measurement_authority_tier.py tests/scripts/test_generate_contract_drift_inventory.py -q` → 965 passed.
- `check_contract_drift_ratchet.py --mode pr --strict` (full SHAs base=f184e2f73f... head=79ab1db8ef...) → status=pass.
- `make lint`, `ruff format --check`, mypy (script clean), `make test-smoke`, smoke tier 138 passed.
- Spec untouched: 2888 paths / 3105 ops unchanged; doc gates verified no-op (`check_docs_consistency` no findings, `check_capability_matrix_sync` up to date, `doc_stats` counts unchanged).
- Pre-existing (reproduced identically on clean origin/main, out of scope): 6 failures in tests/scripts (charter-compliance multiline, inference-site manifest, elves-aragora references, capability-matrix CLI count 110!=111, measure-work-loss e2e, run-boss-cycle refill argv).

## Risks

- Checker semantic change = baseline-authority ⇒ **Tier 4 chronology: parked draft, prepare-only evidence, operator settlement required — do NOT merge without exact-pair delegation.**
- The plane is static AST over literals: it can under-credit (computed mounts) but never over-credit; fail-closed on uninspectable mounted modules guards against silent blind spots.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>
