### PR TITLE
fix(governance): bind route truth to exact refs [Tier 4]

### DIFF
--- a/scripts/validate_openapi_routes.py
+++ b/scripts/validate_openapi_routes.py
@@ -2764,7 +2764,19 @@ def validate_method_aware_plane(
     inventory_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Compute the complete VAL-CDG-011 method-aware operation plane."""
-    ref = _prove_bound_tree(ref) if _BOUND_TREE_ROOT else _require_exact_ref(ref)
+    if not _BOUND_TREE_ROOT:
+        resolved_ref = _require_exact_ref(ref, source_repo_root=_SOURCE_REPO_ROOT)
+        return _run_method_aware_plane_at_commit(
+            spec_path=spec_path,
+            resolved_ref=resolved_ref,
+            internal_prefixes_path=(
+                internal_prefixes_path or "scripts/baselines/internal_route_prefixes.json"
+            ),
+            inventory_path=inventory_path,
+            source_repo_root=_SOURCE_REPO_ROOT,
+        )
+
+    ref = _prove_bound_tree(ref)
     internal_prefixes = load_internal_prefixes(internal_prefixes_path)
 
     wired_witnesses: list[dict[str, Any]] = []

--- a/scripts/validate_openapi_routes.py
+++ b/scripts/validate_openapi_routes.py
@@ -38,13 +38,18 @@ import inspect
 import json
 import os
 import re
+import subprocess
 import sys
+import tempfile
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import Any, cast
 
 # Ensure local checkout modules take precedence over any globally installed package.
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SOURCE_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BOUND_TREE_ROOT = os.environ.get("_ARAGORA_OPENAPI_ROUTE_TREE_ROOT")
+_BOUND_TREE_REF = os.environ.get("_ARAGORA_OPENAPI_ROUTE_RESOLVED_REF")
+_REPO_ROOT = Path(_BOUND_TREE_ROOT).resolve() if _BOUND_TREE_ROOT else _SOURCE_REPO_ROOT
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
@@ -1576,6 +1581,15 @@ def path_normalization_binding() -> dict[str, Any]:
     across outputs for schema/version/digest equality.
     """
     authority = _REPO_ROOT / _PATH_NORMALIZE_AUTHORITY
+    if _BOUND_TREE_ROOT:
+        imported_authority = inspect.getsourcefile(normalize_sdk_path)
+        if not imported_authority:
+            raise MethodAwareError("cannot locate imported path-normalization authority")
+        imported_relative = _relative_source_path(imported_authority)
+        if imported_relative != _PATH_NORMALIZE_AUTHORITY:
+            raise MethodAwareError(
+                "imported path-normalization authority does not come from the bound route tree"
+            )
     try:
         authority_bytes = authority.read_bytes()
     except OSError as exc:
@@ -1590,14 +1604,137 @@ def path_normalization_binding() -> dict[str, Any]:
     }
 
 
