### PR TITLE
refactor(governance): unify quorum retrigger selection into one shared helper [Tier 4]

### DIFF
--- a/.github/workflows/aragora-merge-quorum-retrigger.yml
+++ b/.github/workflows/aragora-merge-quorum-retrigger.yml
@@ -10,8 +10,10 @@ name: Aragora Merge Quorum Retrigger
 #   * It NEVER evaluates the quorum, posts comments, approves, or merges.
 #   * Its only privileged action is `gh run rerun` on the existing
 #     "Aragora Merge Quorum" workflow run for the PR's current head.
-#   * It does NOT check out or execute any PR code, so fork-PR comment events
-#     (which run from the BASE repo's workflow definition) cannot inject code.
+#   * It never checks out or executes any PR code — only the BASE repo's
+#     default-branch copy of the shared selection helper — so fork-PR comment
+#     events (which run from the BASE repo's workflow definition) cannot
+#     inject code.
 #
 # This file lives under .github/workflows/, so per REVIEW_AUTHORITY_PRINCIPLES.md
 # every change to it is a Tier 4 "merge-authority self-modification" and requires
@@ -79,6 +81,16 @@ jobs:
             echo "Comment does not match evidence shape; skipping retrigger."
           fi
 
+      - name: Check out the shared selection helper (default branch)
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          steps.shape.outputs.match == 'true'
+        uses: actions/checkout@v4
+        with:
+          # Always run the BASE repo's default-branch copy of the helper —
+          # never PR code (the enforcing evaluation job's same ref pin).
+          ref: ${{ github.event.repository.default_branch }}
+
       - name: Re-run merge-quorum for the PR's current head
         if: >-
           github.event_name == 'workflow_dispatch' ||
@@ -90,83 +102,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
-          # Same gate-deferral rule as the enforcing workflow: drafts and
-          # closed PRs have no active gate to refresh.
-          pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
-          pr_state="$(jq -r '.state' <<<"$pr_json")"
-          pr_draft="$(jq -r '.draft' <<<"$pr_json")"
-          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
-          if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
-            echo "::warning::could not resolve head SHA for PR #${PR_NUMBER}; nothing to do."
-            exit 0
-          fi
-          if [[ "$pr_state" != "open" || "$pr_draft" != "false" ]]; then
-            echo "PR #${PR_NUMBER} state=${pr_state} draft=${pr_draft} — gate not active; no-op."
-            exit 0
-          fi
-          echo "PR #${PR_NUMBER} current head: ${head_sha}"
-
-          # Deterministic selection, identical to the evidence-retrigger job
-          # in aragora-merge-quorum.yml. A rerun re-executes the run's
-          # ORIGINAL frozen event payload, so re-running an evaluation
-          # created while the PR was still a draft replays its draft
-          # short-circuit and resurfaces a stale SUCCESS over the truthful
-          # newest ready-state result (PR #9754: this helper picked
-          # draft-era run 31772664823 precisely because the newest
-          # evaluation was already re-running and a completed-only filter
-          # fell back past it). Enumerate ALL head-bound pull_request
-          # evaluations (full pagination, reconciled against total_count),
-          # drop runs created before the PR's newest ready_for_review
-          # transition (frozen draft payloads), order by (run_started_at,
-          # run_id, run_attempt), and consider ONLY the newest survivor.
-          # In-flight newest: it already evaluates the current evidence —
-          # no-op. Green newest: no recount needed — no-op. Never fall back.
-          runs_url="repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}"
-          total_count="$(gh api "${runs_url}&per_page=1" --jq '.total_count')"
-          runs_json="$(gh api --paginate "${runs_url}&per_page=100" \
-            --jq '.workflow_runs[] | {id, run_attempt, status, conclusion, created_at, run_started_at}' \
-            | jq -s '.')"
-          if [[ "$(jq 'length' <<<"$runs_json")" -ne "$total_count" ]]; then
-            echo "::warning::head-bound run listing inconsistent with total_count=${total_count}; no-op."
-            exit 0
-          fi
-          ready_at="$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/events?per_page=100" \
-            --jq '.[] | select(.event == "ready_for_review") | .created_at' | sort | tail -n1)"
-          target_json="$(jq -c --arg ready "${ready_at}" \
-            '[.[] | select(($ready == "") or (.created_at >= $ready))]
-             | sort_by(.run_started_at, .id, .run_attempt) | last // empty' <<<"$runs_json")"
-          if [[ -z "$target_json" ]]; then
-            echo "No non-draft head-bound evaluation run for ${head_sha} — no-op."
-            echo "(A pull_request-triggered run will evaluate this head on its own.)"
-            exit 0
-          fi
-          run_id="$(jq -r '.id' <<<"$target_json")"
-          run_status="$(jq -r '.status' <<<"$target_json")"
-          run_conclusion="$(jq -r '.conclusion' <<<"$target_json")"
-          if [[ "$run_status" != "completed" ]]; then
-            echo "Newest non-draft evaluation run ${run_id} is ${run_status} — it will see the current evidence; no-op."
-            exit 0
-          fi
-          if [[ "$run_conclusion" == "success" ]]; then
-            echo "Newest non-draft evaluation run ${run_id} already succeeded — no-op."
-            exit 0
-          fi
-
-          # Concurrent evidence comments (and the evidence-retrigger job in
-          # the enforcing workflow) all compute this same target, so a
-          # fresh status read immediately before the request collapses a
-          # burst into ONE rerun: losers see a non-completed run and no-op,
-          # and the rerun API rejecting an already-queued run covers the
-          # residual race.
-          fresh_status="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" --jq '.status')"
-          if [[ "$fresh_status" != "completed" ]]; then
-            echo "Evaluation run ${run_id} is already ${fresh_status} (concurrent retrigger won) — no-op."
-            exit 0
-          fi
-          echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
-          # A rejected rerun request (already re-running) must not turn
-          # comment activity into red noise; the A1 reconciler remains the
-          # safety net.
-          gh run rerun "$run_id" --repo "$GH_REPO" \
-            || echo "::warning::rerun request for run ${run_id} failed (possibly already re-running); no-op."
+          # Gate-deferral check + deterministic newest-survivor selection +
+          # burst dedup live in the shared helper so this surface and the
+          # evidence-retrigger job in aragora-merge-quorum.yml cannot drift
+          # apart (docs/specs/QUORUM_EVIDENCE_RETRIGGER.md, PR #9754).
+          bash scripts/quorum_evidence_retrigger_select.sh

--- a/.github/workflows/aragora-merge-quorum.yml
+++ b/.github/workflows/aragora-merge-quorum.yml
@@ -323,6 +323,10 @@ jobs:
     # keeps the workflow-level read-only permissions unchanged.
     permissions:
       actions: write
+      # Read-only: check out the default-branch shared selection helper
+      # (scripts/quorum_evidence_retrigger_select.sh). Nothing in this job
+      # can write repository contents.
+      contents: read
       pull-requests: read
       # Read-only: the draft-run partition in Guard 3 reads the PR's
       # ready_for_review transitions from the issue-events timeline.
@@ -337,102 +341,53 @@ jobs:
       group: quorum-evidence-retrigger-${{ github.event.issue.number }}
       cancel-in-progress: true
     steps:
-      - name: Guard and re-trigger stale quorum evaluation
+      # Guard 1: the comment's FIRST markdown heading must name a known
+      # reviewer family — the same convention the quorum evidence parsers
+      # key on (review_queue.py heading inference + canonical model-family
+      # markers). Anything else no-ops successfully.
+      - name: Evidence-heading guard
+        id: heading
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
           # Attacker-controlled content enters ONLY via env (never inline
           # ${{ }} inside run:), so comment markdown cannot inject shell.
           COMMENT_BODY: ${{ github.event.comment.body }}
         shell: bash
         run: |
           set -euo pipefail
-
-          # Guard 1: the comment's FIRST markdown heading must name a known
-          # reviewer family — the same convention the quorum evidence
-          # parsers key on (review_queue.py heading inference + canonical
-          # model-family markers). Anything else no-ops successfully.
           heading="$(printf '%s\n' "$COMMENT_BODY" | grep -m1 -E '^[[:space:]]{0,3}#{1,6}[[:space:]]' || true)"
           if [[ -z "$heading" ]]; then
+            echo "match=false" >> "$GITHUB_OUTPUT"
             echo "No markdown heading in comment — not evidence-shaped; no-op."
             exit 0
           fi
           families='claude|anthropic|codex|tesla|harvey|factory|grok|xai|gemini|openai|gpt|mistral|codestral|deepseek|qwen|kimi|moonshot|yi|glm|zhipu|minimax|hermes'
           heading_lower="$(printf '%s' "$heading" | tr '[:upper:]' '[:lower:]')"
           if ! printf '%s' "$heading_lower" | grep -qE "(^|[^a-z0-9])(${families})([^a-z0-9]|$)"; then
+            echo "match=false" >> "$GITHUB_OUTPUT"
             echo "First heading names no known reviewer family — no-op."
             exit 0
           fi
+          echo "match=true" >> "$GITHUB_OUTPUT"
 
-          # Guard 2: PR must be open and non-draft (drafts defer the gate).
-          pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
-          pr_state="$(jq -r '.state' <<<"$pr_json")"
-          pr_draft="$(jq -r '.draft' <<<"$pr_json")"
-          head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
-          if [[ "$pr_state" != "open" || "$pr_draft" != "false" ]]; then
-            echo "PR #${PR_NUMBER} state=${pr_state} draft=${pr_draft} — gate not active; no-op."
-            exit 0
-          fi
+      - name: Check out the shared selection helper (default branch)
+        if: steps.heading.outputs.match == 'true'
+        uses: actions/checkout@v4
+        with:
+          # Always run the BASE repo's default-branch copy of the helper —
+          # never PR code (the enforcing evaluation job's same ref pin).
+          ref: ${{ github.event.repository.default_branch }}
 
-          # Guard 3: deterministically select the ONLY legitimate rerun
-          # target. A rerun re-executes the run's ORIGINAL frozen event
-          # payload, so re-running an evaluation created while the PR was
-          # still a draft replays its draft short-circuit and resurfaces a
-          # stale SUCCESS over the truthful newest ready-state result (PR
-          # #9754: draft-era run 31772664823 attempt 2 masked ready-state
-          # run 31772790229). And when the newest evaluation is busy,
-          # falling back to an OLDER completed run re-executes exactly such
-          # a stale evaluation. So: enumerate ALL head-bound pull_request
-          # evaluations (full pagination, reconciled against total_count),
-          # drop runs created before the PR's newest ready_for_review
-          # transition (frozen draft payloads), order by (run_started_at,
-          # run_id, run_attempt), and consider ONLY the newest survivor.
-          # In-flight newest: it will already see this comment — no-op.
-          # Green newest: no recount needed — no-op. Never fall back.
-          runs_url="repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}"
-          total_count="$(gh api "${runs_url}&per_page=1" --jq '.total_count')"
-          runs_json="$(gh api --paginate "${runs_url}&per_page=100" \
-            --jq '.workflow_runs[] | {id, run_attempt, status, conclusion, created_at, run_started_at}' \
-            | jq -s '.')"
-          if [[ "$(jq 'length' <<<"$runs_json")" -ne "$total_count" ]]; then
-            echo "::warning::head-bound run listing inconsistent with total_count=${total_count}; no-op."
-            exit 0
-          fi
-          ready_at="$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/events?per_page=100" \
-            --jq '.[] | select(.event == "ready_for_review") | .created_at' | sort | tail -n1)"
-          target_json="$(jq -c --arg ready "${ready_at}" \
-            '[.[] | select(($ready == "") or (.created_at >= $ready))]
-             | sort_by(.run_started_at, .id, .run_attempt) | last // empty' <<<"$runs_json")"
-          if [[ -z "$target_json" ]]; then
-            echo "No non-draft head-bound evaluation run for ${head_sha} — no-op."
-            exit 0
-          fi
-          run_id="$(jq -r '.id' <<<"$target_json")"
-          run_status="$(jq -r '.status' <<<"$target_json")"
-          run_conclusion="$(jq -r '.conclusion' <<<"$target_json")"
-          if [[ "$run_status" != "completed" ]]; then
-            echo "Newest non-draft evaluation run ${run_id} is ${run_status} — it will see this comment; no-op."
-            exit 0
-          fi
-          if [[ "$run_conclusion" == "success" ]]; then
-            echo "Newest non-draft evaluation run ${run_id} already succeeded — no-op."
-            exit 0
-          fi
-
-          # Concurrent evidence comments (and the standalone retrigger
-          # helper) all compute this same target, so a fresh status read
-          # immediately before the request collapses a burst into ONE
-          # rerun: losers see a non-completed run and no-op, and the rerun
-          # API rejecting an already-queued run covers the residual race.
-          fresh_status="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" --jq '.status')"
-          if [[ "$fresh_status" != "completed" ]]; then
-            echo "Evaluation run ${run_id} is already ${fresh_status} (concurrent retrigger won) — no-op."
-            exit 0
-          fi
-          echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
-          # Tolerate rerun races (e.g. a manual rerun already in progress):
-          # failure to request a rerun must not turn comment activity into
-          # red noise. The A1 reconciler remains the safety net.
-          gh run rerun "$run_id" --repo "$GH_REPO" \
-            || echo "::warning::rerun request for run ${run_id} failed (possibly already re-running); no-op."
+      # Guards 2-3: gate-deferral check + deterministic newest-survivor
+      # selection + burst dedup live in the shared helper so this job and
+      # the standalone aragora-merge-quorum-retrigger.yml helper cannot
+      # drift apart (docs/specs/QUORUM_EVIDENCE_RETRIGGER.md, PR #9754).
+      - name: Guard and re-trigger stale quorum evaluation
+        if: steps.heading.outputs.match == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/quorum_evidence_retrigger_select.sh

--- a/docs-site/docs/specs/quorum-evidence-retrigger.md
+++ b/docs-site/docs/specs/quorum-evidence-retrigger.md
@@ -55,7 +55,7 @@ could not move the head-bound required check at all.
 
 The job instead performs the known-safe deterministic recovery — the
 exact manual fix used on #7727 and the A1 reconciler motion — at the
