### PR TITLE
fix(governance): deterministic non-draft selection for quorum evidence retriggers [Tier 4]

### DIFF
--- a/.github/workflows/aragora-merge-quorum-retrigger.yml
+++ b/.github/workflows/aragora-merge-quorum-retrigger.yml
@@ -35,6 +35,9 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  # Read-only: the draft-run partition reads the PR's ready_for_review
+  # transitions from the issue-events timeline.
+  issues: read
   actions: write
 
 jobs:
@@ -84,35 +87,86 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.inputs.pr_number }}
-          WORKFLOW_NAME: "Aragora Merge Quorum"
         shell: bash
         run: |
           set -euo pipefail
 
-          head_sha="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json headRefOid --jq .headRefOid)"
-          if [[ -z "$head_sha" ]]; then
+          # Same gate-deferral rule as the enforcing workflow: drafts and
+          # closed PRs have no active gate to refresh.
+          pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+          pr_state="$(jq -r '.state' <<<"$pr_json")"
+          pr_draft="$(jq -r '.draft' <<<"$pr_json")"
+          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+          if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
             echo "::warning::could not resolve head SHA for PR #${PR_NUMBER}; nothing to do."
+            exit 0
+          fi
+          if [[ "$pr_state" != "open" || "$pr_draft" != "false" ]]; then
+            echo "PR #${PR_NUMBER} state=${pr_state} draft=${pr_draft} — gate not active; no-op."
             exit 0
           fi
           echo "PR #${PR_NUMBER} current head: ${head_sha}"
 
-          # Most recent COMPLETED enforcing merge-quorum run for this exact head.
-          # gh run rerun only works on completed runs; an in-progress run will
-          # already evaluate the current head, so skipping it is correct.
-          # head_sha is bound through jq --arg (never interpolated into the program)
-          # so the selection is independent of upstream API formatting guarantees.
-          run_id="$(gh run list --repo "$GH_REPO" --workflow "$WORKFLOW_NAME" \
-            --limit 100 \
-            --json databaseId,headSha,status,createdAt \
-            | jq -r --arg head "$head_sha" \
-                '[.[] | select(.headSha==$head and .status=="completed")]
-                 | sort_by(.createdAt) | last | .databaseId // empty')"
-
-          if [[ -z "$run_id" || "$run_id" == "null" ]]; then
-            echo "No completed merge-quorum run for head ${head_sha}; nothing to re-run."
+          # Deterministic selection, identical to the evidence-retrigger job
+          # in aragora-merge-quorum.yml. A rerun re-executes the run's
+          # ORIGINAL frozen event payload, so re-running an evaluation
+          # created while the PR was still a draft replays its draft
+          # short-circuit and resurfaces a stale SUCCESS over the truthful
+          # newest ready-state result (PR #9754: this helper picked
+          # draft-era run 31772664823 precisely because the newest
+          # evaluation was already re-running and a completed-only filter
+          # fell back past it). Enumerate ALL head-bound pull_request
+          # evaluations (full pagination, reconciled against total_count),
+          # drop runs created before the PR's newest ready_for_review
+          # transition (frozen draft payloads), order by (run_started_at,
+          # run_id, run_attempt), and consider ONLY the newest survivor.
+          # In-flight newest: it already evaluates the current evidence —
+          # no-op. Green newest: no recount needed — no-op. Never fall back.
+          runs_url="repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}"
+          total_count="$(gh api "${runs_url}&per_page=1" --jq '.total_count')"
+          runs_json="$(gh api --paginate "${runs_url}&per_page=100" \
+            --jq '.workflow_runs[] | {id, run_attempt, status, conclusion, created_at, run_started_at}' \
+            | jq -s '.')"
+          if [[ "$(jq 'length' <<<"$runs_json")" -ne "$total_count" ]]; then
+            echo "::warning::head-bound run listing inconsistent with total_count=${total_count}; no-op."
+            exit 0
+          fi
+          ready_at="$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+            --jq '.[] | select(.event == "ready_for_review") | .created_at' | sort | tail -n1)"
+          target_json="$(jq -c --arg ready "${ready_at}" \
+            '[.[] | select(($ready == "") or (.created_at >= $ready))]
+             | sort_by(.run_started_at, .id, .run_attempt) | last // empty' <<<"$runs_json")"
+          if [[ -z "$target_json" ]]; then
+            echo "No non-draft head-bound evaluation run for ${head_sha} — no-op."
             echo "(A pull_request-triggered run will evaluate this head on its own.)"
             exit 0
           fi
