### PR TITLE
feat(nomic): add generic repository profiles

### DIFF
--- a/aragora/nomic/__init__.py
+++ b/aragora/nomic/__init__.py
@@ -123,6 +123,19 @@ from aragora.nomic.meta_planner import (
     PrioritizedGoal,
 )
 
+# Generic repository planning profiles and commit-addressed context packs
+from aragora.nomic.repository_profile import (
+    ContextEvidenceReference,
+    ContextPack,
+    EvaluationCriterion,
+    NomicProfileError,
+    NomicRepositoryProfile,
+    RepositoryRevision,
+    RepositoryStateError,
+    assert_clean_revision,
+    load_nomic_repository_profile,
+)
+
 # Self-correction (cross-cycle pattern analysis)
 from aragora.nomic.self_correction import (
     CorrectionReport,
@@ -657,6 +670,16 @@ __all__ = [
     "MetaPlannerConfig",
     "PrioritizedGoal",
     "PlanningContext",
+    # Generic repository planning
+    "EvaluationCriterion",
+    "NomicRepositoryProfile",
+    "RepositoryRevision",
+    "ContextEvidenceReference",
+    "ContextPack",
+    "NomicProfileError",
+    "RepositoryStateError",
+    "assert_clean_revision",
+    "load_nomic_repository_profile",
     # Branch coordination
     "BranchCoordinator",
     "BranchCoordinatorConfig",

--- a/aragora/nomic/repository_profile.py
+++ b/aragora/nomic/repository_profile.py
@@ -38,6 +38,15 @@ def normalize_remote_url(remote_url: str | None) -> str | None:
     if not remote_url:
         return None
     value = remote_url.strip()
+    windows_drive_path = re.match(r"^[A-Za-z]:", value) is not None
+    if (
+        windows_drive_path
+        or value.startswith(("/", "\\", "~", "./", "../", "file://"))
+        or ("://" not in value and ":" not in value)
+    ):
+        # Filesystem remotes are machine-local and must not enter portable pack
+        # metadata or content-address computation.
+        return None
     scp_match = re.match(r"^(?:[^@]+@)?([^:]+):(.+)$", value)
     if scp_match and "://" not in value:
         host, path = scp_match.groups()
@@ -46,12 +55,14 @@ def normalize_remote_url(remote_url: str | None) -> str | None:
         parsed = urlparse(value)
         value = f"https://{parsed.hostname or ''}{parsed.path}"
     parsed = urlparse(value)
-    if parsed.scheme in {"http", "https"}:
+    if parsed.scheme in {"http", "https", "git"}:
         host = (parsed.hostname or "").lower()
         path = parsed.path.rstrip("/")
         if path.endswith(".git"):
             path = path[:-4]
         return f"https://{host}{path}"
+    if parsed.scheme:
+        return None
     return value.removesuffix(".git").rstrip("/")
 
 
@@ -92,6 +103,8 @@ class EvaluationCriterion:
     description: str
 
     def __post_init__(self) -> None:
+        if not isinstance(self.id, str) or not isinstance(self.description, str):
+            raise NomicProfileError("evaluation criterion id and description must be strings")
         if not re.fullmatch(r"[a-z][a-z0-9_-]*", self.id):
             raise NomicProfileError(f"invalid evaluation criterion id: {self.id!r}")
         if not self.description.strip():
@@ -207,11 +220,31 @@ class NomicRepositoryProfile:
         repository = value.get("repository") or {}
         if not isinstance(repository, Mapping):
             raise NomicProfileError("nomic.repository must be a mapping")
+        raw_name = repository.get("name")
+        raw_id = repository.get("id")
         remote = repository.get("remote_url")
+        for key, raw_value in (
+            ("name", raw_name),
+            ("id", raw_id),
+            ("remote_url", remote),
+        ):
+            if raw_value is not None and not isinstance(raw_value, str):
+                raise NomicProfileError(f"nomic.repository.{key} must be a string")
         if remote is None:
             remote = RepositoryRevision.resolve(repo_root).remote_url
-        name = str(repository.get("name") or repo_root.resolve().name)
-        repository_id = str(repository.get("id") or infer_repository_id(remote, name))
+        name = raw_name if raw_name is not None else repo_root.resolve().name
+        repository_id = raw_id if raw_id is not None else infer_repository_id(remote, name)
+
+        def configured_paths(key: str) -> tuple[str, ...]:
+            raw_paths = value.get(key)
+            if raw_paths is None:
+                return ()
+            if not isinstance(raw_paths, list) or not all(
+                isinstance(path, str) for path in raw_paths
+            ):
+                raise NomicProfileError(f"nomic.{key} must be a list of strings")
+            return tuple(raw_paths)
+
         raw_criteria = value.get("evaluation_criteria")
         criteria: tuple[EvaluationCriterion, ...]
         if raw_criteria is None:
@@ -219,15 +252,29 @@ class NomicRepositoryProfile:
         elif isinstance(raw_criteria, list) and all(
             isinstance(item, Mapping) for item in raw_criteria
         ):
-            criteria = tuple(EvaluationCriterion(**item) for item in raw_criteria)
+            parsed: list[EvaluationCriterion] = []
+            for item in raw_criteria:
+                unknown = set(item) - {"id", "description"}
+                if unknown:
+                    raise NomicProfileError(
+                        "unknown evaluation criterion field(s): "
+                        + ", ".join(sorted(str(field) for field in unknown))
+                    )
+                try:
+                    parsed.append(EvaluationCriterion(**item))
+                except TypeError as exc:
+                    raise NomicProfileError(
+                        "each evaluation criterion requires string id and description fields"
+                    ) from exc
+            criteria = tuple(parsed)
         else:
             raise NomicProfileError("nomic.evaluation_criteria must be a list of mappings")
         return cls(
             repository_name=name,
             repository_id=repository_id,
-            remote_url=str(remote) if remote else None,
-            roadmap_paths=tuple(value.get("roadmap_paths") or ()),
-            context_entry_files=tuple(value.get("context_entry_files") or ()),
+            remote_url=remote or None,
+            roadmap_paths=configured_paths("roadmap_paths"),
+            context_entry_files=configured_paths("context_entry_files"),
             evaluation_criteria=criteria,
             source_config_sha256=source_config_sha256,
         )
@@ -244,14 +291,21 @@ class NomicRepositoryProfile:
                 ) from exc
             if not resolved.is_relative_to(root):
                 raise NomicProfileError(f"configured symlink escapes repository: {relative}")
+            if not resolved.is_file():
+                raise NomicProfileError(f"configured repository path is not a file: {relative}")
             tracked = subprocess.run(
-                ["git", "-C", str(root), "cat-file", "-e", f"{revision.commit_sha}:{relative}"],
+                ["git", "-C", str(root), "cat-file", "-t", f"{revision.commit_sha}:{relative}"],
                 capture_output=True,
+                text=True,
                 check=False,
             )
             if tracked.returncode != 0:
                 raise NomicProfileError(
                     f"configured file is not tracked at {revision.commit_sha}: {relative}"
+                )
+            if tracked.stdout.strip() != "blob":
+                raise NomicProfileError(
+                    f"configured path is not a tracked file at {revision.commit_sha}: {relative}"
                 )
 
 
@@ -308,6 +362,7 @@ class ContextPack:
     """Published context-pack metadata plus its local artifact directory."""
 
     pack_id: str
+    objective: str
     repository: NomicRepositoryProfile
     revision: RepositoryRevision
     profile_hash: str
@@ -315,6 +370,10 @@ class ContextPack:
     artifact_digests: Mapping[str, str]
     pack_path: Path = field(compare=False, repr=False)
     corpus_included: bool = False
+    corpus_truncated: bool = False
+    context_byte_budget: int = 100_000_000
+    include_tests: bool = True
+    rlm_summary: str = field(default="", repr=False)
 
     @property
     def reference(self) -> str:
@@ -325,12 +384,17 @@ class ContextPack:
             "schema_version": "nomic-context-pack/1.0",
             "pack_id": self.pack_id,
             "reference": self.reference,
+            "objective": self.objective,
             "repository": self.repository.to_dict(),
             "revision": self.revision.to_dict(),
             "profile_hash": self.profile_hash,
             "evidence": [item.to_dict() for item in self.evidence],
             "artifact_digests": dict(sorted(self.artifact_digests.items())),
             "corpus_included": self.corpus_included,
+            "corpus_truncated": self.corpus_truncated,
+            "context_byte_budget": self.context_byte_budget,
+            "include_tests": self.include_tests,
+            "rlm_summary": self.rlm_summary,
         }
 
 

