### PR TITLE
fix(openapi): align success statuses with runtime

### DIFF
--- a/aragora/server/openapi/endpoints/integrations.py
+++ b/aragora/server/openapi/endpoints/integrations.py
@@ -107,13 +107,20 @@ INTEGRATION_ENDPOINTS = {
             },
             "responses": {
                 "200": _response(
-                    "Integration configured",
+                    "Integration configuration updated",
                     {
                         "type": "object",
                         "properties": {
-                            "type": {"type": "string"},
-                            "configured": {"type": "boolean"},
-                            "message": {"type": "string"},
+                            "integration": {"type": "object"},
+                        },
+                    },
+                ),
+                "201": _response(
+                    "Integration configuration created",
+                    {
+                        "type": "object",
+                        "properties": {
+                            "integration": {"type": "object"},
                         },
                     },
                 ),

--- a/aragora/server/openapi/endpoints/integrations.py
+++ b/aragora/server/openapi/endpoints/integrations.py
@@ -14,6 +14,36 @@ def _response(description: str, schema: dict[str, Any] | None = None) -> dict[st
     return resp
 
 
+_INTEGRATION_CONFIG_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+    "properties": {
+        "type": {"type": "string"},
+        "enabled": {"type": "boolean"},
+        "created_at": {"type": "number"},
+        "updated_at": {"type": "number"},
+        "notify_on_consensus": {"type": "boolean"},
+        "notify_on_debate_end": {"type": "boolean"},
+        "notify_on_error": {"type": "boolean"},
+        "notify_on_leaderboard": {"type": "boolean"},
+        "settings": {"type": "object", "additionalProperties": True},
+        "messages_sent": {"type": "integer"},
+        "errors_24h": {"type": "integer"},
+        "last_activity": {"type": ["number", "null"]},
+        "last_error": {"type": ["string", "null"]},
+        "user_id": {"type": ["string", "null"]},
+        "workspace_id": {"type": ["string", "null"]},
+    },
+    "required": ["type", "enabled"],
+}
+
+_INTEGRATION_CONFIG_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"integration": _INTEGRATION_CONFIG_SCHEMA},
+    "required": ["integration"],
+}
+
+
 INTEGRATION_ENDPOINTS = {
     "/api/v1/integrations/status": {
         "get": {
@@ -108,21 +138,11 @@ INTEGRATION_ENDPOINTS = {
             "responses": {
                 "200": _response(
                     "Integration configuration updated",
-                    {
-                        "type": "object",
-                        "properties": {
-                            "integration": {"type": "object"},
-                        },
-                    },
+                    _INTEGRATION_CONFIG_RESPONSE_SCHEMA,
                 ),
                 "201": _response(
                     "Integration configuration created",
-                    {
-                        "type": "object",
-                        "properties": {
-                            "integration": {"type": "object"},
-                        },
-                    },
+                    _INTEGRATION_CONFIG_RESPONSE_SCHEMA,
                 ),
                 "400": STANDARD_ERRORS["400"],
                 "401": STANDARD_ERRORS["401"],

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -103277,9 +103277,77 @@
                   "type": "object",
                   "properties": {
                     "integration": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
                     }
-                  }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }
@@ -103424,9 +103492,77 @@
                   "type": "object",
                   "properties": {
                     "integration": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
                     }
-                  }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }
@@ -254184,21 +254320,167 @@
         },
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "Integration configuration updated",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "integration": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }
           },
           "201": {
-            "description": "Created",
+            "description": "Integration configuration created",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "integration": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -103270,20 +103270,14 @@
         },
         "responses": {
           "200": {
-            "description": "Integration configured",
+            "description": "Integration configuration updated",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "configured": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
+                    "integration": {
+                      "type": "object"
                     }
                   }
                 }
@@ -103416,6 +103410,21 @@
                       "code": "INTERNAL_ERROR",
                       "trace_id": "req_abc123xyz",
                       "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Integration configuration created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "integration": {
+                      "type": "object"
                     }
                   }
                 }
@@ -253706,8 +253715,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -254176,6 +254185,16 @@
         "responses": {
           "200": {
             "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {
@@ -255127,8 +255146,8 @@
           }
         },
         "responses": {
-          "200": {
-            "description": "Success",
+          "201": {
+            "description": "Created",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -166644,20 +166644,29 @@
         },
         "responses": {
           "200": {
-            "description": "Integration configured",
+            "description": "Integration configuration updated",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "type": {
-                      "type": "string"
-                    },
-                    "configured": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
+                    "integration": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Integration configuration created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "integration": {
+                      "type": "object"
                     }
                   }
                 }

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -166651,9 +166651,77 @@
                   "type": "object",
                   "properties": {
                     "integration": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
                     }
-                  }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }
@@ -166666,9 +166734,77 @@
                   "type": "object",
                   "properties": {
                     "integration": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "created_at": {
+                          "type": "number"
+                        },
+                        "updated_at": {
+                          "type": "number"
+                        },
+                        "notify_on_consensus": {
+                          "type": "boolean"
+                        },
+                        "notify_on_debate_end": {
+                          "type": "boolean"
+                        },
+                        "notify_on_error": {
+                          "type": "boolean"
+                        },
+                        "notify_on_leaderboard": {
+                          "type": "boolean"
+                        },
+                        "settings": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "messages_sent": {
+                          "type": "integer"
+                        },
+                        "errors_24h": {
+                          "type": "integer"
+                        },
+                        "last_activity": {
+                          "type": [
+                            "number",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "user_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "workspace_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "enabled"
+                      ]
                     }
-                  }
+                  },
+                  "required": [
+                    "integration"
+                  ]
                 }
               }
             }

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -94483,18 +94483,23 @@ paths:
                   description: Authentication credentials
       responses:
         '200':
-          description: Integration configured
+          description: Integration configuration updated
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  type:
-                    type: string
-                  configured:
-                    type: boolean
-                  message:
-                    type: string
+                  integration:
+                    type: object
+        '201':
+          description: Integration configuration created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  integration:
+                    type: object
         '400': &id740
           description: Bad request - Invalid input or malformed JSON
           headers: *id737

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -94391,7 +94391,7 @@ paths:
                   connected_at:
                     type: string
                     format: date-time
-        '401': &id738
+        '401': &id739
           description: Unauthorized - Authentication required or token invalid
           headers: &id737
             X-Request-ID:
@@ -94436,7 +94436,7 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id739
+        '500': &id740
           description: Internal server error - Unexpected error occurred
           headers: *id737
           content:
@@ -94486,21 +94486,63 @@ paths:
           description: Integration configuration updated
           content:
             application/json:
-              schema:
+              schema: &id738
                 type: object
                 properties:
                   integration:
                     type: object
+                    additionalProperties: true
+                    properties:
+                      type:
+                        type: string
+                      enabled:
+                        type: boolean
+                      created_at:
+                        type: number
+                      updated_at:
+                        type: number
+                      notify_on_consensus:
+                        type: boolean
+                      notify_on_debate_end:
+                        type: boolean
+                      notify_on_error:
+                        type: boolean
+                      notify_on_leaderboard:
+                        type: boolean
+                      settings:
+                        type: object
+                        additionalProperties: true
+                      messages_sent:
+                        type: integer
+                      errors_24h:
+                        type: integer
+                      last_activity:
+                        type:
+                        - number
+                        - 'null'
+                      last_error:
+                        type:
+                        - string
+                        - 'null'
+                      user_id:
+                        type:
+                        - string
+                        - 'null'
+                      workspace_id:
+                        type:
+                        - string
+                        - 'null'
+                    required:
+                    - type
+                    - enabled
+                required:
+                - integration
         '201':
           description: Integration configuration created
           content:
             application/json:
-              schema:
-                type: object
-                properties:
-                  integration:
-                    type: object
-        '400': &id740
+              schema: *id738
+        '400': &id741
           description: Bad request - Invalid input or malformed JSON
           headers: *id737
           content:
@@ -94528,8 +94570,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id738
-        '500': *id739
+        '401': *id739
+        '500': *id740
       x-aragora-stability: stable
     patch:
       tags:
@@ -94571,9 +94613,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': *id740
-        '401': *id738
-        '500': *id739
+        '400': *id741
+        '401': *id739
+        '500': *id740
       x-aragora-stability: stable
     delete:
       tags:
@@ -94602,8 +94644,8 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id738
-        '500': *id739
+        '401': *id739
+        '500': *id740
       x-aragora-stability: stable
   /api/v1/integrations/{type}/test:
     post:
@@ -94637,7 +94679,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id741
+          headers: &id742
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94666,7 +94708,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id741
+          headers: *id742
           content:
             application/json:
               schema:
@@ -95023,7 +95065,7 @@ paths:
       responses:
         '200':
           description: List of checkpoints
-          headers: &id742
+          headers: &id743
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95037,9 +95079,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointList'
-        '401': &id743
+        '401': &id744
           description: Unauthorized - Authentication required or token invalid
-          headers: *id742
+          headers: *id743
           content:
             application/json:
               schema:
@@ -95091,14 +95133,14 @@ paths:
       responses:
         '201':
           description: Checkpoint created
-          headers: *id742
+          headers: *id743
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id742
+          headers: *id743
           content:
             application/json:
               schema:
@@ -95124,7 +95166,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id743
+        '401': *id744
         '409':
           description: Checkpoint with this name already exists
           content:
@@ -95186,7 +95228,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id744
+          headers: &id745
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95223,7 +95265,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id744
+          headers: *id745
           content:
             application/json:
               schema:
@@ -95243,7 +95285,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id744
+          headers: *id745
           content:
             application/json:
               schema:
@@ -95276,7 +95318,7 @@ paths:
       responses:
         '200':
           description: Checkpoint metadata
-          headers: &id745
+          headers: &id746
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95290,9 +95332,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
-        '401': &id746
+        '401': &id747
           description: Unauthorized - Authentication required or token invalid
-          headers: *id745
+          headers: *id746
           content:
             application/json:
               schema:
@@ -95310,9 +95352,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id747
+        '404': &id748
           description: Not found - The requested resource does not exist
-          headers: *id745
+          headers: *id746
           content:
             application/json:
               schema:
@@ -95344,7 +95386,7 @@ paths:
       responses:
         '200':
           description: Checkpoint deleted
-          headers: *id745
+          headers: *id746
           content:
             application/json:
               schema:
@@ -95356,8 +95398,8 @@ paths:
                   name:
                     type: string
                     description: Name of deleted checkpoint
-        '401': *id746
-        '404': *id747
+        '401': *id747
+        '404': *id748
       x-aragora-stability: stable
   /api/v1/km/checkpoints/{checkpoint_name}/compare:
     get:
@@ -95398,7 +95440,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id748
+          headers: &id749
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95427,7 +95469,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id748
+          headers: *id749
           content:
             application/json:
               schema:
@@ -95467,7 +95509,7 @@ paths:
                 format: binary
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id749
+          headers: &id750
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95496,7 +95538,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id749
+          headers: *id750
           content:
             application/json:
               schema:
@@ -95547,7 +95589,7 @@ paths:
       responses:
         '200':
           description: Restore result
-          headers: &id750
+          headers: &id751
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95563,7 +95605,7 @@ paths:
                 $ref: '#/components/schemas/RestoreResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id750
+          headers: *id751
           content:
             application/json:
               schema:
@@ -95591,7 +95633,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id750
+          headers: *id751
           content:
             application/json:
               schema:
@@ -95611,7 +95653,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id750
+          headers: *id751
           content:
             application/json:
               schema:
@@ -95771,7 +95813,7 @@ paths:
       summary: List facts
       operationId: listKnowledgeFacts
       description: List knowledge facts with optional filtering.
-      security: &id752
+      security: &id753
       - bearerAuth: []
       parameters:
       - name: workspace_id
@@ -95807,7 +95849,7 @@ paths:
       responses:
         '200':
           description: Knowledge facts
-          headers: &id751
+          headers: &id752
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95821,9 +95863,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFactList'
-        '500': &id753
+        '500': &id754
           description: Internal server error - Unexpected error occurred
-          headers: *id751
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95843,7 +95885,7 @@ paths:
       summary: Create fact
       operationId: createKnowledgeFact
       description: Create a new knowledge fact.
-      security: *id752
+      security: *id753
       requestBody:
         required: true
         content:
@@ -95876,14 +95918,14 @@ paths:
       responses:
         '201':
           description: Created fact
-          headers: *id751
+          headers: *id752
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id751
+          headers: *id752
           content:
             application/json:
               schema:
@@ -95909,7 +95951,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id753
+        '500': *id754
       x-aragora-stability: stable
   /api/v1/knowledge/facts/relations:
     post:
@@ -95960,7 +96002,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: &id754
+          headers: &id755
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95989,7 +96031,7 @@ paths:
                     description: Type of relation
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id754
+          headers: *id755
           content:
             application/json:
               schema:
@@ -96021,7 +96063,7 @@ paths:
 
         - Supersession history (if applicable)'
       operationId: getKnowledgeFact
-      security: &id756
+      security: &id757
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -96032,7 +96074,7 @@ paths:
       responses:
         '200':
           description: Knowledge fact
-          headers: &id755
+          headers: &id756
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96046,9 +96088,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': &id757
+        '404': &id758
           description: Not found - The requested resource does not exist
-          headers: *id755
+          headers: *id756
           content:
             application/json:
               schema:
@@ -96062,9 +96104,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id758
+        '500': &id759
           description: Internal server error - Unexpected error occurred
-          headers: *id755
+          headers: *id756
           content:
             application/json:
               schema:
@@ -96098,7 +96140,7 @@ paths:
 
         **Note:** Updates create an audit trail. Consider superseding instead of updating for significant changes.'
       operationId: updateKnowledgeFact
-      security: *id756
+      security: *id757
       parameters:
       - name: fact_id
         in: path
@@ -96129,13 +96171,13 @@ paths:
       responses:
         '200':
           description: Updated fact
-          headers: *id755
+          headers: *id756
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': *id757
-        '500': *id758
+        '404': *id758
+        '500': *id759
       x-aragora-stability: experimental
     delete:
       tags:
@@ -96155,7 +96197,7 @@ paths:
 
         **Note:** Deleted facts can be restored by admin if needed.'
       operationId: deleteKnowledgeFact
-      security: *id756
+      security: *id757
       parameters:
       - name: fact_id
         in: path
@@ -96165,7 +96207,7 @@ paths:
       responses:
         '200':
           description: Deleted fact
-          headers: *id755
+          headers: *id756
           content:
             application/json:
               schema:
@@ -96177,8 +96219,8 @@ paths:
                   fact_id:
                     type: string
                     description: ID of deleted fact
-        '404': *id757
-        '500': *id758
+        '404': *id758
+        '500': *id759
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/contradictions:
     get:
@@ -96216,7 +96258,7 @@ paths:
       responses:
         '200':
           description: Contradicting facts
-          headers: &id759
+          headers: &id760
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96232,7 +96274,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeFactList'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id759
+          headers: *id760
           content:
             application/json:
               schema:
@@ -96264,7 +96306,7 @@ paths:
 
         - derived_from: Source facts used to derive this one'
       operationId: listKnowledgeRelations
-      security: &id761
+      security: &id762
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -96275,7 +96317,7 @@ paths:
       responses:
         '200':
           description: Fact relations
-          headers: &id760
+          headers: &id761
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96289,9 +96331,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
-        '500': &id762
+        '500': &id763
           description: Internal server error - Unexpected error occurred
-          headers: *id760
+          headers: *id761
           content:
             application/json:
               schema:
@@ -96325,7 +96367,7 @@ paths:
 
         - evidence: Supporting evidence for the relation'
       operationId: addKnowledgeRelation
-      security: *id761
+      security: *id762
       parameters:
       - name: fact_id
         in: path
@@ -96362,7 +96404,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: *id760
+          headers: *id761
           content:
             application/json:
               schema:
@@ -96380,7 +96422,7 @@ paths:
                   relation_type:
                     type: string
                     description: Type of relation
-        '500': *id762
+        '500': *id763
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/verify:
     post:
@@ -96412,7 +96454,7 @@ paths:
       responses:
         '200':
           description: Fact verification started
-          headers: &id763
+          headers: &id764
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96441,7 +96483,7 @@ paths:
                     description: Verification status
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id763
+          headers: *id764
           content:
             application/json:
               schema:
@@ -97094,7 +97136,7 @@ paths:
       responses:
         '200':
           description: Culture patterns
-          headers: &id764
+          headers: &id765
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97110,7 +97152,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id764
+          headers: *id765
           content:
             application/json:
               schema:
@@ -97126,7 +97168,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id764
+          headers: *id765
           content:
             application/json:
               schema:
@@ -98118,7 +98160,7 @@ paths:
       responses:
         '200':
           description: Audit trail
-          headers: &id765
+          headers: &id766
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98134,7 +98176,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id765
+          headers: *id766
           content:
             application/json:
               schema:
@@ -98187,7 +98229,7 @@ paths:
       responses:
         '200':
           description: User audit
-          headers: &id766
+          headers: &id767
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98203,7 +98245,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id766
+          headers: *id767
           content:
             application/json:
               schema:
@@ -98219,7 +98261,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id766
+          headers: *id767
           content:
             application/json:
               schema:
@@ -98285,7 +98327,7 @@ paths:
       responses:
         '200':
           description: Permission check
-          headers: &id767
+          headers: &id768
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98301,7 +98343,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id767
+          headers: *id768
           content:
             application/json:
               schema:
@@ -98329,7 +98371,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id767
+          headers: *id768
           content:
             application/json:
               schema:
@@ -98361,7 +98403,7 @@ paths:
       responses:
         '200':
           description: Permissions
-          headers: &id768
+          headers: &id769
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98377,7 +98419,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id768
+          headers: *id769
           content:
             application/json:
               schema:
@@ -98393,7 +98435,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id768
+          headers: *id769
           content:
             application/json:
               schema:
@@ -98440,7 +98482,7 @@ paths:
       responses:
         '200':
           description: Role created
-          headers: &id769
+          headers: &id770
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98456,7 +98498,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id769
+          headers: *id770
           content:
             application/json:
               schema:
@@ -98484,7 +98526,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id769
+          headers: *id770
           content:
             application/json:
               schema:
@@ -98554,95 +98596,6 @@ paths:
       responses:
         '200':
           description: Role assigned
-          headers: &id770
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id770
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id770
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/knowledge/mound/governance/roles/revoke:
-    post:
-      tags:
-      - Knowledge Mound
-      summary: Revoke role
-      operationId: createKnowledgeMoundGovernanceRolesRevoke
-      description: Revoke a governance role from a user.
-      security:
-      - {}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user_id:
-                  type: string
-                  description: User to revoke role from
-                role_id:
-                  type: string
-                  description: Role to revoke
-                resource_id:
-                  type: string
-                  description: Resource ID for scoped revocation
-              required:
-              - user_id
-              - role_id
-      responses:
-        '200':
-          description: Role revoked
           headers: &id771
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -98701,6 +98654,95 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
+  /api/v1/knowledge/mound/governance/roles/revoke:
+    post:
+      tags:
+      - Knowledge Mound
+      summary: Revoke role
+      operationId: createKnowledgeMoundGovernanceRolesRevoke
+      description: Revoke a governance role from a user.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                  description: User to revoke role from
+                role_id:
+                  type: string
+                  description: Role to revoke
+                resource_id:
+                  type: string
+                  description: Resource ID for scoped revocation
+              required:
+              - user_id
+              - role_id
+      responses:
+        '200':
+          description: Role revoked
+          headers: &id772
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id772
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id772
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
   /api/v1/knowledge/mound/governance/stats:
     get:
       tags:
@@ -98713,7 +98755,7 @@ paths:
       responses:
         '200':
           description: Stats
-          headers: &id772
+          headers: &id773
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98729,7 +98771,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id772
+          headers: *id773
           content:
             application/json:
               schema:
@@ -99474,7 +99516,7 @@ paths:
       responses:
         '200':
           description: Node revalidated
-          headers: &id773
+          headers: &id774
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99490,7 +99532,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id773
+          headers: *id774
           content:
             application/json:
               schema:
@@ -99518,7 +99560,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id773
+          headers: *id774
           content:
             application/json:
               schema:
@@ -99534,7 +99576,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id773
+          headers: *id774
           content:
             application/json:
               schema:
@@ -99779,7 +99821,7 @@ paths:
       responses:
         '200':
           description: Sync triggered
-          headers: &id774
+          headers: &id775
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99795,7 +99837,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id774
+          headers: *id775
           content:
             application/json:
               schema:
@@ -99823,7 +99865,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id774
+          headers: *id775
           content:
             application/json:
               schema:
@@ -99839,7 +99881,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id774
+          headers: *id775
           content:
             application/json:
               schema:
@@ -99880,7 +99922,7 @@ paths:
       responses:
         '200':
           description: Knowledge query response
-          headers: &id775
+          headers: &id776
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99896,7 +99938,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id775
+          headers: *id776
           content:
             application/json:
               schema:
@@ -99924,7 +99966,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id775
+          headers: *id776
           content:
             application/json:
               schema:
@@ -100006,7 +100048,7 @@ paths:
       responses:
         '200':
           description: Knowledge search response
-          headers: &id776
+          headers: &id777
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100022,7 +100064,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeSearchResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id776
+          headers: *id777
           content:
             application/json:
               schema:
@@ -100050,7 +100092,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id776
+          headers: *id777
           content:
             application/json:
               schema:
@@ -100081,7 +100123,7 @@ paths:
       responses:
         '200':
           description: Knowledge stats
-          headers: &id777
+          headers: &id778
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100097,7 +100139,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeStats'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id777
+          headers: *id778
           content:
             application/json:
               schema:
@@ -100972,195 +101014,6 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id778
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          type: object
-                          additionalProperties: true
-                          properties:
-                            id:
-                              type: string
-                            name:
-                              type: string
-                            type:
-                              type: string
-                            category:
-                              type: string
-                            description:
-                              type: string
-                            featured:
-                              type: boolean
-                            tags:
-                              type: array
-                              items:
-                                type: string
-                      total:
-                        type: integer
-                      limit:
-                        type: integer
-                      offset:
-                        type: integer
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id778
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id778
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id778
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id778
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: type
-        in: query
-        description: Filter by listing type.
-        schema:
-          type: string
-      - name: tag
-        in: query
-        description: Filter by tag.
-        schema:
-          type: string
-      - name: category
-        in: query
-        description: Filter by category.
-        schema:
-          type: string
-      - name: search
-        in: query
-        description: Search query.
-        schema:
-          type: string
-          maxLength: 500
-      - name: q
-        in: query
-        description: Alias for the search query.
-        schema:
-          type: string
-          maxLength: 500
-      - name: limit
-        in: query
-        description: Maximum number of listings to return.
-        schema:
-          type: integer
-          minimum: 1
-          maximum: 200
-          default: 50
-      - name: offset
-        in: query
-        description: Pagination offset.
-        schema:
-          type: integer
-          minimum: 0
-          maximum: 10000
-          default: 0
-      x-aragora-stability: stable
-  /api/v1/marketplace/listings/featured:
-    get:
-      tags:
-      - Marketplace
-      summary: List featured marketplace listings
-      operationId: marketplaceListFeaturedListings
-      description: Return featured marketplace listings. Requires `marketplace:read`.
-      responses:
-        '200':
-          description: Marketplace listing response.
           headers: &id779
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -101296,22 +101149,57 @@ paths:
       security:
       - bearerAuth: []
       parameters:
+      - name: type
+        in: query
+        description: Filter by listing type.
+        schema:
+          type: string
+      - name: tag
+        in: query
+        description: Filter by tag.
+        schema:
+          type: string
+      - name: category
+        in: query
+        description: Filter by category.
+        schema:
+          type: string
+      - name: search
+        in: query
+        description: Search query.
+        schema:
+          type: string
+          maxLength: 500
+      - name: q
+        in: query
+        description: Alias for the search query.
+        schema:
+          type: string
+          maxLength: 500
       - name: limit
         in: query
-        description: Maximum number of featured listings to return.
+        description: Maximum number of listings to return.
         schema:
           type: integer
           minimum: 1
-          maximum: 50
-          default: 10
+          maximum: 200
+          default: 50
+      - name: offset
+        in: query
+        description: Pagination offset.
+        schema:
+          type: integer
+          minimum: 0
+          maximum: 10000
+          default: 0
       x-aragora-stability: stable
-  /api/v1/marketplace/listings/stats:
+  /api/v1/marketplace/listings/featured:
     get:
       tags:
       - Marketplace
-      summary: Get marketplace listing stats
-      operationId: marketplaceGetListingStats
-      description: Return marketplace listing counts grouped by type. Requires `marketplace:read`.
+      summary: List featured marketplace listings
+      operationId: marketplaceListFeaturedListings
+      description: Return featured marketplace listings. Requires `marketplace:read`.
       responses:
         '200':
           description: Marketplace listing response.
@@ -101334,12 +101222,34 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      total_items:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                          additionalProperties: true
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            type:
+                              type: string
+                            category:
+                              type: string
+                            description:
+                              type: string
+                            featured:
+                              type: boolean
+                            tags:
+                              type: array
+                              items:
+                                type: string
+                      total:
                         type: integer
-                      types:
-                        type: object
-                        additionalProperties:
-                          type: integer
+                      limit:
+                        type: integer
+                      offset:
+                        type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
           headers: *id780
@@ -101427,6 +101337,138 @@ paths:
                     trace_id: req_abc123xyz
       security:
       - bearerAuth: []
+      parameters:
+      - name: limit
+        in: query
+        description: Maximum number of featured listings to return.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 50
+          default: 10
+      x-aragora-stability: stable
+  /api/v1/marketplace/listings/stats:
+    get:
+      tags:
+      - Marketplace
+      summary: Get marketplace listing stats
+      operationId: marketplaceGetListingStats
+      description: Return marketplace listing counts grouped by type. Requires `marketplace:read`.
+      responses:
+        '200':
+          description: Marketplace listing response.
+          headers: &id781
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                    properties:
+                      total_items:
+                        type: integer
+                      types:
+                        type: object
+                        additionalProperties:
+                          type: integer
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id781
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id781
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id781
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id781
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
       x-aragora-stability: stable
   /api/v1/marketplace/listings/{listing_id}:
     get:
@@ -101438,7 +101480,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id781
+          headers: &id782
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101479,7 +101521,7 @@ paths:
                               type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id781
+          headers: *id782
           content:
             application/json:
               schema:
@@ -101507,7 +101549,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id781
+          headers: *id782
           content:
             application/json:
               schema:
@@ -101522,7 +101564,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id781
+          headers: *id782
           content:
             application/json:
               schema:
@@ -101538,7 +101580,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id781
+          headers: *id782
           content:
             application/json:
               schema:
@@ -101558,7 +101600,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id781
+          headers: *id782
           content:
             application/json:
               schema:
@@ -101596,146 +101638,6 @@ paths:
       summary: Install marketplace listing
       operationId: marketplaceInstallListing
       description: Install a marketplace listing for the authenticated user.
-      responses:
-        '200':
-          description: Marketplace listing response.
-          headers: &id782
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id782
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id782
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id782
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id782
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id782
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: listing_id
-        in: path
-        required: true
-        schema:
-          type: string
-          maxLength: 128
-        description: Marketplace listing ID.
-      x-aragora-stability: experimental
-  /api/v1/marketplace/listings/{listing_id}/launch-debate:
-    post:
-      tags:
-      - Marketplace
-      summary: Launch debate from marketplace listing
-      operationId: marketplaceLaunchDebateFromListing
-      description: Build a debate configuration from a marketplace listing for the authenticated user.
       responses:
         '200':
           description: Marketplace listing response.
@@ -101868,30 +101770,14 @@ paths:
           type: string
           maxLength: 128
         description: Marketplace listing ID.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - question
-              properties:
-                question:
-                  type: string
-                  maxLength: 5000
-                rounds:
-                  type: integer
-                  minimum: 1
-                  maximum: 20
       x-aragora-stability: experimental
-  /api/v1/marketplace/listings/{listing_id}/rate:
+  /api/v1/marketplace/listings/{listing_id}/launch-debate:
     post:
       tags:
       - Marketplace
-      summary: Rate marketplace listing
-      operationId: marketplaceRateListing
-      description: Submit a rating and optional review for a marketplace listing.
+      summary: Launch debate from marketplace listing
+      operationId: marketplaceLaunchDebateFromListing
+      description: Build a debate configuration from a marketplace listing for the authenticated user.
       responses:
         '200':
           description: Marketplace listing response.
@@ -102031,6 +101917,162 @@ paths:
             schema:
               type: object
               required:
+              - question
+              properties:
+                question:
+                  type: string
+                  maxLength: 5000
+                rounds:
+                  type: integer
+                  minimum: 1
+                  maximum: 20
+      x-aragora-stability: experimental
+  /api/v1/marketplace/listings/{listing_id}/rate:
+    post:
+      tags:
+      - Marketplace
+      summary: Rate marketplace listing
+      operationId: marketplaceRateListing
+      description: Submit a rating and optional review for a marketplace listing.
+      responses:
+        '200':
+          description: Marketplace listing response.
+          headers: &id785
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id785
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id785
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id785
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id785
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id785
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: listing_id
+        in: path
+        required: true
+        schema:
+          type: string
+          maxLength: 128
+        description: Marketplace listing ID.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
               - score
               properties:
                 score:
@@ -102093,7 +102135,7 @@ paths:
       responses:
         '200':
           description: Marketplace listing response.
-          headers: &id785
+          headers: &id786
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102148,7 +102190,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id785
+          headers: *id786
           content:
             application/json:
               schema:
@@ -102176,7 +102218,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id785
+          headers: *id786
           content:
             application/json:
               schema:
@@ -102191,7 +102233,7 @@ paths:
                     support_url: https://github.com/synaptent/aragora/issues
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id785
+          headers: *id786
           content:
             application/json:
               schema:
@@ -102211,7 +102253,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id785
+          headers: *id786
           content:
             application/json:
               schema:
@@ -102590,7 +102632,7 @@ paths:
       responses:
         '200':
           description: Matrix debate details
-          headers: &id786
+          headers: &id787
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102619,7 +102661,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id786
+          headers: *id787
           content:
             application/json:
               schema:
@@ -102652,7 +102694,7 @@ paths:
       responses:
         '200':
           description: MCP tool catalog
-          headers: &id787
+          headers: &id788
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102694,7 +102736,7 @@ paths:
                     type: integer
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id787
+          headers: *id788
           content:
             application/json:
               schema:
@@ -102727,7 +102769,7 @@ paths:
       responses:
         '200':
           description: MCP tool details
-          headers: &id788
+          headers: &id789
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102765,7 +102807,7 @@ paths:
                             default: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id788
+          headers: *id789
           content:
             application/json:
               schema:
@@ -102781,7 +102823,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id788
+          headers: *id789
           content:
             application/json:
               schema:
@@ -106268,7 +106310,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry page
-          headers: &id790
+          headers: &id791
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106289,13 +106331,13 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
-                  total: &id789
+                  total: &id790
                     type: integer
-                  limit: *id789
-                  offset: *id789
+                  limit: *id790
+                  offset: *id790
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id790
+          headers: *id791
           content:
             application/json:
               schema:
@@ -106315,7 +106357,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id790
+          headers: *id791
           content:
             application/json:
               schema:
@@ -106335,9 +106377,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '429': &id792
+        '429': &id793
           description: Too many requests - Rate limit exceeded
-          headers: *id790
+          headers: *id791
           content:
             application/json:
               schema:
@@ -106376,35 +106418,35 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      message: &id791
+                      message: &id792
                         type: string
-                      stack: *id791
-                      componentStack: *id791
-                      url: *id791
-                      timestamp: *id791
-                      userAgent: *id791
-                      sessionId: *id791
-                      componentName: *id791
-                      fingerprint: *id791
+                      stack: *id792
+                      componentStack: *id792
+                      url: *id792
+                      timestamp: *id792
+                      userAgent: *id792
+                      sessionId: *id792
+                      componentName: *id792
+                      fingerprint: *id792
                   maxItems: 50
               required:
               - reports
       responses:
         '202':
           description: Crash telemetry accepted
-          headers: *id790
+          headers: *id791
           content:
             application/json:
               schema:
                 type: object
                 additionalProperties: false
                 properties:
-                  accepted: *id789
-                  duplicates: *id789
-                  total_stored: *id789
+                  accepted: *id790
+                  duplicates: *id790
+                  total_stored: *id790
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id790
+          headers: *id791
           content:
             application/json:
               schema:
@@ -106430,7 +106472,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '429': *id792
+        '429': *id793
       security: []
       x-aragora-stability: stable
   /api/v1/observability/crashes/stats:
@@ -106443,7 +106485,7 @@ paths:
       responses:
         '200':
           description: Crash telemetry stats
-          headers: &id795
+          headers: &id796
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106459,23 +106501,23 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  total_ingested: &id793
+                  total_ingested: &id794
                     type: integer
-                  total_stored: *id793
-                  total_duplicates: *id793
-                  total_rate_limited: *id793
-                  unique_fingerprints: *id793
-                  last_hour: *id793
-                  last_24h: *id793
-                  top_fingerprints: &id794
+                  total_stored: *id794
+                  total_duplicates: *id794
+                  total_rate_limited: *id794
+                  unique_fingerprints: *id794
+                  last_hour: *id794
+                  last_24h: *id794
+                  top_fingerprints: &id795
                     type: array
                     items:
                       type: object
                       additionalProperties: true
-                  top_components: *id794
+                  top_components: *id795
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id795
+          headers: *id796
           content:
             application/json:
               schema:
@@ -106495,7 +106537,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id795
+          headers: *id796
           content:
             application/json:
               schema:
@@ -106517,7 +106559,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id795
+          headers: *id796
           content:
             application/json:
               schema:
@@ -106547,7 +106589,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability dashboard
-          headers: &id798
+          headers: &id799
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106563,23 +106605,23 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  timestamp: &id797
+                  timestamp: &id798
                     type: number
-                  debate_metrics: &id796
+                  debate_metrics: &id797
                     type: object
                     additionalProperties: true
-                  agent_rankings: *id796
-                  circuit_breakers: *id796
-                  self_improve: *id796
+                  agent_rankings: *id797
+                  circuit_breakers: *id797
+                  self_improve: *id797
                   alerts:
                     type: array
-                    items: *id796
-                  system_health: *id796
-                  error_rates: *id796
-                  collection_time_ms: *id797
+                    items: *id797
+                  system_health: *id797
+                  error_rates: *id797
+                  collection_time_ms: *id798
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id798
+          headers: *id799
           content:
             application/json:
               schema:
@@ -106599,7 +106641,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id798
+          headers: *id799
           content:
             application/json:
               schema:
@@ -106621,7 +106663,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id798
+          headers: *id799
           content:
             application/json:
               schema:
@@ -106649,7 +106691,7 @@ paths:
       responses:
         '200':
           description: Aggregated observability metrics
-          headers: &id799
+          headers: &id800
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106666,7 +106708,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id799
+          headers: *id800
           content:
             application/json:
               schema:
@@ -106686,7 +106728,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id799
+          headers: *id800
           content:
             application/json:
               schema:
@@ -106708,7 +106750,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id799
+          headers: *id800
           content:
             application/json:
               schema:
@@ -106782,7 +106824,7 @@ paths:
                         format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id800
+          headers: &id801
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106811,7 +106853,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id800
+          headers: *id801
           content:
             application/json:
               schema:
@@ -106833,7 +106875,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id800
+          headers: *id801
           content:
             application/json:
               schema:
@@ -106932,7 +106974,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id801
+          headers: &id802
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106969,7 +107011,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id801
+          headers: *id802
           content:
             application/json:
               schema:
@@ -106989,7 +107031,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id801
+          headers: *id802
           content:
             application/json:
               schema:
@@ -107093,9 +107135,9 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/StarterTemplate'
-        '401': &id803
+        '401': &id804
           description: Unauthorized - Authentication required or token invalid
-          headers: &id802
+          headers: &id803
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107122,9 +107164,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id804
+        '500': &id805
           description: Internal server error - Unexpected error occurred
-          headers: *id802
+          headers: *id803
           content:
             application/json:
               schema:
@@ -107214,7 +107256,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id802
+          headers: *id803
           content:
             application/json:
               schema:
@@ -107240,8 +107282,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id803
-        '500': *id804
+        '401': *id804
+        '500': *id805
       x-aragora-stability: stable
   /api/v1/onboarding/flow/step:
     put:
@@ -107323,7 +107365,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id805
+          headers: &id806
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107360,7 +107402,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id805
+          headers: *id806
           content:
             application/json:
               schema:
@@ -107380,7 +107422,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id805
+          headers: *id806
           content:
             application/json:
               schema:
@@ -107469,7 +107511,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id806
+          headers: &id807
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107506,7 +107548,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id806
+          headers: *id807
           content:
             application/json:
               schema:
@@ -107526,7 +107568,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id806
+          headers: *id807
           content:
             application/json:
               schema:
@@ -107620,7 +107662,7 @@ paths:
                     - 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id807
+          headers: &id808
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107649,7 +107691,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id807
+          headers: *id808
           content:
             application/json:
               schema:
@@ -107875,7 +107917,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id808
+          headers: &id809
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -107912,7 +107954,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id808
+          headers: *id809
           content:
             application/json:
               schema:
@@ -107932,7 +107974,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id808
+          headers: *id809
           content:
             application/json:
               schema:
@@ -107954,7 +107996,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id808
+          headers: *id809
           content:
             application/json:
               schema:
@@ -107970,7 +108012,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id808
+          headers: *id809
           content:
             application/json:
               schema:
@@ -108062,7 +108104,7 @@ paths:
                         description: Action metadata
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id809
+          headers: &id810
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108091,7 +108133,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id809
+          headers: *id810
           content:
             application/json:
               schema:
@@ -108113,7 +108155,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id809
+          headers: *id810
           content:
             application/json:
               schema:
@@ -108129,7 +108171,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id809
+          headers: *id810
           content:
             application/json:
               schema:
@@ -108223,7 +108265,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id810
+          headers: &id811
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108260,7 +108302,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id810
+          headers: *id811
           content:
             application/json:
               schema:
@@ -108280,7 +108322,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id810
+          headers: *id811
           content:
             application/json:
               schema:
@@ -108302,7 +108344,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id810
+          headers: *id811
           content:
             application/json:
               schema:
@@ -108318,7 +108360,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id810
+          headers: *id811
           content:
             application/json:
               schema:
@@ -108411,7 +108453,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id811
+          headers: &id812
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108440,7 +108482,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id811
+          headers: *id812
           content:
             application/json:
               schema:
@@ -108462,7 +108504,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id811
+          headers: *id812
           content:
             application/json:
               schema:
@@ -108503,201 +108545,6 @@ paths:
       responses:
         '200':
           description: Action approved
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  approval:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        description: Unique approval identifier
-                      action_id:
-                        type: string
-                        description: Associated action ID
-                      session_id:
-                        type: string
-                        description: Associated session ID
-                      user_id:
-                        type: string
-                        description: User who requested the action
-                      status:
-                        type: string
-                        enum:
-                        - pending
-                        - approved
-                        - denied
-                        description: Approval status
-                      action_type:
-                        type: string
-                        description: Type of action requiring approval
-                      action_data:
-                        type: object
-                        description: Action input data for review
-                      requested_at:
-                        type: string
-                        format: date-time
-                        description: Request timestamp
-                      decided_at:
-                        type:
-                        - string
-                        - 'null'
-                        format: date-time
-                        description: Decision timestamp
-                      decided_by:
-                        type:
-                        - string
-                        - 'null'
-                        description: User who made the decision
-                      reason:
-                        type:
-                        - string
-                        - 'null'
-                        description: Decision reason
-                  message:
-                    type: string
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: &id812
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id812
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id812
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id812
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id812
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/openclaw/approvals/{approval_id}/deny:
-    post:
-      tags:
-      - OpenClaw
-      summary: Deny action
-      description: Deny a pending action request.
-      operationId: denyOpenclawAction
-      parameters:
-      - name: approval_id
-        in: path
-        required: true
-        description: Unique approval identifier
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - reason
-              properties:
-                reason:
-                  type: string
-                  description: Reason for denial
-      responses:
-        '200':
-          description: Action denied
           content:
             application/json:
               schema:
@@ -108864,6 +108711,201 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
+  /api/v1/openclaw/approvals/{approval_id}/deny:
+    post:
+      tags:
+      - OpenClaw
+      summary: Deny action
+      description: Deny a pending action request.
+      operationId: denyOpenclawAction
+      parameters:
+      - name: approval_id
+        in: path
+        required: true
+        description: Unique approval identifier
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - reason
+              properties:
+                reason:
+                  type: string
+                  description: Reason for denial
+      responses:
+        '200':
+          description: Action denied
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  approval:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        description: Unique approval identifier
+                      action_id:
+                        type: string
+                        description: Associated action ID
+                      session_id:
+                        type: string
+                        description: Associated session ID
+                      user_id:
+                        type: string
+                        description: User who requested the action
+                      status:
+                        type: string
+                        enum:
+                        - pending
+                        - approved
+                        - denied
+                        description: Approval status
+                      action_type:
+                        type: string
+                        description: Type of action requiring approval
+                      action_data:
+                        type: object
+                        description: Action input data for review
+                      requested_at:
+                        type: string
+                        format: date-time
+                        description: Request timestamp
+                      decided_at:
+                        type:
+                        - string
+                        - 'null'
+                        format: date-time
+                        description: Decision timestamp
+                      decided_by:
+                        type:
+                        - string
+                        - 'null'
+                        description: User who made the decision
+                      reason:
+                        type:
+                        - string
+                        - 'null'
+                        description: Decision reason
+                  message:
+                    type: string
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id814
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id814
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
   /api/v1/openclaw/audit:
     get:
       tags:
@@ -108949,7 +108991,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id814
+          headers: &id815
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -108978,7 +109020,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id814
+          headers: *id815
           content:
             application/json:
               schema:
@@ -109000,7 +109042,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id814
+          headers: *id815
           content:
             application/json:
               schema:
@@ -109027,7 +109069,7 @@ paths:
         description: Filter by credential type
         schema:
           type: string
-          enum: &id815
+          enum: &id816
           - api_key
           - oauth_token
           - password
@@ -109044,7 +109086,7 @@ paths:
                 properties:
                   credentials:
                     type: array
-                    items: &id817
+                    items: &id818
                       type: object
                       description: Credential metadata (never includes actual secret values)
                       properties:
@@ -109056,7 +109098,7 @@ paths:
                           description: Human-readable credential name
                         credential_type:
                           type: string
-                          enum: *id815
+                          enum: *id816
                           description: Type of credential
                         user_id:
                           type: string
@@ -109091,9 +109133,9 @@ paths:
                           description: Credential metadata
                   total:
                     type: integer
-        '401': &id818
+        '401': &id819
           description: Unauthorized - Authentication required or token invalid
-          headers: &id816
+          headers: &id817
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109120,9 +109162,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id819
+        '403': &id820
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id816
+          headers: *id817
           content:
             application/json:
               schema:
@@ -109142,9 +109184,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id820
+        '500': &id821
           description: Internal server error - Unexpected error occurred
-          headers: *id816
+          headers: *id817
           content:
             application/json:
               schema:
@@ -109180,7 +109222,7 @@ paths:
                   description: Human-readable credential name
                 credential_type:
                   type: string
-                  enum: *id815
+                  enum: *id816
                   description: Type of credential
                 value:
                   type: string
@@ -109200,12 +109242,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  credential: *id817
+                  credential: *id818
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id816
+          headers: *id817
           content:
             application/json:
               schema:
@@ -109231,9 +109273,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id818
-        '403': *id819
-        '500': *id820
+        '401': *id819
+        '403': *id820
+        '500': *id821
       x-aragora-stability: stable
   /api/v1/openclaw/credentials/{credential_id}:
     delete:
@@ -109261,7 +109303,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id821
+          headers: &id822
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109290,7 +109332,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id821
+          headers: *id822
           content:
             application/json:
               schema:
@@ -109312,7 +109354,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id821
+          headers: *id822
           content:
             application/json:
               schema:
@@ -109328,7 +109370,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id821
+          headers: *id822
           content:
             application/json:
               schema:
@@ -109431,7 +109473,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id822
+          headers: &id823
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109468,7 +109510,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id822
+          headers: *id823
           content:
             application/json:
               schema:
@@ -109488,7 +109530,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id822
+          headers: *id823
           content:
             application/json:
               schema:
@@ -109510,7 +109552,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id822
+          headers: *id823
           content:
             application/json:
               schema:
@@ -109526,7 +109568,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id822
+          headers: *id823
           content:
             application/json:
               schema:
@@ -109637,7 +109679,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id823
+          headers: &id824
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109666,7 +109708,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id823
+          headers: *id824
           content:
             application/json:
               schema:
@@ -109688,7 +109730,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id823
+          headers: *id824
           content:
             application/json:
               schema:
@@ -109725,7 +109767,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id825
+                    items: &id826
                       type: object
                       properties:
                         name:
@@ -109757,9 +109799,9 @@ paths:
                           description: Whether the rule is active
                   total:
                     type: integer
-        '401': &id826
+        '401': &id827
           description: Unauthorized - Authentication required or token invalid
-          headers: &id824
+          headers: &id825
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109786,9 +109828,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id827
+        '403': &id828
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id824
+          headers: *id825
           content:
             application/json:
               schema:
@@ -109808,9 +109850,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id828
+        '500': &id829
           description: Internal server error - Unexpected error occurred
-          headers: *id824
+          headers: *id825
           content:
             application/json:
               schema:
@@ -109877,12 +109919,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id825
+                  rule: *id826
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id824
+          headers: *id825
           content:
             application/json:
               schema:
@@ -109908,9 +109950,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id826
-        '403': *id827
-        '500': *id828
+        '401': *id827
+        '403': *id828
+        '500': *id829
       x-aragora-stability: stable
   /api/v1/openclaw/policy/rules/{rule_name}:
     delete:
@@ -109938,7 +109980,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id829
+          headers: &id830
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -109967,7 +110009,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id829
+          headers: *id830
           content:
             application/json:
               schema:
@@ -109989,7 +110031,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id829
+          headers: *id830
           content:
             application/json:
               schema:
@@ -110005,7 +110047,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id829
+          headers: *id830
           content:
             application/json:
               schema:
@@ -110032,7 +110074,7 @@ paths:
         description: Filter by session status
         schema:
           type: string
-          enum: &id830
+          enum: &id831
           - active
           - idle
           - closing
@@ -110061,7 +110103,7 @@ paths:
                 properties:
                   sessions:
                     type: array
-                    items: &id832
+                    items: &id833
                       type:
                       - object
                       - 'null'
@@ -110085,7 +110127,7 @@ paths:
                           type:
                           - string
                           - 'null'
-                          enum: *id830
+                          enum: *id831
                           description: Current session status
                         created_at:
                           type:
@@ -110113,9 +110155,9 @@ paths:
                           description: Session metadata
                   total:
                     type: integer
-        '401': &id833
+        '401': &id834
           description: Unauthorized - Authentication required or token invalid
-          headers: &id831
+          headers: &id832
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110142,9 +110184,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id834
+        '403': &id835
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id831
+          headers: *id832
           content:
             application/json:
               schema:
@@ -110164,9 +110206,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id835
+        '500': &id836
           description: Internal server error - Unexpected error occurred
-          headers: *id831
+          headers: *id832
           content:
             application/json:
               schema:
@@ -110207,12 +110249,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id832
+                  session: *id833
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id831
+          headers: *id832
           content:
             application/json:
               schema:
@@ -110238,9 +110280,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id833
-        '403': *id834
-        '500': *id835
+        '401': *id834
+        '403': *id835
+        '500': *id836
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}:
     get:
@@ -110254,7 +110296,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: &id837
+        schema: &id838
           type: string
       responses:
         '200':
@@ -110264,7 +110306,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: &id838
+                  session: &id839
                     type:
                     - object
                     - 'null'
@@ -110319,9 +110361,9 @@ paths:
                       metadata:
                         type: object
                         description: Session metadata
-        '401': &id839
+        '401': &id840
           description: Unauthorized - Authentication required or token invalid
-          headers: &id836
+          headers: &id837
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110348,9 +110390,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id840
+        '403': &id841
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id836
+          headers: *id837
           content:
             application/json:
               schema:
@@ -110370,9 +110412,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id841
+        '404': &id842
           description: Not found - The requested resource does not exist
-          headers: *id836
+          headers: *id837
           content:
             application/json:
               schema:
@@ -110386,9 +110428,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id842
+        '500': &id843
           description: Internal server error - Unexpected error occurred
-          headers: *id836
+          headers: *id837
           content:
             application/json:
               schema:
@@ -110413,7 +110455,7 @@ paths:
         in: path
         required: true
         description: Unique session identifier
-        schema: *id837
+        schema: *id838
       responses:
         '200':
           description: Session closed
@@ -110422,13 +110464,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id838
+                  session: *id839
                   message:
                     type: string
-        '401': *id839
-        '403': *id840
-        '404': *id841
-        '500': *id842
+        '401': *id840
+        '403': *id841
+        '404': *id842
+        '500': *id843
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}/end:
     post:
@@ -110511,123 +110553,6 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id843
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id843
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id843
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id843
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/openclaw/stats:
-    get:
-      tags:
-      - OpenClaw
-      summary: Gateway statistics
-      description: Get comprehensive OpenClaw gateway statistics.
-      operationId: getOpenclawStats
-      responses:
-        '200':
-          description: Gateway statistics
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sessions_created:
-                    type: integer
-                  actions_executed:
-                    type: integer
-                  actions_succeeded:
-                    type: integer
-                  actions_failed:
-                    type: integer
-                  approvals_pending:
-                    type: integer
-                  credentials_stored:
-                    type: integer
-                  policy_rules_active:
-                    type: integer
-                  uptime_seconds:
-                    type: number
-                  timestamp:
-                    type: string
-                    format: date-time
-        '401':
-          description: Unauthorized - Authentication required or token invalid
           headers: &id844
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -110677,9 +110602,126 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id844
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id844
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/openclaw/stats:
+    get:
+      tags:
+      - OpenClaw
+      summary: Gateway statistics
+      description: Get comprehensive OpenClaw gateway statistics.
+      operationId: getOpenclawStats
+      responses:
+        '200':
+          description: Gateway statistics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sessions_created:
+                    type: integer
+                  actions_executed:
+                    type: integer
+                  actions_succeeded:
+                    type: integer
+                  actions_failed:
+                    type: integer
+                  approvals_pending:
+                    type: integer
+                  credentials_stored:
+                    type: integer
+                  policy_rules_active:
+                    type: integer
+                  uptime_seconds:
+                    type: number
+                  timestamp:
+                    type: string
+                    format: date-time
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: &id845
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id845
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id845
           content:
             application/json:
               schema:
@@ -110754,7 +110796,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id845
+          headers: &id846
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110813,7 +110855,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id845
+          headers: *id846
           content:
             application/json:
               schema:
@@ -110833,7 +110875,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id845
+          headers: *id846
           content:
             application/json:
               schema:
@@ -110855,7 +110897,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id845
+          headers: *id846
           content:
             application/json:
               schema:
@@ -110871,7 +110913,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id845
+          headers: *id846
           content:
             application/json:
               schema:
@@ -110928,7 +110970,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id846
+          headers: &id847
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110974,7 +111016,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id846
+          headers: *id847
           content:
             application/json:
               schema:
@@ -110994,7 +111036,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id846
+          headers: *id847
           content:
             application/json:
               schema:
@@ -111016,7 +111058,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id846
+          headers: *id847
           content:
             application/json:
               schema:
@@ -111453,89 +111495,6 @@ paths:
       responses:
         '200':
           description: Conversation
-          headers: &id847
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id847
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id847
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id847
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/outlook/folders:
-    get:
-      tags:
-      - Email
-      summary: List folders
-      operationId: listOutlookFolders
-      description: List Outlook mail folders.
-      security:
-      - {}
-      parameters:
-      - name: workspace_id
-        in: query
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Folders
           headers: &id848
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -111570,9 +111529,92 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id848
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id848
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/outlook/folders:
+    get:
+      tags:
+      - Email
+      summary: List folders
+      operationId: listOutlookFolders
+      description: List Outlook mail folders.
+      security:
+      - {}
+      parameters:
+      - name: workspace_id
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Folders
+          headers: &id849
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id849
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id849
           content:
             application/json:
               schema:
@@ -111619,7 +111661,7 @@ paths:
       responses:
         '200':
           description: Messages
-          headers: &id849
+          headers: &id850
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111635,7 +111677,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id849
+          headers: *id850
           content:
             application/json:
               schema:
@@ -111655,7 +111697,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id849
+          headers: *id850
           content:
             application/json:
               schema:
@@ -111739,7 +111781,7 @@ paths:
       summary: Get message
       operationId: getOutlookMessage
       description: Fetch Outlook message details.
-      security: &id851
+      security: &id852
       - {}
       parameters:
       - name: message_id
@@ -111754,7 +111796,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id850
+          headers: &id851
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111768,9 +111810,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id852
+        '401': &id853
           description: Unauthorized - Authentication required or token invalid
-          headers: *id850
+          headers: *id851
           content:
             application/json:
               schema:
@@ -111788,9 +111830,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id853
+        '404': &id854
           description: Not found - The requested resource does not exist
-          headers: *id850
+          headers: *id851
           content:
             application/json:
               schema:
@@ -111804,9 +111846,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id854
+        '500': &id855
           description: Internal server error - Unexpected error occurred
-          headers: *id850
+          headers: *id851
           content:
             application/json:
               schema:
@@ -111826,7 +111868,7 @@ paths:
       summary: Delete message
       operationId: deleteOutlookMessage
       description: Delete an Outlook message.
-      security: *id851
+      security: *id852
       parameters:
       - name: message_id
         in: path
@@ -111836,14 +111878,14 @@ paths:
       responses:
         '200':
           description: Message deleted
-          headers: *id850
+          headers: *id851
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id852
-        '404': *id853
-        '500': *id854
+        '401': *id853
+        '404': *id854
+        '500': *id855
       x-aragora-stability: stable
   /api/v1/outlook/messages/{message_id}/move:
     post:
@@ -111878,87 +111920,6 @@ paths:
       responses:
         '200':
           description: Message moved
-          headers: &id855
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id855
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id855
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/outlook/messages/{message_id}/read:
-    post:
-      tags:
-      - Email
-      summary: Mark read/unread
-      operationId: createOutlookMessagesRead
-      description: Toggle read state for an Outlook message.
-      security:
-      - {}
-      parameters:
-      - name: message_id
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                is_read:
-                  type: boolean
-                  description: True to mark as read, false for unread
-                workspace_id:
-                  type: string
-                  description: Workspace ID
-      responses:
-        '200':
-          description: Message updated
           headers: &id856
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -112008,6 +111969,87 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/outlook/messages/{message_id}/read:
+    post:
+      tags:
+      - Email
+      summary: Mark read/unread
+      operationId: createOutlookMessagesRead
+      description: Toggle read state for an Outlook message.
+      security:
+      - {}
+      parameters:
+      - name: message_id
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                is_read:
+                  type: boolean
+                  description: True to mark as read, false for unread
+                workspace_id:
+                  type: string
+                  description: Workspace ID
+      responses:
+        '200':
+          description: Message updated
+          headers: &id857
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id857
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id857
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
   /api/v1/outlook/oauth/callback:
     post:
@@ -112037,86 +112079,6 @@ paths:
       responses:
         '200':
           description: OAuth complete
-          headers: &id857
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id857
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id857
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/outlook/oauth/url:
-    get:
-      tags:
-      - Email
-      summary: Get OAuth URL
-      operationId: listOutlookOauthUrl
-      description: Generate Outlook OAuth authorization URL.
-      security:
-      - {}
-      parameters:
-      - name: redirect_uri
-        in: query
-        required: true
-        schema:
-          type: string
-      - name: workspace_id
-        in: query
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OAuth URL
           headers: &id858
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -112174,41 +112136,29 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/outlook/reply:
-    post:
+      x-aragora-stability: experimental
+  /api/v1/outlook/oauth/url:
+    get:
       tags:
       - Email
-      summary: Reply to message
-      operationId: createOutlookReply
-      description: Reply to an Outlook message.
+      summary: Get OAuth URL
+      operationId: listOutlookOauthUrl
+      description: Generate Outlook OAuth authorization URL.
       security:
       - {}
-      requestBody:
+      parameters:
+      - name: redirect_uri
+        in: query
         required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                message_id:
-                  type: string
-                  description: ID of message to reply to
-                body:
-                  type: string
-                  description: Reply body (HTML or plain text)
-                reply_all:
-                  type: boolean
-                  description: Reply to all recipients
-                workspace_id:
-                  type: string
-                  description: Workspace ID
-              required:
-              - message_id
-              - body
+        schema:
+          type: string
+      - name: workspace_id
+        in: query
+        schema:
+          type: string
       responses:
         '200':