-source: `gh run rerun <latest head-bound pull_request run>`. The rerun
+source: `gh run rerun <newest surviving head-bound pull_request run>`. The rerun
 executes in the original `pull_request` context, so its check run binds
 to the PR head and the gate genuinely re-reads the evidence.
 
@@ -105,22 +105,35 @@ In-step (read-only `gh api` + `jq`):
      timeline is read through the job's read-only `issues: read`
      scope); a PR with no `ready_for_review` transition keeps all
      runs;
-   - orders the survivors by `(run_started_at, run_id, run_attempt)`
-     and considers ONLY the newest survivor. No survivor: no-op (a
-     `pull_request`-triggered run will evaluate the head on its own).
-     Newest survivor in-flight: no-op (it already sees the comment).
-     Newest survivor concluded `success`: no-op (green gates need no
-     recount). The guard NEVER falls back to an older run.
+   - orders the survivors by
+     `((run_started_at // created_at), run_id, run_attempt)` — a
+     still-queued run has null `run_started_at`, which must not sort
+     the newest evaluation below an older completed one — and
+     considers ONLY the newest survivor. No survivor: no-op. Newest
+     survivor in-flight or concluded `success`: no-op. The guard
+     NEVER falls back to an older run.
 
 Only then: `gh run rerun <newest survivor>`. Concurrent evidence
 comments collapse to ONE rerun: every retrigger surface (this job and
 the standalone helper workflow `aragora-merge-quorum-retrigger.yml`,
-which applies this same deterministic selection) computes the same
+which runs the same shared selection helper) computes the same
 target, a fresh status read immediately before the rerun request
 makes burst losers see a non-completed run and no-op, and the rerun
 API rejecting an already-queued run covers the residual race (a
 rejected request logs a warning and exits 0 — comment activity must
 never manufacture red noise).
+
+### Single shared selection surface
+
+Guards 2–3 — gate-deferral, deterministic selection, burst dedup +
+rerun — live in ONE checked-in helper,
+`scripts/quorum_evidence_retrigger_select.sh`, run by BOTH retrigger
+surfaces from a BASE-repo default-branch checkout (the enforcing
+evaluation job's existing ref pin): comment events still never
+execute PR-author-controlled code, and the surfaces cannot drift
+apart. Only the by-design different comment-shape guards (Guard 1
+here; the heading-marker plus head-SHA-citation pre-filter in the
+standalone helper) remain in the workflow files.
 
 ### Comment-shape filter boundary (intentional)
 
@@ -138,7 +151,7 @@ a gap: the distinct post-settlement quorum execution required by
 Tier-4 chronology is produced by the sanctioned manual `gh run rerun`
 of the newest head-bound quorum run, which is the permanent
 post-settlement step in every Tier-4 settlement chronology (proven on
-PR #9770, 2026-08-16).
+PR #9770, 2026-08-16 UTC).
 
 ### Permissions
 
@@ -148,9 +161,10 @@ unchanged.
 
 **Deliberate deviation from the one-line B1 sketch** ("permissions
 unchanged"): the `evidence-retrigger` job carries job-scoped
-`permissions: { actions: write, pull-requests: read, issues: read }`
-(`issues: read` exists solely for Guard 3's read-only
-`ready_for_review` timeline read). A purely
+`permissions: { actions: write, contents: read, pull-requests: read,
+issues: read }` (`issues: read` exists solely for Guard 3's read-only
+`ready_for_review` timeline read; `contents: read` solely to check
+out the default-branch shared selection helper). A purely
 read-permission comment-triggered run cannot move the head-bound
 required check (see "Why re-run instead of evaluating inline"), so
 `actions: write` — the capability to re-run this workflow's own prior
@@ -192,11 +206,12 @@ grepped; it is never evaluated, and no other event field
 **Fork-PR permissions.** `issue_comment` workflows run **on the base
 repository**, from the default-branch workflow file, with the base
 repo's `GITHUB_TOKEN` — stated explicitly per the B1 caveat. The
-retrigger job checks out nothing and executes no PR-author-controlled
-code; the rerun it requests also checks out only the default branch
-(the evaluation job pins `ref: default_branch`) and is read-only. A
-fork commenter therefore gets no code execution with the token; worst
-case is triggering a read-only recount.
+retrigger job checks out only the BASE repo's default branch (the
+shared selection helper, `ref: default_branch`) and executes no
+PR-author-controlled code; the rerun it requests also checks out only
+the default branch (the evaluation job pins `ref: default_branch`)
+and is read-only. A fork commenter therefore gets no code execution
+with the token; worst case is triggering a read-only recount.
 
 **Cancellation abuse.** `cancel-in-progress: true` is scoped to the
 retrigger job's own per-PR group. The required evaluation runs keep
@@ -247,10 +262,15 @@ workflow with `yaml.safe_load` and pins:
   while the workflow-level group keeps `cancel-in-progress: false`;
 - the enforcing job is excluded from `issue_comment` events and gains
   no write permission; the retrigger job's write surface is exactly
-  `actions: write`;
+  `actions: write` (its `contents` scope stays read-only, present
+  solely for the helper checkout);
 - the comment body enters only via `env:`, never inline in `run:`;
-- the guard step references the known-reviewer-family heading match
-  and the head-bound stale-run conditions.
+- the guard step references the known-reviewer-family heading match;
+- both surfaces delegate Guards 2–3 to the single default-branch
+  shared helper with no inline selection copy left in either
+  workflow; the helper carries the stale-run conditions and the
+  coalesced ordering, and behavioral fixture tests execute it
+  against a fake `gh`.
 
 The suite FAILS against the pre-change workflow (RED) and PASSES with
 the change (GREEN); the RED proof is captured in the PR body.

--- a/docs/specs/QUORUM_EVIDENCE_RETRIGGER.md
+++ b/docs/specs/QUORUM_EVIDENCE_RETRIGGER.md
@@ -50,7 +50,7 @@ could not move the head-bound required check at all.
 
 The job instead performs the known-safe deterministic recovery — the
 exact manual fix used on #7727 and the A1 reconciler motion — at the
-source: `gh run rerun <latest head-bound pull_request run>`. The rerun
+source: `gh run rerun <newest surviving head-bound pull_request run>`. The rerun
 executes in the original `pull_request` context, so its check run binds
 to the PR head and the gate genuinely re-reads the evidence.
 
@@ -100,22 +100,35 @@ In-step (read-only `gh api` + `jq`):
      timeline is read through the job's read-only `issues: read`
      scope); a PR with no `ready_for_review` transition keeps all
      runs;
-   - orders the survivors by `(run_started_at, run_id, run_attempt)`
-     and considers ONLY the newest survivor. No survivor: no-op (a
-     `pull_request`-triggered run will evaluate the head on its own).
-     Newest survivor in-flight: no-op (it already sees the comment).
-     Newest survivor concluded `success`: no-op (green gates need no
-     recount). The guard NEVER falls back to an older run.
+   - orders the survivors by
+     `((run_started_at // created_at), run_id, run_attempt)` — a
+     still-queued run has null `run_started_at`, which must not sort
+     the newest evaluation below an older completed one — and
+     considers ONLY the newest survivor. No survivor: no-op. Newest
+     survivor in-flight or concluded `success`: no-op. The guard
+     NEVER falls back to an older run.
 
 Only then: `gh run rerun <newest survivor>`. Concurrent evidence
 comments collapse to ONE rerun: every retrigger surface (this job and
 the standalone helper workflow `aragora-merge-quorum-retrigger.yml`,
-which applies this same deterministic selection) computes the same
+which runs the same shared selection helper) computes the same
 target, a fresh status read immediately before the rerun request
 makes burst losers see a non-completed run and no-op, and the rerun
 API rejecting an already-queued run covers the residual race (a
 rejected request logs a warning and exits 0 — comment activity must
 never manufacture red noise).