--- a/aragora/nomic/repository_profile.py
+++ b/aragora/nomic/repository_profile.py
@@ -9,7 +9,7 @@ import subprocess
 from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Mapping
-from urllib.parse import quote, urlparse
+from urllib.parse import ParseResult, quote, urlparse
 
 
 class NomicProfileError(ValueError):
@@ -33,6 +33,22 @@ def _git(repo_root: Path, *args: str, check: bool = True) -> str:
     return result.stdout.strip()
 
 
+def _normalized_remote_host(parsed: ParseResult, *, default_port: int | None) -> str | None:
+    """Return a credential-free host while preserving identity-bearing ports."""
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if port is not None and port != default_port:
+        host = f"{host}:{port}"
+    return host
+
+
 def normalize_remote_url(remote_url: str | None) -> str | None:
     """Normalize common Git remote forms without embedding credentials or ``.git``."""
     if not remote_url:
@@ -53,10 +69,16 @@ def normalize_remote_url(remote_url: str | None) -> str | None:
         value = f"https://{host}/{path.lstrip('/')}"
     elif value.startswith(("ssh://", "git+ssh://")):
         parsed = urlparse(value)
-        value = f"https://{parsed.hostname or ''}{parsed.path}"
+        host = _normalized_remote_host(parsed, default_port=22)
+        if not host:
+            return None
+        value = f"https://{host}{parsed.path}"
     parsed = urlparse(value)
     if parsed.scheme in {"http", "https", "git"}:
-        host = (parsed.hostname or "").lower()
+        default_port = {"http": 80, "https": 443, "git": 9418}[parsed.scheme]
+        host = _normalized_remote_host(parsed, default_port=default_port)
+        if not host:
+            return None
         path = parsed.path.rstrip("/")
         if path.endswith(".git"):
             path = path[:-4]
@@ -73,7 +95,7 @@ def infer_repository_id(remote_url: str | None, fallback_name: str) -> str:
         parsed = urlparse(normalized)
         path = parsed.path.strip("/")
         if path:
-            return path if parsed.hostname == "github.com" else f"{parsed.hostname}/{path}"
+            return path if parsed.hostname == "github.com" else f"{parsed.netloc}/{path}"
     return fallback_name
 
 
@@ -81,6 +103,8 @@ def validate_repository_path(path: str) -> str:
     """Return a normalized explicit repository-relative POSIX path."""
     if not isinstance(path, str) or not path.strip():
         raise NomicProfileError("repository paths must be non-empty strings")
+    if any(ord(character) < 32 or ord(character) == 127 for character in path):
+        raise NomicProfileError(f"repository path must not contain control characters: {path!r}")
     if "\\" in path:
         raise NomicProfileError(f"repository path must use '/' separators: {path!r}")
     candidate = PurePosixPath(path)
@@ -217,11 +241,36 @@ class NomicRepositoryProfile:
         repo_root: Path,
         source_config_sha256: str | None = None,
     ) -> NomicRepositoryProfile:
+        allowed_fields = {
+            "repository",
+            "roadmap_paths",
+            "context_entry_files",
+            "evaluation_criteria",
+            "source_config_sha256",
+        }
+        unknown_fields = set(value) - allowed_fields
+        if unknown_fields:
+            raise NomicProfileError(
+                "unknown nomic field(s): "
+                + ", ".join(sorted(str(field) for field in unknown_fields))
+            )
+        embedded_source_hash = value.get("source_config_sha256")
+        if embedded_source_hash is not None and not isinstance(embedded_source_hash, str):
+            raise NomicProfileError("nomic.source_config_sha256 must be a string")
+        if source_config_sha256 is None:
+            source_config_sha256 = embedded_source_hash
+
         repository = value.get("repository")
         if repository is None:
             repository = {}
         if not isinstance(repository, Mapping):
             raise NomicProfileError("nomic.repository must be a mapping")
+        unknown_repository_fields = set(repository) - {"name", "id", "remote_url"}
+        if unknown_repository_fields:
+            raise NomicProfileError(
+                "unknown nomic.repository field(s): "
+                + ", ".join(sorted(str(field) for field in unknown_repository_fields))
+            )
         raw_name = repository.get("name")
         raw_id = repository.get("id")
         remote = repository.get("remote_url")
@@ -233,9 +282,15 @@ class NomicRepositoryProfile:
             if raw_value is not None and not isinstance(raw_value, str):
                 raise NomicProfileError(f"nomic.repository.{key} must be a string")
         if remote is None:
-            remote = RepositoryRevision.resolve(repo_root).remote_url
-        name = raw_name if raw_name is not None else repo_root.resolve().name
-        repository_id = raw_id if raw_id is not None else infer_repository_id(remote, name)
+            remote = normalize_remote_url(
+                _git(repo_root.resolve(), "remote", "get-url", "origin", check=False) or None
+            )
+        if raw_id is None and not remote:
+            raise NomicProfileError(
+                "nomic.repository.id is required when no portable origin remote is available"
+            )
+        repository_id = raw_id if raw_id is not None else infer_repository_id(remote, "")
+        name = raw_name if raw_name is not None else repository_id.rstrip("/").rsplit("/", 1)[-1]
 
         def configured_paths(key: str) -> tuple[str, ...]:
             raw_paths = value.get(key)
@@ -287,7 +342,7 @@ class NomicRepositoryProfile:
             candidate = root / relative
             try:
                 resolved = candidate.resolve(strict=True)
-            except OSError as exc:
+            except (OSError, ValueError) as exc:
                 raise NomicProfileError(
                     f"configured repository file is missing: {relative}"
                 ) from exc
@@ -295,19 +350,31 @@ class NomicRepositoryProfile:
                 raise NomicProfileError(f"configured symlink escapes repository: {relative}")
             if not resolved.is_file():
                 raise NomicProfileError(f"configured repository path is not a file: {relative}")
+            if candidate.is_symlink():
+                raise NomicProfileError(
+                    f"configured repository path must not be a symlink: {relative}"
+                )
             tracked = subprocess.run(
-                ["git", "-C", str(root), "cat-file", "-t", f"{revision.commit_sha}:{relative}"],
+                ["git", "-C", str(root), "ls-tree", "-z", revision.commit_sha, "--", relative],
                 capture_output=True,
-                text=True,
                 check=False,
             )
-            if tracked.returncode != 0:
+            entry = tracked.stdout.rstrip(b"\0")
+            if tracked.returncode != 0 or not entry:
                 raise NomicProfileError(
                     f"configured file is not tracked at {revision.commit_sha}: {relative}"
                 )
-            if tracked.stdout.strip() != "blob":
+            metadata, separator, _ = entry.partition(b"\t")
+            try:
+                mode, object_type, _blob_id = metadata.decode("ascii").split()
+            except (UnicodeDecodeError, ValueError) as exc:
                 raise NomicProfileError(
-                    f"configured path is not a tracked file at {revision.commit_sha}: {relative}"
+                    f"configured file has invalid Git metadata at {revision.commit_sha}: {relative}"
+                ) from exc
+            if not separator or object_type != "blob" or mode not in {"100644", "100755"}:
+                raise NomicProfileError(
+                    f"configured path is not a regular tracked file at "
+                    f"{revision.commit_sha}: {relative}"
                 )
 
 
@@ -376,7 +443,7 @@ class ContextPack:
     revision: RepositoryRevision
     profile_hash: str
     evidence: tuple[ContextEvidenceReference, ...]
-    artifact_digests: Mapping[str, str]
+    artifact_digests: Mapping[str, str] = field(hash=False)
     pack_path: Path = field(compare=False, repr=False)
     corpus_included: bool = False
     corpus_truncated: bool = False

