### PR TITLE
[Tier 4] fix(pre-commit): preserve trusted launcher bytes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: trailing-whitespace
         exclude: (^docs/|\.md$)
       - id: end-of-file-fixer
-        exclude: (^docs/|\.md$|\.json$|\.lock$)
+        exclude: (^docs/|\.md$|\.json$|\.lock$|^\.github/workflows/contract_drift_trusted_launcher\.py$)
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags
         exclude: ^(deploy/(helm|multi-region/helm|kubernetes/helm)|aragora-operator/helm)/.*templates/  # Helm templates use Go templating
@@ -30,9 +30,10 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
         types_or: [python, pyi]
+        exclude: ^\.github/workflows/contract_drift_trusted_launcher\.py$
       - id: ruff-format
         types_or: [python, pyi]
-        exclude: ^sdk/python/aragora/generated_types\.py$  # Auto-generated, must stay stable
+        exclude: ^(sdk/python/aragora/generated_types\.py|\.github/workflows/contract_drift_trusted_launcher\.py)$  # Integrity-pinned/generated, must stay stable
 
   # Type checking with mypy on the same local planning surface as CI's REQUIRED
   # phase-1 typecheck gate. Touched `aragora/**.py` files use CI's changed-file

--- a/tests/scripts/test_precommit_baseline_policy.py
+++ b/tests/scripts/test_precommit_baseline_policy.py
@@ -49,6 +49,13 @@ def test_eof_normalizer_excludes_structured_artifacts(path: str) -> None:
     assert pattern.search(path)
 
 
+@pytest.mark.parametrize("hook_id", ["end-of-file-fixer", "ruff", "ruff-format"])
+def test_python_rewriters_exclude_integrity_pinned_launcher(hook_id: str) -> None:
+    pattern = re.compile(str(_hook(hook_id)["exclude"]))
+    assert pattern.search(".github/workflows/contract_drift_trusted_launcher.py")
+    assert not pattern.search(".github/workflows/contract_drift_trusted_bootstrap.py")
+
+
 def test_yaml_hook_excludes_only_helm_template_trees() -> None:
     pattern = re.compile(str(_hook("check-yaml")["exclude"]))
     assert pattern.search("deploy/kubernetes/helm/aragora/templates/deployment-backend.yaml")


### PR DESCRIPTION
## Summary
- exclude the integrity-pinned trusted launcher from EOF fixing, Ruff fix/lint, and Ruff formatting
- add regression coverage proving neighboring workflow Python files remain governed
- leave the launcher and trusted-bootstrap manifest byte-identical

## Risk / authority
Tier 4 tool-policy change. Explicit operator preapproval was granted before implementation in the originating Codex task. Exact-head human settlement is still required before merge. Keep this repair separate from PRs #9756-#9760.

## Verification
- `pytest -q tests/scripts/test_precommit_baseline_policy.py tests/scripts/test_contract_drift_trusted_bootstrap.py` -> 48 passed
- `pre-commit run --all-files` -> passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> passed
- launcher SHA-256 remains `1bcf2e69038d8c91abb260e588946aab7b3dffdaead394992bd44eaceed070c1`
- manifest SHA-256 remains `ac2d311db10bac9942a5119bf5c39c8079808644cd260f8c13306fdeac3a28b1`

## Rollback
`elves/codex/precommit-trusted-launcher-exclusion/pre-batch-0`

Co-authored-by: codex[bot] <codex[bot]@users.noreply.github.com>