### PR TITLE
fix(scripts): validate cross-SDK parity baseline value shapes and keep --json stdout pure

### DIFF
--- a/scripts/check_cross_sdk_parity.py
+++ b/scripts/check_cross_sdk_parity.py
@@ -122,6 +122,16 @@ def main() -> int:
             return _config_error(f"could not load baseline {args.baseline}: {exc}")
         if not isinstance(data, dict):
             return _config_error(f"baseline {args.baseline} must be a JSON object")
+        # A null value would raise an uncaught TypeError below, and a string
+        # would silently dissolve into a set of characters; both must fail as
+        # configuration errors instead of gating against a corrupted baseline.
+        for key in ("python_only", "typescript_only"):
+            value = data.get(key, [])
+            if not isinstance(value, list):
+                return _config_error(
+                    f"baseline {args.baseline} key {key!r} must be a JSON array, "
+                    f"got {type(value).__name__}"
+                )
         baseline_py_only = set(data.get("python_only", []))
         baseline_ts_only = set(data.get("typescript_only", []))
     elif args.strict:
@@ -183,7 +193,12 @@ def main() -> int:
 
     if args.strict:
         if new_py_only or new_ts_only:
-            print("\nFAILED: Cross-SDK parity regression (--strict mode)")
+            # Under --json stdout must stay pure machine-readable JSON, so the
+            # human-facing verdict line moves to stderr there.
+            print(
+                "\nFAILED: Cross-SDK parity regression (--strict mode)",
+                file=sys.stderr if args.json else sys.stdout,
+            )
             return 1
         if not args.json:
             print("\nPASS: No new cross-SDK parity regressions")

--- a/scripts/check_cross_sdk_parity.py
+++ b/scripts/check_cross_sdk_parity.py
@@ -122,15 +122,21 @@ def main() -> int:
             return _config_error(f"could not load baseline {args.baseline}: {exc}")
         if not isinstance(data, dict):
             return _config_error(f"baseline {args.baseline} must be a JSON object")
-        # A null value would raise an uncaught TypeError below, and a string
-        # would silently dissolve into a set of characters; both must fail as
-        # configuration errors instead of gating against a corrupted baseline.
+        # A null value would raise an uncaught TypeError below, a string would
+        # silently dissolve into a set of characters, and non-string elements
+        # either crash set() (unhashable) or silently never match any path;
+        # all must fail as configuration errors instead of gating against a
+        # corrupted baseline.
         for key in ("python_only", "typescript_only"):
             value = data.get(key, [])
             if not isinstance(value, list):
                 return _config_error(
                     f"baseline {args.baseline} key {key!r} must be a JSON array, "
                     f"got {type(value).__name__}"
+                )
+            if not all(isinstance(item, str) for item in value):
+                return _config_error(
+                    f"baseline {args.baseline} key {key!r} must be a JSON array of strings"
                 )
         baseline_py_only = set(data.get("python_only", []))
         baseline_ts_only = set(data.get("typescript_only", []))

--- a/tests/scripts/test_check_cross_sdk_parity.py
+++ b/tests/scripts/test_check_cross_sdk_parity.py
@@ -112,6 +112,29 @@ def test_string_baseline_value_is_config_error(tmp_path: Path) -> None:
     assert "typescript_only" in proc.stderr
 
 
+def test_non_string_baseline_element_is_config_error(tmp_path: Path) -> None:
+    nested = tmp_path / "nested_element.json"
+    nested.write_text(
+        json.dumps({"python_only": [["/api/x"]], "typescript_only": []}),
+        encoding="utf-8",
+    )
+    proc = _run("--strict", "--baseline", str(nested))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(nested) in proc.stderr
+    assert "python_only" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+    numeric = tmp_path / "numeric_element.json"
+    numeric.write_text(
+        json.dumps({"python_only": [], "typescript_only": [1, 2]}),
+        encoding="utf-8",
+    )
+    proc = _run("--strict", "--baseline", str(numeric))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(numeric) in proc.stderr
+    assert "typescript_only" in proc.stderr
+
+
 def test_strict_with_valid_baseline_passes_unchanged(tmp_path: Path) -> None:
     baseline = _live_baseline(tmp_path)
     proc = _run("--strict", "--baseline", str(baseline))