--- a/aragora/nomic/repository_profile.py
+++ b/aragora/nomic/repository_profile.py
@@ -1,0 +1,353 @@
+"""Repository identity, revision, and evidence models for generic Nomic planning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping
+from urllib.parse import quote, urlparse
+
+
+class NomicProfileError(ValueError):
+    """Raised when a repository planning profile is invalid."""
+
+
+class RepositoryStateError(RuntimeError):
+    """Raised when a repository cannot provide a stable clean revision."""
+
+
+def _git(repo_root: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RepositoryStateError(f"git {' '.join(args)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def normalize_remote_url(remote_url: str | None) -> str | None:
+    """Normalize common Git remote forms without embedding credentials or ``.git``."""
+    if not remote_url:
+        return None
+    value = remote_url.strip()
+    scp_match = re.match(r"^(?:[^@]+@)?([^:]+):(.+)$", value)
+    if scp_match and "://" not in value:
+        host, path = scp_match.groups()
+        value = f"https://{host}/{path}"
+    elif value.startswith("ssh://"):
+        parsed = urlparse(value)
+        value = f"https://{parsed.hostname or ''}{parsed.path}"
+    parsed = urlparse(value)
+    if parsed.scheme in {"http", "https"}:
+        host = (parsed.hostname or "").lower()
+        path = parsed.path.rstrip("/")
+        if path.endswith(".git"):
+            path = path[:-4]
+        return f"https://{host}{path}"
+    return value.removesuffix(".git").rstrip("/")
+
+
+def infer_repository_id(remote_url: str | None, fallback_name: str) -> str:
+    """Infer a stable repository ID from a normalized remote URL."""
+    normalized = normalize_remote_url(remote_url)
+    if normalized:
+        parsed = urlparse(normalized)
+        path = parsed.path.strip("/")
+        if path:
+            return path if parsed.hostname == "github.com" else f"{parsed.hostname}/{path}"
+    return fallback_name
+
+
+def validate_repository_path(path: str) -> str:
+    """Return a normalized explicit repository-relative POSIX path."""
+    if not isinstance(path, str) or not path.strip():
+        raise NomicProfileError("repository paths must be non-empty strings")
+    if "\\" in path:
+        raise NomicProfileError(f"repository path must use '/' separators: {path!r}")
+    candidate = PurePosixPath(path)
+    if candidate.is_absolute() or path.startswith("/"):
+        raise NomicProfileError(f"absolute repository path is not allowed: {path!r}")
+    if (
+        candidate == PurePosixPath(".")
+        or candidate.as_posix() != path
+        or any(part in {"", ".", ".."} for part in candidate.parts)
+    ):
+        raise NomicProfileError(f"repository path must be explicit and traversal-free: {path!r}")
+    return candidate.as_posix()
+
+
+@dataclass(frozen=True)
+class EvaluationCriterion:
+    """One ordered planning criterion returned as a normalized 0-1 score."""
+
+    id: str
+    description: str
+
+    def __post_init__(self) -> None:
+        if not re.fullmatch(r"[a-z][a-z0-9_-]*", self.id):
+            raise NomicProfileError(f"invalid evaluation criterion id: {self.id!r}")
+        if not self.description.strip():
+            raise NomicProfileError(f"criterion {self.id!r} requires a description")
+
+
+DEFAULT_EVALUATION_CRITERIA = (
+    EvaluationCriterion(
+        id="usefulness",
+        description="Produces practical, measurable repository improvement",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class RepositoryRevision:
+    """Exact Git revision used to build a context pack."""
+
+    commit_sha: str
+    tree_sha: str
+    branch: str | None
+    remote_url: str | None
+
+    @classmethod
+    def resolve(cls, repo_root: Path) -> RepositoryRevision:
+        root = repo_root.resolve()
+        top_level = Path(_git(root, "rev-parse", "--show-toplevel")).resolve()
+        if top_level != root:
+            raise RepositoryStateError(f"repository root must be the Git top-level: {top_level}")
+        commit_sha = _git(root, "rev-parse", "HEAD^{commit}")
+        tree_sha = _git(root, "rev-parse", "HEAD^{tree}")
+        branch = _git(root, "symbolic-ref", "--short", "-q", "HEAD", check=False) or None
+        remote = _git(root, "remote", "get-url", "origin", check=False) or None
+        return cls(commit_sha, tree_sha, branch, normalize_remote_url(remote))
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def assert_clean_revision(
+    repo_root: Path, expected: RepositoryRevision | None = None
+) -> RepositoryRevision:
+    """Fail unless tracked, staged, and untracked state is clean at one exact HEAD."""
+    status = _git(repo_root, "status", "--porcelain=v1", "--untracked-files=all")
+    if status:
+        raise RepositoryStateError("repository must be clean before planning")
+    revision = RepositoryRevision.resolve(repo_root)
+    if expected and (
+        revision.commit_sha != expected.commit_sha or revision.tree_sha != expected.tree_sha
+    ):
+        raise RepositoryStateError(
+            f"repository revision drifted from {expected.commit_sha} to {revision.commit_sha}"
+        )
+    return revision
+
+
+@dataclass(frozen=True)
+class NomicRepositoryProfile:
+    """Typed repository-owned configuration for the generic planning path."""
+
+    repository_name: str
+    repository_id: str
+    remote_url: str | None = None
+    roadmap_paths: tuple[str, ...] = ()
+    context_entry_files: tuple[str, ...] = ()
+    evaluation_criteria: tuple[EvaluationCriterion, ...] = DEFAULT_EVALUATION_CRITERIA
+    source_config_sha256: str | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.repository_name.strip() or not self.repository_id.strip():
+            raise NomicProfileError("repository name and id are required")
+        object.__setattr__(self, "remote_url", normalize_remote_url(self.remote_url))
+        object.__setattr__(
+            self, "roadmap_paths", tuple(validate_repository_path(p) for p in self.roadmap_paths)
+        )
+        object.__setattr__(
+            self,
+            "context_entry_files",
+            tuple(validate_repository_path(p) for p in self.context_entry_files),
+        )
+        ids = [criterion.id for criterion in self.evaluation_criteria]
+        if len(ids) != len(set(ids)):
+            raise NomicProfileError("evaluation criterion IDs must be unique")
+        if not ids:
+            raise NomicProfileError("at least one evaluation criterion is required")
+
+    @property
+    def profile_hash(self) -> str:
+        payload = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "repository": {
+                "name": self.repository_name,
+                "id": self.repository_id,
+                "remote_url": self.remote_url,
+            },
+            "roadmap_paths": list(self.roadmap_paths),
+            "context_entry_files": list(self.context_entry_files),
+            "evaluation_criteria": [asdict(item) for item in self.evaluation_criteria],
+            "source_config_sha256": self.source_config_sha256,
+        }
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, Any],
+        *,
+        repo_root: Path,
+        source_config_sha256: str | None = None,
+    ) -> NomicRepositoryProfile:
+        repository = value.get("repository") or {}
+        if not isinstance(repository, Mapping):
+            raise NomicProfileError("nomic.repository must be a mapping")
+        remote = repository.get("remote_url")
+        if remote is None:
+            remote = RepositoryRevision.resolve(repo_root).remote_url
+        name = str(repository.get("name") or repo_root.resolve().name)
+        repository_id = str(repository.get("id") or infer_repository_id(remote, name))
+        raw_criteria = value.get("evaluation_criteria")
+        criteria: tuple[EvaluationCriterion, ...]
+        if raw_criteria is None:
+            criteria = DEFAULT_EVALUATION_CRITERIA
+        elif isinstance(raw_criteria, list) and all(
+            isinstance(item, Mapping) for item in raw_criteria
+        ):
+            criteria = tuple(EvaluationCriterion(**item) for item in raw_criteria)
+        else:
+            raise NomicProfileError("nomic.evaluation_criteria must be a list of mappings")
+        return cls(
+            repository_name=name,
+            repository_id=repository_id,
+            remote_url=str(remote) if remote else None,
+            roadmap_paths=tuple(value.get("roadmap_paths") or ()),
+            context_entry_files=tuple(value.get("context_entry_files") or ()),
+            evaluation_criteria=criteria,
+            source_config_sha256=source_config_sha256,
+        )
+
+    def validate_files(self, repo_root: Path, revision: RepositoryRevision) -> None:
+        root = repo_root.resolve()
+        for relative in (*self.roadmap_paths, *self.context_entry_files):
+            candidate = root / relative
+            try:
+                resolved = candidate.resolve(strict=True)
+            except OSError as exc:
+                raise NomicProfileError(
+                    f"configured repository file is missing: {relative}"
+                ) from exc
+            if not resolved.is_relative_to(root):
+                raise NomicProfileError(f"configured symlink escapes repository: {relative}")
+            tracked = subprocess.run(
+                ["git", "-C", str(root), "cat-file", "-e", f"{revision.commit_sha}:{relative}"],
+                capture_output=True,
+                check=False,
+            )
+            if tracked.returncode != 0:
+                raise NomicProfileError(
+                    f"configured file is not tracked at {revision.commit_sha}: {relative}"
+                )
+
+
+def load_nomic_repository_profile(
+    repo_root: Path,
+    config_path: Path | None = None,
+) -> NomicRepositoryProfile:
+    """Load the typed ``nomic`` section, supporting config files outside the repository."""
+    import yaml
+
+    root = repo_root.resolve()
+    path = config_path.resolve() if config_path else root / ".aragora.yaml"
+    if not path.exists():
+        if config_path is not None:
+            raise NomicProfileError(f"configuration file does not exist: {path.name}")
+        return NomicRepositoryProfile.from_mapping({}, repo_root=root)
+    raw = path.read_bytes()
+    try:
+        loaded = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:
+        raise NomicProfileError(f"invalid YAML in {path.name}: {exc}") from exc
+    if not isinstance(loaded, Mapping):
+        raise NomicProfileError(".aragora.yaml must contain a mapping")
+    nomic = loaded.get("nomic") or {}
+    if not isinstance(nomic, Mapping):
+        raise NomicProfileError("nomic must be a mapping")
+    return NomicRepositoryProfile.from_mapping(
+        nomic,
+        repo_root=root,
+        source_config_sha256=hashlib.sha256(raw).hexdigest(),
+    )
+
+
+@dataclass(frozen=True)
+class ContextEvidenceReference:
+    """Portable file-level evidence included in a commit-addressed context pack."""
+
+    evidence_id: str
+    path: str
+    blob_id: str
+    sha256: str
+    size_bytes: int
+    line_count: int
+    role: str
+    uri: str
+    http_permalink: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ContextPack:
+    """Published context-pack metadata plus its local artifact directory."""
+
+    pack_id: str
+    repository: NomicRepositoryProfile
+    revision: RepositoryRevision
+    profile_hash: str
+    evidence: tuple[ContextEvidenceReference, ...]
+    artifact_digests: Mapping[str, str]
+    pack_path: Path = field(compare=False, repr=False)
+    corpus_included: bool = False
+
+    @property
+    def reference(self) -> str:
+        return f".nomic/context/packs/{self.revision.commit_sha}/{self.pack_id}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "nomic-context-pack/1.0",
+            "pack_id": self.pack_id,
+            "reference": self.reference,
+            "repository": self.repository.to_dict(),
+            "revision": self.revision.to_dict(),
+            "profile_hash": self.profile_hash,
+            "evidence": [item.to_dict() for item in self.evidence],
+            "artifact_digests": dict(sorted(self.artifact_digests.items())),
+            "corpus_included": self.corpus_included,
+        }
+
+
+def portable_evidence_uri(repository_id: str, commit_sha: str, path: str, lines: int) -> str:
+    end = max(lines, 1)
+    return f"repo://{quote(repository_id, safe='/')}@{commit_sha}/{quote(path)}#L1-L{end}"
+
+
+def http_permalink(remote_url: str | None, commit_sha: str, path: str, lines: int) -> str | None:
+    normalized = normalize_remote_url(remote_url)
+    if not normalized:
+        return None
+    host = urlparse(normalized).hostname
+    encoded = quote(path)
+    end = max(lines, 1)
+    if host in {"github.com", "gitlab.com"}:
+        return f"{normalized}/blob/{commit_sha}/{encoded}#L1-L{end}"
+    if host == "bitbucket.org":
+        return f"{normalized}/src/{commit_sha}/{encoded}#lines-1:{end}"
+    return None

--- a/aragora/nomic/repository_profile.py
+++ b/aragora/nomic/repository_profile.py
@@ -51,7 +51,7 @@ def normalize_remote_url(remote_url: str | None) -> str | None:
     if scp_match and "://" not in value:
         host, path = scp_match.groups()
         value = f"https://{host}/{path.lstrip('/')}"
-    elif value.startswith("ssh://"):
+    elif value.startswith(("ssh://", "git+ssh://")):
         parsed = urlparse(value)
         value = f"https://{parsed.hostname or ''}{parsed.path}"
     parsed = urlparse(value)
@@ -324,13 +324,18 @@ def load_nomic_repository_profile(
         if config_path is not None:
             raise NomicProfileError(f"configuration file does not exist: {path.name}")
         return NomicRepositoryProfile.from_mapping({}, repo_root=root)
-    raw = path.read_bytes()
+    if not path.is_file():
+        raise NomicProfileError(f"configuration path is not a file: {path.name}")
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise NomicProfileError(f"cannot read configuration file {path.name}: {exc}") from exc
     try:
         loaded = yaml.safe_load(raw) or {}
     except yaml.YAMLError as exc:
         raise NomicProfileError(f"invalid YAML in {path.name}: {exc}") from exc
     if not isinstance(loaded, Mapping):
-        raise NomicProfileError(".aragora.yaml must contain a mapping")
+        raise NomicProfileError(f"{path.name} must contain a mapping")
     nomic = loaded.get("nomic")
     if nomic is None:
         nomic = {}
@@ -378,6 +383,12 @@ class ContextPack:
     context_byte_budget: int = 100_000_000
     include_tests: bool = True
     rlm_summary: str = field(default="", repr=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.pack_id, str) or not re.fullmatch(
+            r"[A-Za-z0-9][A-Za-z0-9._-]*", self.pack_id
+        ):
+            raise NomicProfileError("context pack ID must be a non-empty portable path segment")
 
     @property
     def reference(self) -> str:

--- a/aragora/nomic/repository_profile.py
+++ b/aragora/nomic/repository_profile.py
@@ -50,7 +50,7 @@ def normalize_remote_url(remote_url: str | None) -> str | None:
     scp_match = re.match(r"^(?:[^@]+@)?([^:]+):(.+)$", value)
     if scp_match and "://" not in value:
         host, path = scp_match.groups()
-        value = f"https://{host}/{path}"
+        value = f"https://{host}/{path.lstrip('/')}"
     elif value.startswith("ssh://"):
         parsed = urlparse(value)
         value = f"https://{parsed.hostname or ''}{parsed.path}"
@@ -217,7 +217,9 @@ class NomicRepositoryProfile:
         repo_root: Path,
         source_config_sha256: str | None = None,
     ) -> NomicRepositoryProfile:
-        repository = value.get("repository") or {}
+        repository = value.get("repository")
+        if repository is None:
+            repository = {}
         if not isinstance(repository, Mapping):
             raise NomicProfileError("nomic.repository must be a mapping")
         raw_name = repository.get("name")
@@ -329,7 +331,9 @@ def load_nomic_repository_profile(
         raise NomicProfileError(f"invalid YAML in {path.name}: {exc}") from exc
     if not isinstance(loaded, Mapping):
         raise NomicProfileError(".aragora.yaml must contain a mapping")
-    nomic = loaded.get("nomic") or {}
+    nomic = loaded.get("nomic")
+    if nomic is None:
+        nomic = {}
     if not isinstance(nomic, Mapping):
         raise NomicProfileError("nomic must be a mapping")
     return NomicRepositoryProfile.from_mapping(

--- a/tests/nomic/test_repository_profile.py
+++ b/tests/nomic/test_repository_profile.py
@@ -1,0 +1,181 @@
+"""Tests for typed generic Nomic repository profiles."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from aragora.nomic.repository_profile import (
+    EvaluationCriterion,
+    NomicProfileError,
+    NomicRepositoryProfile,
+    RepositoryRevision,
+    assert_clean_revision,
+    infer_repository_id,
+    load_nomic_repository_profile,
+    normalize_remote_url,
+)
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Path:
+    git(tmp_path, "init")
+    git(tmp_path, "config", "user.email", "nomic@example.test")
+    git(tmp_path, "config", "user.name", "Nomic Test")
+    (tmp_path / "README.md").write_text("# Example\n", encoding="utf-8")
+    plans = tmp_path / "docs" / "plans"
+    plans.mkdir(parents=True)
+    (plans / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+    git(tmp_path, "add", "README.md", "docs/plans/ROADMAP.md")
+    git(tmp_path, "commit", "-m", "initial")
+    git(tmp_path, "remote", "add", "origin", "git@github.com:example/project.git")
+    return tmp_path
+
+
+def test_defaults_infer_repository_identity(repository: Path) -> None:
+    profile = load_nomic_repository_profile(repository)
+
+    assert profile.repository_name == repository.name
+    assert profile.repository_id == "example/project"
+    assert profile.remote_url == "https://github.com/example/project"
+    assert [item.id for item in profile.evaluation_criteria] == ["usefulness"]
+
+
+def test_yaml_round_trip_and_external_config_hash(repository: Path, tmp_path: Path) -> None:
+    config = tmp_path / "external.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "nomic": {
+                    "repository": {
+                        "name": "Example",
+                        "id": "example/project",
+                        "remote_url": "https://github.com/example/project.git",
+                    },
+                    "roadmap_paths": ["docs/plans/ROADMAP.md"],
+                    "context_entry_files": ["README.md"],
+                    "evaluation_criteria": [
+                        {"id": "impact", "description": "Creates measurable impact"}
+                    ],
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    profile = load_nomic_repository_profile(repository, config)
+    round_tripped = NomicRepositoryProfile.from_mapping(
+        profile.to_dict(),
+        repo_root=repository,
+        source_config_sha256=profile.source_config_sha256,
+    )
+
+    assert round_tripped == profile
+    assert profile.source_config_sha256
+    assert profile.profile_hash == round_tripped.profile_hash
+    assert str(tmp_path) not in str(profile.to_dict())
+
+
+def test_duplicate_criterion_ids_rejected(repository: Path) -> None:
+    with pytest.raises(NomicProfileError, match="unique"):
+        NomicRepositoryProfile.from_mapping(
+            {
+                "evaluation_criteria": [
+                    {"id": "impact", "description": "First"},
+                    {"id": "impact", "description": "Second"},
+                ]
+            },
+            repo_root=repository,
+        )
+
+
+@pytest.mark.parametrize("path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md"])
+def test_invalid_repository_paths_rejected(repository: Path, path: str) -> None:
+    with pytest.raises(NomicProfileError, match="path"):
+        NomicRepositoryProfile.from_mapping(
+            {"roadmap_paths": [path]},
+            repo_root=repository,
+        )
+
+
+def test_missing_and_untracked_files_rejected(repository: Path) -> None:
+    revision = RepositoryRevision.resolve(repository)
+    missing = NomicRepositoryProfile.from_mapping(
+        {"context_entry_files": ["MISSING.md"]}, repo_root=repository
+    )
+    with pytest.raises(NomicProfileError, match="missing"):
+        missing.validate_files(repository, revision)
+
+    (repository / "NOTES.md").write_text("untracked\n", encoding="utf-8")
+    untracked = NomicRepositoryProfile.from_mapping(
+        {"context_entry_files": ["NOTES.md"]}, repo_root=repository
+    )
+    with pytest.raises(NomicProfileError, match="not tracked"):
+        untracked.validate_files(repository, revision)
+
+
+def test_symlink_escaping_repository_rejected(repository: Path) -> None:
+    external = repository.parent / f"{repository.name}-external.md"
+    external.write_text("outside\n", encoding="utf-8")
+    link = repository / "outside.md"
+    link.symlink_to(external)
+    git(repository, "add", "outside.md")
+    git(repository, "commit", "-m", "track escaping link")
+    profile = NomicRepositoryProfile.from_mapping(
+        {"context_entry_files": ["outside.md"]}, repo_root=repository
+    )
+
+    with pytest.raises(NomicProfileError, match="escapes"):
+        profile.validate_files(repository, RepositoryRevision.resolve(repository))
+
+
+def test_revision_and_cleanliness(repository: Path) -> None:
+    revision = assert_clean_revision(repository)
+    assert len(revision.commit_sha) == 40
+    assert len(revision.tree_sha) == 40
+    assert revision.remote_url == "https://github.com/example/project"
+
+    (repository / "README.md").write_text("dirty\n", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="clean"):
+        assert_clean_revision(repository)
+
+
+@pytest.mark.parametrize(
+    ("raw", "normalized", "repository_id"),
+    [
+        (
+            "git@github.com:synaptent/aragora.git",
+            "https://github.com/synaptent/aragora",
+            "synaptent/aragora",
+        ),
+        (
+            "ssh://git@gitlab.com/group/project.git",
+            "https://gitlab.com/group/project",
+            "gitlab.com/group/project",
+        ),
+    ],
+)
+def test_remote_normalization(raw: str, normalized: str, repository_id: str) -> None:
+    assert normalize_remote_url(raw) == normalized
+    assert infer_repository_id(raw, "fallback") == repository_id
+
+
+def test_criterion_validation() -> None:
+    with pytest.raises(NomicProfileError):
+        EvaluationCriterion(id="Not Valid", description="description")
+    with pytest.raises(NomicProfileError):
+        EvaluationCriterion(id="valid", description=" ")