-          description: Reply sent
+          description: OAuth URL
           headers: &id859
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -112251,9 +112201,101 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id859
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/outlook/reply:
+    post:
+      tags:
+      - Email
+      summary: Reply to message
+      operationId: createOutlookReply
+      description: Reply to an Outlook message.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message_id:
+                  type: string
+                  description: ID of message to reply to
+                body:
+                  type: string
+                  description: Reply body (HTML or plain text)
+                reply_all:
+                  type: boolean
+                  description: Reply to all recipients
+                workspace_id:
+                  type: string
+                  description: Workspace ID
+              required:
+              - message_id
+              - body
+      responses:
+        '200':
+          description: Reply sent
+          headers: &id860
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id860
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id859
+          headers: *id860
           content:
             application/json:
               schema:
@@ -112273,7 +112315,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id859
+          headers: *id860
           content:
             application/json:
               schema:
@@ -112308,7 +112350,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id860
+          headers: &id861
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112324,7 +112366,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id860
+          headers: *id861
           content:
             application/json:
               schema:
@@ -112344,7 +112386,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id860
+          headers: *id861
           content:
             application/json:
               schema:
@@ -112408,7 +112450,7 @@ paths:
       responses:
         '200':
           description: Message sent
-          headers: &id861
+          headers: &id862
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112424,7 +112466,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id861
+          headers: *id862
           content:
             application/json:
               schema:
@@ -112452,7 +112494,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id861
+          headers: *id862
           content:
             application/json:
               schema:
@@ -112472,7 +112514,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id861
+          headers: *id862
           content:
             application/json:
               schema:
@@ -112503,7 +112545,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id862
+          headers: &id863
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112519,7 +112561,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id862
+          headers: *id863
           content:
             application/json:
               schema:
@@ -112539,7 +112581,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id862
+          headers: *id863
           content:
             application/json:
               schema:
@@ -112695,7 +112737,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id863
+          headers: &id864
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112711,7 +112753,7 @@ paths:
                 $ref: '#/components/schemas/PatternTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id863
+          headers: *id864
           content:
             application/json:
               schema:
@@ -113952,7 +113994,7 @@ paths:
       responses:
         '200':
           description: List of playbooks
-          headers: &id864
+          headers: &id865
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114126,7 +114168,7 @@ paths:
                   count: 1
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id864
+          headers: *id865
           content:
             application/json:
               schema:
@@ -114163,7 +114205,7 @@ paths:
       responses:
         '200':
           description: Playbook details
-          headers: &id865
+          headers: &id866
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114327,7 +114369,7 @@ paths:
                   metadata: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id865
+          headers: *id866
           content:
             application/json:
               schema:
@@ -114407,7 +114449,7 @@ paths:
       responses:
         '202':
           description: Playbook run queued
-          headers: &id866
+          headers: &id867
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114508,7 +114550,7 @@ paths:
                     consensus_threshold: 0.75
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id866
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114536,7 +114578,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id866
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114552,7 +114594,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id866
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114572,7 +114614,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id866
+          headers: *id867
           content:
             application/json:
               schema:
@@ -114625,13 +114667,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  type: &id868
+                  type: &id869
                     type: string
-                  option: &id867
+                  option: &id868
                     type: object
-                  preflight: *id867
-                  error: *id868
-                  code: *id868
+                  preflight: *id868
+                  error: *id869
+                  code: *id869
                   retry_after:
                     type: integer
       x-aragora-stability: stable
@@ -114795,7 +114837,7 @@ paths:
       responses:
         '200':
           description: Landing feedback summary
-          headers: &id869
+          headers: &id870
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114821,7 +114863,7 @@ paths:
       responses:
         '202':
           description: Feedback accepted
-          headers: *id869
+          headers: *id870
           content:
             application/json:
               schema:
@@ -114859,9 +114901,9 @@ paths:
                 properties:
                   ok:
                     type: boolean
-                  id: &id870
+                  id: &id871
                     type: string
-                  review_status: *id870
+                  review_status: *id871
                   reviewed_at:
                     type:
                     - string
@@ -115210,7 +115252,7 @@ paths:
       - name: name
         in: path
         required: true
-        schema: &id871
+        schema: &id872
           type: string
         description: Plugin name (lowercase alphanumeric with hyphens)
       requestBody:
@@ -115228,7 +115270,7 @@ paths:
       responses:
         '200':
           description: Installation result
-          headers: &id872
+          headers: &id873
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115260,12 +115302,12 @@ paths:
       - name: name
         in: path
         required: true
-        schema: *id871
+        schema: *id872
         description: Plugin name (lowercase alphanumeric with hyphens)
       responses:
         '200':
           description: Uninstallation result
-          headers: *id872
+          headers: *id873
           content:
             application/json:
               schema:
@@ -115539,7 +115581,7 @@ paths:
       summary: Get policy by ID
       operationId: getPolicy
       description: Retrieve a specific governance policy by its unique identifier.
-      security: &id874
+      security: &id875
       - bearerAuth: []
       parameters:
       - name: policy_id
@@ -115551,7 +115593,7 @@ paths:
       responses:
         '200':
           description: Policy details
-          headers: &id873
+          headers: &id874
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115565,9 +115607,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
-        '401': &id875
+        '401': &id876
           description: Unauthorized - Authentication required or token invalid
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115585,9 +115627,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id876
+        '403': &id877
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115607,9 +115649,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id877
+        '404': &id878
           description: Not found - The requested resource does not exist
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115623,9 +115665,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id878
+        '500': &id879
           description: Internal server error - Unexpected error occurred
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115646,7 +115688,7 @@ paths:
       summary: Update policy
       operationId: updatePolicy
       description: Update an existing governance policy. Validates for conflicts with other active policies.
-      security: *id874
+      security: *id875
       parameters:
       - name: policy_id
         in: path
@@ -115681,14 +115723,14 @@ paths:
       responses:
         '200':
           description: Policy updated
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115714,16 +115756,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id875
-        '403': *id876
-        '404': *id877
+        '401': *id876
+        '403': *id877
+        '404': *id878
         '409':
           description: Policy conflict detected with existing policies
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id878
+        '500': *id879
       x-aragora-stability: experimental
     delete:
       tags:
@@ -115732,7 +115774,7 @@ paths:
       summary: Delete policy
       operationId: deletePolicy
       description: Delete a governance policy by ID. Active policies must be disabled before deletion.
-      security: *id874
+      security: *id875
       parameters:
       - name: policy_id
         in: path
@@ -115743,7 +115785,7 @@ paths:
       responses:
         '200':
           description: Policy deleted
-          headers: *id873
+          headers: *id874
           content:
             application/json:
               schema:
@@ -115753,16 +115795,16 @@ paths:
                     type: string
                   deleted:
                     type: boolean
-        '401': *id875
-        '403': *id876
-        '404': *id877
+        '401': *id876
+        '403': *id877
+        '404': *id878
         '409':
           description: Cannot delete an active policy - disable it first
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id878
+        '500': *id879
       x-aragora-stability: stable
   /api/v1/postman.json:
     get:
@@ -115813,7 +115855,7 @@ paths:
       responses:
         '200':
           description: Account deletion scheduled
-          headers: &id879
+          headers: &id880
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115840,7 +115882,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id879
+          headers: *id880
           content:
             application/json:
               schema:
@@ -115868,7 +115910,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id879
+          headers: *id880
           content:
             application/json:
               schema:
@@ -115888,7 +115930,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id879
+          headers: *id880
           content:
             application/json:
               schema:
@@ -115921,7 +115963,7 @@ paths:
       responses:
         '200':
           description: Privacy data inventory
-          headers: &id880
+          headers: &id881
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115959,7 +116001,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id880
+          headers: *id881
           content:
             application/json:
               schema:
@@ -116001,7 +116043,7 @@ paths:
       responses:
         '200':
           description: User data export
-          headers: &id881
+          headers: &id882
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116053,7 +116095,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id881
+          headers: *id882
           content:
             application/json:
               schema:
@@ -116084,7 +116126,7 @@ paths:
       responses:
         '200':
           description: Privacy preferences
-          headers: &id882
+          headers: &id883
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116096,10 +116138,10 @@ paths:
                 type: integer
           content:
             application/json:
-              schema: &id884
+              schema: &id885
                 type: object
                 properties:
-                  preferences: &id883
+                  preferences: &id884
                     type: object
                     properties:
                       do_not_sell:
@@ -116110,9 +116152,9 @@ paths:
                         type: boolean
                       third_party_sharing:
                         type: boolean
-        '401': &id885
+        '401': &id886
           description: Unauthorized - Authentication required or token invalid
-          headers: *id882
+          headers: *id883
           content:
             application/json:
               schema:
@@ -116143,17 +116185,17 @@ paths:
         required: true
         content:
           application/json:
-            schema: *id883
+            schema: *id884
       responses:
         '200':
           description: Privacy preferences updated
-          headers: *id882
+          headers: *id883
           content:
             application/json:
-              schema: *id884
+              schema: *id885
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id882
+          headers: *id883
           content:
             application/json:
               schema:
@@ -116179,7 +116221,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id885
+        '401': *id886
       x-aragora-stability: stable
   /api/v1/probes/capability:
     post:
@@ -116304,7 +116346,7 @@ paths:
       responses:
         '200':
           description: Prompt intent
-          headers: &id887
+          headers: &id888
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116319,7 +116361,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  intent: &id886
+                  intent: &id887
                     type: object
                     additionalProperties: true
                   timing:
@@ -116328,13 +116370,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id886
+                      stage_durations_ms: *id887
                       operation_timings:
                         type: array
-                        items: *id886
+                        items: *id887
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id887
+          headers: *id888
           content:
             application/json:
               schema:
@@ -116389,7 +116431,7 @@ paths:
       responses:
         '200':
           description: Clarifying questions
-          headers: &id890
+          headers: &id891
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116404,9 +116446,9 @@ paths:
               schema:
                 type: object
                 properties:
-                  questions: &id889
+                  questions: &id890
                     type: array
-                    items: &id888
+                    items: &id889
                       type: object
                       additionalProperties: true
                   timing:
@@ -116415,11 +116457,11 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id888
-                      operation_timings: *id889
+                      stage_durations_ms: *id889
+                      operation_timings: *id890
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id890
+          headers: *id891
           content:
             application/json:
               schema:
@@ -116473,7 +116515,7 @@ paths:
       responses:
         '200':
           description: Research report
-          headers: &id892
+          headers: &id893
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116488,7 +116530,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  research: &id891
+                  research: &id892
                     type: object
                     additionalProperties: true
                   timing:
@@ -116497,13 +116539,13 @@ paths:
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id891
+                      stage_durations_ms: *id892
                       operation_timings:
                         type: array
-                        items: *id891
+                        items: *id892
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id892
+          headers: *id893
           content:
             application/json:
               schema:
@@ -116552,13 +116594,13 @@ paths:
                   description: Natural-language operator prompt to transform into a structured specification.
                 context:
                   description: Optional contextual data to pass into the prompt-engine stage.
-                profile: &id893
+                profile: &id894
                   type: string
-                autonomy: *id893
-                skip_research: &id894
+                autonomy: *id894
+                skip_research: &id895
                   type: boolean
-                skip_interrogation: *id894
-                decision_plan: &id895
+                skip_interrogation: *id895
+                decision_plan: &id896
                   type: object
                   additionalProperties: true
               required:
@@ -116566,7 +116608,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine pipeline result
-          headers: &id897
+          headers: &id898
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116582,35 +116624,35 @@ paths:
                 type: object
                 additionalProperties: true
                 properties:
-                  specification: *id895
-                  spec_bundle: *id895
-                  intent: *id895
-                  questions: &id896
+                  specification: *id896
+                  spec_bundle: *id896
+                  intent: *id896
+                  questions: &id897
                     type: array
-                    items: *id895
+                    items: *id896
                   research:
                     anyOf:
-                    - *id895
+                    - *id896
                     - type: 'null'
-                  auto_approved: *id894
+                  auto_approved: *id895
                   stages_completed:
                     type: array
-                    items: *id893
-                  validation: *id895
+                    items: *id894
+                  validation: *id896
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id895
-                      operation_timings: *id896
-                  run: *id895
-                  decision_plan: *id895
-                  execution: *id895
+                      stage_durations_ms: *id896
+                      operation_timings: *id897
+                  run: *id896
+                  decision_plan: *id896
+                  execution: *id896
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id897
+          headers: *id898
           content:
             application/json:
               schema:
@@ -116638,13 +116680,13 @@ paths:
                     trace_id: req_abc123xyz
         '422':
           description: Specification is not execution-grade
-          headers: *id897
+          headers: *id898
           content:
             application/json:
-              schema: *id895
+              schema: *id896
         '503':
           description: Internal server error - Unexpected error occurred
-          headers: *id897
+          headers: *id898
           content:
             application/json:
               schema:
@@ -116670,17 +116712,17 @@ paths:
       parameters:
       - name: status
         in: query
-        schema: &id898
+        schema: &id899
           type: string
       - name: plan_id
         in: query
-        schema: *id898
+        schema: *id899
       - name: debate_id
         in: query
-        schema: *id898
+        schema: *id899
       - name: execution_id
         in: query
-        schema: *id898
+        schema: *id899
       - name: limit
         in: query
         schema:
@@ -116737,7 +116779,7 @@ paths:
       responses:
         '200':
           description: Prompt-engine run
-          headers: &id899
+          headers: &id900
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116757,7 +116799,7 @@ paths:
                     additionalProperties: true
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id899
+          headers: *id900
           content:
             application/json:
               schema:
@@ -116793,19 +116835,19 @@ paths:
                   type: object
                   description: PromptIntent payload returned by decompose or by the full pipeline.
                   additionalProperties: true
-                questions: &id901
+                questions: &id902
                   type: array
-                  items: &id900
+                  items: &id901
                     type: object
                     additionalProperties: true
-                research: *id900
+                research: *id901
                 context: {}
               required:
               - intent
       responses:
         '200':
           description: Prompt specification
-          headers: &id902
+          headers: &id903
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116820,19 +116862,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  specification: *id900
-                  spec_bundle: *id900
+                  specification: *id901
+                  spec_bundle: *id901
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id900
-                      operation_timings: *id901
+                      stage_durations_ms: *id901
+                      operation_timings: *id902
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id902
+          headers: *id903
           content:
             application/json:
               schema:
@@ -116876,7 +116918,7 @@ paths:
               type: object
               additionalProperties: true
               properties:
-                specification: &id903
+                specification: &id904
                   type: object
                   additionalProperties: true
               required:
@@ -116884,7 +116926,7 @@ paths:
       responses:
         '200':
           description: Validation result
-          headers: &id904
+          headers: &id905
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116899,21 +116941,21 @@ paths:
               schema:
                 type: object
                 properties:
-                  validation: *id903
-                  spec_bundle: *id903
+                  validation: *id904
+                  spec_bundle: *id904
                   timing:
                     type: object
                     additionalProperties: true
                     properties:
                       total_duration_ms:
                         type: number
-                      stage_durations_ms: *id903
+                      stage_durations_ms: *id904
                       operation_timings:
                         type: array
-                        items: *id903
+                        items: *id904
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id904
+          headers: *id905
           content:
             application/json:
               schema:
@@ -117026,9 +117068,9 @@ paths:
                           - placeholder_backed
                           - details
                           properties:
-                            id: &id905
+                            id: &id906
                               type: string
-                            name: *id905
+                            name: *id906
                             readiness:
                               type: string
                               enum:
@@ -117037,12 +117079,12 @@ paths:
                               description: Readiness state for this exposed public surface.
                             paths:
                               type: array
-                              items: *id905
+                              items: *id906
                               description: Public paths that belong to this surface.
-                            message: *id905
-                            backend_conditional: &id906
+                            message: *id906
+                            backend_conditional: &id907
                               type: boolean
-                            placeholder_backed: *id906
+                            placeholder_backed: *id907
                             details:
                               type: object
                               additionalProperties: true
@@ -117560,7 +117602,7 @@ paths:
       responses:
         '200':
           description: List of jobs
-          headers: &id907
+          headers: &id908
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117597,9 +117639,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id908
+        '401': &id909
           description: Unauthorized - Authentication required or token invalid
-          headers: *id907
+          headers: *id908
           content:
             application/json:
               schema:
@@ -117662,7 +117704,7 @@ paths:
       responses:
         '201':
           description: Job created
-          headers: *id907
+          headers: *id908
           content:
             application/json:
               schema:
@@ -117674,7 +117716,7 @@ paths:
                     type: string
                   position:
                     type: integer
-        '401': *id908
+        '401': *id909
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -117694,7 +117736,7 @@ paths:
       responses:
         '200':
           description: Job details
-          headers: &id909
+          headers: &id910
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117726,9 +117768,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id910
+        '404': &id911
           description: Not found - The requested resource does not exist
-          headers: *id909
+          headers: *id910
           content:
             application/json:
               schema:
@@ -117760,7 +117802,7 @@ paths:
       responses:
         '200':
           description: Job cancelled
-          headers: *id909
+          headers: *id910
           content:
             application/json:
               schema:
@@ -117768,7 +117810,7 @@ paths:
                 properties:
                   cancelled:
                     type: boolean
-        '404': *id910
+        '404': *id911
         '409':
           description: Job cannot be cancelled (already running or completed)
           content:
@@ -117799,7 +117841,7 @@ paths:
       responses:
         '200':
           description: Job re-queued
-          headers: &id911
+          headers: &id912
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117820,7 +117862,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id911
+          headers: *id912
           content:
             application/json:
               schema:
@@ -118065,7 +118107,7 @@ paths:
       responses:
         '200':
           description: Ralph blocker breakdown
-          headers: &id912
+          headers: &id913
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118086,7 +118128,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id912
+          headers: *id913
           content:
             application/json:
               schema:
@@ -118106,7 +118148,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id912
+          headers: *id913
           content:
             application/json:
               schema:
@@ -118128,7 +118170,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id912
+          headers: *id913
           content:
             application/json:
               schema:
@@ -118156,7 +118198,7 @@ paths:
       responses:
         '200':
           description: Ralph campaigns
-          headers: &id913
+          headers: &id914
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118181,7 +118223,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id913
+          headers: *id914
           content:
             application/json:
               schema:
@@ -118201,7 +118243,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id913
+          headers: *id914
           content:
             application/json:
               schema:
@@ -118223,7 +118265,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id913
+          headers: *id914
           content:
             application/json:
               schema:
@@ -118258,120 +118300,6 @@ paths:
       responses:
         '200':
           description: Get Ralph campaign detail
-          headers: &id914
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: false
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '429':
-          description: Too many requests - Rate limit exceeded
-          headers: *id914
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                rate_limited:
-                  summary: Rate limit exceeded
-                  value:
-                    error: Rate limit exceeded
-                    code: RATE_LIMITED
-                    limit: 60
-                    window: 1 minute
-                    retry_after: 45
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/blockers:
-    get:
-      tags:
-      - Ralph
-      summary: Get Ralph campaign blockers
-      description: Return blocker breakdown data for a specific Ralph campaign.
-      operationId: getRalphCampaignBlockers
-      parameters:
-      - name: campaign_id
-        in: path
-        required: true
-        description: Ralph campaign identifier
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Get Ralph campaign blockers
           headers: &id915
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118469,13 +118397,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/budget:
+  /api/v1/ralph/campaigns/{campaign_id}/blockers:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign budget
-      description: Return budget burn and limit data for a specific Ralph campaign.
-      operationId: getRalphCampaignBudget
+      summary: Get Ralph campaign blockers
+      description: Return blocker breakdown data for a specific Ralph campaign.
+      operationId: getRalphCampaignBlockers
       parameters:
       - name: campaign_id
         in: path
