### PR TITLE
fix(ci): reject malformed scope output [Tier 4]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -183,19 +183,26 @@ jobs:
             echo "::error::Change classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::Lint concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$WORKER_RESULT" != "success" ]]; then
+                echo "::error::Lint concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                exit 1
+              fi
+              echo "Lint passed."
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::Lint was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "Lint not required — no Python-relevant changes."
+              ;;
+            *)
+              echo "::error::Change classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "Lint passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::Lint was out of scope but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          echo "Lint not required — no Python-relevant changes."
+              ;;
+          esac
 
   connector-exception-hygiene:
     runs-on: ubuntu-latest
@@ -483,19 +490,26 @@ jobs:
             echo "::error::Change classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::Type check concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$WORKER_RESULT" != "success" ]]; then
+                echo "::error::Type check concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                exit 1
+              fi
+              echo "Type check passed."
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::Type check was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "Type check not required — no Python-relevant changes."
+              ;;
+            *)
+              echo "::error::Change classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "Type check passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::Type check was out of scope but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          echo "Type check not required — no Python-relevant changes."
+              ;;
+          esac
 
   typecheck-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -639,16 +639,23 @@ jobs:
             echo "::error::OpenAPI scope classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::OpenAPI generate & validate concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$WORKER_RESULT" != "success" ]]; then
+                echo "::error::OpenAPI generate & validate concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                exit 1
+              fi
+              echo "OpenAPI generate & validate passed."
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::OpenAPI was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "OpenAPI not required — no relevant changes."
+              ;;
+            *)
+              echo "::error::OpenAPI scope classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "OpenAPI generate & validate passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::OpenAPI was out of scope but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          echo "OpenAPI not required — no relevant changes."
+              ;;
+          esac

--- a/.github/workflows/quality-smoke.yml
+++ b/.github/workflows/quality-smoke.yml
@@ -162,20 +162,31 @@ jobs:
             echo "::error::Change classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" && "$IS_DRAFT" != "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::Quality pipeline smoke concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$IS_DRAFT" == "true" ]]; then
+                if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                  echo "::error::Quality pipeline smoke was deferred for a draft but concluded '$WORKER_RESULT'. Failing closed."
+                  exit 1
+                fi
+                echo "Quality pipeline smoke deferred — draft PR."
+              else
+                if [[ "$WORKER_RESULT" != "success" ]]; then
+                  echo "::error::Quality pipeline smoke concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                  exit 1
+                fi
+                echo "Quality pipeline smoke passed."
+              fi
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::Quality pipeline smoke was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "Quality pipeline smoke not required — no relevant changes."
+              ;;
+            *)
+              echo "::error::Change classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "Quality pipeline smoke passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::Quality pipeline smoke was not required but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          if [[ "$IS_DRAFT" == "true" ]]; then
-            echo "Quality pipeline smoke deferred — draft PR."
-          else
-            echo "Quality pipeline smoke not required — no relevant changes."
-          fi
+              ;;
+          esac

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -195,16 +195,23 @@ jobs:
             echo "::error::Change classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::SDK parity concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$WORKER_RESULT" != "success" ]]; then
+                echo "::error::SDK parity concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                exit 1
+              fi
+              echo "SDK parity passed."
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::SDK parity was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "SDK parity not required — no relevant changes."
+              ;;
+            *)
+              echo "::error::Change classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "SDK parity passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::SDK parity was out of scope but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          echo "SDK parity not required — no relevant changes."
+              ;;
+          esac

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -275,16 +275,23 @@ jobs:
             echo "::error::Change classification concluded '$CLASSIFIER_RESULT'; its scope verdict cannot be trusted. Failing closed."
             exit 1
           fi
-          if [[ "$IN_SCOPE" == "true" ]]; then
-            if [[ "$WORKER_RESULT" != "success" ]]; then
-              echo "::error::TypeScript SDK type check concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+          case "$IN_SCOPE" in
+            true)
+              if [[ "$WORKER_RESULT" != "success" ]]; then
+                echo "::error::TypeScript SDK type check concluded '$WORKER_RESULT' (expected 'success'). Failing closed."
+                exit 1
+              fi
+              echo "TypeScript SDK type check passed."
+              ;;
+            false)
+              if [[ "$WORKER_RESULT" != "skipped" ]]; then
+                echo "::error::TypeScript SDK type check was out of scope but concluded '$WORKER_RESULT'. Failing closed."
+                exit 1
+              fi
+              echo "TypeScript SDK type check not required — no relevant changes."
+              ;;
+            *)
+              echo "::error::Change classification produced invalid IN_SCOPE value '$IN_SCOPE' (expected exactly 'true' or 'false'). Failing closed."
               exit 1
-            fi
-            echo "TypeScript SDK type check passed."
-            exit 0
-          fi
-          if [[ "$WORKER_RESULT" != "skipped" ]]; then
-            echo "::error::TypeScript SDK type check was out of scope but concluded '$WORKER_RESULT'. Failing closed."
-            exit 1
-          fi
-          echo "TypeScript SDK type check not required — no relevant changes."
+              ;;
+          esac