-def _require_exact_ref(ref: str) -> str:
-    # 40 hex is a SHA-1 object name; 64 hex supports SHA-256 object-format repos.
-    if not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", ref or ""):
-        raise MethodAwareError(
-            f"--ref must be an exact 40- or 64-hex commit SHA, got {ref!r}; "
-            'run with --ref "$(git rev-parse HEAD)"'
+def _git(
+    source_repo_root: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    git_env = {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+        "HOME": os.environ.get("HOME", ""),
+        "LC_ALL": "C",
+        "PATH": os.environ.get("PATH", ""),
+        "TMPDIR": os.environ.get("TMPDIR", tempfile.gettempdir()),
+    }
+    try:
+        return subprocess.run(
+            [
+                "git",
+                "-c",
+                "core.fsmonitor=false",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-C",
+                str(source_repo_root),
+                *args,
+            ],
+            check=False,
+            capture_output=True,
+            env=git_env,
+            text=True,
         )
-    return ref
+    except OSError as exc:
+        raise MethodAwareError(f"cannot execute git: {exc}") from exc
+
+
+def _require_exact_ref(
+    ref: str | None,
+    *,
+    source_repo_root: Path = _SOURCE_REPO_ROOT,
+) -> str:
+    if not ref or "\x00" in ref or ref.startswith("-"):
+        raise MethodAwareError("--ref cannot resolve to a commit")
+
+    source_repo_root = source_repo_root.resolve()
+    result = _git(source_repo_root, "rev-parse", "--verify", f"{ref}^{{commit}}")
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        suffix = f": {detail}" if detail else ""
+        raise MethodAwareError(f"--ref {ref!r} cannot resolve to a commit{suffix}")
+
+    return _require_resolved_commit_id(result.stdout.strip().lower(), label=f"--ref {ref!r}")
+
+
+def _require_resolved_commit_id(value: str, *, label: str = "resolved ref") -> str:
+    if not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", value) or set(value) == {"0"}:
+        raise MethodAwareError(f"{label} is not a valid resolved commit object ID")
+    return value
+
+
+def _repo_relative_input(path: str | Path, *, source_repo_root: Path, label: str) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        try:
+            candidate = candidate.relative_to(source_repo_root)
+        except ValueError as exc:
+            raise MethodAwareError(f"{label} must be inside the source repository") from exc
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise MethodAwareError(f"{label} must be a repository-relative path")
+    return candidate
+
+
+def _create_detached_checkout(
+    *,
+    source_repo_root: Path,
+    resolved_ref: str,
+    target_root: Path,
+) -> None:
+    template_root = target_root.parent / "git-template"
+    template_root.mkdir()
+    clone = _git(
+        source_repo_root,
+        "clone",
+        "--no-checkout",
+        "--shared",
+        f"--template={template_root}",
+        str(source_repo_root),
+        str(target_root),
+    )
+    if clone.returncode != 0:
+        detail = clone.stderr.strip() or clone.stdout.strip()
+        raise MethodAwareError(
+            f"cannot create isolated checkout for resolved commit {resolved_ref}: {detail}"
+        )
+
+    checkout = _git(
+        target_root,
+        "checkout",
+        "--detach",
+        resolved_ref,
+    )
+    if checkout.returncode != 0:
+        detail = checkout.stderr.strip() or checkout.stdout.strip()
+        raise MethodAwareError(
+            f"cannot detach isolated checkout at resolved commit {resolved_ref}: {detail}"
+        )
+
+
+def _prove_bound_tree(ref: str) -> str:
+    resolved = _require_resolved_commit_id(ref)
+    head_result = _git(_REPO_ROOT, "rev-parse", "--verify", "HEAD^{commit}")
+    if head_result.returncode != 0:
+        detail = head_result.stderr.strip() or head_result.stdout.strip()
+        raise MethodAwareError(f"cannot resolve bound route tree HEAD: {detail}")
+    head = _require_resolved_commit_id(
+        head_result.stdout.strip().lower(),
+        label="bound route tree HEAD",
+    )
+    if resolved != head:
+        raise MethodAwareError(
+            f"bound route tree HEAD {head} does not equal resolved commit {resolved}"
+        )
+    status = _git(_REPO_ROOT, "status", "--porcelain", "--untracked-files=all")
+    if status.returncode != 0:
+        detail = status.stderr.strip() or status.stdout.strip()
+        raise MethodAwareError(f"cannot prove bound route tree cleanliness: {detail}")
+    if status.stdout:
+        raise MethodAwareError("bound route tree is dirty; refusing to bind operation evidence")
+    if _BOUND_TREE_REF != resolved:
+        raise MethodAwareError(
+            "bound route tree environment does not name its exact resolved commit"
+        )
+    return resolved
 
 
 def _clean_literal_path(raw: str) -> str | None:
@@ -1617,6 +1754,16 @@ def _clean_literal_path(raw: str) -> str | None:
 
 def _relative_source_path(path: Path | str) -> str:
     candidate = Path(path)
+    if _BOUND_TREE_ROOT:
+        resolved = (
+            candidate.resolve() if candidate.is_absolute() else (_REPO_ROOT / candidate).resolve()
+        )
+        try:
+            return str(resolved.relative_to(_REPO_ROOT))
+        except ValueError as exc:
+            raise MethodAwareError(
+                f"authority source path escapes the bound route tree: {candidate}"
+            ) from exc
     try:
         return str(candidate.relative_to(_REPO_ROOT))
     except ValueError:
@@ -1680,6 +1827,15 @@ def _active_handler_source_files() -> frozenset[str]:
     files: set[str] = set()
 
     def _add(source_file: str) -> None:
+        if _BOUND_TREE_ROOT:
+            resolved = Path(source_file).resolve()
+            try:
+                files.add(str(resolved.relative_to(_REPO_ROOT)))
+            except ValueError:
+                # Standard-library and dependency MRO methods are not handler
+                # source authority and cannot be scanned under the repository.
+                pass
+            return
         # Key the census on BOTH the raw and resolved spellings so the
         # membership check in get_handler_source_literal_operations (which
         # resolves the scanned file) agrees under symlinked checkouts.
@@ -1779,6 +1935,12 @@ def _iter_registry_handler_classes() -> Iterator[Any]:
         handler_registry = importlib.import_module("aragora.server.handler_registry")
     except ImportError as exc:  # pragma: no cover - environment failure
         raise MethodAwareError(f"cannot import handler_registry: {exc}") from exc
+
+    if _BOUND_TREE_ROOT:
+        registry_source = getattr(handler_registry, "__file__", None)
+        if not registry_source:
+            raise MethodAwareError("cannot locate imported handler_registry authority")
+        _relative_source_path(registry_source)
 
     registry = handler_registry.HANDLER_REGISTRY
     filter_by_tier = getattr(handler_registry, "filter_registry_by_tier", None)
@@ -2514,6 +2676,87 @@ def load_operation_projection(inventory_path: str | Path | None = None) -> dict[
     }
 
 
+def _run_method_aware_plane_at_commit(
+    *,
+    spec_path: str | Path,
+    resolved_ref: str,
+    internal_prefixes_path: str | Path,
+    inventory_path: str | Path | None = None,
+    source_repo_root: Path = _SOURCE_REPO_ROOT,
+) -> dict[str, Any]:
+    source_repo_root = source_repo_root.resolve()
+    resolved_ref = _require_resolved_commit_id(resolved_ref)
+    spec_relative = _repo_relative_input(
+        spec_path,
+        source_repo_root=source_repo_root,
+        label="--spec",
+    )
+    internal_prefixes_relative = _repo_relative_input(
+        internal_prefixes_path,
+        source_repo_root=source_repo_root,
+        label="--internal-prefixes",
+    )
+    inventory_relative = _repo_relative_input(
+        inventory_path or Path("scripts/baselines/contract_drift_inventory.json"),
+        source_repo_root=source_repo_root,
+        label="--inventory",
+    )
+
+    with tempfile.TemporaryDirectory(prefix="aragora-openapi-route-tree-") as temp_dir:
+        temporary_root = Path(temp_dir)
+        target_root = temporary_root / "tree"
+        _create_detached_checkout(
+            source_repo_root=source_repo_root,
+            resolved_ref=resolved_ref,
+            target_root=target_root,
+        )
+
+        command = [
+            sys.executable,
+            "-I",
+            "-B",
+            str(_SOURCE_REPO_ROOT / "scripts/validate_openapi_routes.py"),
+            "--ref",
+            resolved_ref,
+            "--spec",
+            str(spec_relative),
+            "--internal-prefixes",
+            str(internal_prefixes_relative),
+            "--inventory",
+            str(inventory_relative),
+            "--json",
+        ]
+        child_env = {
+            "PATH": os.environ.get("PATH", ""),
+            "_ARAGORA_OPENAPI_ROUTE_TREE_ROOT": str(target_root),
+            "_ARAGORA_OPENAPI_ROUTE_RESOLVED_REF": resolved_ref,
+        }
+        result = subprocess.run(
+            command,
+            cwd=target_root,
+            env=child_env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip()
+            raise MethodAwareError(
+                f"method-aware validation failed at resolved commit {resolved_ref}: {detail}"
+            )
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise MethodAwareError(
+                f"method-aware validation returned invalid JSON at {resolved_ref}"
+            ) from exc
+        if not isinstance(payload, dict) or payload.get("ref") != resolved_ref:
+            raise MethodAwareError(
+                f"method-aware validation did not bind output to resolved commit {resolved_ref}"
+            )
+        return cast(dict[str, Any], payload)
+
+
 def validate_method_aware_plane(
     spec_path: str,
     ref: str,
@@ -2521,7 +2764,7 @@ def validate_method_aware_plane(
     inventory_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Compute the complete VAL-CDG-011 method-aware operation plane."""
-    ref = _require_exact_ref(ref)
+    ref = _prove_bound_tree(ref) if _BOUND_TREE_ROOT else _require_exact_ref(ref)
     internal_prefixes = load_internal_prefixes(internal_prefixes_path)
 
     wired_witnesses: list[dict[str, Any]] = []
@@ -2623,6 +2866,8 @@ def validate_method_aware_plane(
     for name, operations in collections.items():
         plane[name] = operations
         plane[f"{name}_count"] = len(operations)
+    if _BOUND_TREE_ROOT:
+        _prove_bound_tree(ref)
     return plane
 
 
@@ -2886,9 +3131,14 @@ def main():
         "--ref",
         default=None,
         help=(
-            "Exact 40-hex commit SHA to bind operation evidence to; enables the "
-            "method-aware VAL-CDG-011 operation plane"
+            "Git ref resolved exactly once as <ref>^{commit}; enables the "
+            "method-aware VAL-CDG-011 operation plane bound to that immutable tree"
         ),
+    )
+    parser.add_argument(
+        "--inventory",
+        default="scripts/baselines/contract_drift_inventory.json",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--fail-on-missing",
@@ -2922,11 +3172,36 @@ def main():
     args = parser.parse_args()
     if args.ref is not None:
         try:
-            plane = validate_method_aware_plane(
-                args.spec,
-                args.ref,
-                internal_prefixes_path=args.internal_prefixes,
-            )
+            if _BOUND_TREE_ROOT:
+                spec_relative = _repo_relative_input(
+                    args.spec,
+                    source_repo_root=_REPO_ROOT,
+                    label="--spec",
+                )
+                internal_prefixes_relative = _repo_relative_input(
+                    args.internal_prefixes,
+                    source_repo_root=_REPO_ROOT,
+                    label="--internal-prefixes",
+                )
+                inventory_relative = _repo_relative_input(
+                    args.inventory,
+                    source_repo_root=_REPO_ROOT,
+                    label="--inventory",
+                )
+                plane = validate_method_aware_plane(
+                    str(_REPO_ROOT / spec_relative),
+                    args.ref,
+                    internal_prefixes_path=str(_REPO_ROOT / internal_prefixes_relative),
+                    inventory_path=_REPO_ROOT / inventory_relative,
+                )
+            else:
+                resolved_ref = _require_exact_ref(args.ref)
+                plane = _run_method_aware_plane_at_commit(
+                    spec_path=args.spec,
+                    resolved_ref=resolved_ref,
+                    internal_prefixes_path=args.internal_prefixes,
+                    inventory_path=args.inventory,
+                )
         except MethodAwareError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             sys.exit(1)

--- a/tests/scripts/test_validate_openapi_routes.py
+++ b/tests/scripts/test_validate_openapi_routes.py
@@ -251,6 +251,46 @@ def test_moving_symbolic_ref_is_resolved_once(
     assert {entry["operation_id"] for entry in plane["declared_and_served"]} == {"GET /api/ref-a"}
 
 
+def test_direct_method_aware_entrypoint_delegates_to_exact_tree(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    resolved = "a" * 40
+    expected = {"ref": resolved}
+    captured: dict[str, object] = {}
+
+    def fake_resolve(ref, *, source_repo_root):
+        captured["ref"] = ref
+        captured["source_repo_root"] = source_repo_root
+        return resolved
+
+    def fake_run(**kwargs):
+        captured.update(kwargs)
+        return expected
+
+    monkeypatch.setattr(validate_openapi_routes, "_require_exact_ref", fake_resolve)
+    monkeypatch.setattr(
+        validate_openapi_routes,
+        "_run_method_aware_plane_at_commit",
+        fake_run,
+    )
+
+    result = validate_openapi_routes.validate_method_aware_plane(
+        "docs/api/openapi.json",
+        "moving-ref",
+        internal_prefixes_path="scripts/baselines/internal_route_prefixes.json",
+    )
+
+    assert result is expected
+    assert captured == {
+        "ref": "moving-ref",
+        "source_repo_root": validate_openapi_routes._SOURCE_REPO_ROOT,
+        "spec_path": "docs/api/openapi.json",
+        "resolved_ref": resolved,
+        "internal_prefixes_path": "scripts/baselines/internal_route_prefixes.json",
+        "inventory_path": None,
+    }
+
+
 def _fake_registry(entries):
     """Fake handler_registry module mirroring the real tier-filter surface."""
     return types.SimpleNamespace(

--- a/tests/scripts/test_validate_openapi_routes.py
+++ b/tests/scripts/test_validate_openapi_routes.py
@@ -5,13 +5,250 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import shutil
+import subprocess
 import sys
 import types
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
 
 import scripts.validate_openapi_routes as validate_openapi_routes
+
+
+def _git(repo: Path, *args: str, input_bytes: bytes | None = None) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        input=input_bytes,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.decode("utf-8").strip()
+
+
+@dataclass(frozen=True)
+class ExactRefRepo:
+    repo: Path
+    handler_registry: Path
+    spec: Path
+    ref_a: str
+    ref_b: str
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    return repo
+
+
+@pytest.fixture
+def exact_ref_repo(git_repo: Path) -> ExactRefRepo:
+    repo = git_repo
+    source_root = Path(validate_openapi_routes.__file__).resolve().parents[1]
+
+    for relative in (
+        "scripts/sdk_path_normalize.py",
+        "scripts/baselines/contract_drift_inventory.json",
+    ):
+        destination = repo / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_root / relative, destination)
+
+    (repo / "scripts/baselines/internal_route_prefixes.json").write_text(
+        '{"prefixes":["/api/v1/internal/"]}\n',
+        encoding="utf-8",
+    )
+    for relative in (
+        "aragora/__init__.py",
+        "aragora/server/__init__.py",
+        "aragora/server/stream/__init__.py",
+    ):
+        destination = repo / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text("", encoding="utf-8")
+    registration = repo / "aragora/server/stream/servers_route_registration.py"
+    registration.write_text("# no literal wired registrations\n", encoding="utf-8")
+
+    handler_registry = repo / "aragora/server/handler_registry.py"
+    handler_registry.write_text(
+        """
+class ExactRefHandler:
+    GET_ROUTES = ["/api/v1/ref-a"]
+
+HANDLER_REGISTRY = [("_exact_ref", ExactRefHandler)]
+
+def get_active_tiers():
+    return {"core"}
+
+def filter_registry_by_tier(registry, active_tiers=None):
+    return list(registry)
+""".lstrip(),
+        encoding="utf-8",
+    )
+    spec = repo / "docs/api/openapi.json"
+    spec.parent.mkdir(parents=True)
+    spec.write_text(
+        json.dumps({"paths": {"/api/v1/ref-a": {"get": {}}}}) + "\n",
+        encoding="utf-8",
+    )
+
+    _git(repo, "config", "user.name", "Exact Ref Test")
+    _git(repo, "config", "user.email", "exact-ref@example.invalid")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "fixture ref a")
+    ref_a = _git(repo, "rev-parse", "HEAD")
+
+    handler_registry.write_text(
+        handler_registry.read_text(encoding="utf-8").replace("/api/v1/ref-a", "/api/v1/ref-b"),
+        encoding="utf-8",
+    )
+    spec.write_text(
+        json.dumps({"paths": {"/api/v1/ref-b": {"post": {}}}}) + "\n",
+        encoding="utf-8",
+    )
+    registration.write_text(
+        'router.add_post("/api/v1/ref-b-wired", handler)\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/sdk_path_normalize.py").write_text(
+        'def normalize_sdk_path(path): return "/api/ref-b-normalized"\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/baselines/internal_route_prefixes.json").write_text(
+        '{"prefixes":["/api/"]}\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/baselines/contract_drift_inventory.json").write_text(
+        '{"ref_b":"not valid projection authority"}\n',
+        encoding="utf-8",
+    )
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "fixture ref b")
+    ref_b = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "branch", "moving-ref", ref_a)
+
+    return ExactRefRepo(
+        repo=repo,
+        handler_registry=handler_registry,
+        spec=spec,
+        ref_a=ref_a,
+        ref_b=ref_b,
+    )
+
+
+def _run_exact_ref_fixture(fixture: ExactRefRepo, resolved_ref: str) -> dict:
+    return validate_openapi_routes._run_method_aware_plane_at_commit(
+        spec_path="docs/api/openapi.json",
+        resolved_ref=resolved_ref,
+        internal_prefixes_path="scripts/baselines/internal_route_prefixes.json",
+        source_repo_root=fixture.repo,
+    )
+
+
+def test_zero_sha_ref_fails_closed(git_repo: Path):
+    with pytest.raises(validate_openapi_routes.MethodAwareError, match="cannot resolve"):
+        validate_openapi_routes._require_exact_ref(
+            "0" * 40,
+            source_repo_root=git_repo,
+        )
+
+
+def test_nonexistent_and_noncommit_refs_fail_closed(git_repo: Path):
+    repo = git_repo
+    with pytest.raises(validate_openapi_routes.MethodAwareError, match="cannot resolve"):
+        validate_openapi_routes._require_exact_ref(
+            "refs/heads/does-not-exist",
+            source_repo_root=repo,
+        )
+
+    blob = _git(repo, "hash-object", "-w", "--stdin", input_bytes=b"not a commit\n")
+    _git(repo, "tag", "blob-ref", blob)
+    with pytest.raises(validate_openapi_routes.MethodAwareError, match="commit"):
+        validate_openapi_routes._require_exact_ref("blob-ref", source_repo_root=repo)
+
+
+def test_valid_non_head_ref_reads_only_that_commit(exact_ref_repo: ExactRefRepo):
+    ref_a = exact_ref_repo.ref_a
+    assert _git(exact_ref_repo.repo, "rev-parse", "HEAD") == exact_ref_repo.ref_b
+
+    plane = _run_exact_ref_fixture(exact_ref_repo, ref_a)
+
+    assert plane["ref"] == ref_a
+    assert {entry["operation_id"] for entry in plane["declared_and_served"]} == {"GET /api/ref-a"}
+    assert all(entry["source_sha"] == ref_a for entry in plane["served_operations"])
+    assert all(entry["source_sha"] == ref_a for entry in plane["spec_operations"])
+    assert "POST /api/ref-b" not in {entry["operation_id"] for entry in plane["spec_operations"]}
+
+
+def test_dirty_caller_state_cannot_change_same_sha_output(exact_ref_repo: ExactRefRepo):
+    ref_a = exact_ref_repo.ref_a
+    clean = _run_exact_ref_fixture(exact_ref_repo, ref_a)
+
+    exact_ref_repo.handler_registry.write_text(
+        """
+class DirtyHandler:
+    DELETE_ROUTES = ["/api/v1/dirty-only"]
+HANDLER_REGISTRY = [("_dirty", DirtyHandler)]
+def get_active_tiers():
+    return {"core"}
+def filter_registry_by_tier(registry, active_tiers=None):
+    return list(registry)
+""".lstrip(),
+        encoding="utf-8",
+    )
+    exact_ref_repo.spec.write_text(
+        json.dumps({"paths": {"/api/v1/dirty-only": {"delete": {}}}}) + "\n",
+        encoding="utf-8",
+    )
+    repo = exact_ref_repo.repo
+    (repo / "aragora/server/stream/servers_route_registration.py").write_text(
+        'router.add_delete("/api/v1/dirty-wired", handler)\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/sdk_path_normalize.py").write_text(
+        'def normalize_sdk_path(path): return "/api/dirty-normalized"\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/baselines/internal_route_prefixes.json").write_text(
+        '{"prefixes":["/api/"]}\n',
+        encoding="utf-8",
+    )
+    (repo / "scripts/baselines/contract_drift_inventory.json").write_text(
+        '{"dirty":"ambient inventory must not be read"}\n',
+        encoding="utf-8",
+    )
+    (repo / "untracked-dirty.txt").write_text(
+        "ambient caller state\n",
+        encoding="utf-8",
+    )
+
+    dirty = _run_exact_ref_fixture(exact_ref_repo, ref_a)
+
+    assert dirty == clean
+    assert all("/dirty-only" not in entry["operation_id"] for entry in dirty["served_operations"])
+
+
+def test_moving_symbolic_ref_is_resolved_once(
+    exact_ref_repo: ExactRefRepo,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    repo = exact_ref_repo.repo
+    with monkeypatch.context() as isolated_env:
+        isolated_env.setenv("GIT_DIR", str(repo / "ambient-wrong.git"))
+        resolved = validate_openapi_routes._require_exact_ref(
+            "moving-ref",
+            source_repo_root=repo,
+        )
+    assert resolved == exact_ref_repo.ref_a
+
+    _git(repo, "branch", "-f", "moving-ref", exact_ref_repo.ref_b)
+    plane = _run_exact_ref_fixture(exact_ref_repo, resolved)
+
+    assert plane["ref"] == exact_ref_repo.ref_a
+    assert {entry["operation_id"] for entry in plane["declared_and_served"]} == {"GET /api/ref-a"}
 
 
 def _fake_registry(entries):


### PR DESCRIPTION
## Summary
- resolve every supplied route-truth ref exactly once as `<ref>^{commit}`
- execute registry/import, handler-source, OpenAPI, policy, inventory, and normalization authority reads from one isolated detached checkout
- delegate direct programmatic method-aware calls through the same isolated exact-tree path
- fail closed on zero, nonexistent, non-commit, dirty ambient, and moving symbolic ref attacks
- preserve existing method-aware and mounted-FastAPI route semantics

## Validation
- `285 passed`: full focused route-validator and contract-drift inventory suites
- `34 passed`: VAL-CDG-011 execution selectors
- `34/285 collected`: VAL-CDG-011 named-test collection proof
- exact-HEAD route validator plus contract jq: pass
- Ruff check/format, changed-file mypy, import canary, automation preflight: pass
- `make test-smoke`: pass

## Exact identity
- Base: `ed373278f0d995222b048ec6af50dcd5810e95d8`
- Head: `1e8403c26ddfd2bfed9c279c2441ed39fb14e132`
- Feature: `cdg-route-core-exact-ref-binding-repair`

## Tier 4 parked state
This PR is intentionally a **PARKED DRAFT** and is labeled `operator-review-required`.
Do not mark ready, post settlement, rerun post-settlement quorum, or merge from this feature.
Terminal settlement/merge ownership remains with `cdg-route-core-exact-ref-binding-settlement` after a later exact PR/head ledger delegation.
