### PR TITLE
test(contract-drift): fail closed on accepted-authority fixtures

### DIFF
--- a/tests/scripts/test_check_contract_drift_ratchet.py
+++ b/tests/scripts/test_check_contract_drift_ratchet.py
@@ -1515,7 +1515,7 @@ def _clone_repository_with_synthetic_accepted_authority(
     *,
     cohort_path: Path,
     provenance_path: Path,
-) -> tuple[Path, str, str, bool]:
+) -> tuple[Path, str, str]:
     source_repo = Path(__file__).resolve().parents[2]
     repo_root = tmp_path / "synthetic-authority-repo"
     subprocess.run(
@@ -1529,27 +1529,87 @@ def _clone_repository_with_synthetic_accepted_authority(
     inventory_path = repo_root / gen.DEFAULT_INVENTORY
     inventory = json.loads(inventory_path.read_bytes())
     accepted_authority = inventory.get("accepted_authority")
-    has_accepted_authority = isinstance(accepted_authority, dict)
-    if accepted_authority is not None and not has_accepted_authority:
-        raise AssertionError("production accepted authority is malformed")
-    if has_accepted_authority:
-        canonical_artifacts = accepted_authority.get("canonical_artifacts")
-        if not isinstance(canonical_artifacts, dict):
-            raise AssertionError("production accepted authority lacks canonical artifacts")
-        before = copy.deepcopy(inventory)
-        original_canonical_artifacts = copy.deepcopy(canonical_artifacts)
-        cohort = json.loads(cohort_path.read_bytes())
-        provenance = json.loads(provenance_path.read_bytes())
-        canonical_artifacts["original_cohort"] = cohort
-        canonical_artifacts["sdk_provenance"] = provenance
-        reverted = copy.deepcopy(inventory)
-        reverted_artifacts = reverted["accepted_authority"]["canonical_artifacts"]
-        reverted_artifacts["original_cohort"] = original_canonical_artifacts["original_cohort"]
-        reverted_artifacts["sdk_provenance"] = original_canonical_artifacts["sdk_provenance"]
-        assert reverted == before
-        _write_json(inventory_path, inventory)
+    if not isinstance(accepted_authority, dict):
+        raise AssertionError("production accepted authority is missing or malformed")
+    canonical_artifacts = accepted_authority.get("canonical_artifacts")
+    if not isinstance(canonical_artifacts, dict):
+        raise AssertionError("production accepted authority lacks canonical artifacts")
+    before = copy.deepcopy(inventory)
+    original_canonical_artifacts = copy.deepcopy(canonical_artifacts)
+    cohort = json.loads(cohort_path.read_bytes())
+    provenance = json.loads(provenance_path.read_bytes())
+    canonical_artifacts["original_cohort"] = cohort
+    canonical_artifacts["sdk_provenance"] = provenance
+    reverted = copy.deepcopy(inventory)
+    reverted_artifacts = reverted["accepted_authority"]["canonical_artifacts"]
+    reverted_artifacts["original_cohort"] = original_canonical_artifacts["original_cohort"]
+    reverted_artifacts["sdk_provenance"] = original_canonical_artifacts["sdk_provenance"]
+    assert reverted == before
+    _write_json(inventory_path, inventory)
     fixture_sha = _commit(repo_root, "bind synthetic accepted authority")
-    return repo_root, production_sha, fixture_sha, has_accepted_authority
+    return repo_root, production_sha, fixture_sha
+
+
+def _mutate_cloned_production_inventory(
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Any,
+) -> None:
+    real_run = subprocess.run
+
+    def run_then_mutate(
+        argv: list[str],
+        *args: Any,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[Any]:
+        result = real_run(argv, *args, **kwargs)
+        if argv[:3] == ["git", "clone", "-q"]:
+            inventory_path = Path(argv[-1]) / gen.DEFAULT_INVENTORY
+            inventory = json.loads(inventory_path.read_bytes())
+            mutate(inventory)
+            _write_json(inventory_path, inventory)
+        return result
+
+    monkeypatch.setattr(subprocess, "run", run_then_mutate)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    (
+        pytest.param(
+            lambda inventory: inventory.pop("accepted_authority"),
+            "production accepted authority",
+            id="missing-authority",
+        ),
+        pytest.param(
+            lambda inventory: inventory.__setitem__("accepted_authority", None),
+            "production accepted authority",
+            id="malformed-authority",
+        ),
+        pytest.param(
+            lambda inventory: inventory["accepted_authority"].pop("canonical_artifacts"),
+            "lacks canonical artifacts",
+            id="missing-canonical-artifacts",
+        ),
+    ),
+)
+def test_synthetic_accepted_authority_fixture_rejects_invalid_production_authority(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutate: Any,
+    message: str,
+):
+    cohort_path, provenance_path = _write_synthetic_canonical_artifacts(
+        tmp_path,
+        monkeypatch,
+    )
+    _mutate_cloned_production_inventory(monkeypatch, mutate)
+
+    with pytest.raises(AssertionError, match=message):
+        _clone_repository_with_synthetic_accepted_authority(
+            tmp_path,
+            cohort_path=cohort_path,
+            provenance_path=provenance_path,
+        )
 
 
 def _fixture_sdk_partitions() -> dict[str, list[str]]:
@@ -2185,12 +2245,10 @@ def test_boundary_pass_fixture_uses_production_artifact_and_authority_authentica
         tmp_path,
         monkeypatch,
     )
-    repo_root, start_sha, end_sha, _has_accepted_authority = (
-        _clone_repository_with_synthetic_accepted_authority(
-            tmp_path,
-            cohort_path=cohort_path,
-            provenance_path=provenance_path,
-        )
+    repo_root, start_sha, end_sha = _clone_repository_with_synthetic_accepted_authority(
+        tmp_path,
+        cohort_path=cohort_path,
+        provenance_path=provenance_path,
     )
     operation_log: list[dict[str, Any]] = []
     authority = ratchet._authenticate_authority_manifest(
@@ -2530,29 +2588,26 @@ def test_canonical_cohort_and_provenance_artifacts_are_in_authority_closure(
         "sha256",
         hashlib.sha256(original_raw).hexdigest(),
     )
-    repo_root, production_sha, end_sha, has_accepted_authority = (
-        _clone_repository_with_synthetic_accepted_authority(
-            tmp_path,
-            cohort_path=cohort_path,
-            provenance_path=provenance_path,
-        )
+    repo_root, production_sha, end_sha = _clone_repository_with_synthetic_accepted_authority(
+        tmp_path,
+        cohort_path=cohort_path,
+        provenance_path=provenance_path,
     )
-    if has_accepted_authority:
-        with pytest.raises(
-            gen.AuthorityClosureError,
-            match="accepted authority differs from authenticated canonical artifacts",
-        ):
-            ratchet._authenticate_authority_manifest(
-                repo_root=repo_root,
-                end_sha=production_sha,
-                authority_manifest_path=None,
-                authority_manifest_byte_length=None,
-                authority_manifest_sha256=None,
-                cohort_artifact_path=cohort_path,
-                sdk_provenance_artifact_path=provenance_path,
-                scratch_root=tmp_path,
-                operation_log=[],
-            )
+    with pytest.raises(
+        gen.AuthorityClosureError,
+        match="accepted authority differs from authenticated canonical artifacts",
+    ):
+        ratchet._authenticate_authority_manifest(
+            repo_root=repo_root,
+            end_sha=production_sha,
+            authority_manifest_path=None,
+            authority_manifest_byte_length=None,
+            authority_manifest_sha256=None,
+            cohort_artifact_path=cohort_path,
+            sdk_provenance_artifact_path=provenance_path,
+            scratch_root=tmp_path,
+            operation_log=[],
+        )
     captured: dict[str, Any] = {}
     original_build = ratchet.inventory_mod.build_authority_manifest
 


### PR DESCRIPTION
## Summary

- close FIX-RT-003 by requiring production `accepted_authority` and `canonical_artifacts` before constructing the synthetic exact-ref fixture
- always execute the unmodified-production-authority rejection instead of conditionally skipping it
- add explicit missing, malformed, and missing-canonical-artifacts negative cases while preserving every existing test selector

## Risk

Tier 0, tests-only. No production authority, baseline, checker, workflow, or selector behavior changes.

## Validation

- red first: `python3 -B -m pytest tests/scripts/test_check_contract_drift_ratchet.py -q --timeout=120 -k 'synthetic_accepted_authority_fixture_rejects_missing_production_authority or synthetic_accepted_authority_fixture_rejects_malformed_production_authority'` -> 2 failed because neither case raised before the repair
- `python3 -B -m pytest tests/scripts/test_check_contract_drift_ratchet.py -q --timeout=300` -> 264 passed
- `make lint` -> all checks passed
- `ruff format --check aragora/ tests/ scripts/` -> 10,798 files already formatted
- `MYPY_CACHE_DIR=$(mktemp -d) bash scripts/preflight_mypy.sh --diff-base origin/main` -> no production Python changes, skipped cleanly
- `ARAGORA_SECRETS_STRICT=false AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` -> Core/Server/Memory imports OK
- `ARAGORA_SECRETS_STRICT=false AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true PYTEST_BIN='python3 -m pytest' bash scripts/test_tiers.sh smoke` -> 138 passed
- selector census: base 220, head 221, missing 0, duplicated 0
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight ok

## Mission

Feature: `cdg-stage2-authority-fixture-fail-closed`