--- a/tests/nomic/test_repository_profile.py
+++ b/tests/nomic/test_repository_profile.py
@@ -49,7 +49,7 @@ def repository(tmp_path: Path) -> Path:
 def test_defaults_infer_repository_identity(repository: Path) -> None:
     profile = load_nomic_repository_profile(repository)
 
-    assert profile.repository_name == repository.name
+    assert profile.repository_name == "project"
     assert profile.repository_id == "example/project"
     assert profile.remote_url == "https://github.com/example/project"
     assert [item.id for item in profile.evaluation_criteria] == ["usefulness"]
@@ -119,6 +119,8 @@ def test_duplicate_criterion_ids_rejected(repository: Path) -> None:
             {"evaluation_criteria": [{"id": "impact", "description": "Impact", "weight": 1}]},
             "unknown evaluation criterion",
         ),
+        ({"roadmap_path": ["README.md"]}, "unknown nomic field"),
+        ({"repository": {"slug": "example/project"}}, "unknown nomic.repository field"),
     ],
 )
 def test_profile_fields_are_strictly_typed(
@@ -152,7 +154,9 @@ def test_external_config_errors_name_the_selected_file(repository: Path) -> None
         load_nomic_repository_profile(repository, config)
 
 
-@pytest.mark.parametrize("path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md"])
+@pytest.mark.parametrize(
+    "path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md", "bad\x00path"]
+)
 def test_invalid_repository_paths_rejected(repository: Path, path: str) -> None:
     with pytest.raises(NomicProfileError, match="path"):
         NomicRepositoryProfile.from_mapping(
@@ -201,6 +205,34 @@ def test_symlink_escaping_repository_rejected(repository: Path) -> None:
         profile.validate_files(repository, RepositoryRevision.resolve(repository))
 
 
+def test_tracked_in_repository_symlink_cannot_redirect_to_ignored_content(
+    repository: Path,
+) -> None:
+    (repository / ".gitignore").write_text("ignored.md\n", encoding="utf-8")
+    (repository / "ignored.md").write_text("not in the commit\n", encoding="utf-8")
+    (repository / "context.md").symlink_to("ignored.md")
+    git(repository, "add", ".gitignore", "context.md")
+    git(repository, "commit", "-m", "track in-repository symlink")
+    profile = NomicRepositoryProfile.from_mapping(
+        {"context_entry_files": ["context.md"]}, repo_root=repository
+    )
+
+    assert git(repository, "status", "--porcelain") == ""
+    with pytest.raises(NomicProfileError, match="must not be a symlink"):
+        profile.validate_files(repository, RepositoryRevision.resolve(repository))
+
+
+def test_profile_without_remote_requires_explicit_portable_id(tmp_path: Path) -> None:
+    with pytest.raises(NomicProfileError, match="repository.id is required"):
+        NomicRepositoryProfile.from_mapping({}, repo_root=tmp_path)
+
+    profile = NomicRepositoryProfile.from_mapping(
+        {"repository": {"id": "local/example"}}, repo_root=tmp_path
+    )
+    assert profile.repository_name == "example"
+    assert profile.repository_id == "local/example"
+
+
 def test_revision_and_cleanliness(repository: Path) -> None:
     revision = assert_clean_revision(repository)
     assert len(revision.commit_sha) == 40
@@ -238,6 +270,11 @@ def test_revision_and_cleanliness(repository: Path) -> None:
             "git://github.com/example/project.git",
             "https://github.com/example/project",
             "example/project",
+        ),
+        (
+            "https://git.corp.example:8443/team/repo.git",
+            "https://git.corp.example:8443/team/repo",
+            "git.corp.example:8443/team/repo",
         ),
         ("git@host:/srv/repo.git", "https://host/srv/repo", "host/srv/repo"),
         ("file:///opt/example/project.git", None, "fallback"),
