### PR TITLE
chore(lint): remove invalid WPS433 noqa code from argv-pollution test

### DIFF
--- a/tests/cli/test_main_argv_pollution.py
+++ b/tests/cli/test_main_argv_pollution.py
@@ -32,7 +32,7 @@ def _restore_sys_argv():
 
 def _import_dispatch_main():
     """Import ``aragora.__main__.main`` fresh so patching is deterministic."""
-    import aragora.__main__ as pkg_main  # noqa: WPS433 - intentional local import
+    import aragora.__main__ as pkg_main  # intentional local import
 
     return pkg_main
 


### PR DESCRIPTION
## Source

Tracked lint-hygiene item from the 2026-08-15 PR #9768 settlement handoff (mission structex, feature `misc-lint-invalid-noqa-wps433-cleanup`): `make lint` on fresh main emitted a pre-existing cosmetic warning

```
warning: Invalid rule code provided to `# noqa` at tests/cli/test_main_argv_pollution.py:35: WPS433
```

`WPS433` is a wemake-python-styleguide code that ruff cannot parse.

## Change

Drop only the invalid `noqa: WPS433` directive from the trailing comment on the function-local import (the intent note is kept). No suppression is needed: `PLC0415` (import-outside-top-level) is not in the repo's ruff `select`, so no active rule fires on that line. Behavior-neutral, comment-only, 1+/1- in a single test file.

A sweep of fresh main (`da13fb1681`) confirmed this was the only invalid noqa rule code ruff reports (`make lint 2>&1 | grep -ci invalid` = 1 before, 0 after).

## Validation

- `make lint` -> exit 0, **zero** invalid-noqa warnings (was exactly one on fresh main)
- `ruff format --check aragora/ tests/ scripts/` -> exit 0 (10806 files already formatted)
- `bash scripts/preflight_mypy.sh --diff-base origin/main` -> Success: no issues found in 1 source file
- `python3 -m pytest tests/cli/test_main_argv_pollution.py -q --timeout=120` -> 5 passed
- `make test-smoke` (AWS-neutralized) -> Core/Server/Memory imports OK, Smoke tests passed
- `PYTEST_BIN="python3 -m pytest" bash scripts/test_tiers.sh smoke` -> 138 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> preflight: ok

## Risks

None identified: comment-only diff in one test file; test semantics and collection unchanged.