+          run_id="$(jq -r '.id' <<<"$target_json")"
+          run_status="$(jq -r '.status' <<<"$target_json")"
+          run_conclusion="$(jq -r '.conclusion' <<<"$target_json")"
+          if [[ "$run_status" != "completed" ]]; then
+            echo "Newest non-draft evaluation run ${run_id} is ${run_status} — it will see the current evidence; no-op."
+            exit 0
+          fi
+          if [[ "$run_conclusion" == "success" ]]; then
+            echo "Newest non-draft evaluation run ${run_id} already succeeded — no-op."
+            exit 0
+          fi
 
-          echo "Re-running merge-quorum run ${run_id} for head ${head_sha}"
-          gh run rerun "$run_id" --repo "$GH_REPO"
+          # Concurrent evidence comments (and the evidence-retrigger job in
+          # the enforcing workflow) all compute this same target, so a
+          # fresh status read immediately before the request collapses a
+          # burst into ONE rerun: losers see a non-completed run and no-op,
+          # and the rerun API rejecting an already-queued run covers the
+          # residual race.
+          fresh_status="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" --jq '.status')"
+          if [[ "$fresh_status" != "completed" ]]; then
+            echo "Evaluation run ${run_id} is already ${fresh_status} (concurrent retrigger won) — no-op."
+            exit 0
+          fi
+          echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
+          # A rejected rerun request (already re-running) must not turn
+          # comment activity into red noise; the A1 reconciler remains the
+          # safety net.
+          gh run rerun "$run_id" --repo "$GH_REPO" \
+            || echo "::warning::rerun request for run ${run_id} failed (possibly already re-running); no-op."

--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -324,6 +324,9 @@ jobs:
     permissions:
       actions: write
       pull-requests: read
+      # Read-only: the draft-run partition in Guard 3 reads the PR's
+      # ready_for_review transitions from the issue-events timeline.
+      issues: read
     # Debounce comment floods: a newer evidence comment for the same PR
     # cancels an older still-pending retrigger. cancel-in-progress here is
     # safe precisely because this job is NOT the required check — the
@@ -372,28 +375,61 @@ jobs:
             exit 0
           fi
 
-          # Guard 3: only re-run a COMPLETED, non-success evaluation bound to
-          # the CURRENT head SHA. In-flight runs will already see the new
-          # comment; a green gate needs no recount; runs for old heads are
-          # correctly superseded by the next pull_request event.
-          run_json="$(gh api "repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}&per_page=1" \
-            --jq '.workflow_runs[0] // empty')"
-          if [[ -z "$run_json" ]]; then
-            echo "No prior head-bound evaluation run for ${head_sha} — no-op."
+          # Guard 3: deterministically select the ONLY legitimate rerun
+          # target. A rerun re-executes the run's ORIGINAL frozen event
+          # payload, so re-running an evaluation created while the PR was
+          # still a draft replays its draft short-circuit and resurfaces a
+          # stale SUCCESS over the truthful newest ready-state result (PR
+          # #9754: draft-era run 31772664823 attempt 2 masked ready-state
+          # run 31772790229). And when the newest evaluation is busy,
+          # falling back to an OLDER completed run re-executes exactly such
+          # a stale evaluation. So: enumerate ALL head-bound pull_request
+          # evaluations (full pagination, reconciled against total_count),
+          # drop runs created before the PR's newest ready_for_review
+          # transition (frozen draft payloads), order by (run_started_at,
+          # run_id, run_attempt), and consider ONLY the newest survivor.
+          # In-flight newest: it will already see this comment — no-op.
+          # Green newest: no recount needed — no-op. Never fall back.
+          runs_url="repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}"
+          total_count="$(gh api "${runs_url}&per_page=1" --jq '.total_count')"
+          runs_json="$(gh api --paginate "${runs_url}&per_page=100" \
+            --jq '.workflow_runs[] | {id, run_attempt, status, conclusion, created_at, run_started_at}' \
+            | jq -s '.')"
+          if [[ "$(jq 'length' <<<"$runs_json")" -ne "$total_count" ]]; then
+            echo "::warning::head-bound run listing inconsistent with total_count=${total_count}; no-op."
             exit 0
           fi