--- a/tests/scripts/test_check_cross_sdk_parity.py
+++ b/tests/scripts/test_check_cross_sdk_parity.py
@@ -1,15 +1,18 @@
 """Focused regression tests for scripts/check_cross_sdk_parity.py baseline resolution.
 
 A named-but-unresolvable baseline (missing file, unreadable/unparseable
-content, or ``--strict`` with no baseline at all) must exit with a distinct
-configuration-error status naming the attempted path, never silently gate
-against an empty baseline. Valid-baseline callers keep identical behavior,
-output, and exit codes.
+content, malformed value shapes, or ``--strict`` with no baseline at all)
+must exit with a distinct configuration-error status naming the attempted
+path, never silently gate against an empty or corrupted baseline. Valid-
+baseline callers keep identical behavior, output, and exit codes, and
+``--json`` stdout stays pure machine-readable JSON under every flag
+combination.
 """
 
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -87,13 +90,35 @@ def test_non_object_baseline_is_config_error(tmp_path: Path) -> None:
     assert str(non_object) in proc.stderr
 
 
+def test_null_baseline_value_is_config_error(tmp_path: Path) -> None:
+    baseline = tmp_path / "null_value.json"
+    baseline.write_text(json.dumps({"python_only": None}), encoding="utf-8")
+    proc = _run("--strict", "--baseline", str(baseline))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(baseline) in proc.stderr
+    assert "python_only" in proc.stderr
+    assert "Traceback" not in proc.stderr
+
+
+def test_string_baseline_value_is_config_error(tmp_path: Path) -> None:
+    baseline = tmp_path / "string_value.json"
+    baseline.write_text(
+        json.dumps({"python_only": ["/api/kept"], "typescript_only": "abc"}),
+        encoding="utf-8",
+    )
+    proc = _run("--strict", "--baseline", str(baseline))
+    assert proc.returncode == CONFIG_ERROR_EXIT
+    assert str(baseline) in proc.stderr
+    assert "typescript_only" in proc.stderr
+
+
 def test_strict_with_valid_baseline_passes_unchanged(tmp_path: Path) -> None:
     baseline = _live_baseline(tmp_path)
     proc = _run("--strict", "--baseline", str(baseline))
     assert proc.returncode == 0
     assert "PASS: No new cross-SDK parity regressions" in proc.stdout
     assert "Baseline regressions: python_only=0 typescript_only=0" in proc.stdout
-    assert proc.stderr == ""
+    assert "configuration error" not in proc.stderr
 
 
 def test_plain_invocation_unchanged() -> None:
@@ -101,4 +126,85 @@ def test_plain_invocation_unchanged() -> None:
     assert proc.returncode == 0
     assert "Python SDK paths:" in proc.stdout
     assert "Baseline regressions" not in proc.stdout