@@ -118485,7 +118413,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign budget
+          description: Get Ralph campaign blockers
           headers: &id916
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118583,13 +118511,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/pr-gate:
+  /api/v1/ralph/campaigns/{campaign_id}/budget:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign PR gate
-      description: Return PR merge gate readiness for a specific Ralph campaign.
-      operationId: getRalphCampaignPrGate
+      summary: Get Ralph campaign budget
+      description: Return budget burn and limit data for a specific Ralph campaign.
+      operationId: getRalphCampaignBudget
       parameters:
       - name: campaign_id
         in: path
@@ -118599,7 +118527,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign PR gate
+          description: Get Ralph campaign budget
           headers: &id917
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118697,13 +118625,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/repairs:
+  /api/v1/ralph/campaigns/{campaign_id}/pr-gate:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign repairs
-      description: Return repair statistics for a specific Ralph campaign.
-      operationId: getRalphCampaignRepairs
+      summary: Get Ralph campaign PR gate
+      description: Return PR merge gate readiness for a specific Ralph campaign.
+      operationId: getRalphCampaignPrGate
       parameters:
       - name: campaign_id
         in: path
@@ -118713,7 +118641,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign repairs
+          description: Get Ralph campaign PR gate
           headers: &id918
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118811,13 +118739,13 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/campaigns/{campaign_id}/timeline:
+  /api/v1/ralph/campaigns/{campaign_id}/repairs:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign timeline
-      description: Return the step timeline for a Ralph campaign supervisor run.
-      operationId: getRalphCampaignTimeline
+      summary: Get Ralph campaign repairs
+      description: Return repair statistics for a specific Ralph campaign.
+      operationId: getRalphCampaignRepairs
       parameters:
       - name: campaign_id
         in: path
@@ -118827,7 +118755,7 @@ paths:
           type: string
       responses:
         '200':
-          description: Get Ralph campaign timeline
+          description: Get Ralph campaign repairs
           headers: &id919
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118844,11 +118772,9 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  timeline:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
+                  data:
+                    type: object
+                    additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: *id919
@@ -118927,16 +118853,23 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/ralph/overview:
+  /api/v1/ralph/campaigns/{campaign_id}/timeline:
     get:
       tags:
       - Ralph
-      summary: Get Ralph campaign overview
-      description: Return aggregate status, progress, and throughput metrics for Ralph campaign supervisor runs.
-      operationId: getRalphOverview
+      summary: Get Ralph campaign timeline
+      description: Return the step timeline for a Ralph campaign supervisor run.
+      operationId: getRalphCampaignTimeline
+      parameters:
+      - name: campaign_id
+        in: path
+        required: true
+        description: Ralph campaign identifier
+        schema:
+          type: string
       responses:
         '200':
-          description: Ralph campaign overview
+          description: Get Ralph campaign timeline
           headers: &id920
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -118953,9 +118886,11 @@ paths:
                 type: object
                 additionalProperties: false
                 properties:
-                  data:
-                    type: object
-                    additionalProperties: true
+                  timeline:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: *id920
@@ -118998,9 +118933,116 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id920
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
           headers: *id920
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                rate_limited:
+                  summary: Rate limit exceeded
+                  value:
+                    error: Rate limit exceeded
+                    code: RATE_LIMITED
+                    limit: 60
+                    window: 1 minute
+                    retry_after: 45
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/ralph/overview:
+    get:
+      tags:
+      - Ralph
+      summary: Get Ralph campaign overview
+      description: Return aggregate status, progress, and throughput metrics for Ralph campaign supervisor runs.
+      operationId: getRalphOverview
+      responses:
+        '200':
+          description: Ralph campaign overview
+          headers: &id921
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id921
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id921
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '429':
+          description: Too many requests - Rate limit exceeded
+          headers: *id921
           content:
             application/json:
               schema:
@@ -119312,7 +119354,7 @@ paths:
       responses:
         '200':
           description: Readiness report
-          headers: &id921
+          headers: &id922
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119433,7 +119475,7 @@ paths:
                   timestamp: '2026-02-21T12:00:00Z'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id921
+          headers: *id922
           content:
             application/json:
               schema:
@@ -119510,7 +119552,7 @@ paths:
       responses:
         '200':
           description: Receipt delivery history
-          headers: &id922
+          headers: &id923
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119537,7 +119579,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id922
+          headers: *id923
           content:
             application/json:
               schema:
@@ -119557,7 +119599,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id922
+          headers: *id923
           content:
             application/json:
               schema:
@@ -119592,7 +119634,7 @@ paths:
       responses:
         '200':
           description: Recently anchored receipts
-          headers: &id923
+          headers: &id924
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119617,7 +119659,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id923
+          headers: *id924
           content:
             application/json:
               schema:
@@ -119637,7 +119679,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id923
+          headers: *id924
           content:
             application/json:
               schema:
@@ -119671,7 +119713,7 @@ paths:
       responses:
         '200':
           description: Receipt anchor verification status
-          headers: &id924
+          headers: &id925
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119696,7 +119738,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id924
+          headers: *id925
           content:
             application/json:
               schema:
@@ -119716,7 +119758,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id924
+          headers: *id925
           content:
             application/json:
               schema:
@@ -119732,7 +119774,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id924
+          headers: *id925
           content:
             application/json:
               schema:
@@ -119809,7 +119851,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id925
+          headers: &id926
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119846,7 +119888,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id925
+          headers: *id926
           content:
             application/json:
               schema:
@@ -119866,7 +119908,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id925
+          headers: *id926
           content:
             application/json:
               schema:
@@ -119882,7 +119924,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id925
+          headers: *id926
           content:
             application/json:
               schema:
@@ -119975,7 +120017,7 @@ paths:
       responses:
         '200':
           description: Bulk resolution results
-          headers: &id926
+          headers: &id927
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119991,7 +120033,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id926
+          headers: *id927
           content:
             application/json:
               schema:
@@ -120019,7 +120061,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id926
+          headers: *id927
           content:
             application/json:
               schema:
@@ -120089,7 +120131,7 @@ paths:
       responses:
         '200':
           description: Reconciliation job started
-          headers: &id927
+          headers: &id928
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120105,7 +120147,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id927
+          headers: *id928
           content:
             application/json:
               schema:
@@ -120133,7 +120175,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id927
+          headers: *id928
           content:
             application/json:
               schema:
@@ -120225,7 +120267,7 @@ paths:
       responses:
         '200':
           description: Approval confirmation
-          headers: &id928
+          headers: &id929
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120241,7 +120283,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id928
+          headers: *id929
           content:
             application/json:
               schema:
@@ -120257,7 +120299,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id928
+          headers: *id929
           content:
             application/json:
               schema:
@@ -120338,7 +120380,7 @@ paths:
       responses:
         '200':
           description: Resolution confirmation
-          headers: &id929
+          headers: &id930
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120354,7 +120396,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id929
+          headers: *id930
           content:
             application/json:
               schema:
@@ -120382,7 +120424,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id929
+          headers: *id930
           content:
             application/json:
               schema:
@@ -120398,7 +120440,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id929
+          headers: *id930
           content:
             application/json:
               schema:
@@ -121072,7 +121114,7 @@ paths:
       responses:
         '200':
           description: List of expiring items
-          headers: &id930
+          headers: &id931
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121095,7 +121137,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id930
+          headers: *id931
           content:
             application/json:
               schema:
@@ -121126,7 +121168,7 @@ paths:
       responses:
         '200':
           description: List of retention policies
-          headers: &id931
+          headers: &id932
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121140,9 +121182,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicyList'
-        '401': &id932
+        '401': &id933
           description: Unauthorized - Authentication required or token invalid
-          headers: *id931
+          headers: *id932
           content:
             application/json:
               schema:
@@ -121200,14 +121242,14 @@ paths:
       responses:
         '201':
           description: Policy created
-          headers: *id931
+          headers: *id932
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id931
+          headers: *id932
           content:
             application/json:
               schema:
@@ -121233,10 +121275,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id932
+        '401': *id933
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id931
+          headers: *id932
           content:
             application/json:
               schema:
@@ -121347,7 +121389,7 @@ paths:
       responses:
         '200':
           description: Execution result with affected items count
-          headers: &id933
+          headers: &id934
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121370,7 +121412,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id933
+          headers: *id934
           content:
             application/json:
               schema:
@@ -121390,7 +121432,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id933
+          headers: *id934
           content:
             application/json:
               schema:
@@ -121412,7 +121454,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id933
+          headers: *id934
           content:
             application/json:
               schema:
@@ -121443,7 +121485,7 @@ paths:
       responses:
         '200':
           description: Rolling-window triage metrics
-          headers: &id935
+          headers: &id936
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121465,7 +121507,7 @@ paths:
                     - 7d
                     - 30d
                     properties:
-                      7d: &id934
+                      7d: &id935
                         type: object
                         additionalProperties: false
                         required:
@@ -121562,7 +121604,7 @@ paths:
                               type: string
                             description: Explanations keyed by metric name for any null-valued metric above. Empty when no
                               metrics were suppressed.
-                      30d: *id934
+                      30d: *id935
                   drift:
                     type: object
                     additionalProperties:
@@ -121599,7 +121641,7 @@ paths:
           description: "Not Modified \u2014 ETag matched If-None-Match."
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id935
+          headers: *id936
           content:
             application/json:
               schema:
@@ -121619,7 +121661,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id935
+          headers: *id936
           content:
             application/json:
               schema:
@@ -121641,7 +121683,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id935
+          headers: *id936
           content:
             application/json:
               schema:
@@ -121658,7 +121700,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id935
+          headers: *id936
           content:
             application/json:
               schema:
@@ -121738,7 +121780,7 @@ paths:
       responses:
         '200':
           description: Review details
-          headers: &id936
+          headers: &id937
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121766,9 +121808,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '400': &id937
+        '400': &id938
           description: Bad request - Invalid input or malformed JSON
-          headers: *id936
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121794,9 +121836,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id938
+        '404': &id939
           description: Not found - The requested resource does not exist
-          headers: *id936
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121810,9 +121852,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id939
+        '500': &id940
           description: Internal server error - Unexpected error occurred
-          headers: *id936
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121861,7 +121903,7 @@ paths:
       responses:
         '200':
           description: Review updated
-          headers: *id936
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121871,9 +121913,9 @@ paths:
                     type: boolean
                   review_id:
                     type: string
-        '400': *id937
-        '404': *id938
-        '500': *id939
+        '400': *id938
+        '404': *id939
+        '500': *id940
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -121893,7 +121935,7 @@ paths:
       responses:
         '200':
           description: Review deleted
-          headers: *id936
+          headers: *id937
           content:
             application/json:
               schema:
@@ -121903,8 +121945,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id938
-        '500': *id939
+        '404': *id939
+        '500': *id940
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -122737,7 +122779,7 @@ paths:
       responses:
         '200':
           description: Execution timeline
-          headers: &id940
+          headers: &id941
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122758,7 +122800,7 @@ paths:
                     additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id940
+          headers: *id941
           content:
             application/json:
               schema:
@@ -122778,7 +122820,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id940
+          headers: *id941
           content:
             application/json:
               schema:
@@ -122916,7 +122958,7 @@ paths:
       responses:
         '201':
           description: Queued improvement goal
-          headers: &id941
+          headers: &id942
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122950,7 +122992,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id941
+          headers: *id942
           content:
             application/json:
               schema:
@@ -122978,7 +123020,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id941
+          headers: *id942
           content:
             application/json:
               schema:
@@ -122998,7 +123040,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id941
+          headers: *id942
           content:
             application/json:
               schema:
@@ -123048,7 +123090,7 @@ paths:
       responses:
         '200':
           description: Deleted queue item
-          headers: &id942
+          headers: &id943
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123082,7 +123124,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id942
+          headers: *id943
           content:
             application/json:
               schema:
@@ -123102,7 +123144,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id942
+          headers: *id943
           content:
             application/json:
               schema:
@@ -123124,7 +123166,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id942
+          headers: *id943
           content:
             application/json:
               schema:
@@ -123182,7 +123224,7 @@ paths:
       responses:
         '200':
           description: Updated queue item priority
-          headers: &id943
+          headers: &id944
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123216,7 +123258,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id943
+          headers: *id944
           content:
             application/json:
               schema:
@@ -123244,7 +123286,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id943
+          headers: *id944
           content:
             application/json:
               schema:
@@ -123264,7 +123306,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id943
+          headers: *id944
           content:
             application/json:
               schema:
@@ -123286,7 +123328,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id943
+          headers: *id944
           content:
             application/json:
               schema:
@@ -123323,81 +123365,6 @@ paths:
       responses:
         '200':
           description: Learning insights
-          headers: &id944
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                additionalProperties: true
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id944
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id944
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/self-improve/meta-planner/goals:
-    get:
-      tags:
-      - Nomic
-      summary: List self-improvement meta-planner goals
-      description: Return prioritized MetaPlanner goals, codebase signals, and queue summary data for the self-improvement
-        dashboard.
-      operationId: listSelfImproveMetaPlannerGoals
-      responses:
-        '200':
-          description: Meta-planner goals
           headers: &id945
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -123462,16 +123429,17 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/self-improve/metrics/comparison:
+  /api/v1/self-improve/meta-planner/goals:
     get:
       tags:
       - Nomic
-      summary: Get self-improvement metrics comparison
-      description: Return before/after codebase metrics and regression comparisons across self-improvement cycles.
-      operationId: getSelfImproveMetricsComparison
+      summary: List self-improvement meta-planner goals
+      description: Return prioritized MetaPlanner goals, codebase signals, and queue summary data for the self-improvement
+        dashboard.
+      operationId: listSelfImproveMetaPlannerGoals
       responses:
         '200':
-          description: Metrics comparison
+          description: Meta-planner goals
           headers: &id946
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -123514,6 +123482,80 @@ paths:
         '403':
           description: Forbidden - Insufficient permissions for this operation
           headers: *id946
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/self-improve/metrics/comparison:
+    get:
+      tags:
+      - Nomic
+      summary: Get self-improvement metrics comparison
+      description: Return before/after codebase metrics and regression comparisons across self-improvement cycles.
+      operationId: getSelfImproveMetricsComparison
+      responses:
+        '200':
+          description: Metrics comparison
+          headers: &id947
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id947
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id947
           content:
             application/json:
               schema:
@@ -123725,7 +123767,7 @@ paths:
       responses:
         '200':
           description: Cycle trends
-          headers: &id949
+          headers: &id950
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123745,16 +123787,16 @@ paths:
                     type: object
                     additionalProperties: true
                     properties:
-                      cycles: &id948
+                      cycles: &id949
                         type: array
-                        items: &id947
+                        items: &id948
                           type: object
                           additionalProperties: true
-                      summary: *id947
-                      run_costs: *id948
+                      summary: *id948
+                      run_costs: *id949
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id949
+          headers: *id950
           content:
             application/json:
               schema:
@@ -123774,7 +123816,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id949
+          headers: *id950
           content:
             application/json:
               schema:
@@ -124649,7 +124691,7 @@ paths:
       responses:
         '200':
           description: Spectate events emitted
-          headers: &id950
+          headers: &id951
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124670,7 +124712,7 @@ paths:
                     type: string
         '503':
           description: Bridge unavailable
-          headers: *id950
+          headers: *id951
           content:
             application/json:
               schema:
@@ -124695,12 +124737,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id951
+        schema: &id952
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id951
+        schema: *id952
       responses:
         '200':
           description: Recent spectate events
@@ -124763,12 +124805,12 @@ paths:
       - name: debate_id
         in: query
         description: Limit results to one debate.
-        schema: &id952
+        schema: &id953
           type: string
       - name: pipeline_id
         in: query
         description: Limit results to one pipeline.
-        schema: *id952
+        schema: *id953
       - name: format
         in: query
         description: Use `sse` to request a finite SSE snapshot instead of JSON.
@@ -125278,13 +125320,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id953
+        schema: &id954
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id953
+        schema: *id954
       responses:
         '200':
           description: Ticket updated
@@ -125315,13 +125357,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id954
+        schema: &id955
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id954
+        schema: *id955
       responses:
         '200':
           description: Reply sent
@@ -125602,7 +125644,7 @@ paths:
       responses:
         '200':
           description: Active leases
-          headers: &id955
+          headers: &id956
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125627,7 +125669,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id955
+          headers: *id956
           content:
             application/json:
               schema:
@@ -125647,7 +125689,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id955
+          headers: *id956
           content:
             application/json:
               schema:
@@ -125747,132 +125789,6 @@ paths:
       responses:
         '200':
           description: Completion receipt
-          headers: &id956
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id956
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id956
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id956
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '409':
-          description: Lease or file-scope conflict
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  conflicts:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
-                  violations:
-                    type: array
-                    items:
-                      type: object
-                      additionalProperties: true
-                additionalProperties: true
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/leases/{lease_id}/heartbeat:
-    post:
-      tags:
-      - Tasks
-      summary: Heartbeat task lease
-      description: Refresh an active task lease and optionally adjust its TTL.
-      operationId: heartbeatTaskQueueLease
-      parameters:
-      - name: lease_id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Task lease id.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                ttl_hours:
-                  type: number
-              additionalProperties: true
-      responses:
-        '200':
-          description: Updated lease
           headers: &id957
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -125950,16 +125866,36 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
+        '409':
+          description: Lease or file-scope conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  conflicts:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                  violations:
+                    type: array
+                    items:
+                      type: object
+                      additionalProperties: true
+                additionalProperties: true
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/tasks/leases/{lease_id}/release:
+  /api/v1/tasks/leases/{lease_id}/heartbeat:
     post:
       tags:
       - Tasks
-      summary: Release task lease
-      description: Release a task lease without recording completion.
-      operationId: releaseTaskQueueLease
+      summary: Heartbeat task lease
+      description: Refresh an active task lease and optionally adjust its TTL.
+      operationId: heartbeatTaskQueueLease
       parameters:
       - name: lease_id
         in: path
@@ -125967,9 +125903,18 @@ paths:
         schema:
           type: string
         description: Task lease id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ttl_hours:
+                  type: number
+              additionalProperties: true
       responses:
         '200':
-          description: Released lease
+          description: Updated lease
           headers: &id958
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -126050,6 +125995,103 @@ paths:
       security:
       - bearerAuth: []
       x-aragora-stability: stable
+  /api/v1/tasks/leases/{lease_id}/release:
+    post:
+      tags:
+      - Tasks
+      summary: Release task lease
+      description: Release a task lease without recording completion.
+      operationId: releaseTaskQueueLease
+      parameters:
+      - name: lease_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Task lease id.
+      responses:
+        '200':
+          description: Released lease
+          headers: &id959
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id959
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id959
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id959
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
   /api/v1/tasks/queue:
     get:
       tags:
@@ -126079,7 +126121,7 @@ paths:
       responses:
         '200':
           description: Queue items
-          headers: &id959
+          headers: &id960
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126104,7 +126146,7 @@ paths:
                 additionalProperties: true
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id959
+          headers: *id960
           content:
             application/json:
               schema:
@@ -126132,7 +126174,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id959
+          headers: *id960
           content:
             application/json:
               schema:
@@ -126152,7 +126194,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id959
+          headers: *id960
           content:
             application/json:
               schema:
@@ -126185,96 +126227,6 @@ paths:
       responses:
         '200':
           description: Queue statistics
-          headers: &id960
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    additionalProperties: true
-                additionalProperties: true
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id960
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id960
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-      security:
-      - bearerAuth: []
-      x-aragora-stability: stable
-  /api/v1/tasks/queue/sync:
-    post:
-      tags:
-      - Tasks
-      summary: Synchronize task queue
-      description: Project pending and developer coordination work into the global task queue.
-      operationId: syncTaskQueue
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                include_pending:
-                  type: boolean
-                  default: true
-                include_developer_tasks:
-                  type: boolean
-                  default: true
-                complete_missing:
-                  type: boolean
-                  default: true
-              additionalProperties: true
-      responses:
-        '200':
-          description: Queue synchronization result
           headers: &id961
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -126336,41 +126288,35 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id961
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/tasks/queue/{task_id}:
-    get:
+  /api/v1/tasks/queue/sync:
+    post:
       tags:
       - Tasks
-      summary: Get task queue item
-      description: Retrieve a single task queue item by id.
-      operationId: getTaskQueueItem
-      parameters:
-      - name: task_id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Task queue item id.
+      summary: Synchronize task queue
+      description: Project pending and developer coordination work into the global task queue.
+      operationId: syncTaskQueue
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                include_pending:
+                  type: boolean
+                  default: true
+                include_developer_tasks:
+                  type: boolean
+                  default: true
+                complete_missing:
+                  type: boolean
+                  default: true
+              additionalProperties: true
       responses:
         '200':
-          description: Queue item
+          description: Queue synchronization result
           headers: &id962
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -126432,32 +126378,31 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
+        '500':
+          description: Internal server error - Unexpected error occurred
           headers: *id962
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
               examples:
-                not_found:
-                  summary: Resource not found
+                internal_error:
+                  summary: Internal server error
                   value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
       security:
       - bearerAuth: []
       x-aragora-stability: stable
-  /api/v1/tasks/queue/{task_id}/claim:
-    post:
+  /api/v1/tasks/queue/{task_id}:
+    get:
       tags:
       - Tasks
-      summary: Claim task queue item
-      description: Claim a task queue item and create a lease for bounded implementation work.
-      operationId: claimTaskQueueItem
+      summary: Get task queue item
+      description: Retrieve a single task queue item by id.
+      operationId: getTaskQueueItem
       parameters:
       - name: task_id
         in: path
@@ -126465,49 +126410,9 @@ paths:
         schema:
           type: string
         description: Task queue item id.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                title:
-                  type: string
-                owner_agent:
-                  type: string
-                  default: unknown
-                owner_session_id:
-                  type: string
-                  default: public-api
-                branch:
-                  type: string
-                worktree_path:
-                  type: string
-                ttl_hours:
-                  type: number
-                  default: 8.0
-                expected_tests:
-                  type: array
-                  items:
-                    type: string
-                allowed_globs:
-                  type: array
-                  items:
-                    type: string
-                claimed_paths:
-                  type: array
-                  items:
-                    type: string
-                metadata:
-                  type: object
-                  additionalProperties: true
-                allow_overlap:
-                  type: boolean
-                  default: false
-              additionalProperties: true
       responses:
-        '201':
-          description: Created lease
+        '200':
+          description: Queue item
           headers: &id963
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -126585,6 +126490,143 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
+      security:
+      - bearerAuth: []
+      x-aragora-stability: stable
+  /api/v1/tasks/queue/{task_id}/claim:
+    post:
+      tags:
+      - Tasks
+      summary: Claim task queue item
+      description: Claim a task queue item and create a lease for bounded implementation work.
+      operationId: claimTaskQueueItem
+      parameters:
+      - name: task_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Task queue item id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                owner_agent:
+                  type: string
+                  default: unknown
+                owner_session_id:
+                  type: string
+                  default: public-api
+                branch:
+                  type: string
+                worktree_path:
+                  type: string
+                ttl_hours:
+                  type: number
+                  default: 8.0
+                expected_tests:
+                  type: array
+                  items:
+                    type: string
+                allowed_globs:
+                  type: array
+                  items:
+                    type: string
+                claimed_paths:
+                  type: array
+                  items:
+                    type: string
+                metadata:
+                  type: object
+                  additionalProperties: true
+                allow_overlap:
+                  type: boolean
+                  default: false
+              additionalProperties: true
+      responses:
+        '201':
+          description: Created lease
+          headers: &id964
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    additionalProperties: true
+                additionalProperties: true
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id964
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
         '409':
           description: Lease or file-scope conflict
           content:
@@ -126618,7 +126660,7 @@ paths:
       responses:
         '200':
           description: Salvage candidates
-          headers: &id964
+          headers: &id965
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126643,7 +126685,7 @@ paths:
                 additionalProperties: true
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id964
+          headers: *id965
           content:
             application/json:
               schema:
@@ -126663,7 +126705,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id964
+          headers: *id965
           content:
             application/json:
               schema:
@@ -126989,7 +127031,7 @@ paths:
       responses:
         '200':
           description: Template registry listing
-          headers: &id965
+          headers: &id966
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127062,7 +127104,7 @@ paths:
                 - approved_by
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id965
+          headers: *id966
           content:
             application/json:
               schema:
@@ -127164,7 +127206,7 @@ paths:
       responses:
         '200':
           description: Email scan
-          headers: &id966
+          headers: &id967
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127180,7 +127222,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id966
+          headers: *id967
           content:
             application/json:
               schema:
@@ -127208,7 +127250,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id966
+          headers: *id967
           content:
             application/json:
               schema:
@@ -127228,7 +127270,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id966
+          headers: *id967
           content:
             application/json:
               schema:
@@ -127260,7 +127302,7 @@ paths:
       responses:
         '200':
           description: Hash result
-          headers: &id967
+          headers: &id968
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127276,7 +127318,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id967
+          headers: *id968
           content:
             application/json:
               schema:
@@ -127296,7 +127338,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id967
+          headers: *id968
           content:
             application/json:
               schema:
@@ -127343,7 +127385,7 @@ paths:
       responses:
         '200':
           description: Hash results
-          headers: &id968
+          headers: &id969
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127359,7 +127401,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id968
+          headers: *id969
           content:
             application/json:
               schema:
@@ -127387,7 +127429,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id968
+          headers: *id969
           content:
             application/json:
               schema:
@@ -127407,7 +127449,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id968
+          headers: *id969
           content:
             application/json:
               schema:
@@ -127439,7 +127481,7 @@ paths:
       responses:
         '200':
           description: IP result
-          headers: &id969
+          headers: &id970
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127455,7 +127497,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id969
+          headers: *id970
           content:
             application/json:
               schema:
@@ -127475,7 +127517,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id969
+          headers: *id970
           content:
             application/json:
               schema:
@@ -127516,7 +127558,7 @@ paths:
       responses:
         '200':
           description: IP results
-          headers: &id970
+          headers: &id971
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127532,7 +127574,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id970
+          headers: *id971
           content:
             application/json:
               schema:
@@ -127560,7 +127602,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id970
+          headers: *id971
           content:
             application/json:
               schema:
@@ -127580,7 +127622,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id970
+          headers: *id971
           content:
             application/json:
               schema:
@@ -127606,7 +127648,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id971
+          headers: &id972
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -127622,7 +127664,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id971
+          headers: *id972
           content:
             application/json:
               schema:
@@ -127642,7 +127684,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id971
+          headers: *id972
           content:
             application/json:
               schema:
@@ -127681,111 +127723,6 @@ paths:
       responses:
         '200':
           description: Threat result
-          headers: &id972
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id972
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id972
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id972
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/threat/urls:
-    post:
-      tags:
-      - Threat Intel
-      summary: Batch scan URLs
-      operationId: createThreatUrls
-      description: Check multiple URLs for threats.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                urls:
-                  type: array
-                  items:
-                    type: string
-                    format: uri
-                  description: URLs to scan for threats
-              required:
-              - urls
-      responses:
-        '200':
-          description: Threat results
           headers: &id973
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -127851,6 +127788,111 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id973
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/threat/urls:
+    post:
+      tags:
+      - Threat Intel
+      summary: Batch scan URLs
+      operationId: createThreatUrls
+      description: Check multiple URLs for threats.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                  description: URLs to scan for threats
+              required:
+              - urls
+      responses:
+        '200':
+          description: Threat results
+          headers: &id974
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id974
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id974
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id974
           content:
             application/json:
               schema:
@@ -128092,7 +128134,7 @@ paths:
       responses:
         '200':
           description: Tournament details
-          headers: &id974
+          headers: &id975
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -128122,9 +128164,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id975
+        '404': &id976
           description: Not found - The requested resource does not exist
-          headers: *id974
+          headers: *id975
           content:
             application/json:
               schema:
@@ -128138,9 +128180,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id976
+        '500': &id977
           description: Internal server error - Unexpected error occurred
-          headers: *id974
+          headers: *id975
           content:
             application/json:
               schema:
@@ -128170,7 +128212,7 @@ paths:
       responses:
         '200':
           description: Tournament deleted
-          headers: *id974
+          headers: *id975
           content:
             application/json:
               schema:
@@ -128180,8 +128222,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id975
-        '500': *id976
+        '404': *id976
+        '500': *id977
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -129085,7 +129127,7 @@ paths:
       responses:
         '200':
           description: List of linked providers
-          headers: &id977
+          headers: &id978
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -129112,7 +129154,7 @@ paths:
                           format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id977
+          headers: *id978
           content:
             application/json:
               schema:
@@ -129719,9 +129761,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id979
+        '404': &id980
           description: Not found - The requested resource does not exist
-          headers: &id978
+          headers: &id979
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -129782,7 +129824,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id978
+          headers: *id979
           content:
             application/json:
               schema:
@@ -129794,7 +129836,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id978
+          headers: *id979
           content:
             application/json:
               schema:
@@ -129820,7 +129862,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id979
+        '404': *id980
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -130343,7 +130385,7 @@ paths:
                     format: date-time
         '404':
           description: Delivery not found
-          headers: &id980
+          headers: &id981
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -130373,7 +130415,7 @@ paths:
           description: Delivery deleted
         '404':
           description: Delivery not found
-          headers: *id980
+          headers: *id981
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -130824,7 +130866,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: &id981
+        schema: &id982
           type: string
           format: uuid
         description: Webhook ID
@@ -130872,7 +130914,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: &id982
+          headers: &id983
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -130895,7 +130937,7 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id981
+        schema: *id982
         description: Webhook ID
       requestBody:
         required: true
@@ -130959,7 +131001,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: *id982
+          headers: *id983
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -130973,14 +131015,14 @@ paths:
       - name: id
         in: path
         required: true
-        schema: *id981
+        schema: *id982
         description: Webhook ID
       responses:
         '204':
           description: Webhook deleted
         '404':
           description: Webhook not found
-          headers: *id982
+          headers: *id983
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -131052,7 +131094,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id983
+          headers: &id984
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131075,7 +131117,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id983
+          headers: *id984
           content:
             application/json:
               schema:
@@ -131128,7 +131170,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id984
+          headers: &id985
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131151,7 +131193,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id984
+          headers: *id985
           content:
             application/json:
               schema:
@@ -131179,7 +131221,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id984
+          headers: *id985
           content:
             application/json:
               schema:
@@ -131199,7 +131241,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id984
+          headers: *id985
           content:
             application/json:
               schema:
@@ -131305,7 +131347,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id985
+          headers: &id986
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131332,9 +131374,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id986
+        '404': &id987
           description: Not found - The requested resource does not exist
-          headers: *id985
+          headers: *id986
           content:
             application/json:
               schema:
@@ -131364,7 +131406,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id985
+          headers: *id986
           content:
             application/json:
               schema:
@@ -131376,7 +131418,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id985
+          headers: *id986
           content:
             application/json:
               schema:
@@ -131402,7 +131444,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id986
+        '404': *id987
       x-aragora-stability: stable
   /api/v1/workflow-templates:
     get:
@@ -131451,7 +131493,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id987
+          headers: &id988
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131467,7 +131509,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id987
+          headers: *id988
           content:
             application/json:
               schema:
@@ -131551,7 +131593,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id988
+          headers: &id989
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131588,7 +131630,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id988
+          headers: *id989
           content:
             application/json:
               schema:
@@ -131634,7 +131676,7 @@ paths:
       responses:
         '201':
           description: Workflow instantiated
-          headers: &id989
+          headers: &id990
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131655,7 +131697,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id989
+          headers: *id990
           content:
             application/json:
               schema:
@@ -131683,7 +131725,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id989
+          headers: *id990
           content:
             application/json:
               schema:
@@ -131699,7 +131741,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id989
+          headers: *id990
           content:
             application/json:
               schema:
@@ -131786,7 +131828,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id990
+          headers: &id991
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131802,7 +131844,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id990
+          headers: *id991
           content:
             application/json:
               schema:
@@ -131830,7 +131872,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id990
+          headers: *id991
           content:
             application/json:
               schema:
@@ -131926,7 +131968,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id991
+          headers: &id992
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -131942,7 +131984,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id991
+          headers: *id992
           content:
             application/json:
               schema:
@@ -132124,7 +132166,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id992
+          headers: &id993
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132161,7 +132203,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id992
+          headers: *id993
           content:
             application/json:
               schema:
@@ -132218,7 +132260,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id993
+          headers: &id994
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132279,14 +132321,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id993
+          headers: *id994
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id993
+          headers: *id994
           content:
             application/json:
               schema:
@@ -132409,7 +132451,7 @@ paths:
       responses:
         '200':
           description: Workflow execution details
-          headers: &id994
+          headers: &id995
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132432,9 +132474,9 @@ paths:
                     type: string
                   result:
                     type: object
-        '404': &id995
+        '404': &id996
           description: Not found - The requested resource does not exist
-          headers: *id994
+          headers: *id995
           content:
             application/json:
               schema:
@@ -132467,7 +132509,7 @@ paths:
       responses:
         '200':
           description: Workflow execution deleted
-          headers: *id994
+          headers: *id995
           content:
             application/json:
               schema:
@@ -132479,7 +132521,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id994
+          headers: *id995
           content:
             application/json:
               schema:
@@ -132505,7 +132547,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id995
+        '404': *id996
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -132647,7 +132689,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id996
+          headers: &id997
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132661,9 +132703,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '404': &id997
+        '404': &id998
           description: Not found - The requested resource does not exist
-          headers: *id996
+          headers: *id997
           content:
             application/json:
               schema:
@@ -132725,14 +132767,14 @@ paths:
       responses:
         '200':
           description: Workflow template updated
-          headers: *id996
+          headers: *id997
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '400': &id998
+        '400': &id999
           description: Bad request - Invalid input or malformed JSON
-          headers: *id996
+          headers: *id997
           content:
             application/json:
               schema:
@@ -132758,7 +132800,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id997
+        '404': *id998
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -132778,7 +132820,7 @@ paths:
       responses:
         '200':
           description: Workflow template deleted
-          headers: *id996
+          headers: *id997
           content:
             application/json:
               schema:
@@ -132788,8 +132830,8 @@ paths:
                     type: boolean
                   template_id:
                     type: string
-        '400': *id998
-        '404': *id997
+        '400': *id999
+        '404': *id998
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -132858,7 +132900,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id999
+          headers: &id1000
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -132872,9 +132914,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1000
+        '404': &id1001
           description: Not found - The requested resource does not exist
-          headers: *id999
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -132910,14 +132952,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id999
+          headers: *id1000
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id999
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -132943,7 +132985,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1000
+        '404': *id1001
       x-aragora-stability: stable
     delete:
       tags:
@@ -132960,7 +133002,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id999
+          headers: *id1000
           content:
             application/json:
               schema:
@@ -132970,7 +133012,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1000
+        '404': *id1001
       x-aragora-stability: stable
     patch:
       summary: Update a workflow
@@ -133029,7 +133071,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1001
+          headers: &id1002
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133052,7 +133094,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1001
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -133080,7 +133122,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1001
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -133096,7 +133138,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1001
+          headers: *id1002
           content:
             application/json:
               schema:
@@ -133182,7 +133224,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1002
+          headers: &id1003
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133205,7 +133247,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1002
+          headers: *id1003
           content:
             application/json:
               schema:
@@ -133283,7 +133325,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1003
+          headers: &id1004
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133297,9 +133339,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1004
+        '401': &id1005
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1003
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -133354,14 +133396,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1003
+          headers: *id1004
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1003
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -133387,10 +133429,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1004
+        '401': *id1005
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1003
+          headers: *id1004
           content:
             application/json:
               schema:
@@ -133435,7 +133477,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1005
+          headers: &id1006
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133463,7 +133505,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1005
+          headers: *id1006
           content:
             application/json:
               schema:
@@ -133500,7 +133542,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1006
+          headers: &id1007
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133514,9 +133556,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1007
+        '401': &id1008
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1006
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -133534,9 +133576,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1008
+        '403': &id1009
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1006
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -133556,9 +133598,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1009
+        '404': &id1010
           description: Not found - The requested resource does not exist
-          headers: *id1006
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -133590,7 +133632,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1006
+          headers: *id1007
           content:
             application/json:
               schema:
@@ -133600,9 +133642,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1007
-        '403': *id1008
-        '404': *id1009
+        '401': *id1008
+        '403': *id1009
+        '404': *id1010
       x-aragora-stability: stable
   /api/v1/workspaces/{workspace_id}/activity:
     get:
@@ -133815,7 +133857,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1010
+          headers: &id1011
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -133838,7 +133880,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1010
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -133866,7 +133908,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1010
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -133886,7 +133928,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1010
+          headers: *id1011
           content:
             application/json:
               schema:
@@ -134022,7 +134064,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1011
+          headers: &id1012
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134045,7 +134087,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1011
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -134073,7 +134115,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1011
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -134093,7 +134135,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1011
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -134115,7 +134157,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1011
+          headers: *id1012
           content:
             application/json:
               schema:
@@ -134167,7 +134209,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1012
+          headers: &id1013
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134194,7 +134236,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1012
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -134214,7 +134256,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1012
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -134236,7 +134278,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1012
+          headers: *id1013
           content:
             application/json:
               schema:
@@ -134422,9 +134464,9 @@ paths:
                           type: integer
                   total:
                     type: integer
-        '401': &id1014
+        '401': &id1015
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1013
+          headers: &id1014
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134451,9 +134493,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1015
+        '403': &id1016
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1013
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -134473,9 +134515,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id1016
+        '500': &id1017
           description: Internal server error - Unexpected error occurred
-          headers: *id1013
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -134548,7 +134590,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1013
+          headers: *id1014
           content:
             application/json:
               schema:
@@ -134574,15 +134616,15 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1014
-        '403': *id1015
+        '401': *id1015
+        '403': *id1016
         '409':
           description: Another backup is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1016
+        '500': *id1017
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -134649,9 +134691,9 @@ paths:
                   expires_at:
                     type: string
                     format: date-time