-          run_id="$(jq -r '.id' <<<"$run_json")"
-          run_status="$(jq -r '.status' <<<"$run_json")"
-          run_conclusion="$(jq -r '.conclusion' <<<"$run_json")"
+          ready_at="$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+            --jq '.[] | select(.event == "ready_for_review") | .created_at' | sort | tail -n1)"
+          target_json="$(jq -c --arg ready "${ready_at}" \
+            '[.[] | select(($ready == "") or (.created_at >= $ready))]
+             | sort_by(.run_started_at, .id, .run_attempt) | last // empty' <<<"$runs_json")"
+          if [[ -z "$target_json" ]]; then
+            echo "No non-draft head-bound evaluation run for ${head_sha} — no-op."
+            exit 0
+          fi
+          run_id="$(jq -r '.id' <<<"$target_json")"
+          run_status="$(jq -r '.status' <<<"$target_json")"
+          run_conclusion="$(jq -r '.conclusion' <<<"$target_json")"
           if [[ "$run_status" != "completed" ]]; then
-            echo "Latest evaluation run ${run_id} is ${run_status} — it will see this comment; no-op."
+            echo "Newest non-draft evaluation run ${run_id} is ${run_status} — it will see this comment; no-op."
             exit 0
           fi
           if [[ "$run_conclusion" == "success" ]]; then
-            echo "Latest evaluation run ${run_id} already succeeded — no-op."
+            echo "Newest non-draft evaluation run ${run_id} already succeeded — no-op."
             exit 0
           fi
 
+          # Concurrent evidence comments (and the standalone retrigger
+          # helper) all compute this same target, so a fresh status read
+          # immediately before the request collapses a burst into ONE
+          # rerun: losers see a non-completed run and no-op, and the rerun
+          # API rejecting an already-queued run covers the residual race.
+          fresh_status="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" --jq '.status')"
+          if [[ "$fresh_status" != "completed" ]]; then
+            echo "Evaluation run ${run_id} is already ${fresh_status} (concurrent retrigger won) — no-op."
+            exit 0
+          fi
           echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
           # Tolerate rerun races (e.g. a manual rerun already in progress):
           # failure to request a rerun must not turn comment activity into

--- a/tests/governance/test_quorum_evidence_retrigger.py
+++ b/tests/governance/test_quorum_evidence_retrigger.py
@@ -13,7 +13,13 @@ They pin the structural contract of ``aragora-merge-quorum.yml``:
 * the re-trigger path is guarded, debounced, and least-privileged;
 * the enforcing evaluation job is untouched: no comment event reaches
   it, its permissions stay read-only, and its anti-doom-loop
-  ``cancel-in-progress: false`` invariant is preserved.
+  ``cancel-in-progress: false`` invariant is preserved;
+* BOTH retrigger surfaces (the in-file ``evidence-retrigger`` job and
+  the standalone ``aragora-merge-quorum-retrigger.yml`` helper) select
+  their rerun target deterministically: the newest completed non-draft
+  head-bound evaluation ordered by ``(run_started_at, run_id,
+  run_attempt)``, with concurrent comment bursts collapsing into a
+  single rerun (``TestDeterministicNonDraftSelection``).
 
 The suite must FAIL against the pre-B1 workflow and PASS with the
 change (RED/GREEN proof captured in the implementing PR).
@@ -30,11 +36,22 @@ import yaml
 WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "aragora-merge-quorum.yml"
 )
+STANDALONE_WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "aragora-merge-quorum-retrigger.yml"
+)
 
 
 @pytest.fixture(scope="module")
 def workflow() -> dict[str, Any]:
     return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def standalone_workflow() -> dict[str, Any]:
+    return yaml.safe_load(STANDALONE_WORKFLOW_PATH.read_text(encoding="utf-8"))
 
 
 @pytest.fixture(scope="module")
@@ -181,3 +198,132 @@ class TestEnforcingJobUnchanged:
         assert writes == ["actions"]
         assert permissions.get("contents") is None
         assert permissions.get("statuses") is None
