### PR TITLE
fix(scripts): fail loud when cross-SDK parity baseline cannot be resolved

### DIFF
--- a/scripts/check_cross_sdk_parity.py
+++ b/scripts/check_cross_sdk_parity.py
@@ -84,10 +84,21 @@ def _extract_typescript_paths() -> set[str]:
 # Main
 # ---------------------------------------------------------------------------
 
+_CONFIG_ERROR_EXIT = 2
+
+
+def _config_error(message: str) -> int:
+    print(f"check_cross_sdk_parity: configuration error: {message}", file=sys.stderr)
+    return _CONFIG_ERROR_EXIT
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Cross-language SDK parity check")
-    parser.add_argument("--strict", action="store_true", help="Fail on regressions beyond baseline")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on regressions beyond baseline (requires --baseline)",
+    )
     parser.add_argument(
         "--baseline",
         type=Path,
@@ -96,6 +107,27 @@ def main() -> int:
     )
     parser.add_argument("--json", action="store_true", help="JSON output")
     args = parser.parse_args()
+
+    # Resolve the baseline up front and fail loudly when it cannot be
+    # resolved: silently gating against an implicitly empty baseline would
+    # re-flag every grandfathered gap as a new regression.
+    baseline_py_only: set[str] = set()
+    baseline_ts_only: set[str] = set()
+    if args.baseline is not None:
+        if not args.baseline.exists():
+            return _config_error(f"baseline file not found: {args.baseline}")
+        try:
+            data = json.loads(args.baseline.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            return _config_error(f"could not load baseline {args.baseline}: {exc}")
+        if not isinstance(data, dict):
+            return _config_error(f"baseline {args.baseline} must be a JSON object")
+        baseline_py_only = set(data.get("python_only", []))
+        baseline_ts_only = set(data.get("typescript_only", []))
+    elif args.strict:
+        return _config_error(
+            "--strict requires --baseline (canonical: scripts/baselines/cross_sdk_parity.json)"
+        )
 
     py_paths = _extract_python_paths()
     ts_paths = _extract_typescript_paths()
@@ -136,13 +168,6 @@ def main() -> int:
                 print(f"  ... and {len(typescript_only) - 20} more")
 
     # Baseline regression check
-    baseline_py_only: set[str] = set()
-    baseline_ts_only: set[str] = set()
-    if args.baseline and args.baseline.exists():
-        data = json.loads(args.baseline.read_text())
-        baseline_py_only = set(data.get("python_only", []))
-        baseline_ts_only = set(data.get("typescript_only", []))
-
     new_py_only = set(python_only) - baseline_py_only
     new_ts_only = set(typescript_only) - baseline_ts_only
 

--- a/tests/scripts/test_check_cross_sdk_parity.py
+++ b/tests/scripts/test_check_cross_sdk_parity.py
@@ -1,0 +1,104 @@
+"""Focused regression tests for scripts/check_cross_sdk_parity.py baseline resolution.
+
+A named-but-unresolvable baseline (missing file, unreadable/unparseable
+content, or ``--strict`` with no baseline at all) must exit with a distinct
+configuration-error status naming the attempted path, never silently gate
+against an empty baseline. Valid-baseline callers keep identical behavior,
+output, and exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_cross_sdk_parity.py"
+
+CONFIG_ERROR_EXIT = 2
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *argv],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+
+
+def _live_baseline(tmp_path: Path) -> Path:
+    """Write a baseline grandfathering exactly the current live gaps."""
+    report_proc = _run("--json")
+    assert report_proc.returncode == 0, report_proc.stderr
+    report = json.loads(report_proc.stdout)
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "python_only": report["python_only"],
+                "typescript_only": report["typescript_only"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return baseline
+
+
+def test_strict_with_missing_baseline_is_config_error(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.json"
+    proc = _run("--strict", "--baseline", str(missing))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(missing) in proc.stderr
+    assert "FAILED: Cross-SDK parity regression" not in proc.stdout
+
+
+def test_missing_baseline_is_config_error_without_strict(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.json"
+    proc = _run("--baseline", str(missing))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(missing) in proc.stderr
+
+
+def test_strict_without_baseline_is_config_error() -> None:
+    proc = _run("--strict")
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert "--baseline" in proc.stderr
+    assert "FAILED: Cross-SDK parity regression" not in proc.stdout
+
+
+def test_unparseable_baseline_is_config_error(tmp_path: Path) -> None:
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not valid json", encoding="utf-8")
+    proc = _run("--strict", "--baseline", str(corrupt))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(corrupt) in proc.stderr
+
+
+def test_non_object_baseline_is_config_error(tmp_path: Path) -> None:
+    non_object = tmp_path / "non_object.json"
+    non_object.write_text("[]", encoding="utf-8")
+    proc = _run("--strict", "--baseline", str(non_object))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(non_object) in proc.stderr
+
+
+def test_strict_with_valid_baseline_passes_unchanged(tmp_path: Path) -> None:
+    baseline = _live_baseline(tmp_path)
+    proc = _run("--strict", "--baseline", str(baseline))
+    assert proc.returncode == 0
+    assert "PASS: No new cross-SDK parity regressions" in proc.stdout
+    assert "Baseline regressions: python_only=0 typescript_only=0" in proc.stdout
+    assert proc.stderr == ""
+
+
+def test_plain_invocation_unchanged() -> None:
+    proc = _run()
+    assert proc.returncode == 0
+    assert "Python SDK paths:" in proc.stdout
+    assert "Baseline regressions" not in proc.stdout
+    assert proc.stderr == ""


### PR DESCRIPTION
## Summary

`scripts/check_cross_sdk_parity.py --strict` with a nonexistent, unreadable, or non-object `--baseline` silently gated against an EMPTY baseline and false-failed on every grandfathered gap (~121 false `NEW TS-ONLY` regressions, exit 1). This PR makes baseline resolution fail loudly instead:

- `--baseline <missing path>` -> exit **2** (distinct configuration-error status) with `check_cross_sdk_parity: configuration error: baseline file not found: <path>` on stderr
- unreadable / unparseable / non-object baseline JSON -> exit 2, message naming the attempted path
- `--strict` without `--baseline` -> exit 2, message naming the canonical baseline `scripts/baselines/cross_sdk_parity.json`
- No silent empty-baseline gating remains reachable

Remedy chosen (per the 2026-08-15 handoff options): keep the explicit-flag requirement with fail-loud on missing/unresolved. Every live caller (`.github/workflows/sdk-parity.yml`, `.github/workflows/release.yml`, `Makefile ci-required`, `scripts/pre_release_check.py`, `scripts/pristine_main_health.py`) passes both `--strict` and `--baseline` explicitly, so no caller behavior changes.

## Byte-compatibility proof

Ran pristine `origin/main` script vs. patched script side-by-side from `scripts/` for all three live invocation shapes (plain, `--json`, `--strict --baseline scripts/baselines/cross_sdk_parity.json`): stdout, stderr, and exit code **byte-identical** in all three (`cmp` clean, rc=0).

## Tests (red-first)

New focused file `tests/scripts/test_check_cross_sdk_parity.py` (7 subprocess tests) was written first and captured red against the silent-empty behavior (5 failed: exits 1/1/0/1/1 instead of 2; 2 compat guards passed). After the fix: 7/7 green.

## Gates

- ruff format + ruff check: clean; `make lint`: pass
- `preflight_mypy --diff-base origin/main`: pass (no aragora/ python changes)
- AWS-neutralized `make test-smoke`: pass
- smoke tier `pytest -m smoke`: **138 passed** (matches baseline)
- `automation_pr_preflight.sh origin/main HEAD`: ok
- Diff: exactly the checker + one focused test file, +137/-8 (145 LOC, cap 800)

## Tier

`scripts/check_cross_sdk_parity.py` is a CDG authority dependency (`CONTRACT_DRIFT_AUTHORITY_DEPENDENCY_PREFIXES` -> `TIER_4_PREFIXES` in `review_queue.py`), so this PR is expected Tier 4: parked draft, `operator-review-required`, prepare-only evidence, operator exact-head settlement before merge.