@@ -296,6 +333,7 @@ def test_context_pack_serializes_complete_metadata_contract(tmp_path: Path) -> N
     assert payload["context_byte_budget"] == 4096
     assert payload["include_tests"] is False
     assert payload["rlm_summary"] == "Repository summary"
+    assert isinstance(hash(pack), int)
 
 
 @pytest.mark.parametrize("pack_id", ["", ".", "..", "nested/pack", r"nested\\pack", "pack id"])

--- a/tests/nomic/test_repository_profile.py
+++ b/tests/nomic/test_repository_profile.py
@@ -55,8 +55,8 @@ def test_defaults_infer_repository_identity(repository: Path) -> None:
     assert [item.id for item in profile.evaluation_criteria] == ["usefulness"]
 
 
-def test_yaml_round_trip_and_external_config_hash(repository: Path, tmp_path: Path) -> None:
-    config = tmp_path / "external.yaml"
+def test_yaml_round_trip_and_external_config_hash(repository: Path) -> None:
+    config = repository.parent / f"{repository.name}-external.yaml"
     config.write_text(
         yaml.safe_dump(
             {
@@ -86,9 +86,10 @@ def test_yaml_round_trip_and_external_config_hash(repository: Path, tmp_path: Pa
     )
 
     assert round_tripped == profile
+    assert not config.is_relative_to(repository)
     assert profile.source_config_sha256
     assert profile.profile_hash == round_tripped.profile_hash
-    assert str(tmp_path) not in str(profile.to_dict())
+    assert str(repository.parent) not in str(profile.to_dict())
 
 
 def test_duplicate_criterion_ids_rejected(repository: Path) -> None:
@@ -127,6 +128,16 @@ def test_profile_fields_are_strictly_typed(
 ) -> None:
     with pytest.raises(NomicProfileError, match=message):
         NomicRepositoryProfile.from_mapping(value, repo_root=repository)
+
+
+def test_falsy_non_mapping_sections_are_rejected(repository: Path) -> None:
+    with pytest.raises(NomicProfileError, match="repository must be a mapping"):
+        NomicRepositoryProfile.from_mapping({"repository": []}, repo_root=repository)
+
+    config = repository.parent / f"{repository.name}-invalid-nomic.yaml"
+    config.write_text(yaml.safe_dump({"nomic": []}), encoding="utf-8")
+    with pytest.raises(NomicProfileError, match="nomic must be a mapping"):
+        load_nomic_repository_profile(repository, config)
 
 
 @pytest.mark.parametrize("path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md"])
@@ -211,6 +222,7 @@ def test_revision_and_cleanliness(repository: Path) -> None:
             "https://github.com/example/project",
             "example/project",
         ),
+        ("git@host:/srv/repo.git", "https://host/srv/repo", "host/srv/repo"),
         ("file:///opt/example/project.git", None, "fallback"),
         ("/opt/example/project.git", None, "fallback"),
         ("../project.git", None, "fallback"),

--- a/tests/nomic/test_repository_profile.py
+++ b/tests/nomic/test_repository_profile.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from aragora.nomic.repository_profile import (
+    ContextPack,
     EvaluationCriterion,
     NomicProfileError,
     NomicRepositoryProfile,
@@ -103,6 +104,31 @@ def test_duplicate_criterion_ids_rejected(repository: Path) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ({"repository": {"name": 7}}, "repository.name"),
+        ({"roadmap_paths": "README.md"}, "list of strings"),
+        ({"context_entry_files": [1]}, "list of strings"),
+        (
+            {"evaluation_criteria": [{"id": "impact"}]},
+            "requires string id and description",
+        ),
+        (
+            {"evaluation_criteria": [{"id": "impact", "description": "Impact", "weight": 1}]},
+            "unknown evaluation criterion",
+        ),
+    ],
+)
+def test_profile_fields_are_strictly_typed(
+    repository: Path,
+    value: dict,
+    message: str,
+) -> None:
+    with pytest.raises(NomicProfileError, match=message):
+        NomicRepositoryProfile.from_mapping(value, repo_root=repository)
+
+
 @pytest.mark.parametrize("path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md"])
 def test_invalid_repository_paths_rejected(repository: Path, path: str) -> None:
     with pytest.raises(NomicProfileError, match="path"):