-        '401': &id1018
+        '401': &id1019
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1017
+          headers: &id1018
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134678,9 +134720,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1019
+        '403': &id1020
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1017
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -134700,9 +134742,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1020
+        '404': &id1021
           description: Not found - The requested resource does not exist
-          headers: *id1017
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -134716,9 +134758,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1021
+        '500': &id1022
           description: Internal server error - Unexpected error occurred
-          headers: *id1017
+          headers: *id1018
           content:
             application/json:
               schema:
@@ -134760,16 +134802,16 @@ paths:
                     type: boolean
                   backup_id:
                     type: string
-        '401': *id1018
-        '403': *id1019
-        '404': *id1020
+        '401': *id1019
+        '403': *id1020
+        '404': *id1021
         '409':
           description: Cannot delete an in-progress backup
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1021
+        '500': *id1022
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -134838,7 +134880,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1022
+          headers: &id1023
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134867,7 +134909,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1022
+          headers: *id1023
           content:
             application/json:
               schema:
@@ -134889,7 +134931,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1022
+          headers: *id1023
           content:
             application/json:
               schema:
@@ -134968,7 +135010,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1023
+          headers: &id1024
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -134997,7 +135039,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1023
+          headers: *id1024
           content:
             application/json:
               schema:
@@ -135019,7 +135061,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1023
+          headers: *id1024
           content:
             application/json:
               schema:
@@ -135035,7 +135077,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1023
+          headers: *id1024
           content:
             application/json:
               schema:
@@ -135120,7 +135162,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1024
+          headers: &id1025
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135149,7 +135191,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1024
+          headers: *id1025
           content:
             application/json:
               schema:
@@ -135171,7 +135213,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1024
+          headers: *id1025
           content:
             application/json:
               schema:
@@ -135264,9 +135306,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id1026
+        '401': &id1027
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1025
+          headers: &id1026
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135293,9 +135335,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1027
+        '403': &id1028
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1025
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -135315,9 +135357,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1028
+        '404': &id1029
           description: Not found - The requested resource does not exist
-          headers: *id1025
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -135331,9 +135373,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1029
+        '500': &id1030
           description: Internal server error - Unexpected error occurred
-          headers: *id1025
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -135413,7 +135455,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1025
+          headers: *id1026
           content:
             application/json:
               schema:
@@ -135439,16 +135481,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1026
-        '403': *id1027
-        '404': *id1028
+        '401': *id1027
+        '403': *id1028
+        '404': *id1029
         '409':
           description: Another DR execution is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id1029
+        '500': *id1030
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -135532,7 +135574,7 @@ paths:
                         type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1030
+          headers: &id1031
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135561,7 +135603,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1030
+          headers: *id1031
           content:
             application/json:
               schema:
@@ -135614,7 +135656,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1031
+          headers: &id1032
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135643,7 +135685,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1031
+          headers: *id1032
           content:
             application/json:
               schema:
@@ -135680,7 +135722,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1032
+          headers: &id1033
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135709,7 +135751,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1032
+          headers: *id1033
           content:
             application/json:
               schema:
@@ -135761,7 +135803,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1033
+          headers: &id1034
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135790,7 +135832,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1033
+          headers: *id1034
           content:
             application/json:
               schema:
@@ -135831,7 +135873,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1034
+          headers: &id1035
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135860,7 +135902,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1034
+          headers: *id1035
           content:
             application/json:
               schema:
@@ -135917,7 +135959,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1035
+          headers: &id1036
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -135954,7 +135996,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1035
+          headers: *id1036
           content:
             application/json:
               schema:
@@ -135974,7 +136016,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1035
+          headers: *id1036
           content:
             application/json:
               schema:
@@ -136056,9 +136098,9 @@ paths:
                       type: object
                   health:
                     type: object
-        '400': &id1037
+        '400': &id1038
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1036
+          headers: &id1037
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136093,9 +136135,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id1038
+        '401': &id1039
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1036
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -136113,9 +136155,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1039
+        '404': &id1040
           description: Not found - The requested resource does not exist
-          headers: *id1036
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -136129,9 +136171,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1040
+        '500': &id1041
           description: Internal server error - Unexpected error occurred
-          headers: *id1036
+          headers: *id1037
           content:
             application/json:
               schema:
@@ -136189,10 +136231,10 @@ paths:
                     type: string
                   workspace_id:
                     type: string
-        '400': *id1037
-        '401': *id1038
-        '404': *id1039
-        '500': *id1040
+        '400': *id1038
+        '401': *id1039
+        '404': *id1040
+        '500': *id1041
       x-aragora-stability: stable
   /api/v2/integrations/{type}/health:
     get:
@@ -136262,147 +136304,6 @@ paths:
                 required:
                 - type
                 - healthy
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: &id1041
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id1041
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id1041
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id1041
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v2/integrations/{type}/test:
-    post:
-      tags:
-      - Integrations
-      summary: Test integration connectivity
-      description: Test the connectivity and health of a specific integration.
-      operationId: testIntegration
-      parameters:
-      - name: type
-        in: path
-        required: true
-        description: Integration type
-        schema:
-          type: string
-          enum:
-          - slack
-          - teams
-          - discord
-          - email
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                workspace_id:
-                  type: string
-                  description: Workspace/tenant ID to test
-      responses:
-        '200':
-          description: Test result
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  type:
-                    type: string
-                  workspace_id:
-                    type: string
-                  test_result:
-                    type: object
-                    properties:
-                      status:
-                        type: string
-                      error:
-                        type:
-                        - string
-                        - 'null'
-                  tested_at:
-                    type: string
-                    format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
           headers: &id1042
@@ -136479,6 +136380,147 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id1042
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v2/integrations/{type}/test:
+    post:
+      tags:
+      - Integrations
+      summary: Test integration connectivity
+      description: Test the connectivity and health of a specific integration.
+      operationId: testIntegration
+      parameters:
+      - name: type
+        in: path
+        required: true
+        description: Integration type
+        schema:
+          type: string
+          enum:
+          - slack
+          - teams
+          - discord
+          - email
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workspace_id:
+                  type: string
+                  description: Workspace/tenant ID to test
+      responses:
+        '200':
+          description: Test result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  type:
+                    type: string
+                  workspace_id:
+                    type: string
+                  test_result:
+                    type: object
+                    properties:
+                      status:
+                        type: string
+                      error:
+                        type:
+                        - string
+                        - 'null'
+                  tested_at:
+                    type: string
+                    format: date-time
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id1043
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id1043
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id1043
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id1043
           content:
             application/json:
               schema:
@@ -136775,7 +136817,7 @@ paths:
       responses:
         '200':
           description: Marketplace categories.
-          headers: &id1043
+          headers: &id1044
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136796,7 +136838,7 @@ paths:
                       type: string
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1043
+          headers: *id1044
           content:
             application/json:
               schema:
@@ -136891,7 +136933,7 @@ paths:
       responses:
         '200':
           description: Marketplace templates.
-          headers: &id1044
+          headers: &id1045
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -136916,9 +136958,9 @@ paths:
                     type: integer
                   offset:
                     type: integer
-        '400': &id1045
+        '400': &id1046
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1044
+          headers: *id1045
           content:
             application/json:
               schema:
@@ -136944,9 +136986,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': &id1046
+        '500': &id1047
           description: Internal server error - Unexpected error occurred
-          headers: *id1044
+          headers: *id1045
           content:
             application/json:
               schema:
@@ -137000,7 +137042,7 @@ paths:
       responses:
         '201':
           description: Template created.
-          headers: *id1044
+          headers: *id1045
           content:
             application/json:
               schema:
@@ -137010,10 +137052,10 @@ paths:
                     type: string
                   success:
                     type: boolean
-        '400': *id1045
+        '400': *id1046
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1044
+          headers: *id1045
           content:
             application/json:
               schema:
@@ -137033,7 +137075,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1044
+          headers: *id1045
           content:
             application/json:
               schema:
@@ -137053,7 +137095,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id1046
+        '500': *id1047
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/import:
     post:
@@ -137096,7 +137138,7 @@ paths:
       responses:
         '201':
           description: Template imported.
-          headers: &id1047
+          headers: &id1048
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137117,7 +137159,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1047
+          headers: *id1048
           content:
             application/json:
               schema:
@@ -137145,7 +137187,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1047
+          headers: *id1048
           content:
             application/json:
               schema:
@@ -137165,7 +137207,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1047
+          headers: *id1048
           content:
             application/json:
               schema:
@@ -137187,7 +137229,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1047
+          headers: *id1048
           content:
             application/json:
               schema:
@@ -137213,13 +137255,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1049
+        schema: &id1050
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template details.
-          headers: &id1048
+          headers: &id1049
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137254,9 +137296,9 @@ paths:
                     type: integer
                   average_rating:
                     type: number
-        '400': &id1050
+        '400': &id1051
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137282,9 +137324,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1051
+        '404': &id1052
           description: Not found - The requested resource does not exist
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137298,9 +137340,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1052
+        '500': &id1053
           description: Internal server error - Unexpected error occurred
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137326,12 +137368,12 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1049
+        schema: *id1050
         description: Marketplace template ID.
       responses:
         '200':
           description: Template deleted.
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137341,10 +137383,10 @@ paths:
                     type: boolean
                   deleted:
                     type: string
-        '400': *id1050
+        '400': *id1051
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137364,7 +137406,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1048
+          headers: *id1049
           content:
             application/json:
               schema:
@@ -137384,8 +137426,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1051
-        '500': *id1052
+        '404': *id1052
+        '500': *id1053
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/export:
     get:
@@ -137411,7 +137453,7 @@ paths:
                 type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1053
+          headers: &id1054
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137448,7 +137490,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1053
+          headers: *id1054
           content:
             application/json:
               schema:
@@ -137464,7 +137506,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1053
+          headers: *id1054
           content:
             application/json:
               schema:
@@ -137490,13 +137532,13 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: &id1055
+        schema: &id1056
           type: string
         description: Marketplace template ID.
       responses:
         '200':
           description: Template ratings.
-          headers: &id1054
+          headers: &id1055
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137529,9 +137571,9 @@ paths:
                     type: number
                   count:
                     type: integer
-        '400': &id1056
+        '400': &id1057
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137557,9 +137599,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id1057
+        '404': &id1058
           description: Not found - The requested resource does not exist
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137573,9 +137615,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1058
+        '500': &id1059
           description: Internal server error - Unexpected error occurred
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137601,7 +137643,7 @@ paths:
       - name: template_id
         in: path
         required: true
-        schema: *id1055
+        schema: *id1056
         description: Marketplace template ID.
       requestBody:
         required: true
@@ -137622,7 +137664,7 @@ paths:
       responses:
         '200':
           description: Template rating saved.
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137632,10 +137674,10 @@ paths:
                     type: boolean
                   average_rating:
                     type: number
-        '400': *id1056
+        '400': *id1057
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137655,7 +137697,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1054
+          headers: *id1055
           content:
             application/json:
               schema:
@@ -137675,8 +137717,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id1057
-        '500': *id1058
+        '404': *id1058
+        '500': *id1059
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/star:
     post:
@@ -137697,7 +137739,7 @@ paths:
       responses:
         '200':
           description: Template starred.
-          headers: &id1059
+          headers: &id1060
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -137718,7 +137760,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1059
+          headers: *id1060
           content:
             application/json:
               schema:
@@ -137746,7 +137788,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1059
+          headers: *id1060
           content:
             application/json:
               schema:
@@ -137766,7 +137808,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1059
+          headers: *id1060
           content:
             application/json:
               schema:
@@ -137788,7 +137830,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1059
+          headers: *id1060
           content:
             application/json:
               schema:
@@ -137804,7 +137846,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1059
+          headers: *id1060
           content:
             application/json:
               schema:
@@ -137972,7 +138014,7 @@ paths:
                       type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1060
+          headers: &id1061
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138009,7 +138051,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1060
+          headers: *id1061
           content:
             application/json:
               schema:
@@ -138029,7 +138071,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1060
+          headers: *id1061
           content:
             application/json:
               schema:
@@ -138051,7 +138093,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1060
+          headers: *id1061
           content:
             application/json:
               schema:
@@ -138209,7 +138251,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1061
+          headers: &id1062
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138246,7 +138288,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1061
+          headers: *id1062
           content:
             application/json:
               schema:
@@ -138266,7 +138308,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1061
+          headers: *id1062
           content:
             application/json:
               schema:
@@ -138288,7 +138330,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1061
+          headers: *id1062
           content:
             application/json:
               schema:
@@ -138321,7 +138363,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id1062
+          headers: &id1063
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138380,7 +138422,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1062
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -138400,7 +138442,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1062
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -138422,7 +138464,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1062
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -138438,7 +138480,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1062
+          headers: *id1063
           content:
             application/json:
               schema:
@@ -138495,7 +138537,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id1063
+          headers: &id1064
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138541,7 +138583,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1063
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -138561,7 +138603,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1063
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -138583,7 +138625,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1063
+          headers: *id1064
           content:
             application/json:
               schema:
@@ -138609,7 +138651,7 @@ paths:
       responses:
         '200':
           description: Receipt list
-          headers: &id1064
+          headers: &id1065
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138644,7 +138686,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1064
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -138664,7 +138706,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1064
+          headers: *id1065
           content:
             application/json:
               schema:
@@ -138691,7 +138733,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id1065
+          headers: &id1066
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138716,7 +138758,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1065
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -138736,7 +138778,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1065
+          headers: *id1066
           content:
             application/json:
               schema:
@@ -138775,7 +138817,7 @@ paths:
       responses:
         '200':
           description: Shared receipt payload
-          headers: &id1066
+          headers: &id1067
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138798,7 +138840,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1066
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -138816,7 +138858,7 @@ paths:
           description: Share link expired or access limit reached
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1066
+          headers: *id1067
           content:
             application/json:
               schema:
@@ -138843,7 +138885,7 @@ paths:
       responses:
         '200':
           description: Signing public key
-          headers: &id1067
+          headers: &id1068
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138866,7 +138908,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1067
+          headers: *id1068
           content:
             application/json:
               schema:
@@ -138882,7 +138924,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1067
+          headers: *id1068
           content:
             application/json:
               schema:
@@ -138909,7 +138951,7 @@ paths:
       responses:
         '200':
           description: Receipt stats
-          headers: &id1068
+          headers: &id1069
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -138939,7 +138981,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1068
+          headers: *id1069
           content:
             application/json:
               schema:
@@ -138959,7 +139001,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1068
+          headers: *id1069
           content:
             application/json:
               schema:
@@ -138991,7 +139033,7 @@ paths:
       responses:
         '200':
           description: Receipt details
-          headers: &id1069
+          headers: &id1070
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139021,7 +139063,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1069
+          headers: *id1070
           content:
             application/json:
               schema:
@@ -139041,7 +139083,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1069
+          headers: *id1070
           content:
             application/json:
               schema:
@@ -139057,7 +139099,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1069
+          headers: *id1070
           content:
             application/json:
               schema:
@@ -139090,7 +139132,7 @@ paths:
       responses:
         '200':
           description: Exported receipt
-          headers: &id1070
+          headers: &id1071
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139113,7 +139155,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1070
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -139133,7 +139175,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1070
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -139149,7 +139191,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1070
+          headers: *id1071
           content:
             application/json:
               schema:
@@ -139210,161 +139252,6 @@ paths:
                   formatted:
                     type: object
                     description: Channel-specific formatted content
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: &id1071
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id1071
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id1071
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id1071
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v2/receipts/{receipt_id}/send-to-channel:
-    post:
-      tags:
-      - Receipts
-      - Integrations
-      summary: Send receipt to channel
-      description: Route a decision receipt to a specific channel (Slack, Teams, Email, Discord).
-      operationId: sendReceiptToChannel
-      parameters:
-      - name: receipt_id
-        in: path
-        required: true
-        description: Receipt ID
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - channel_type
-              - channel_id
-              properties:
-                channel_type:
-                  type: string
-                  enum:
-                  - slack
-                  - teams
-                  - email
-                  - discord
-                  description: Target channel type
-                channel_id:
-                  type: string
-                  description: Channel/conversation ID or email address
-                workspace_id:
-                  type: string
-                  description: Workspace/tenant ID (required for Slack/Teams)
-                options:
-                  type: object
-                  properties:
-                    compact:
-                      type: boolean
-                      default: false
-                      description: Use compact formatting
-      responses:
-        '200':
-          description: Receipt sent successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  sent:
-                    type: boolean
-                  receipt_id:
-                    type: string
-                  channel_type:
-                    type: string
-                  channel_id:
-                    type: string
-                  message_ts:
-                    type: string
-                  message_id:
-                    type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
           headers: &id1072
@@ -139453,6 +139340,161 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v2/receipts/{receipt_id}/send-to-channel:
+    post:
+      tags:
+      - Receipts
+      - Integrations
+      summary: Send receipt to channel
+      description: Route a decision receipt to a specific channel (Slack, Teams, Email, Discord).
+      operationId: sendReceiptToChannel
+      parameters:
+      - name: receipt_id
+        in: path
+        required: true
+        description: Receipt ID
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - channel_type
+              - channel_id
+              properties:
+                channel_type:
+                  type: string
+                  enum:
+                  - slack
+                  - teams
+                  - email
+                  - discord
+                  description: Target channel type
+                channel_id:
+                  type: string
+                  description: Channel/conversation ID or email address
+                workspace_id:
+                  type: string
+                  description: Workspace/tenant ID (required for Slack/Teams)
+                options:
+                  type: object
+                  properties:
+                    compact:
+                      type: boolean
+                      default: false
+                      description: Use compact formatting
+      responses:
+        '200':
+          description: Receipt sent successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  sent:
+                    type: boolean
+                  receipt_id:
+                    type: string
+                  channel_type:
+                    type: string
+                  channel_id:
+                    type: string
+                  message_ts:
+                    type: string
+                  message_id:
+                    type: string
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id1073
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id1073
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id1073
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id1073
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
         '501':
           description: Channel not available
           content:
@@ -139481,7 +139523,7 @@ paths:
       responses:
         '200':
           description: Receipt shared
-          headers: &id1073
+          headers: &id1074
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139513,7 +139555,7 @@ paths:
                     - type: 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1073
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -139533,7 +139575,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1073
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -139555,7 +139597,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1073
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -139571,7 +139613,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1073
+          headers: *id1074
           content:
             application/json:
               schema:
@@ -139593,7 +139635,7 @@ paths:
       summary: Verify receipt
       operationId: verifyReceiptById
       description: Verify receipt integrity.
-      security: &id1075
+      security: &id1076
       - bearerAuth: []
       parameters:
       - name: receipt_id
@@ -139604,7 +139646,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id1074
+          headers: &id1075
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139628,9 +139670,9 @@ paths:
                   verified_at:
                     type: string
                     format: date-time
-        '401': &id1076
+        '401': &id1077
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1074
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -139648,9 +139690,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id1077
+        '404': &id1078
           description: Not found - The requested resource does not exist
-          headers: *id1074
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -139664,9 +139706,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id1078
+        '500': &id1079
           description: Internal server error - Unexpected error occurred
-          headers: *id1074
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -139687,7 +139729,7 @@ paths:
       summary: Verify receipt integrity
       operationId: verifyReceiptIntegrity
       description: Verify receipt integrity with payload.