--- a/tests/ci/test_required_aggregator_fail_closed.py
+++ b/tests/ci/test_required_aggregator_fail_closed.py
@@ -111,6 +111,17 @@ AGGREGATORS: tuple[Aggregator, ...] = (
 # GitHub only ever reports these four in `needs.<job>.result`, but a required gate
 # should also refuse anything it does not recognize rather than defaulting to green.
 NON_SUCCESS_WORKER_RESULTS = ("failure", "cancelled", "timed_out", "action_required", "stale")
+MALFORMED_SCOPE_FLAGS = (
+    "",
+    " ",
+    "\t",
+    "TRUE",
+    "False",
+    " true",
+    "false ",
+    "yes",
+    "unexpected",
+)
 
 _EXPRESSION = re.compile(r"\$\{\{\s*(?P<body>[^}]+?)\s*\}\}")
 _RESULT_REF = re.compile(r"^needs\.(?P<job>[A-Za-z0-9_-]+)\.result$")
@@ -237,6 +248,46 @@ def test_out_of_scope_skip_is_green(spec: Aggregator) -> None:
     assert proc.returncode == 0, (
         f"{spec.workflow}::{spec.job} rejected a legitimate scope skip "
         f"(exit {proc.returncode}).\n{proc.stdout}\n{proc.stderr}"
+    )
+
+
+@pytest.mark.parametrize("spec", AGGREGATORS, ids=_ids(AGGREGATORS))
+@pytest.mark.parametrize("scope_flag", MALFORMED_SCOPE_FLAGS, ids=repr)
+def test_successful_classifier_with_malformed_scope_fails_closed(
+    spec: Aggregator, scope_flag: str
+) -> None:
+    """A successful classifier must still publish an exact boolean verdict.
+
+    Missing output is represented by the empty string in GitHub expressions. The
+    other cases cover whitespace, mixed case, and arbitrary values that must not be
+    mistaken for an explicit out-of-scope decision merely because they are not
+    equal to ``"true"``.
+    """
+    proc = _run_aggregator(
+        spec,
+        worker_result="skipped",
+        classifier_result="success",
+        scope_flag=scope_flag,
+    )
+    assert proc.returncode != 0, (
+        f"{spec.workflow}::{spec.job} reported SUCCESS after its classifier succeeded "
+        f"but published malformed scope output {scope_flag!r}.\n{proc.stdout}"
+    )
+
+
+@pytest.mark.parametrize("spec", AGGREGATORS, ids=_ids(AGGREGATORS))
+@pytest.mark.parametrize("worker_result", ("success", *NON_SUCCESS_WORKER_RESULTS))
+def test_out_of_scope_requires_worker_to_be_skipped(spec: Aggregator, worker_result: str) -> None:
+    """Exact false is green only when the worker was actually skipped."""
+    proc = _run_aggregator(
+        spec,
+        worker_result=worker_result,
+        classifier_result="success",
+        scope_flag="false",
+    )
+    assert proc.returncode != 0, (
+        f"{spec.workflow}::{spec.job} reported SUCCESS for exact out-of-scope output "
+        f"while its worker concluded '{worker_result}'.\n{proc.stdout}"
     )
 
 


### PR DESCRIPTION
## Source

Closes the FIX-RT-016 preparation scope from the route-truth scrutiny correction wave. This is a parked Tier-4 draft only. Terminal settlement and merge remain owned by `misc-required-check-scope-output-settlement` under a later exact-pair delegation.

## Behavior

- Require all six duplicated required-check aggregators to accept only exact classifier outputs `true` or `false`.
- Fail closed for missing, empty, whitespace, mixed-case, or arbitrary classifier output even when the classifier job itself succeeded.
- Keep exact `false` as the only skip-success path, and require the worker job to be `skipped` on that path.
- Require worker `success` for exact `true`.
- Preserve `quality-smoke` draft deferral through `IS_DRAFT` and preserve OpenAPI's `needs.scope` classifier naming.
- Extend the shared executable contract matrix across lint, typecheck, OpenAPI, SDK parity, TypeScript SDK, and quality smoke.

## Scope and overlap controls

Exact authorized response: six files, `+173/-76 = 249` lines.

The operator-approved overlap lift remains bound to:
- #9690 @ `777ad33411dabace9e0eb887fa40aac89abb2a67`
- #9592 @ `d9461889bd7c5bf3e674d80ed0f43c38ad67c9c1`
- #8939 @ `4028b9e3f7ab13dbdb02a75d4a8b1dd32e220a91`

This diff does not touch `actions/setup-node` steps or their `with:` blocks, the `lint-run` step list, or `.github/actions/pr-scope-classifier/action.yml`. It does not include the separate security-gate cancellation-tolerance scope.

## Validation

- `python3 -m pytest tests/ci/test_required_aggregator_fail_closed.py -q` -> `168 passed`
- `actionlint` -> pass
- `make lint` -> pass
- `ruff format --check aragora/ tests/ scripts/` -> pass
- `bash scripts/preflight_mypy.sh --diff-base origin/main` -> no Python changes, skipped cleanly
- `python3 scripts/report_code_quality.py --check` -> ratchet pass
- `ARAGORA_SECRETS_STRICT=false AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true make test-smoke` -> pass
- `ARAGORA_SECRETS_STRICT=false AWS_CONFIG_FILE=/dev/null AWS_SHARED_CREDENTIALS_FILE=/dev/null AWS_EC2_METADATA_DISABLED=true PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> `138 passed`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> pass

## Risk and parking state

Tier 4 workflow change. Keep this PR draft and labeled `operator-review-required`. Do not mark ready, post evidence, settle, dispatch workflows manually, merge, use admin, or mutate overlapping foreign PRs under this feature.