@@ -126,6 +152,15 @@ def test_missing_and_untracked_files_rejected(repository: Path) -> None:
     )
     with pytest.raises(NomicProfileError, match="not tracked"):
         untracked.validate_files(repository, revision)
+
+
+def test_tracked_directory_is_not_a_configured_file(repository: Path) -> None:
+    profile = NomicRepositoryProfile.from_mapping(
+        {"context_entry_files": ["docs"]}, repo_root=repository
+    )
+
+    with pytest.raises(NomicProfileError, match="not a file"):
+        profile.validate_files(repository, RepositoryRevision.resolve(repository))
 
 
 def test_symlink_escaping_repository_rejected(repository: Path) -> None:
@@ -153,6 +188,10 @@ def test_revision_and_cleanliness(repository: Path) -> None:
     with pytest.raises(RuntimeError, match="clean"):
         assert_clean_revision(repository)
 
+    git(repository, "add", "README.md")
+    with pytest.raises(RuntimeError, match="clean"):
+        assert_clean_revision(repository)
+
 
 @pytest.mark.parametrize(
     ("raw", "normalized", "repository_id"),
@@ -167,9 +206,20 @@ def test_revision_and_cleanliness(repository: Path) -> None:
             "https://gitlab.com/group/project",
             "gitlab.com/group/project",
         ),