+
+
+class TestDeterministicNonDraftSelection:
+    """Both retrigger surfaces select their rerun target deterministically.
+
+    Regression target for the 2026-08-14 draft-success resurfacing incident
+    on PR #9754: two pull_request evaluations existed at head ``ee63516c``
+    (draft-era run 31772664823, ready-state run 31772790229), and a
+    two-comment evidence burst rerain BOTH — the standalone helper picked
+    the older draft-era run because the newest one was already re-running,
+    and a rerun re-executes the run's ORIGINAL frozen event payload, so the
+    draft short-circuit replayed a stale SUCCESS over the truthful
+    ready-state ``human_risk_settlement_required`` result.
+
+    The contract pinned here, for the in-file ``evidence-retrigger`` job AND
+    the standalone ``aragora-merge-quorum-retrigger.yml`` helper alike:
+
+    * enumerate ALL head-bound ``pull_request`` evaluations (full
+      pagination reconciled against ``total_count``), never a single
+      API-ordering-dependent first item;
+    * exclude draft-frozen evaluations (runs created before the PR's newest
+      ``ready_for_review`` transition);
+    * order candidates by ``(run_started_at, run_id, run_attempt)`` and
+      consider ONLY the newest survivor — an in-flight or already-green
+      newest evaluation means no-op, never a fallback to an older run;
+    * deduplicate concurrent comment-triggered retriggers into one rerun
+      via a fresh pre-rerun status read plus rerun-rejection tolerance.
+    """
+
+    @pytest.fixture(scope="class")
+    def retrigger_scripts(
+        self, retrigger_job: dict[str, Any], standalone_workflow: dict[str, Any]
+    ) -> dict[str, str]:
+        return {
+            "evidence-retrigger": _run_blocks(retrigger_job),
+            "standalone": _run_blocks(standalone_workflow["jobs"]["retrigger"]),
+        }
+
+    def test_selection_enumerates_all_head_bound_runs(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """Full pagination + total_count reconciliation, per surface."""
+        for surface, script in retrigger_scripts.items():
+            assert "--paginate" in script, f"{surface}: must enumerate ALL head-bound runs"
+            assert "total_count" in script, (
+                f"{surface}: enumeration must be reconciled against total_count"
+            )
+
+    def test_selection_orders_by_run_started_at_run_id_run_attempt(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """The pinned deterministic ordering key, identical on both surfaces."""
+        for surface, script in retrigger_scripts.items():
+            assert "sort_by(.run_started_at, .id, .run_attempt)" in script, (
+                f"{surface}: selection must order by (run_started_at, run_id, run_attempt)"
+            )
+
+    def test_selection_excludes_draft_frozen_evaluations(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """Runs created before the newest ready_for_review transition are
+        frozen draft payloads and must never be rerun targets."""
+        for surface, script in retrigger_scripts.items():
+            assert "ready_for_review" in script, (
+                f"{surface}: selection must partition out draft-created evaluations"
+            )
+            assert "created_at" in script
+
+    def test_nondeterministic_selections_are_gone(self, retrigger_scripts: dict[str, str]) -> None:
+        """The two incident-era selections must not reappear."""
+        for surface, script in retrigger_scripts.items():
+            assert ".workflow_runs[0]" not in script, (
+                f"{surface}: per_page=1 first-item selection is API-ordering-dependent"
+            )
+            assert "sort_by(.createdAt)" not in script, (
+                f"{surface}: createdAt-only ordering ignores reruns and attempt order"
+            )
+            assert '.status=="completed")' not in script, (
+                f"{surface}: filtering to completed runs BEFORE picking the newest "
+                "falls back to older (draft-era) evaluations while the newest is "
+                "re-running — the PR #9754 resurfacing mechanism"
+            )
+
+    def test_only_the_newest_evaluation_may_be_rerun(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """Completed/success checks happen AFTER selection: an in-flight or
+        green newest evaluation no-ops instead of falling back."""
+        for surface, script in retrigger_scripts.items():
+            assert script.count("gh run rerun") == 1, (
+                f"{surface}: exactly one rerun path, for the selected newest run only"
+            )
+            assert '"$run_status" != "completed"' in script, (
+                f"{surface}: in-flight newest evaluation must no-op, not fall back"
+            )
+            assert '"$run_conclusion" == "success"' in script, (
+                f"{surface}: a green newest evaluation needs no recount"
+            )
+
+    def test_concurrent_retriggers_collapse_into_one_rerun(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """All surfaces compute the same target; a fresh pre-rerun status
+        read plus rerun-rejection tolerance turns burst losers into no-ops."""
+        for surface, script in retrigger_scripts.items():
+            assert "actions/runs/${run_id}" in script, (
+                f"{surface}: must re-read the selected run's status just before rerun"
+            )
+            assert "concurrent retrigger won" in script
+            assert "::warning::rerun request" in script, (
+                f"{surface}: a rejected rerun (already re-running) must not be red noise"
+            )
+
+    def test_standalone_guards_open_non_draft_pr(self, standalone_workflow: dict[str, Any]) -> None:
+        """The helper must observe the same gate-deferral rule as the job."""
+        script = _run_blocks(standalone_workflow["jobs"]["retrigger"])
+        assert ".draft" in script
+        assert ".state" in script
+
+    def test_issue_events_read_permission_present(
+        self, retrigger_job: dict[str, Any], standalone_workflow: dict[str, Any]
+    ) -> None:
+        """The ready_for_review partition reads issue events on both surfaces."""
+        job_permissions = retrigger_job.get("permissions") or {}
+        assert job_permissions.get("issues") == "read"
+        workflow_permissions = standalone_workflow.get("permissions") or {}
+        assert workflow_permissions.get("issues") == "read"
+        writes = sorted(scope for scope, level in workflow_permissions.items() if level == "write")
+        assert writes == ["actions"], "helper workflow write surface stays exactly actions"


### PR DESCRIPTION
## Tier 4 parked draft — operator settlement required

Merge-authority self-modification (two `.github/workflows/` files). Prepared as a PARKED DRAFT per `docs/REVIEW_AUTHORITY_PRINCIPLES.md`; no ready transition, evidence posting, settlement, or merge without exact-head operator settlement.

## Source incident (2026-08-14, PR #9754)

Posting model-evidence comments retriggered every `pull_request` quorum evaluation at head `ee63516c242c9d26dacf3ff29657f51062ce28df`, and a stale draft-era SUCCESS resurfaced over the truthful newest evaluation:

- Two head-bound evaluations existed: draft-era run 31772664823 (created 05:20:04, frozen `draft=true` payload, success) and ready-state run 31772790229 (created 05:22:27, truthfully failing with `human_risk_settlement_required`).
- A two-comment evidence burst fired BOTH retrigger surfaces. The in-file `quorum-evidence-retrigger` job (run 31773287972) correctly reran 31772790229 at 05:32:00. The standalone helper (run 31773287932) then selected "newest COMPLETED by createdAt" — the truthful run was already re-running, so the completed-only filter fell back to the older draft-era run and logged `Re-running merge-quorum run 31772664823` at 05:32:04. Its rerun re-executed the frozen draft payload and reported SUCCESS (attempt 2, 05:32:05), resurfacing a stale draft conclusion in required-check views.
- A third executor (run 31773288078) raced to a no-op. Net effect: every evaluation at the head was rerun; concurrent comment triggers were not deduplicated.

**Host confirmation (per the tracked defect):** the retrigger mechanism spans two files. The expected host `aragora-merge-quorum.yml` carries the nondeterministic `per_page=1` first-item selection (no draft partition, no ordering key); the incident-causing fallback selection lives in the sibling `aragora-merge-quorum-retrigger.yml`. A single-file fix cannot deliver the required behavior (the other surface would keep re-running stale draft evaluations), so this PR repairs both surfaces with identical selection semantics.

## Behavior after this change (both retrigger surfaces)

- Enumerate ALL head-bound `pull_request` evaluations (full pagination, reconciled against `total_count`; inconsistent listing = warn + no-op).
- Exclude draft-frozen evaluations: runs created before the PR's newest `ready_for_review` transition (issue-events timeline; new read-only `issues: read` permission).
- Order candidates by `(run_started_at, run_id, run_attempt)` and consider ONLY the newest survivor: in-flight → no-op (it already sees the evidence); success → no-op; never fall back to an older run.
- Deduplicate concurrent comment-triggered retriggers into one rerun: all surfaces compute the same target, a fresh pre-rerun status read turns burst losers into no-ops, and a rejected rerun request is a tolerated warning, not red noise.
- Standalone helper additionally gains the same open+non-draft PR guard as the in-file job.
- Enforcing `merge-quorum` job, triggers, concurrency groups, and write surfaces are unchanged (`actions: write` remains the only write scope on both surfaces).

## Validation (all local, this head)

- Red-first: `python3 -m pytest tests/governance/test_quorum_evidence_retrigger.py -q` → 8 failed (new `TestDeterministicNonDraftSelection`), 15 passed before the workflow edits; 23 passed after.
- `python3 -m pytest tests/governance/test_quorum_evidence_retrigger.py tests/workflows/test_aragora_merge_quorum_workflow.py -q` → 25 passed.
- `actionlint` (all workflows) → clean. `make lint` + `ruff format --check aragora/ tests/ scripts/` → clean. `bash scripts/preflight_mypy.sh --diff-base origin/main` → no production Python changes.
- `make test-smoke` + `bash scripts/test_tiers.sh smoke` → 138 passed.
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` → preflight: ok.

## Risks and rollback

- Both scripts fail closed to no-op on inconsistent listings; a missed retrigger only defers to the next `pull_request` event or the A1 reconciler (`scripts/quorum_rerun_reconciler.py`), unchanged as the safety net.
- `docs/specs/QUORUM_EVIDENCE_RETRIGGER.md` still describes Guard 3 as "latest head-bound run"; this PR intentionally does not edit the spec (diff bounded to retrigger logic + one focused structural test). The spec's Guard-3 wording can absorb the deterministic-selection refinement in a follow-up docs change.
- Rollback is a revert of this single commit; no state, baseline, or protection is touched.