-      security: *id1075
+      security: *id1076
       parameters:
       - name: receipt_id
         in: path
@@ -139697,7 +139739,7 @@ paths:
       responses:
         '200':
           description: Integrity verification result
-          headers: *id1074
+          headers: *id1075
           content:
             application/json:
               schema:
@@ -139709,9 +139751,9 @@ paths:
                     type: boolean
                   integrity_verified:
                     type: boolean
-        '401': *id1076
-        '404': *id1077
-        '500': *id1078
+        '401': *id1077
+        '404': *id1078
+        '500': *id1079
       x-aragora-stability: experimental
   /api/v2/receipts/{receipt_id}/verify-signature:
     post:
@@ -139732,7 +139774,7 @@ paths:
       responses:
         '200':
           description: Signature verification result
-          headers: &id1079
+          headers: &id1080
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -139757,7 +139799,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1079
+          headers: *id1080
           content:
             application/json:
               schema:
@@ -139777,7 +139819,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1079
+          headers: *id1080
           content:
             application/json:
               schema:
@@ -139793,7 +139835,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1079
+          headers: *id1080
           content:
             application/json:
               schema:
@@ -140433,9 +140475,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id1081
+        '404': &id1082
           description: Not found - The requested resource does not exist
-          headers: &id1080
+          headers: &id1081
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140496,7 +140538,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id1080
+          headers: *id1081
           content:
             application/json:
               schema:
@@ -140508,7 +140550,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1080
+          headers: *id1081
           content:
             application/json:
               schema:
@@ -140534,7 +140576,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1081
+        '404': *id1082
       security:
       - bearerAuth: []
       deprecated: true
@@ -140638,7 +140680,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id1082
+          headers: &id1083
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140661,7 +140703,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1082
+          headers: *id1083
           content:
             application/json:
               schema:
@@ -140714,7 +140756,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id1083
+          headers: &id1084
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140737,7 +140779,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1083
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -140765,7 +140807,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1083
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -140785,7 +140827,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1083
+          headers: *id1084
           content:
             application/json:
               schema:
@@ -140863,7 +140905,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id1084
+          headers: &id1085
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -140890,9 +140932,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id1085
+        '404': &id1086
           description: Not found - The requested resource does not exist
-          headers: *id1084
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -140922,7 +140964,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id1084
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -140934,7 +140976,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1084
+          headers: *id1085
           content:
             application/json:
               schema:
@@ -140960,7 +141002,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1085
+        '404': *id1086
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflow-templates:
@@ -141009,7 +141051,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id1086
+          headers: &id1087
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141025,7 +141067,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1086
+          headers: *id1087
           content:
             application/json:
               schema:
@@ -141144,7 +141186,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id1087
+          headers: &id1088
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141160,7 +141202,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1087
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -141188,7 +141230,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1087
+          headers: *id1088
           content:
             application/json:
               schema:
@@ -141284,7 +141326,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id1088
+          headers: &id1089
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141300,7 +141342,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1088
+          headers: *id1089
           content:
             application/json:
               schema:
@@ -141482,7 +141524,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id1089
+          headers: &id1090
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141519,7 +141561,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1089
+          headers: *id1090
           content:
             application/json:
               schema:
@@ -141576,7 +141618,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id1090
+          headers: &id1091
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141637,14 +141679,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id1090
+          headers: *id1091
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1090
+          headers: *id1091
           content:
             application/json:
               schema:
@@ -141687,7 +141729,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id1091
+          headers: &id1092
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141701,9 +141743,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id1092
+        '404': &id1093
           description: Not found - The requested resource does not exist
-          headers: *id1091
+          headers: *id1092
           content:
             application/json:
               schema:
@@ -141739,14 +141781,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id1091
+          headers: *id1092
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1091
+          headers: *id1092
           content:
             application/json:
               schema:
@@ -141772,7 +141814,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id1092
+        '404': *id1093
       deprecated: true
       x-aragora-stability: deprecated
     delete:
@@ -141789,7 +141831,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id1091
+          headers: *id1092
           content:
             application/json:
               schema:
@@ -141799,7 +141841,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id1092
+        '404': *id1093
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflows/{workflow_id}/execute:
@@ -141831,7 +141873,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id1093
+          headers: &id1094
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141854,7 +141896,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1093
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -141882,7 +141924,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1093
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -141898,7 +141940,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id1093
+          headers: *id1094
           content:
             application/json:
               schema:
@@ -141933,7 +141975,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id1094
+          headers: &id1095
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -141956,7 +141998,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1094
+          headers: *id1095
           content:
             application/json:
               schema:
@@ -141995,7 +142037,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id1095
+          headers: &id1096
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142009,9 +142051,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id1096
+        '401': &id1097
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1095
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -142066,14 +142108,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id1095
+          headers: *id1096
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1095
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -142099,10 +142141,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1096
+        '401': *id1097
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1095
+          headers: *id1096
           content:
             application/json:
               schema:
@@ -142147,7 +142189,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id1097
+          headers: &id1098
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142175,7 +142217,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1097
+          headers: *id1098
           content:
             application/json:
               schema:
@@ -142212,7 +142254,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id1098
+          headers: &id1099
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142226,9 +142268,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id1099
+        '401': &id1100
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1098
+          headers: *id1099
           content:
             application/json:
               schema:
@@ -142246,9 +142288,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1100
+        '403': &id1101
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1098
+          headers: *id1099
           content:
             application/json:
               schema:
@@ -142268,9 +142310,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1101
+        '404': &id1102
           description: Not found - The requested resource does not exist
-          headers: *id1098
+          headers: *id1099
           content:
             application/json:
               schema:
@@ -142302,7 +142344,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id1098
+          headers: *id1099
           content:
             application/json:
               schema:
@@ -142312,9 +142354,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id1099
-        '403': *id1100
-        '404': *id1101
+        '401': *id1100
+        '403': *id1101
+        '404': *id1102
       deprecated: true
       x-aragora-stability: deprecated
   /api/workspaces/{workspace_id}/members:
@@ -142352,7 +142394,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id1102
+          headers: &id1103
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142375,7 +142417,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1102
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -142403,7 +142445,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1102
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -142423,7 +142465,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1102
+          headers: *id1103
           content:
             application/json:
               schema:
@@ -142508,7 +142550,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id1103
+          headers: &id1104
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142531,7 +142573,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1103
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -142559,7 +142601,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1103
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -142579,7 +142621,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1103
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -142601,7 +142643,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1103
+          headers: *id1104
           content:
             application/json:
               schema:
@@ -142653,7 +142695,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id1104
+          headers: &id1105
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -142680,7 +142722,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id1104
+          headers: *id1105
           content:
             application/json:
               schema:
@@ -142700,7 +142742,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1104
+          headers: *id1105
           content:
             application/json:
               schema:
@@ -142722,7 +142764,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id1104
+          headers: *id1105
           content:
             application/json:
               schema:
@@ -143314,9 +143356,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1106
+        '401': &id1107
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1105
+          headers: &id1106
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143343,9 +143385,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1107
+        '403': &id1108
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1105
+          headers: *id1106
           content:
             application/json:
               schema:
@@ -143365,9 +143407,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1108
+        '404': &id1109
           description: Not found - The requested resource does not exist
-          headers: *id1105
+          headers: *id1106
           content:
             application/json:
               schema:
@@ -143438,9 +143480,9 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': &id1109
+        '400': &id1110
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1105
+          headers: *id1106
           content:
             application/json:
               schema:
@@ -143466,9 +143508,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1106
-        '403': *id1107
-        '404': *id1108
+        '401': *id1107
+        '403': *id1108
+        '404': *id1109
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -143531,10 +143573,10 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': *id1109
-        '401': *id1106
-        '403': *id1107
-        '404': *id1108
+        '400': *id1110
+        '401': *id1107
+        '403': *id1108
+        '404': *id1109
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -143554,9 +143596,9 @@ paths:
       responses:
         '204':
           description: Group deleted successfully
-        '401': *id1106
-        '403': *id1107
-        '404': *id1108
+        '401': *id1107
+        '403': *id1108
+        '404': *id1109
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -143678,9 +143720,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id1111
+        '401': &id1112
           description: Unauthorized - Authentication required or token invalid
-          headers: &id1110
+          headers: &id1111
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -143707,9 +143749,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id1112
+        '403': &id1113
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id1110
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -143729,9 +143771,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id1113
+        '404': &id1114
           description: Not found - The requested resource does not exist
-          headers: *id1110
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -143816,9 +143858,9 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': &id1114
+        '400': &id1115
           description: Bad request - Invalid input or malformed JSON
-          headers: *id1110
+          headers: *id1111
           content:
             application/json:
               schema:
@@ -143844,9 +143886,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id1111
-        '403': *id1112
-        '404': *id1113
+        '401': *id1112
+        '403': *id1113
+        '404': *id1114
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -143911,10 +143953,10 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': *id1114
-        '401': *id1111
-        '403': *id1112
-        '404': *id1113
+        '400': *id1115
+        '401': *id1112
+        '403': *id1113
+        '404': *id1114
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -143934,9 +143976,9 @@ paths:
       responses:
         '204':
           description: User deleted successfully
-        '401': *id1111
-        '403': *id1112
-        '404': *id1113
+        '401': *id1112
+        '403': *id1113
+        '404': *id1114
       security:
       - bearerAuth: []
       x-aragora-stability: stable

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -143032,16 +143032,25 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Integration configured */
+            /** @description Integration configuration updated */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
-                        type?: string;
-                        configured?: boolean;
-                        message?: string;
+                        integration?: Record<string, never>;
+                    };
+                };
+            };
+            /** @description Integration configuration created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        integration?: Record<string, never>;
                     };
                 };
             };

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -143039,7 +143039,27 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        integration?: Record<string, never>;
+                        integration: {
+                            type: string;
+                            enabled: boolean;
+                            created_at?: number;
+                            updated_at?: number;
+                            notify_on_consensus?: boolean;
+                            notify_on_debate_end?: boolean;
+                            notify_on_error?: boolean;
+                            notify_on_leaderboard?: boolean;
+                            settings?: {
+                                [key: string]: unknown;
+                            };
+                            messages_sent?: number;
+                            errors_24h?: number;
+                            last_activity?: number | null;
+                            last_error?: string | null;
+                            user_id?: string | null;
+                            workspace_id?: string | null;
+                        } & {
+                            [key: string]: unknown;
+                        };
                     };
                 };
             };
@@ -143050,7 +143070,27 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        integration?: Record<string, never>;
+                        integration: {
+                            type: string;
+                            enabled: boolean;
+                            created_at?: number;
+                            updated_at?: number;
+                            notify_on_consensus?: boolean;
+                            notify_on_debate_end?: boolean;
+                            notify_on_error?: boolean;
+                            notify_on_leaderboard?: boolean;
+                            settings?: {
+                                [key: string]: unknown;
+                            };
+                            messages_sent?: number;
+                            errors_24h?: number;
+                            last_activity?: number | null;
+                            last_error?: string | null;
+                            user_id?: string | null;
+                            workspace_id?: string | null;
+                        } & {
+                            [key: string]: unknown;
+                        };
                     };
                 };
             };

--- a/tests/server/openapi/test_success_status_contracts.py
+++ b/tests/server/openapi/test_success_status_contracts.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.server.handlers.admin.credits import CreditsAdminHandler
+from aragora.server.handlers.features.integrations import IntegrationsHandler
+from aragora.server.openapi import generate_openapi_schema
+from aragora.storage.integration_memory import InMemoryIntegrationStore
+
+
+ROOT = Path(__file__).resolve().parents[3]
+OPENAPI_PATH = ROOT / "docs/api/openapi.json"
+GENERATED_OPENAPI_PATH = ROOT / "docs/api/openapi_generated.json"
+
+
+def _documented_success_statuses(spec_path: Path, path: str, method: str) -> set[int]:
+    spec = json.loads(spec_path.read_text())
+    responses = spec["paths"][path][method]["responses"]
+    return {int(status) for status in responses if status.isdigit() and 200 <= int(status) < 300}
+
+
+@pytest.mark.asyncio
+async def test_credit_issue_success_statuses_match_runtime_handler() -> None:
+    transaction = SimpleNamespace(to_dict=lambda: {"id": "credit-1"})
+    manager = SimpleNamespace(issue_credit=AsyncMock(return_value=transaction))
+    runtime_method = inspect.unwrap(CreditsAdminHandler.issue_credit)
+
+    with patch(
+        "aragora.server.handlers.admin.credits.get_credit_manager",
+        return_value=manager,
+    ):
+        result = await runtime_method(
+            CreditsAdminHandler(),
+            "org-1",
+            {
+                "amount_cents": 100,
+                "description": "Contract status probe",
+            },
+            "admin-1",
+        )
+
+    runtime_statuses = {result.status_code}
+    assert runtime_statuses == {201}
+    for path in (
+        "/api/admin/credits/{org_id}/issue",
+        "/api/v1/admin/credits/{org_id}/issue",
+    ):
+        assert _documented_success_statuses(OPENAPI_PATH, path, "post") == runtime_statuses
+
+
+@pytest.mark.asyncio
+async def test_integration_put_success_statuses_match_create_and_update_runtime() -> None:
+    store = InMemoryIntegrationStore()
+    handler = IntegrationsHandler(server_context={})
+
+    with patch(
+        "aragora.server.handlers.features.integrations.get_integration_store",
+        return_value=store,
+    ):
+        created = await handler.configure_integration("email", {}, user_id="user-1")
+        updated = await handler.configure_integration(
+            "email",
+            {"enabled": False},
+            user_id="user-1",
+        )
+
+    runtime_statuses = {created.status_code, updated.status_code}
+    assert runtime_statuses == {200, 201}
+    for path in (
+        "/api/integrations/{type}",
+        "/api/v1/integrations/{type}",
+    ):
+        assert _documented_success_statuses(OPENAPI_PATH, path, "put") == runtime_statuses
+
+    generated_runtime_schema = generate_openapi_schema()
+    generated_responses = generated_runtime_schema["paths"]["/api/v1/integrations/{type}"]["put"][
+        "responses"
+    ]
+    assert {
+        int(status)
+        for status in generated_responses
+        if status.isdigit() and 200 <= int(status) < 300
+    } == runtime_statuses
+
+    assert (
+        _documented_success_statuses(
+            GENERATED_OPENAPI_PATH,
+            "/api/v1/integrations/{type}",
+            "put",
+        )
+        == runtime_statuses
+    )

--- a/tests/server/openapi/test_success_status_contracts.py
+++ b/tests/server/openapi/test_success_status_contracts.py
@@ -4,9 +4,11 @@ import inspect
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from jsonschema import Draft202012Validator
 
 from aragora.server.handlers.admin.credits import CreditsAdminHandler
 from aragora.server.handlers.features.integrations import IntegrationsHandler
@@ -19,8 +21,21 @@ OPENAPI_PATH = ROOT / "docs/api/openapi.json"
 GENERATED_OPENAPI_PATH = ROOT / "docs/api/openapi_generated.json"
 
 
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_spec(spec_path: Path) -> dict[str, Any]:
+    return json.loads(spec_path.read_text(), object_pairs_hook=_reject_duplicate_keys)
+
+
 def _documented_success_statuses(spec_path: Path, path: str, method: str) -> set[int]:
-    spec = json.loads(spec_path.read_text())
+    spec = _load_spec(spec_path)
     responses = spec["paths"][path][method]["responses"]
     return {int(status) for status in responses if status.isdigit() and 200 <= int(status) < 300}
 
@@ -70,7 +85,8 @@ async def test_integration_put_success_statuses_match_create_and_update_runtime(
             user_id="user-1",
         )
 
-    runtime_statuses = {created.status_code, updated.status_code}
+    runtime_results = (created, updated)
+    runtime_statuses = {result.status_code for result in runtime_results}
     assert runtime_statuses == {200, 201}
     for path in (
         "/api/integrations/{type}",
@@ -96,3 +112,16 @@ async def test_integration_put_success_statuses_match_create_and_update_runtime(
         )
         == runtime_statuses
     )
+
+    for spec in (
+        _load_spec(GENERATED_OPENAPI_PATH),
+        generated_runtime_schema,
+    ):
+        responses = spec["paths"]["/api/v1/integrations/{type}"]["put"]["responses"]
+        for result in runtime_results:
+            payload = json.loads(result.body)
+            schema = responses[str(result.status_code)]["content"]["application/json"]["schema"]
+            Draft202012Validator(schema).validate(payload)
+            integration = payload["integration"]
+            assert integration["type"] == "email"
+            assert integration["enabled"] is (result.status_code == 201)


### PR DESCRIPTION
## Source

Closes FIX-RT-018 from the route-truth scrutiny correction wave. The runtime handlers already return `201` for credit issuance, and integration configuration returns `201` on create plus `200` on update, while the checked-in OpenAPI contracts did not fully reflect that behavior.

## Behavior

- document both credit issue POST path forms as `201`-only success
- document legacy and v1 integration PUT as `200` update and `201` create
- align integration response schemas with the runtime `{"integration": ...}` envelope
- regenerate `openapi_generated.json`, `openapi_generated.yaml`, and TypeScript OpenAPI types deterministically
- execute real credit and integration handlers in focused status-contract tests
- validate actual integration response bodies against the documented 200/201 schemas and reject duplicate JSON keys

## Authorized generated-output overlap

PR #9033 remains OPEN/draft at exact head `02bee0a4b187654642aab348b41adc5faae06d5d`. It is the sole open PR touching the three generated paths. Exact immutable base/head semantic comparison shows #9033 changes only 18 `/api/v1/inbox/*` generated JSON operations and the corresponding `handle_*` inbox TypeScript operations. This PR changes only `PUT /api/v1/integrations/{type}` and TypeScript operation `configureIntegrationV1`; both intersections are empty. PR #9033 was not mutated.

## Validation

- `python3 -m pytest tests/server/openapi/test_success_status_contracts.py tests/test_openapi_regeneration.py -q` -> 3 passed
- byte-for-byte regeneration of both generated OpenAPI files and TypeScript types -> identical; SHA-256 `14c5be5a...`, `5bb3f125...`, `5b73a9c5...`
- exact-ref and baseline route gates -> 100% coverage, 0 new missing, 0 new orphaned
- `python3 scripts/audit_openapi_docs.py --spec docs/api/openapi_generated.json --min-coverage 90` -> 3,154/3,154 documented, 99.8% score
- `npm run typecheck && npm run build` in `sdk/typescript` -> passed
- version alignment plus SDK, namespace, and cross-SDK parity gates -> passed
- `make lint && ruff format --check aragora/ tests/ scripts/` -> passed
- `bash scripts/preflight_mypy.sh --diff-base origin/main` with fresh cache -> no issues in 2 changed Python files
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- AWS-neutral `make test-smoke` -> passed
- AWS-neutral smoke tier -> 138 passed

## Risk and settlement

Tier 3 because the generated TypeScript SDK source changes. The implementation is bounded to six files and 790 substantive textual changed lines (`+743/-47`), including binary-attributed generated artifacts measured with YAML anchor-number churn normalized out. The integration SDK response now exposes required `type`/`enabled` fields, named runtime fields, and unknown extension keys instead of `Record<string, never>`. This PR must remain open until human risk settlement, and must not be self-merged.