+        (
+            "git://github.com/example/project.git",
+            "https://github.com/example/project",
+            "example/project",
+        ),
+        ("file:///opt/example/project.git", None, "fallback"),
+        ("/opt/example/project.git", None, "fallback"),
+        ("../project.git", None, "fallback"),
+        ("C:/repos/project.git", None, "fallback"),
+        (r"C:\repos\project.git", None, "fallback"),
+        (r"\\server\share\project.git", None, "fallback"),
     ],
 )
-def test_remote_normalization(raw: str, normalized: str, repository_id: str) -> None:
+def test_remote_normalization(raw: str, normalized: str | None, repository_id: str) -> None:
     assert normalize_remote_url(raw) == normalized
     assert infer_repository_id(raw, "fallback") == repository_id
 
@@ -179,3 +229,41 @@ def test_criterion_validation() -> None:
         EvaluationCriterion(id="Not Valid", description="description")
     with pytest.raises(NomicProfileError):
         EvaluationCriterion(id="valid", description=" ")
+
+
+def test_context_pack_serializes_complete_metadata_contract(tmp_path: Path) -> None:
+    profile = NomicRepositoryProfile(
+        repository_name="Example",
+        repository_id="example/project",
+        remote_url="https://github.com/example/project",
+    )
+    revision = RepositoryRevision(
+        commit_sha="a" * 40,
+        tree_sha="b" * 40,
+        branch="main",
+        remote_url=profile.remote_url,
+    )
+    pack = ContextPack(
+        pack_id="pack-id",
+        objective="Improve the roadmap",
+        repository=profile,
+        revision=revision,
+        profile_hash=profile.profile_hash,
+        evidence=(),
+        artifact_digests={"context.md": "digest"},
+        pack_path=tmp_path,
+        corpus_included=True,
+        corpus_truncated=True,
+        context_byte_budget=4096,
+        include_tests=False,
+        rlm_summary="Repository summary",
+    )
+
+    payload = pack.to_dict()
+
+    assert payload["objective"] == "Improve the roadmap"
+    assert payload["corpus_included"] is True
+    assert payload["corpus_truncated"] is True
+    assert payload["context_byte_budget"] == 4096
+    assert payload["include_tests"] is False
+    assert payload["rlm_summary"] == "Repository summary"

--- a/tests/nomic/test_repository_profile.py
+++ b/tests/nomic/test_repository_profile.py
@@ -140,6 +140,18 @@ def test_falsy_non_mapping_sections_are_rejected(repository: Path) -> None:
         load_nomic_repository_profile(repository, config)
 
 
+def test_external_config_errors_name_the_selected_file(repository: Path) -> None:
+    config_directory = repository.parent / f"{repository.name}-config-directory"
+    config_directory.mkdir()
+    with pytest.raises(NomicProfileError, match=r"configuration path is not a file: .*directory"):
+        load_nomic_repository_profile(repository, config_directory)
+
+    config = repository.parent / f"{repository.name}-list-root.yaml"
+    config.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+    with pytest.raises(NomicProfileError, match=rf"{config.name} must contain a mapping"):
+        load_nomic_repository_profile(repository, config)
+
+
 @pytest.mark.parametrize("path", ["/tmp/ROADMAP.md", "../ROADMAP.md", "docs/../README.md"])
 def test_invalid_repository_paths_rejected(repository: Path, path: str) -> None:
     with pytest.raises(NomicProfileError, match="path"):
@@ -218,6 +230,11 @@ def test_revision_and_cleanliness(repository: Path) -> None:
             "gitlab.com/group/project",
         ),
         (
+            "git+ssh://git@github.com/synaptent/aragora.git",
+            "https://github.com/synaptent/aragora",
+            "synaptent/aragora",
+        ),
+        (
             "git://github.com/example/project.git",
             "https://github.com/example/project",
             "example/project",
@@ -279,3 +296,29 @@ def test_context_pack_serializes_complete_metadata_contract(tmp_path: Path) -> N
     assert payload["context_byte_budget"] == 4096
     assert payload["include_tests"] is False
     assert payload["rlm_summary"] == "Repository summary"
+
+
+@pytest.mark.parametrize("pack_id", ["", ".", "..", "nested/pack", r"nested\\pack", "pack id"])
+def test_context_pack_rejects_path_unsafe_pack_ids(tmp_path: Path, pack_id: str) -> None:
+    profile = NomicRepositoryProfile(
+        repository_name="Example",
+        repository_id="example/project",
+    )
+    revision = RepositoryRevision(
+        commit_sha="a" * 40,
+        tree_sha="b" * 40,
+        branch="main",
+        remote_url=None,
+    )
+
+    with pytest.raises(NomicProfileError, match="portable path segment"):
+        ContextPack(
+            pack_id=pack_id,
+            objective="Improve the roadmap",
+            repository=profile,
+            revision=revision,
+            profile_hash=profile.profile_hash,
+            evidence=(),
+            artifact_digests={},
+            pack_path=tmp_path,
+        )


### PR DESCRIPTION
## Summary
- add typed repository identity, revision, evaluation criterion, evidence reference, and context pack models
- load and hash the `nomic` section from repository-owned or external `.aragora.yaml` files
- fail closed on invalid paths, duplicate criteria, dirty repositories, missing/untracked files, and escaping symlinks

## Risk
Tier 3: additive public planning interfaces and provenance semantics. Requires explicit human risk settlement before landing.

## Verification
- `pre-commit run --files aragora/nomic/repository_profile.py aragora/nomic/__init__.py tests/nomic/test_repository_profile.py`
- `pytest -q tests/nomic/test_repository_profile.py tests/nomic/test_context_builder.py` (25 passed)
- `mypy --follow-imports=skip aragora/nomic/repository_profile.py`

Part 1 of the stacked Generalize Nomic Repository Planning implementation. No legacy execution, governance, workflow, auth, or merge-authority behavior changes.