+
+### Single shared selection surface
+
+Guards 2–3 — gate-deferral, deterministic selection, burst dedup +
+rerun — live in ONE checked-in helper,
+`scripts/quorum_evidence_retrigger_select.sh`, run by BOTH retrigger
+surfaces from a BASE-repo default-branch checkout (the enforcing
+evaluation job's existing ref pin): comment events still never
+execute PR-author-controlled code, and the surfaces cannot drift
+apart. Only the by-design different comment-shape guards (Guard 1
+here; the heading-marker plus head-SHA-citation pre-filter in the
+standalone helper) remain in the workflow files.
 
 ### Comment-shape filter boundary (intentional)
 
@@ -133,7 +146,7 @@ a gap: the distinct post-settlement quorum execution required by
 Tier-4 chronology is produced by the sanctioned manual `gh run rerun`
 of the newest head-bound quorum run, which is the permanent
 post-settlement step in every Tier-4 settlement chronology (proven on
-PR #9770, 2026-08-16).
+PR #9770, 2026-08-16 UTC).
 
 ### Permissions
 
@@ -143,9 +156,10 @@ unchanged.
 
 **Deliberate deviation from the one-line B1 sketch** ("permissions
 unchanged"): the `evidence-retrigger` job carries job-scoped
-`permissions: { actions: write, pull-requests: read, issues: read }`
-(`issues: read` exists solely for Guard 3's read-only
-`ready_for_review` timeline read). A purely
+`permissions: { actions: write, contents: read, pull-requests: read,
+issues: read }` (`issues: read` exists solely for Guard 3's read-only
+`ready_for_review` timeline read; `contents: read` solely to check
+out the default-branch shared selection helper). A purely
 read-permission comment-triggered run cannot move the head-bound
 required check (see "Why re-run instead of evaluating inline"), so
 `actions: write` — the capability to re-run this workflow's own prior
@@ -187,11 +201,12 @@ grepped; it is never evaluated, and no other event field
 **Fork-PR permissions.** `issue_comment` workflows run **on the base
 repository**, from the default-branch workflow file, with the base
 repo's `GITHUB_TOKEN` — stated explicitly per the B1 caveat. The
-retrigger job checks out nothing and executes no PR-author-controlled
-code; the rerun it requests also checks out only the default branch
-(the evaluation job pins `ref: default_branch`) and is read-only. A
-fork commenter therefore gets no code execution with the token; worst
-case is triggering a read-only recount.
+retrigger job checks out only the BASE repo's default branch (the
+shared selection helper, `ref: default_branch`) and executes no
+PR-author-controlled code; the rerun it requests also checks out only
+the default branch (the evaluation job pins `ref: default_branch`)
+and is read-only. A fork commenter therefore gets no code execution
+with the token; worst case is triggering a read-only recount.
 
 **Cancellation abuse.** `cancel-in-progress: true` is scoped to the
 retrigger job's own per-PR group. The required evaluation runs keep
@@ -242,10 +257,15 @@ workflow with `yaml.safe_load` and pins:
   while the workflow-level group keeps `cancel-in-progress: false`;
 - the enforcing job is excluded from `issue_comment` events and gains
   no write permission; the retrigger job's write surface is exactly
-  `actions: write`;
+  `actions: write` (its `contents` scope stays read-only, present
+  solely for the helper checkout);
 - the comment body enters only via `env:`, never inline in `run:`;
-- the guard step references the known-reviewer-family heading match
-  and the head-bound stale-run conditions.
+- the guard step references the known-reviewer-family heading match;
+- both surfaces delegate Guards 2–3 to the single default-branch
+  shared helper with no inline selection copy left in either
+  workflow; the helper carries the stale-run conditions and the
+  coalesced ordering, and behavioral fixture tests execute it
+  against a fake `gh`.
 
 The suite FAILS against the pre-change workflow (RED) and PASSES with
 the change (GREEN); the RED proof is captured in the PR body.

--- a/scripts/quorum_evidence_retrigger_select.sh
+++ b/scripts/quorum_evidence_retrigger_select.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Shared deterministic rerun-target selection for the two Tier 4 quorum
+# evidence-retrigger surfaces (docs/specs/QUORUM_EVIDENCE_RETRIGGER.md):
+#
+#   * the evidence-retrigger job in .github/workflows/aragora-merge-quorum.yml
+#   * .github/workflows/aragora-merge-quorum-retrigger.yml (standalone helper)
+#
+# Both check this file out from the BASE repository's default branch and
+# run it, so the selection semantics exist in exactly one place and the
+# surfaces cannot drift apart (the PR #9754 incident class). Contract
+# pinned by tests/governance/test_quorum_evidence_retrigger.py.
+#
+# Env contract: GH_TOKEN (read PR/run state + re-run workflow runs),
+# GH_REPO (owner/repo), PR_NUMBER.
+#
+# The ONLY mutating action is the single rerun request at the end, on the
+# newest surviving head-bound pull_request evaluation; every other path is
+# a read followed by a no-op exit 0.
+set -euo pipefail
+
+: "${GH_REPO:?GH_REPO is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+
+# Same gate-deferral rule as the enforcing workflow: drafts and closed
+# PRs have no active gate to refresh.
+pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}")"
+pr_state="$(jq -r '.state' <<<"$pr_json")"
+pr_draft="$(jq -r '.draft' <<<"$pr_json")"
+head_sha="$(jq -r '.head.sha' <<<"$pr_json")"
+if [[ -z "$head_sha" || "$head_sha" == "null" ]]; then
+  echo "::warning::could not resolve head SHA for PR #${PR_NUMBER}; nothing to do."
+  exit 0
+fi
+if [[ "$pr_state" != "open" || "$pr_draft" != "false" ]]; then
+  echo "PR #${PR_NUMBER} state=${pr_state} draft=${pr_draft} — gate not active; no-op."
+  exit 0
+fi
+echo "PR #${PR_NUMBER} current head: ${head_sha}"
+
+# Deterministically select the ONLY legitimate rerun target. A rerun
+# re-executes the run's ORIGINAL frozen event payload, so re-running a
+# draft-era evaluation replays its draft short-circuit SUCCESS over the
+# truthful newest ready-state result, and falling back past a busy
+# newest run re-executes exactly such a stale evaluation (PR #9754).
+# So: enumerate ALL head-bound pull_request evaluations (full
+# pagination, reconciled against total_count), drop runs created before
+# the newest ready_for_review transition, order by ((run_started_at //
+# created_at), run_id, run_attempt) — run_started_at is null while a
+# run is still queued, and a null key must not sort the newest run
+# below an older completed one — and consider ONLY the newest survivor.
+# In-flight or green newest: no-op. Never fall back.
+runs_url="repos/${GH_REPO}/actions/workflows/aragora-merge-quorum.yml/runs?event=pull_request&head_sha=${head_sha}"
+total_count="$(gh api "${runs_url}&per_page=1" --jq '.total_count')"
+runs_json="$(gh api --paginate "${runs_url}&per_page=100" \
+  --jq '.workflow_runs[] | {id, run_attempt, status, conclusion, created_at, run_started_at}' \
+  | jq -s '.')"
+if [[ "$(jq 'length' <<<"$runs_json")" -ne "$total_count" ]]; then
+  echo "::warning::head-bound run listing inconsistent with total_count=${total_count}; no-op."
+  exit 0
+fi
+ready_at="$(gh api --paginate "repos/${GH_REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+  --jq '.[] | select(.event == "ready_for_review") | .created_at' | sort | tail -n1)"
+target_json="$(jq -c --arg ready "${ready_at}" \
+  '[.[] | select(($ready == "") or (.created_at >= $ready))]
+   | sort_by((.run_started_at // .created_at), .id, .run_attempt) | last // empty' <<<"$runs_json")"
+if [[ -z "$target_json" ]]; then
+  echo "No non-draft head-bound evaluation run for ${head_sha} — no-op."
+  exit 0
+fi
+run_id="$(jq -r '.id' <<<"$target_json")"
+run_status="$(jq -r '.status' <<<"$target_json")"
+run_conclusion="$(jq -r '.conclusion' <<<"$target_json")"
+if [[ "$run_status" != "completed" ]]; then
+  echo "Newest non-draft evaluation run ${run_id} is ${run_status} — it will already see the current evidence; no-op."
+  exit 0
+fi
+if [[ "$run_conclusion" == "success" ]]; then
+  echo "Newest non-draft evaluation run ${run_id} already succeeded — no-op."
+  exit 0
+fi
+
+# Every retrigger surface computes this same target, so a fresh status
+# read immediately before the request collapses a comment burst into
+# ONE rerun: losers see a non-completed run and no-op.
+fresh_status="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" --jq '.status')"
+if [[ "$fresh_status" != "completed" ]]; then
+  echo "Evaluation run ${run_id} is already ${fresh_status} (concurrent retrigger won) — no-op."
+  exit 0
+fi
+echo "Re-running stale evaluation run ${run_id} (conclusion=${run_conclusion}) for PR #${PR_NUMBER} head ${head_sha}."
+# A rejected rerun (already re-running) must not turn comment activity
+# into red noise; the A1 reconciler remains the safety net.
+gh run rerun "$run_id" --repo "$GH_REPO" \
+  || echo "::warning::rerun request for run ${run_id} failed (possibly already re-running); no-op."

--- a/tests/governance/test_quorum_evidence_retrigger.py
+++ b/tests/governance/test_quorum_evidence_retrigger.py
@@ -14,12 +14,11 @@ They pin the structural contract of ``aragora-merge-quorum.yml``:
 * the enforcing evaluation job is untouched: no comment event reaches
   it, its permissions stay read-only, and its anti-doom-loop
   ``cancel-in-progress: false`` invariant is preserved;
-* BOTH retrigger surfaces (the in-file ``evidence-retrigger`` job and
-  the standalone ``aragora-merge-quorum-retrigger.yml`` helper) select
-  their rerun target deterministically: the newest completed non-draft
-  head-bound evaluation ordered by ``(run_started_at, run_id,
-  run_attempt)``, with concurrent comment bursts collapsing into a
-  single rerun (``TestDeterministicNonDraftSelection``).
+* BOTH retrigger surfaces run the SAME checked-in selection helper,
+  ``scripts/quorum_evidence_retrigger_select.sh``, checked out from the
+  default branch: the newest completed non-draft head-bound evaluation,
+  ordered by ``((run_started_at // created_at), run_id, run_attempt)``,
+  with comment bursts collapsing into a single rerun.
 
 The suite must FAIL against the pre-B1 workflow and PASS with the
 change (RED/GREEN proof captured in the implementing PR).
@@ -27,21 +26,22 @@ change (RED/GREEN proof captured in the implementing PR).
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
 import pytest
 import yaml
 
-WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "aragora-merge-quorum.yml"
-)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "aragora-merge-quorum.yml"
 STANDALONE_WORKFLOW_PATH = (
-    Path(__file__).resolve().parents[2]
-    / ".github"
-    / "workflows"
-    / "aragora-merge-quorum-retrigger.yml"
+    REPO_ROOT / ".github" / "workflows" / "aragora-merge-quorum-retrigger.yml"
 )
+SELECT_SCRIPT_PATH = REPO_ROOT / "scripts" / "quorum_evidence_retrigger_select.sh"
+SELECT_SCRIPT_INVOCATION = "bash scripts/quorum_evidence_retrigger_select.sh"
 
 
 @pytest.fixture(scope="module")
@@ -52,6 +52,14 @@ def workflow() -> dict[str, Any]:
 @pytest.fixture(scope="module")
 def standalone_workflow() -> dict[str, Any]:
     return yaml.safe_load(STANDALONE_WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def select_script() -> str:
+    assert SELECT_SCRIPT_PATH.is_file(), (
+        "both retrigger surfaces must share scripts/quorum_evidence_retrigger_select.sh"
+    )
+    return SELECT_SCRIPT_PATH.read_text(encoding="utf-8")
 
 
 @pytest.fixture(scope="module")
@@ -73,6 +81,16 @@ def retrigger_job(workflow: dict[str, Any]) -> dict[str, Any]:
 @pytest.fixture(scope="module")
 def enforcing_job(workflow: dict[str, Any]) -> dict[str, Any]:
     return workflow["jobs"]["merge-quorum"]
+
+
+@pytest.fixture(scope="module")
+def retrigger_scripts(
+    retrigger_job: dict[str, Any], standalone_workflow: dict[str, Any]
+) -> dict[str, str]:
+    return {
+        "evidence-retrigger": _run_blocks(retrigger_job),
+        "standalone": _run_blocks(standalone_workflow["jobs"]["retrigger"]),
+    }
 
 
 def _run_blocks(job: dict[str, Any]) -> str:
@@ -131,16 +149,17 @@ class TestRetriggerGuards:
             assert family in script, f"guard regex must include reviewer family {family!r}"
 
     def test_guard_requires_open_non_draft_pr_and_stale_head_bound_run(
-        self, retrigger_job: dict[str, Any]
+        self, retrigger_job: dict[str, Any], select_script: str
     ) -> None:
-        script = _run_blocks(retrigger_job)
+        """The gate-deferral + stale-run guards live in the shared helper."""
+        assert SELECT_SCRIPT_INVOCATION in _run_blocks(retrigger_job)
         # PR open + non-draft.
-        assert ".draft" in script
-        assert ".state" in script
-        # Re-run only the latest COMPLETED non-success run for the CURRENT head.
-        assert "head_sha" in script
-        assert "completed" in script
-        assert "gh run rerun" in script
+        assert ".draft" in select_script
+        assert ".state" in select_script
+        # Re-run only the newest COMPLETED non-success run for the CURRENT head.
+        assert "head_sha" in select_script
+        assert "completed" in select_script
+        assert "gh run rerun" in select_script
 
     def test_comment_body_enters_only_via_env(self, retrigger_job: dict[str, Any]) -> None:
         """Injection pin: comment markdown never interpolates into run: text."""
@@ -196,79 +215,120 @@ class TestEnforcingJobUnchanged:
         permissions = retrigger_job.get("permissions") or {}
         writes = sorted(scope for scope, level in permissions.items() if level == "write")
         assert writes == ["actions"]
-        assert permissions.get("contents") is None
+        # contents:read exists solely to check out the default-branch shared
+        # selection helper; the job still cannot write repository contents.
+        assert permissions.get("contents") == "read"
         assert permissions.get("statuses") is None
 
 
-class TestDeterministicNonDraftSelection:
-    """Both retrigger surfaces select their rerun target deterministically.
+class TestSharedSelectionSurface:
+    """The selection logic exists in exactly ONE checked-in helper.
 
-    Regression target for the 2026-08-14 draft-success resurfacing incident
-    on PR #9754: two pull_request evaluations existed at head ``ee63516c``
-    (draft-era run 31772664823, ready-state run 31772790229), and a
-    two-comment evidence burst rerain BOTH — the standalone helper picked
-    the older draft-era run because the newest one was already re-running,
-    and a rerun re-executes the run's ORIGINAL frozen event payload, so the
-    draft short-circuit replayed a stale SUCCESS over the truthful
-    ready-state ``human_risk_settlement_required`` result.
-
-    The contract pinned here, for the in-file ``evidence-retrigger`` job AND
-    the standalone ``aragora-merge-quorum-retrigger.yml`` helper alike:
-
-    * enumerate ALL head-bound ``pull_request`` evaluations (full
-      pagination reconciled against ``total_count``), never a single
-      API-ordering-dependent first item;
-    * exclude draft-frozen evaluations (runs created before the PR's newest
-      ``ready_for_review`` transition);
-    * order candidates by ``(run_started_at, run_id, run_attempt)`` and
-      consider ONLY the newest survivor — an in-flight or already-green
-      newest evaluation means no-op, never a fallback to an older run;
-    * deduplicate concurrent comment-triggered retriggers into one rerun
-      via a fresh pre-rerun status read plus rerun-rejection tolerance.
+    Duplicated merge-authority logic can drift independently, and a
+    drifted copy re-opens the PR #9754 incident class, so both surfaces
+    delegate to the same repo script, checked out from the BASE repo's
+    default branch (the enforcing evaluation job's existing ref pin) so
+    comment events never execute PR-author-controlled code.
     """
 
-    @pytest.fixture(scope="class")
-    def retrigger_scripts(
+    def test_selection_helper_is_strict_bash(self, select_script: str) -> None:
+        assert select_script.startswith("#!/usr/bin/env bash")
+        assert "set -euo pipefail" in select_script
+
+    def test_both_surfaces_delegate_to_the_shared_helper(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        for surface, script in retrigger_scripts.items():
+            assert script.count(SELECT_SCRIPT_INVOCATION) == 1, (
+                f"{surface}: must invoke the shared selection helper exactly once"
+            )
+
+    def test_no_inline_selection_remains_on_either_surface(
+        self, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """Re-introducing a private copy of the selection is drift."""
+        for surface, script in retrigger_scripts.items():
+            for token in (
+                "sort_by(",
+                "--paginate",
+                "total_count",
+                "gh run rerun",
+                "run_started_at",
+            ):
+                assert token not in script, (
+                    f"{surface}: selection logic must live only in the shared helper "
+                    f"(found inline {token!r})"
+                )
+
+    def test_surface_checkouts_pin_the_default_branch(
         self, retrigger_job: dict[str, Any], standalone_workflow: dict[str, Any]
-    ) -> dict[str, str]:
-        return {
-            "evidence-retrigger": _run_blocks(retrigger_job),
-            "standalone": _run_blocks(standalone_workflow["jobs"]["retrigger"]),
+    ) -> None:
+        surfaces = {
+            "evidence-retrigger": retrigger_job,
+            "standalone": standalone_workflow["jobs"]["retrigger"],
         }
-
-    def test_selection_enumerates_all_head_bound_runs(
-        self, retrigger_scripts: dict[str, str]
-    ) -> None:
-        """Full pagination + total_count reconciliation, per surface."""
-        for surface, script in retrigger_scripts.items():
-            assert "--paginate" in script, f"{surface}: must enumerate ALL head-bound runs"
-            assert "total_count" in script, (
-                f"{surface}: enumeration must be reconciled against total_count"
+        for surface, job in surfaces.items():
+            checkouts = [
+                step
+                for step in job.get("steps", [])
+                if str(step.get("uses", "")).startswith("actions/checkout@")
+            ]
+            assert len(checkouts) == 1, f"{surface}: exactly one checkout, for the shared helper"
+            ref = (checkouts[0].get("with") or {}).get("ref")
+            assert ref == "${{ github.event.repository.default_branch }}", (
+                f"{surface}: the helper must come from the default branch, never PR code"
             )
 
-    def test_selection_orders_by_run_started_at_run_id_run_attempt(
-        self, retrigger_scripts: dict[str, str]
-    ) -> None:
-        """The pinned deterministic ordering key, identical on both surfaces."""
-        for surface, script in retrigger_scripts.items():
-            assert "sort_by(.run_started_at, .id, .run_attempt)" in script, (
-                f"{surface}: selection must order by (run_started_at, run_id, run_attempt)"
-            )
 
-    def test_selection_excludes_draft_frozen_evaluations(
-        self, retrigger_scripts: dict[str, str]
-    ) -> None:
-        """Runs created before the newest ready_for_review transition are
-        frozen draft payloads and must never be rerun targets."""
-        for surface, script in retrigger_scripts.items():
-            assert "ready_for_review" in script, (
-                f"{surface}: selection must partition out draft-created evaluations"
-            )
-            assert "created_at" in script
+class TestDeterministicNonDraftSelection:
+    """The shared helper selects its rerun target deterministically.
 
-    def test_nondeterministic_selections_are_gone(self, retrigger_scripts: dict[str, str]) -> None:
-        """The two incident-era selections must not reappear."""
-        for surface, script in retrigger_scripts.items():
+    Regression target for the 2026-08-14 draft-success resurfacing
+    incident on PR #9754: an evidence burst reran BOTH evaluations at
+    head ``ee63516c`` — the older draft-era run was picked because the
+    newest was already re-running, and a rerun re-executes the run's
+    ORIGINAL frozen event payload, so the draft short-circuit replayed
+    a stale SUCCESS over the truthful ready-state result.
+
+    Pinned contract (shared by both surfaces through the helper):
+    enumerate ALL head-bound pull_request evaluations (pagination
+    reconciled against ``total_count``); exclude runs created before
+    the newest ``ready_for_review`` transition; order by
+    ``((run_started_at // created_at), run_id, run_attempt)`` —
+    coalesced because ``run_started_at`` is null while a run is still
+    queued — and consider ONLY the newest survivor (in-flight or green
+    newest: no-op, never a fallback); collapse concurrent retriggers
+    into one rerun via a fresh pre-rerun status read plus
+    rerun-rejection tolerance.
+    """
+
+    def test_selection_enumerates_all_head_bound_runs(self, select_script: str) -> None:
+        """Full pagination + total_count reconciliation."""
+        assert "--paginate" in select_script, "must enumerate ALL head-bound runs"
+        assert "total_count" in select_script, "enumeration must be reconciled against total_count"
+
+    def test_selection_orders_by_coalesced_start_time_run_id_run_attempt(
+        self, select_script: str
+    ) -> None:
+        """The pinned deterministic ordering key, with the null coalesce."""
+        assert "sort_by((.run_started_at // .created_at), .id, .run_attempt)" in select_script, (
+            "selection must order by ((run_started_at // created_at), run_id, run_attempt)"
+        )
+        assert "sort_by(.run_started_at, .id, .run_attempt)" not in select_script, (
+            "an uncoalesced null run_started_at sorts the queued newest run below older runs"
+        )
+
+    def test_selection_excludes_draft_frozen_evaluations(self, select_script: str) -> None:
+        """Runs created before the newest ready_for_review transition are frozen drafts."""
+        assert "ready_for_review" in select_script, "must partition out draft-created evaluations"
+        assert "created_at" in select_script
+
+    def test_nondeterministic_selections_are_gone(
+        self, select_script: str, retrigger_scripts: dict[str, str]
+    ) -> None:
+        """The two incident-era selections must not reappear anywhere."""
+        surfaces = {"shared-helper": select_script, **retrigger_scripts}
+        for surface, script in surfaces.items():
             assert ".workflow_runs[0]" not in script, (
                 f"{surface}: per_page=1 first-item selection is API-ordering-dependent"
             )
@@ -281,41 +341,29 @@ class TestDeterministicNonDraftSelection:
                 "re-running — the PR #9754 resurfacing mechanism"
             )
 
-    def test_only_the_newest_evaluation_may_be_rerun(
-        self, retrigger_scripts: dict[str, str]
-    ) -> None:
+    def test_only_the_newest_evaluation_may_be_rerun(self, select_script: str) -> None:
         """Completed/success checks happen AFTER selection: an in-flight or
         green newest evaluation no-ops instead of falling back."""
-        for surface, script in retrigger_scripts.items():
-            assert script.count("gh run rerun") == 1, (
-                f"{surface}: exactly one rerun path, for the selected newest run only"
-            )
-            assert '"$run_status" != "completed"' in script, (
-                f"{surface}: in-flight newest evaluation must no-op, not fall back"
-            )
-            assert '"$run_conclusion" == "success"' in script, (
-                f"{surface}: a green newest evaluation needs no recount"
-            )
+        assert select_script.count("gh run rerun") == 1, (
+            "exactly one rerun path, for the selected newest run only"
+        )
+        assert '"$run_status" != "completed"' in select_script, (
+            "in-flight newest evaluation must no-op, not fall back"
+        )
+        assert '"$run_conclusion" == "success"' in select_script, (
+            "a green newest evaluation needs no recount"
+        )
 
-    def test_concurrent_retriggers_collapse_into_one_rerun(
-        self, retrigger_scripts: dict[str, str]
-    ) -> None:
+    def test_concurrent_retriggers_collapse_into_one_rerun(self, select_script: str) -> None:
         """All surfaces compute the same target; a fresh pre-rerun status
         read plus rerun-rejection tolerance turns burst losers into no-ops."""
-        for surface, script in retrigger_scripts.items():
-            assert "actions/runs/${run_id}" in script, (
-                f"{surface}: must re-read the selected run's status just before rerun"
-            )
-            assert "concurrent retrigger won" in script
-            assert "::warning::rerun request" in script, (
-                f"{surface}: a rejected rerun (already re-running) must not be red noise"
-            )
-
-    def test_standalone_guards_open_non_draft_pr(self, standalone_workflow: dict[str, Any]) -> None:
-        """The helper must observe the same gate-deferral rule as the job."""
-        script = _run_blocks(standalone_workflow["jobs"]["retrigger"])
-        assert ".draft" in script
-        assert ".state" in script
+        assert "actions/runs/${run_id}" in select_script, (
+            "must re-read the selected run's status just before rerun"
+        )
+        assert "concurrent retrigger won" in select_script
+        assert "::warning::rerun request" in select_script, (
+            "a rejected rerun (already re-running) must not be red noise"
+        )
 
     def test_issue_events_read_permission_present(
         self, retrigger_job: dict[str, Any], standalone_workflow: dict[str, Any]
@@ -325,5 +373,113 @@ class TestDeterministicNonDraftSelection:
         assert job_permissions.get("issues") == "read"
         workflow_permissions = standalone_workflow.get("permissions") or {}
         assert workflow_permissions.get("issues") == "read"
-        writes = sorted(scope for scope, level in workflow_permissions.items() if level == "write")
-        assert writes == ["actions"], "helper workflow write surface stays exactly actions"
+        assert workflow_permissions.get("contents") == "read", (
+            "helper workflow checks out the shared selection helper"
+        )
+        surfaces = {
+            "evidence-retrigger job": job_permissions,
+            "helper workflow": workflow_permissions,
+        }
+        for surface, permissions in surfaces.items():
+            writes = sorted(scope for scope, level in permissions.items() if level == "write")
+            assert writes == ["actions"], f"{surface} write surface stays exactly actions"
+
+
+_GH_SHIM = """\
+#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+case "$args" in
+  *"/pulls/"*) cat "${GH_FIXTURES}/pr.json" ;;
+  *".total_count"*) cat "${GH_FIXTURES}/total_count.txt" ;;
+  *"/actions/workflows/"*) cat "${GH_FIXTURES}/runs.jsonl" ;;
+  *"/issues/"*) cat "${GH_FIXTURES}/ready_events.txt" ;;
+  *"/actions/runs/"*) cat "${GH_FIXTURES}/fresh_status.txt" ;;
+  "run rerun"*) printf '%s\\n' "$args" >>"${GH_FIXTURES}/rerun.log" ;;
+  *) echo "unexpected gh invocation: $args" >&2; exit 64 ;;
+esac
+"""
+
+
+def _run(
+    run_id: int, status: str, conclusion: str | None, created: str, started: str | None
+) -> dict[str, Any]:
+    return {
+        "id": run_id,
+        "run_attempt": 1,
+        "status": status,
+        "conclusion": conclusion,
+        "created_at": created,
+        "run_started_at": started,
+    }
+
+
+def _run_select_script(
+    tmp_path: Path, runs: list[dict[str, Any]], ready_events: list[str]
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    pr_json = {"state": "open", "draft": False, "head": {"sha": "f" * 40}}
+    (fixtures / "pr.json").write_text(json.dumps(pr_json), encoding="utf-8")
+    (fixtures / "total_count.txt").write_text(f"{len(runs)}\n", encoding="utf-8")
+    (fixtures / "runs.jsonl").write_text(
+        "".join(json.dumps(run) + "\n" for run in runs), encoding="utf-8"
+    )
+    (fixtures / "ready_events.txt").write_text(
+        "".join(ts + "\n" for ts in ready_events), encoding="utf-8"
+    )
+    (fixtures / "fresh_status.txt").write_text("completed\n", encoding="utf-8")
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "gh"
+    shim.write_text(_GH_SHIM, encoding="utf-8")
+    shim.chmod(0o755)
+    env = os.environ.copy()
+    env["PATH"] = f"{shim_dir}{os.pathsep}{env['PATH']}"
+    env["GH_FIXTURES"] = str(fixtures)
+    env["GH_REPO"] = "synaptent/aragora"
+    env["PR_NUMBER"] = "1234"
+    proc = subprocess.run(
+        ["bash", str(SELECT_SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+    return proc, fixtures / "rerun.log"
+
+
+class TestSelectionBehavior:
+    """Run the real helper (bash + jq) against a fixture-backed fake gh."""
+
+    def test_reruns_newest_ready_run_and_partitions_draft_era_runs(self, tmp_path: Path) -> None:
+        proc, rerun_log = _run_select_script(
+            tmp_path,
+            runs=[
+                _run(50, "completed", "success", "2026-08-16T09:00Z", "2026-08-16T09:01Z"),
+                _run(300, "completed", "failure", "2026-08-16T10:05Z", "2026-08-16T10:06Z"),
+            ],
+            ready_events=["2026-08-16T10:00Z"],
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert rerun_log.read_text(encoding="utf-8") == "run rerun 300 --repo synaptent/aragora\n"
+        assert "Re-running stale evaluation run 300" in proc.stdout
+
+    def test_null_run_started_at_newest_run_cannot_lose_to_older_completed_run(
+        self, tmp_path: Path
+    ) -> None:
+        """The coalesced key keeps a still-queued newest run (null
+        run_started_at) newest instead of falling back to an older rerun."""
+        proc, rerun_log = _run_select_script(
+            tmp_path,
+            runs=[
+                _run(100, "completed", "failure", "2026-08-16T10:00Z", "2026-08-16T10:01Z"),
+                _run(200, "queued", None, "2026-08-16T10:30Z", None),
+            ],
+            ready_events=[],
+        )
+        assert proc.returncode == 0, proc.stderr
+        assert not rerun_log.exists(), "must not fall back to re-running the older evaluation"
+        assert "run 200 is queued" in proc.stdout
+        assert "no-op" in proc.stdout


### PR DESCRIPTION
## TIER-4 PREPARATION — PARKED DRAFT ONLY

**Do not ready, merge, or settle from this description.** This PR is the prepared implementation for feature `misc-quorum-retrigger-selection-hardening`; it requires separate exact-head operator settlement per `docs/REVIEW_AUTHORITY_PRINCIPLES.md` and `docs/governance/MERGE_GATE_RECONCILIATION.md`. Tracked from the two claude [P3] advisories in the PR #9766 evidence (2026-08-15) plus the PR #9771 handoff docs-sync items.

### What changes

1. **Sort-key null-coalescing** — the Guard 3 primary jq sort key becomes `(.run_started_at // .created_at)`. `run_started_at` is null while a run is still queued, and with the uncoalesced key a still-queued newest evaluation sorts BELOW every older completed run, producing a redundant fallback rerun of a slightly-older non-draft evaluation. The draft partition was and remains unaffected.
2. **One shared selection surface** — the ~90-line gate-deferral + deterministic-selection + burst-dedup block, previously duplicated verbatim across the two Tier-4 retrigger surfaces (`aragora-merge-quorum.yml` `evidence-retrigger` job and the standalone `aragora-merge-quorum-retrigger.yml` helper), now lives in exactly one checked-in helper: `scripts/quorum_evidence_retrigger_select.sh`. Both workflows check it out from the BASE repo's **default branch** (`ref: ${{ github.event.repository.default_branch }}` — the same ref pin the enforcing evaluation job already uses and `tests/workflows/test_aragora_merge_quorum_workflow.py` pins) and delegate to it. Comment events still never execute PR-author-controlled code.
3. **Docs sync** — `docs/specs/QUORUM_EVIDENCE_RETRIGGER.md` now describes the single shared surface (new "Single shared selection surface" section), the coalesced ordering, and the default-branch checkout in the fork-PR threat model + permissions sections; the pre-#9766 design phrase is reworded to `gh run rerun <newest surviving head-bound pull_request run>` (grok P3); the Tier-4 chronology note now reads "proven on PR #9770, 2026-08-16 UTC" (claude P3; the merge was 2026-08-15T23:30:53-05:00 local). Docs-site mirror regenerated via `node scripts/sync-docs.js` in the same commit.

### Invariants preserved (all still pinned)

- Triggers, declarative guards, per-PR debounce concurrency, enforcing-job exclusion from `issue_comment`, workflow-level read-only permissions, `cancel-in-progress: false` on the enforcing group.
- Write surfaces stay **exactly `actions: write`** on both surfaces. The `evidence-retrigger` job gains `contents: read` solely for the helper checkout (pinned read-only by the tests).
- Comment body enters only via `env:`; Guard 1 heading regex unchanged; standalone shape pre-filter unchanged.
- Selection semantics: full pagination + `total_count` reconciliation, `ready_for_review` draft partition, newest-survivor-only with no fallback, fresh pre-rerun status read + rerun-rejection tolerance. Forbidden incident-era patterns (`.workflow_runs[0]`, `sort_by(.createdAt)`, completed-first filtering) are now asserted absent in the helper AND both workflow surfaces.

### Red-first proof

`python3 -m pytest tests/governance/test_quorum_evidence_retrigger.py -q`

- **RED** against the pre-change workflows (final suite, helper absent, uncoalesced key): `6 failed, 14 passed, 8 errors`
- **GREEN** with the change: `28 passed`

New coverage: `TestSharedSelectionSurface` (strict-bash helper, exactly-once delegation per surface, no inline selection reintroduction, default-branch-pinned checkouts), coalesced-ordering pin (uncoalesced key asserted absent), and `TestSelectionBehavior` — the real helper executed (bash + jq) against a fixture-backed fake `gh`: newest-ready-run rerun + draft-era partition, and the null-`run_started_at` no-fallback scenario from advisory (1).

### Validation

- `python3 -m pytest tests/governance/test_quorum_evidence_retrigger.py -q` → 28 passed
- `python3 -m pytest tests/scripts/test_docs_site_sync_links.py -q` → 33 passed
- `python3 -m pytest tests/workflows/test_aragora_merge_quorum_workflow.py tests/ci/test_merge_quorum_status_vocabulary.py tests/scripts/test_check_required_check_priority_policy.py tests/scripts/test_tier4_merge_train.py -q` → all passed (113 in combined run)
- `actionlint` clean on both workflows; `ruff format --check` + `ruff check` clean; `make test-smoke` passed (AWS-neutralized); `bash scripts/automation_pr_preflight.sh origin/main HEAD` → ok
- Diff: 491+/309− = 800 LOC across exactly the two workflows, the shared helper, the governance test, the spec, and its generated mirror

### Settlement

Prepared as a parked draft with fresh exact-head prepare-only two-family model evidence collected but **not posted** (returned to the operator in the settlement packet). No ready, posting, settlement, merge, workflow dispatch/rerun, or protection mutation was or will be performed by the preparing worker.