-    assert proc.stderr == ""
+    assert "configuration error" not in proc.stderr
+
+
+def _sandbox_script(
+    tmp_path: Path,
+    *,
+    python_endpoints: list[str],
+    typescript_endpoints: list[str],
+) -> Path:
+    """Copy the checker into an isolated tree with fabricated SDK namespaces.
+
+    The script resolves its SDK inputs relative to its own location, so a
+    relocated copy reads only the fabricated namespaces. That gives the test
+    deterministic gap sets independent of the live repository state.
+    """
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    for name in ("check_cross_sdk_parity.py", "sdk_path_normalize.py"):
+        shutil.copy(REPO_ROOT / "scripts" / name, scripts_dir / name)
+
+    py_dir = tmp_path / "sdk" / "python" / "aragora_sdk" / "namespaces"
+    py_dir.mkdir(parents=True)
+    py_calls = "".join(
+        f'        self._client.request("GET", "{path}")\n' for path in python_endpoints
+    )
+    py_dir.joinpath("demo.py").write_text(
+        "class Demo:\n    def calls(self):\n" + (py_calls or "        pass\n"),
+        encoding="utf-8",
+    )
+
+    ts_dir = tmp_path / "sdk" / "typescript" / "src" / "namespaces"
+    ts_dir.mkdir(parents=True)
+    ts_calls = "".join(f"this.client.get('{path}');\n" for path in typescript_endpoints)
+    ts_dir.joinpath("demo.ts").write_text(ts_calls, encoding="utf-8")
+
+    return scripts_dir / "check_cross_sdk_parity.py"
+
+
+def _run_sandbox(script: Path, *argv: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *argv],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+        cwd=script.parent.parent,
+    )
+
+
+def test_json_strict_regression_keeps_stdout_pure_json(tmp_path: Path) -> None:
+    script = _sandbox_script(
+        tmp_path,
+        python_endpoints=["/api/v1/demo-only", "/api/v1/shared"],
+        typescript_endpoints=["/api/v1/shared"],
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps({"python_only": [], "typescript_only": []}), encoding="utf-8")
+    proc = _run_sandbox(script, "--json", "--strict", "--baseline", str(baseline))
+    assert proc.returncode == 1
+    report = json.loads(proc.stdout)
+    assert report["python_only"] == ["/api/demo-only"]
+    assert "FAILED: Cross-SDK parity regression" not in proc.stdout
+    assert "FAILED: Cross-SDK parity regression" in proc.stderr
+
+
+def test_json_strict_pass_keeps_stdout_pure_json(tmp_path: Path) -> None:
+    script = _sandbox_script(
+        tmp_path,
+        python_endpoints=["/api/v1/demo-only", "/api/v1/shared"],
+        typescript_endpoints=["/api/v1/shared"],
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(
+        json.dumps({"python_only": ["/api/demo-only"], "typescript_only": []}),
+        encoding="utf-8",
+    )
+    proc = _run_sandbox(script, "--json", "--strict", "--baseline", str(baseline))
+    assert proc.returncode == 0
+    report = json.loads(proc.stdout)
+    assert report["python_only"] == ["/api/demo-only"]
+    assert "PASS" not in proc.stdout
+    assert "FAILED" not in proc.stderr


### PR DESCRIPTION
## Summary

Bounded follow-up closing the three claude [P3] advisories recorded in the PR #9768 merge evidence (2026-08-15), now that #9768 is merged and the paths are unfrozen.

1. **Baseline value-shape validation** — `scripts/check_cross_sdk_parity.py` resolves the baseline up front, but a null or non-list value (`{"python_only": null}`) raised an uncaught `TypeError`, and a string silently dissolved into a character set. Both now exit with the same configuration-error status **2**, naming the baseline path and the offending key. Reviewer round 1 (openai [P2], claude [P3] concurring) extended this to element shapes: a nested-array element (unhashable) previously crashed `set()` with an uncaught `TypeError`, and numeric elements silently never matched any path; both now also exit 2 naming path and key.
2. **`--json --strict` stdout purity** — the `FAILED: Cross-SDK parity regression (--strict mode)` verdict line was printed to stdout, corrupting the machine-readable JSON report. It now goes to stderr under `--json` (unchanged on the human path). No current caller uses the combination (verified: `Makefile`, `release.yml`, `sdk-parity.yml`, `pristine_main_health.py`, `pre_release_check.py` all use `--strict --baseline` without `--json`, or `--json` alone); behavior for every live caller shape is byte-identical (proof below).
3. **Brittle byte-compat guards** — the two `assert proc.stderr == ""` guards in `tests/scripts/test_check_cross_sdk_parity.py` now assert the absence of `"configuration error"` instead, so future benign stderr warnings cannot flake them.

Diff is bounded to the checker and its focused test file: +157/−7 across 2 files.

## Red-first evidence

New tests captured failing before each implementation step:

- `test_null_baseline_value_is_config_error` — rc 1 (uncaught TypeError) instead of 2
- `test_string_baseline_value_is_config_error` — rc 1 (char-set false regression) instead of 2
- `test_json_strict_regression_keeps_stdout_pure_json` — `json.decoder.JSONDecodeError: Extra data` (FAILED line corrupted stdout)
- `test_non_string_baseline_element_is_config_error` — rc 1 (uncaught TypeError from unhashable element) instead of 2 (round-1 fix)

## Validation

- `python3 -m pytest tests/scripts/test_check_cross_sdk_parity.py -q` — **12 passed** (seeds 0/1/2 all green)
- Byte-compat guard vs parent `686d1e7803` (each script at its natural path in its own checkout): **IDENTICAL** stdout+stderr+rc for all 6 live caller shapes — plain, `--json`, `--strict --baseline`, `--baseline`, `--json --baseline`, `--json --strict --baseline` (canonical baseline); re-verified after the round-1 fix
- `make lint` — pass; `ruff format --check` — clean
- `bash scripts/preflight_mypy.sh --diff-base origin/main` — no `aragora/` changes (skipped); direct mypy on the changed script: no issues
- `make test-smoke` — pass; `bash scripts/test_tiers.sh smoke` — **138 passed** (re-run on the round-1 head)
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` — ok

## Risks

- The checker is a CDG authority dependency, so tier classification is path-driven (Tier 4 confirmed by merge-packet; parked draft pending operator settlement).
- New config-error exits only trigger on malformed baseline values that previously crashed (null, nested array) or silently corrupted the gate (string, numeric elements); no well-formed caller changes behavior.
